### PR TITLE
refactor(platform): move Agent and AgentVersion persistence records out of core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,25 @@ jobs:
       - name: Check observability isolation
         run: bash scripts/lib/check-observability-isolation.sh
 
+  # Architecture guard (EVE-877): stored Agent/AgentVersion persistence records
+  # live in crates/platform. Kernel crates (core, engine, provider, capability)
+  # consume only the portable AgentDefinition and the resolved execution
+  # snapshot, and carry no everruns-platform edge.
+  agent-record-isolation:
+    name: Agent-Record Isolation Guard
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Check agent-record isolation
+        run: bash scripts/lib/check-agent-record-isolation.sh
+
   migration-immutability:
     name: Migration Immutability
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **Moved the stored `Agent` and `AgentVersion` records out of
+  `everruns-core`.** The persistence records — `Agent`, `AgentVersion`,
+  `AgentStatus`, `AgentVersionChangeKind`, `MAX_ADDRESSABLE_NAME_LEN`,
+  `validate_addressable_name`, `generate_agent_public_id`, and
+  `validate_agent_public_id` — now live in `everruns-platform`; the
+  `everruns_core::agent` module is gone. Core keeps only the portable
+  `everruns_core::AgentDefinition` (the authored execution configuration),
+  which `AgentStore` implementations now return, and archived or deleted
+  agents fail at that loading seam instead of inside snapshot projection.
+  Direct core consumers that touch the stored records should depend on
+  `everruns-platform` and import them from there; execution-side code should
+  consume `AgentDefinition` or the resolved execution snapshot. REST/gRPC
+  shapes and stored schema are unchanged.
+
 - **Removed the `everruns-runtime` crate.** It was a logic-free 0.17.x
   compatibility layer over `everruns-host` and is no longer published. The
   deprecated `everruns::runtime` module alias is removed with it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ version = "0.17.26"
 dependencies = [
  "chrono",
  "everruns-core",
+ "everruns-platform",
  "prost",
  "prost-types",
  "protox",

--- a/crates/core/src/agent_definition.rs
+++ b/crates/core/src/agent_definition.rs
@@ -1,0 +1,136 @@
+// Portable authored agent execution configuration (EVE-877).
+//
+// Decision: the stored `Agent`/`AgentVersion` persistence records — lifecycle
+// status, versioning and publication metadata, fork lineage, timestamps,
+// usage — live in `everruns-platform`. Core keeps only this portable,
+// execution-facing projection: the authored configuration the runtime folds
+// into the harness → agent → session overlay chain. The platform loading seam
+// (server repositories, worker adapters, hosted stores) projects stored
+// records into this value and enforces lifecycle validation (archived or
+// deleted records fail) before host execution begins.
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability_types::AgentCapabilityConfig;
+use crate::mcp_server::{ScopedMcpServers, scoped_mcp_servers_is_empty};
+use crate::network_access::NetworkAccessList;
+use crate::session_file::InitialFile;
+use crate::tool_types::ToolDefinition;
+use crate::typed_id::{AgentId, ModelId};
+
+/// Portable authored execution configuration for an agent.
+///
+/// Carries exactly what turn execution consumes: the agent's identity for
+/// correlation plus the authored configuration layer merged between the
+/// harness chain and the session overlay. It is not a persistence record —
+/// stored lifecycle/versioning metadata stays in `everruns-platform`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDefinition {
+    /// Public agent identifier (`agent_<32-hex>`), used for correlation and
+    /// session/agent mismatch validation during snapshot projection.
+    pub id: AgentId,
+    /// Addressable name, unique per org (e.g. "customer-support").
+    pub name: String,
+    /// Human-readable display name; falls back to `name` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Human-readable description of what the agent does.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// System prompt contributed by the agent layer.
+    pub system_prompt: String,
+    /// Default LLM model; overridable at the session layer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_model_id: Option<ModelId>,
+    /// Capabilities enabled for this agent with per-agent configuration.
+    #[serde(default)]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Starter files copied into each new session for this agent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub initial_files: Vec<InitialFile>,
+    /// Network access list merged with harness and session layers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_access: Option<NetworkAccessList>,
+    /// Maximum number of LLM iterations per turn for this agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_iterations: Option<usize>,
+    /// Request-level parallel tool calling preference (EVE-598).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel_tool_calls: Option<bool>,
+    /// Client-side tools registered for this agent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolDefinition>,
+    /// Remote MCP servers scoped to this agent and inherited by its sessions.
+    #[serde(
+        default,
+        rename = "mcpServers",
+        alias = "mcp_servers",
+        skip_serializing_if = "scoped_mcp_servers_is_empty"
+    )]
+    pub mcp_servers: ScopedMcpServers,
+}
+
+impl AgentDefinition {
+    /// Create a definition with the given identity and prompt; all other
+    /// configuration starts empty.
+    pub fn new(id: AgentId, name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
+        Self {
+            id,
+            name: name.into(),
+            display_name: None,
+            description: None,
+            system_prompt: system_prompt.into(),
+            default_model_id: None,
+            capabilities: vec![],
+            initial_files: vec![],
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            tools: vec![],
+            mcp_servers: ScopedMcpServers::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_serde_round_trips() {
+        let definition = AgentDefinition::new(
+            "agent_01933b5a000070008000000000000001".parse().unwrap(),
+            "test",
+            "You are helpful.",
+        );
+        let json = serde_json::to_value(&definition).unwrap();
+        assert_eq!(json["id"], "agent_01933b5a000070008000000000000001");
+        let round_tripped: AgentDefinition = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&round_tripped).unwrap(), json);
+    }
+
+    #[test]
+    fn definition_carries_no_persistence_metadata() {
+        let definition = AgentDefinition::new(
+            "agent_01933b5a000070008000000000000001".parse().unwrap(),
+            "test",
+            "prompt",
+        );
+        let json = serde_json::to_value(&definition).unwrap();
+        for persistence_field in [
+            "status",
+            "created_at",
+            "updated_at",
+            "archived_at",
+            "deleted_at",
+            "default_version_id",
+            "forked_from_agent_id",
+            "usage",
+        ] {
+            assert!(
+                json.get(persistence_field).is_none(),
+                "portable definition must not expose {persistence_field}"
+            );
+        }
+    }
+}

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -1525,11 +1525,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_agent_handoff_requires_configured_connection() {
         let store = Arc::new(MockSubagentDelegate::new());
-        let config = target_config(
-            store.agent.public_id,
-            store.session.harness_id,
-            vec!["fake_aws"],
-        );
+        let config = target_config(store.agent.id, store.session.harness_id, vec!["fake_aws"]);
         let tool = spawn_agent_tool(&config);
         let resolver = Arc::new(TestConnectionResolver {
             providers: HashSet::new(),
@@ -1557,7 +1553,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_agent_handoff_rejects_other_target_types() {
         let store = Arc::new(MockSubagentDelegate::new());
-        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let config = target_config(store.agent.id, store.session.harness_id, vec![]);
         let tool = spawn_agent_tool(&config);
         let context = context(store, None);
 
@@ -1583,11 +1579,7 @@ mod tests {
         let resolver = Arc::new(TestConnectionResolver {
             providers: HashSet::from(["fake_aws".to_string()]),
         });
-        let config = target_config(
-            store.agent.public_id,
-            store.session.harness_id,
-            vec!["fake_aws"],
-        );
+        let config = target_config(store.agent.id, store.session.harness_id, vec!["fake_aws"]);
         let tool = spawn_agent_tool(&config);
         let registry = Arc::new(InMemorySessionTaskRegistry::default());
         let mut context = context(store.clone(), Some(resolver));
@@ -1629,7 +1621,7 @@ mod tests {
     async fn schema_bound_handoff_requires_report_result() {
         let store = Arc::new(MockSubagentDelegate::new());
         *store.wait_for_idle_status.lock().unwrap() = "completed".to_string();
-        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let config = target_config(store.agent.id, store.session.harness_id, vec![]);
         let registry = Arc::new(InMemorySessionTaskRegistry::default());
         let mut context = context(store.clone(), None);
         context.session_task_registry = Some(registry.clone());
@@ -1674,7 +1666,7 @@ mod tests {
     #[tokio::test]
     async fn handoff_message_schema_is_task_backed_and_wakes_on_activity() {
         let store = Arc::new(MockSubagentDelegate::new());
-        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let config = target_config(store.agent.id, store.session.harness_id, vec![]);
         let registry = Arc::new(InMemorySessionTaskRegistry::default());
         let mut context = context(store.clone(), None);
         context.session_task_registry = Some(registry.clone());
@@ -1715,7 +1707,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_agent_handoff_background_returns_task_handle() {
         let store = Arc::new(MockSubagentDelegate::new());
-        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let config = target_config(store.agent.id, store.session.harness_id, vec![]);
         let tool = spawn_agent_tool(&config);
         let registry = Arc::new(InMemorySessionTaskRegistry::default());
         let mut context = context(store.clone(), None);
@@ -1768,7 +1760,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_agent_handoff_invite_adds_member_participant() {
         let store = Arc::new(MockSubagentDelegate::new());
-        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let config = target_config(store.agent.id, store.session.harness_id, vec![]);
         let tool = spawn_agent_tool(&config);
         let context = context(store.clone(), None);
 
@@ -1806,7 +1798,7 @@ mod tests {
             .expect("participants lock")
             .clone();
         assert_eq!(participants.len(), 1);
-        assert_eq!(participants[0].agent_id, Some(store.agent.public_id));
+        assert_eq!(participants[0].agent_id, Some(store.agent.id));
         assert_eq!(
             participants[0].role,
             crate::session::SessionParticipantRole::Member
@@ -1840,7 +1832,7 @@ mod tests {
             harnesses.insert(child_harness_id, child_harness);
         }
         let store = Arc::new(store_value);
-        let config = target_config(store.agent.public_id, child_harness_id, vec![]);
+        let config = target_config(store.agent.id, child_harness_id, vec![]);
         let tool = spawn_agent_tool(&config);
         let context = context(store.clone(), None);
 
@@ -1882,7 +1874,7 @@ mod tests {
             json!({"max_bytes": 2048}),
         )];
         let store = Arc::new(store_value);
-        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
+        let config = target_config(store.agent.id, store.session.harness_id, vec![]);
         let tool = spawn_agent_tool(&config);
         let context = context(store.clone(), None);
 
@@ -1928,7 +1920,7 @@ mod tests {
         // otherwise the assertion below cannot distinguish them.
         assert_ne!(store.session.harness_id, target_harness_id);
 
-        let config = target_config(store.agent.public_id, target_harness_id, vec!["fake_aws"]);
+        let config = target_config(store.agent.id, target_harness_id, vec!["fake_aws"]);
         let tool = spawn_agent_tool(&config);
         let context = context(store.clone(), Some(resolver));
 

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -385,7 +385,7 @@ fn usage_json(usage: &TokenUsage) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::{Agent, AgentStatus};
+    use crate::AgentDefinition;
     use crate::events::{Event, EventRequest};
     use crate::session::{Session, SessionStatus};
     use crate::typed_id::{AgentId, EventId, HarnessId, MessageId, ModelId, SessionId, TurnId};
@@ -425,7 +425,7 @@ mod tests {
     }
 
     struct MockAgentStore {
-        agent: Option<Agent>,
+        agent: Option<AgentDefinition>,
     }
 
     #[derive(Clone, Default)]
@@ -446,7 +446,7 @@ mod tests {
 
     #[async_trait]
     impl crate::traits::AgentStore for MockAgentStore {
-        async fn get_agent(&self, _agent_id: AgentId) -> Result<Option<Agent>> {
+        async fn get_agent(&self, _agent_id: AgentId) -> Result<Option<AgentDefinition>> {
             Ok(self.agent.clone())
         }
     }
@@ -645,34 +645,11 @@ mod tests {
         let session = build_session(Some(agent_id));
         let session_id = session.id;
 
-        let agent = Agent {
-            public_id: agent_id,
-            internal_id: agent_id.uuid(),
-            name: "research-agent".to_string(),
+        let agent = AgentDefinition {
             display_name: Some("Research Agent".to_string()),
             description: Some("desc".to_string()),
-            system_prompt: "prompt".to_string(),
-            default_model_id: None,
-
-            harness_id: crate::typed_id::HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
             capabilities: vec![AgentCapabilityConfig::new("session")],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(agent_id, "research-agent", "prompt")
         };
 
         let context = ToolContext::new(session_id)

--- a/crates/core/src/config_layer.rs
+++ b/crates/core/src/config_layer.rs
@@ -23,7 +23,7 @@
 // - parallel_tool_calls: overlay wins if set, else inherit base
 // - mcp_servers: overlay overrides base by logical server name (last wins)
 
-use crate::agent::Agent;
+use crate::agent_definition::AgentDefinition;
 use crate::capability_types::AgentCapabilityConfig;
 use crate::harness::Harness;
 use crate::mcp_server::{ScopedMcpServers, merge_scoped_mcp_servers};
@@ -199,8 +199,8 @@ impl From<&Harness> for AgentConfigOverlay {
     }
 }
 
-impl From<&Agent> for AgentConfigOverlay {
-    fn from(a: &Agent) -> Self {
+impl From<&AgentDefinition> for AgentConfigOverlay {
+    fn from(a: &AgentDefinition) -> Self {
         AgentConfigOverlay {
             system_prompt: Some(a.system_prompt.clone()),
             capabilities: a.capabilities.clone(),

--- a/crates/core/src/dependency_blocker.rs
+++ b/crates/core/src/dependency_blocker.rs
@@ -3,10 +3,10 @@
 // Decision: Shared module in core so both workers and activities don't
 // duplicate harness/agent status checks and error messages.
 
+use crate::HarnessStatus;
 use crate::error::Result;
 use crate::traits::{AgentStore, HarnessStore};
 use crate::typed_id::{AgentId, HarnessId};
-use crate::{AgentStatus, HarnessStatus};
 
 /// Reason why execution was blocked before it started.
 #[derive(Debug, Clone, Copy)]
@@ -62,13 +62,11 @@ pub async fn detect_dependency_blocker(
     }
 
     if let Some(agent_id) = agent_id {
-        match agent_store.get_agent(agent_id).await? {
-            Some(agent) => match agent.status {
-                AgentStatus::Active => {}
-                AgentStatus::Archived => return Ok(Some(DependencyBlocker::AgentArchived)),
-                AgentStatus::Deleted => return Ok(Some(DependencyBlocker::AgentDeleted)),
-            },
-            None => return Ok(Some(DependencyBlocker::AgentDeleted)),
+        // EVE-877: lifecycle status lives on the stored platform record, so
+        // hosted stores answer the availability probe from their own status
+        // column instead of exposing the record here.
+        if let Some(blocker) = agent_store.get_agent_blocker(agent_id).await? {
+            return Ok(Some(blocker));
         }
     }
 

--- a/crates/core/src/execution_snapshot.rs
+++ b/crates/core/src/execution_snapshot.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::agent::{Agent, AgentStatus};
+use crate::agent_definition::AgentDefinition;
 use crate::capability_types::AgentCapabilityConfig;
 use crate::config_layer::AgentConfigOverlay;
 use crate::error::{AgentLoopError, Result};
@@ -122,20 +122,23 @@ pub struct ResolvedExecutionSnapshot {
 }
 
 impl ResolvedExecutionSnapshot {
-    /// Project stored records into the canonical execution value.
+    /// Project loaded records into the canonical execution value.
     ///
     /// This is the platform projection boundary: it fails when the harness
     /// chain is empty or does not terminate at the session's harness, when a
     /// referenced agent is missing or does not match the session's agent id,
-    /// or when the leaf harness / agent is archived or deleted. Host execution
-    /// never sees a snapshot built from broken record wiring.
+    /// or when the leaf harness is archived or deleted. Agent lifecycle
+    /// validation happens one step earlier, at the [`AgentStore`] loading
+    /// seam: stored records that are archived or deleted fail there (EVE-877),
+    /// so only executable [`AgentDefinition`] values reach this projection.
+    /// Host execution never sees a snapshot built from broken record wiring.
     ///
     /// Precedence is applied exactly once, through the same
     /// [`AgentConfigOverlay`] merge semantics the runtime capability
     /// resolution uses.
     pub fn project(
         harness_chain: &[Harness],
-        agent: Option<&Agent>,
+        agent: Option<&AgentDefinition>,
         session: &Session,
     ) -> Result<Self> {
         let Some(leaf) = harness_chain.last() else {
@@ -164,25 +167,11 @@ impl ResolvedExecutionSnapshot {
 
         let agent = match (session.agent_id, agent) {
             (Some(agent_id), Some(agent)) => {
-                if agent.public_id != agent_id {
+                if agent.id != agent_id {
                     return Err(AgentLoopError::config(format!(
                         "session {} references agent {} but agent {} was provided",
-                        session.id, agent_id, agent.public_id
+                        session.id, agent_id, agent.id
                     )));
-                }
-                match agent.status {
-                    AgentStatus::Active => {}
-                    AgentStatus::Archived | AgentStatus::Deleted => {
-                        return Err(AgentLoopError::config(format!(
-                            "agent {} is {} and cannot execute turns",
-                            agent.public_id,
-                            if agent.status == AgentStatus::Archived {
-                                "archived"
-                            } else {
-                                "deleted"
-                            }
-                        )));
-                    }
                 }
                 Some(agent)
             }
@@ -277,7 +266,6 @@ mod tests {
     use crate::session::SessionStatus;
     use chrono::Utc;
     use std::collections::HashMap;
-    use uuid::Uuid;
 
     fn harness(harness_id: HarnessId) -> Harness {
         Harness {
@@ -304,34 +292,11 @@ mod tests {
         }
     }
 
-    fn agent(agent_id: AgentId, harness_id: HarnessId) -> Agent {
-        Agent {
-            public_id: agent_id,
-            internal_id: Uuid::nil(),
-            name: "agent".into(),
-            display_name: Some("Agent".into()),
-            description: None,
-            system_prompt: "Agent prompt.".into(),
-            default_model_id: None,
-            harness_id,
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
-            capabilities: vec![],
-            initial_files: vec![],
-            network_access: None,
+    fn agent(agent_id: AgentId, _harness_id: HarnessId) -> AgentDefinition {
+        AgentDefinition {
             max_iterations: Some(8),
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            display_name: Some("Agent".into()),
+            ..AgentDefinition::new(agent_id, "agent", "Agent prompt.")
         }
     }
 
@@ -657,7 +622,10 @@ mod tests {
     }
 
     #[test]
-    fn projection_fails_on_archived_or_deleted_records() {
+    fn projection_fails_on_archived_or_deleted_harness() {
+        // Agent lifecycle validation moved to the platform loading seam
+        // (EVE-877): archived/deleted stored Agent records fail in
+        // the platform record's `execution_definition` before projection.
         let (harness_id, agent_id, session_id) = ids();
         let session = session(session_id, harness_id, Some(agent_id));
 
@@ -668,16 +636,6 @@ mod tests {
             assert!(
                 ResolvedExecutionSnapshot::project(&[archived], Some(&agent), &session).is_err(),
                 "harness status {status:?} must fail projection"
-            );
-        }
-
-        for status in [AgentStatus::Archived, AgentStatus::Deleted] {
-            let harness = harness(harness_id);
-            let mut inactive = agent(agent_id, harness_id);
-            inactive.status = status.clone();
-            assert!(
-                ResolvedExecutionSnapshot::project(&[harness], Some(&inactive), &session).is_err(),
-                "agent status {status:?} must fail projection"
             );
         }
     }

--- a/crates/core/src/in_memory.rs
+++ b/crates/core/src/in_memory.rs
@@ -8,7 +8,7 @@
 // the deterministic simulator live in the `everruns-test-support` crate
 // (EVE-875), not here.
 
-use crate::agent::Agent;
+use crate::agent_definition::AgentDefinition;
 use crate::credential_provider::CredentialProvider;
 use crate::harness::Harness;
 use crate::provider::DriverId;
@@ -215,7 +215,7 @@ impl MessageRetriever for InMemoryMessageRetriever {
 /// Useful for testing and examples where you want to configure agents without a database.
 #[derive(Debug, Default, Clone)]
 pub struct InMemoryAgentStore {
-    agents: Arc<RwLock<HashMap<AgentId, Agent>>>,
+    agents: Arc<RwLock<HashMap<AgentId, AgentDefinition>>>,
 }
 
 impl InMemoryAgentStore {
@@ -227,8 +227,8 @@ impl InMemoryAgentStore {
     }
 
     /// Add an agent to the store
-    pub async fn add_agent(&self, agent: Agent) {
-        self.agents.write().await.insert(agent.public_id, agent);
+    pub async fn add_agent(&self, agent: AgentDefinition) {
+        self.agents.write().await.insert(agent.id, agent);
     }
 
     /// Get all agent IDs
@@ -244,7 +244,7 @@ impl InMemoryAgentStore {
 
 #[async_trait]
 impl AgentStore for InMemoryAgentStore {
-    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<AgentDefinition>> {
         Ok(self.agents.read().await.get(&agent_id).cloned())
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -86,7 +86,7 @@ pub mod budget;
 
 // Domain entity types
 // These are DB-agnostic entity types used by both API and worker
-pub mod agent;
+pub mod agent_definition;
 pub mod agent_identity;
 pub mod ard_attachment;
 pub mod capability_dto;
@@ -437,10 +437,11 @@ pub use capability_types::{
 
 // Domain entity re-exports
 // Note: Provider entity is in the provider module. Import as: everruns_core::provider::Provider
-pub use agent::{
-    Agent, AgentStatus, AgentVersion, AgentVersionChangeKind, MAX_ADDRESSABLE_NAME_LEN,
-    generate_agent_public_id, validate_addressable_name, validate_agent_public_id,
-};
+// EVE-877: the stored `Agent`/`AgentVersion` persistence records, their
+// lifecycle/versioning enums, and the public-name/persistence helpers moved to
+// the `everruns-platform` crate. Core keeps only the portable authored
+// execution configuration consumed during a turn.
+pub use agent_definition::AgentDefinition;
 pub use agent_identity::{AgentIdentity, AgentIdentityStatus};
 // EVE-841: the app and agent-trigger control-plane records moved to the
 // `everruns-platform` crate. They are hosted orchestration records not consumed

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -13,7 +13,7 @@
 // Legacy per-entity methods (with_harness, with_agent) are kept for
 // backward compatibility but the AgentConfigOverlay path is canonical.
 
-use crate::agent::Agent;
+use crate::agent_definition::AgentDefinition;
 use crate::capabilities::{
     CapabilityRegistry, SystemPromptContext, ToolDefinitionHook, collect_capabilities_with_configs,
     compose_system_prompt, resolve_capability_configs,
@@ -236,7 +236,7 @@ impl RuntimeAgentBuilder {
     /// ```
     pub async fn with_agent(
         self,
-        agent: &Agent,
+        agent: &AgentDefinition,
         registry: &CapabilityRegistry,
         ctx: &SystemPromptContext,
     ) -> Self {
@@ -528,7 +528,6 @@ impl Default for RuntimeAgentBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::AgentStatus;
     use crate::capabilities::{AgentCapabilityConfig, SystemPromptContext};
     use crate::typed_id::AgentId;
 
@@ -679,34 +678,14 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let ts = Timestamp::now(NoContext);
         let uuid = Uuid::new_v7(ts);
-        let agent = Agent {
-            public_id: AgentId::from_uuid(uuid),
-            internal_id: uuid,
-            name: "test-agent".to_string(),
+        let agent = AgentDefinition {
             display_name: Some("Test Agent".to_string()),
-            description: None,
-            system_prompt: "Agent prompt.".to_string(),
-            default_model_id: None,
-
-            harness_id: crate::typed_id::HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
             capabilities: vec![AgentCapabilityConfig::new("current_time")],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            tags: vec![],
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(
+                AgentId::from_uuid(uuid),
+                "test-agent".to_string(),
+                "Agent prompt.".to_string(),
+            )
         };
 
         let runtime_agent = RuntimeAgentBuilder::new()
@@ -850,34 +829,14 @@ mod tests {
             full_parameters: None,
         });
 
-        let agent = Agent {
-            public_id: AgentId::from_uuid(uuid),
-            internal_id: uuid,
-            name: "client-tool-agent".to_string(),
+        let agent = AgentDefinition {
             display_name: Some("Client Tool Agent".to_string()),
-            description: None,
-            system_prompt: "Agent with client tools.".to_string(),
-            default_model_id: None,
-
-            harness_id: crate::typed_id::HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            capabilities: vec![],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
             tools: vec![client_tool],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            tags: vec![],
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(
+                AgentId::from_uuid(uuid),
+                "client-tool-agent".to_string(),
+                "Agent with client tools.".to_string(),
+            )
         };
 
         let runtime_agent = RuntimeAgentBuilder::new()
@@ -914,34 +873,15 @@ mod tests {
             full_parameters: None,
         });
 
-        let agent = Agent {
-            public_id: AgentId::from_uuid(uuid),
-            internal_id: uuid,
-            name: "mixed-tool-agent".to_string(),
+        let agent = AgentDefinition {
             display_name: Some("Mixed Tool Agent".to_string()),
-            description: None,
-            system_prompt: "Agent with mixed tools.".to_string(),
-            default_model_id: None,
-
-            harness_id: crate::typed_id::HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
             capabilities: vec![AgentCapabilityConfig::new("current_time")],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
             tools: vec![client_tool],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            tags: vec![],
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(
+                AgentId::from_uuid(uuid),
+                "mixed-tool-agent".to_string(),
+                "Agent with mixed tools.".to_string(),
+            )
         };
 
         let runtime_agent = RuntimeAgentBuilder::new()
@@ -974,34 +914,14 @@ mod tests {
 
         // Agent has current_time capability (no system prompt addition)
         let uuid = Uuid::new_v7(ts);
-        let agent = Agent {
-            public_id: AgentId::from_uuid(uuid),
-            internal_id: uuid,
-            name: "test-agent".to_string(),
+        let agent = AgentDefinition {
             display_name: Some("Test Agent".to_string()),
-            description: None,
-            system_prompt: "Agent prompt.".to_string(),
-            default_model_id: None,
-
-            harness_id: crate::typed_id::HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
             capabilities: vec![AgentCapabilityConfig::new("current_time")],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            tags: vec![],
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(
+                AgentId::from_uuid(uuid),
+                "test-agent".to_string(),
+                "Agent prompt.".to_string(),
+            )
         };
 
         // Session adds stateless_todo_list capability (additive — has system prompt addition)

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use crate::AgentCapabilityConfig;
-use crate::agent::Agent;
+use crate::agent_definition::AgentDefinition;
 use crate::capabilities::{
     COMPACTION_CAPABILITY_ID, CapabilityRegistry, CompactionConfig, SystemPromptContext,
     resolve_capability_configs,
@@ -33,8 +33,8 @@ use std::sync::Arc;
 pub struct AssembledTurnContext {
     /// Full root-to-leaf harness chain.
     pub harness_chain: Vec<Harness>,
-    /// Optional agent attached to the session.
-    pub agent: Option<Agent>,
+    /// Optional agent execution definition attached to the session.
+    pub agent: Option<AgentDefinition>,
     /// Session being executed.
     pub session: Session,
     /// Effective overlay after merging harness chain → agent → session.
@@ -280,7 +280,7 @@ async fn assemble_turn_context_with_mode(
 /// Resolve the merged overlay and dependency-expanded capability configs for a runtime session.
 pub fn resolve_runtime_capabilities(
     harness_chain: &[Harness],
-    agent: Option<&Agent>,
+    agent: Option<&AgentDefinition>,
     session: &Session,
     capability_registry: &CapabilityRegistry,
 ) -> ResolvedRuntimeCapabilities {
@@ -406,7 +406,7 @@ fn extract_locale_override(messages: &[Message]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::{Agent, AgentStatus};
+
     use crate::capabilities::{AgentBlueprint, BlueprintModel, Capability, CapabilityRegistry};
     use crate::harness::{Harness, HarnessStatus};
     use crate::in_memory::{
@@ -419,7 +419,6 @@ mod tests {
     use crate::tools::{Tool, ToolExecutionResult};
     use crate::typed_id::{AgentId, HarnessId};
     use chrono::Utc;
-    use uuid::Uuid;
 
     /// Local stand-in for the `test_math` fixture capability, which lives in
     /// `everruns-test-support` (EVE-875). These tests only need a registered
@@ -494,35 +493,11 @@ mod tests {
         }
     }
 
-    fn agent(agent_id: AgentId) -> Agent {
-        Agent {
-            public_id: agent_id,
-            internal_id: Uuid::nil(),
-            name: "math-agent".into(),
+    fn agent(agent_id: AgentId) -> crate::AgentDefinition {
+        crate::AgentDefinition {
             display_name: Some("Math Agent".into()),
-            description: None,
-            system_prompt: "Use tools.".into(),
-            default_model_id: None,
-
-            harness_id: crate::typed_id::HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
-            capabilities: vec![],
-            initial_files: vec![],
-            network_access: None,
             max_iterations: Some(8),
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..crate::AgentDefinition::new(agent_id, "math-agent", "Use tools.")
         }
     }
 

--- a/crates/core/src/subagent_delegation.rs
+++ b/crates/core/src/subagent_delegation.rs
@@ -10,7 +10,7 @@
 //! The request/message DTOs live here (not in `everruns-platform`) because the
 //! trait signature needs them and core cannot depend on platform.
 
-use crate::agent::Agent;
+use crate::agent_definition::AgentDefinition;
 use crate::error::Result;
 use crate::harness::Harness;
 use crate::session::{Session, SessionParticipant, SessionSeedMode};
@@ -51,8 +51,10 @@ pub struct PlatformCreateSessionRequest {
 /// carried on [`ToolContext`](crate::ToolContext) as an optional service.
 #[async_trait]
 pub trait SubagentSessionDelegate: Send + Sync {
-    /// Look up an agent by id (target validation for handoff/spawn).
-    async fn get_agent_by_id(&self, id: AgentId) -> Result<Option<Agent>>;
+    /// Look up an agent's execution definition by id (target validation for
+    /// handoff/spawn). Stored persistence records stay behind the hosted
+    /// platform adapter (EVE-877).
+    async fn get_agent_by_id(&self, id: AgentId) -> Result<Option<AgentDefinition>>;
 
     /// Look up a harness by id (parent harness resolution).
     async fn get_harness(&self, id: HarnessId) -> Result<Option<Harness>>;
@@ -119,7 +121,6 @@ pub trait SubagentSessionDelegate: Send + Sync {
 pub mod tests {
     use super::*;
     use crate::AgentCapabilityConfig;
-    use crate::agent::AgentStatus;
     use crate::harness::HarnessStatus;
     use crate::session::{SessionParticipant, SessionStatus};
 
@@ -131,7 +132,7 @@ pub mod tests {
     pub struct MockSubagentDelegate {
         pub harness: Harness,
         pub extra_harnesses: std::sync::Mutex<std::collections::HashMap<HarnessId, Harness>>,
-        pub agent: Agent,
+        pub agent: AgentDefinition,
         pub session: Session,
         pub extra_sessions: std::sync::Mutex<std::collections::HashMap<SessionId, Session>>,
         pub joined_participants: std::sync::Mutex<Vec<SessionParticipant>>,
@@ -173,33 +174,14 @@ pub mod tests {
                     deleted_at: None,
                 },
                 extra_harnesses: std::sync::Mutex::new(std::collections::HashMap::new()),
-                agent: Agent {
-                    public_id: crate::typed_id::AgentId::new(),
-                    internal_id: uuid::Uuid::now_v7(),
-                    name: "test-agent".to_string(),
+                agent: AgentDefinition {
                     display_name: Some("Test Agent".to_string()),
                     description: Some("test agent".to_string()),
-                    system_prompt: "You are helpful.".to_string(),
-                    default_model_id: None,
-                    harness_id: crate::typed_id::HarnessId::from_uuid(uuid::Uuid::nil()),
-                    default_version_id: None,
-                    forked_from_agent_id: None,
-                    forked_from_version_id: None,
-                    root_agent_id: None,
-                    tags: vec![],
-                    capabilities: vec![],
-                    initial_files: vec![],
-                    network_access: None,
-                    max_iterations: None,
-                    parallel_tool_calls: None,
-                    tools: vec![],
-                    mcp_servers: Default::default(),
-                    status: AgentStatus::Active,
-                    created_at: chrono::Utc::now(),
-                    updated_at: chrono::Utc::now(),
-                    archived_at: None,
-                    deleted_at: None,
-                    usage: None,
+                    ..AgentDefinition::new(
+                        crate::typed_id::AgentId::new(),
+                        "test-agent",
+                        "You are helpful.",
+                    )
                 },
                 session: {
                     let session_id = SessionId::new();
@@ -290,7 +272,10 @@ pub mod tests {
 
     #[async_trait]
     impl SubagentSessionDelegate for MockSubagentDelegate {
-        async fn get_agent_by_id(&self, _id: crate::typed_id::AgentId) -> Result<Option<Agent>> {
+        async fn get_agent_by_id(
+            &self,
+            _id: crate::typed_id::AgentId,
+        ) -> Result<Option<AgentDefinition>> {
             Ok(Some(self.agent.clone()))
         }
 
@@ -304,7 +289,7 @@ pub mod tests {
                 session_id,
                 kind: crate::session::SessionParticipantKind::Agent,
                 agent_id: Some(agent_id),
-                agent_version_id: self.agent.default_version_id,
+                agent_version_id: None,
                 principal_id: self.session.owner_principal_id,
                 display_name: None,
                 role: crate::session::SessionParticipantRole::Member,

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -2488,7 +2488,7 @@ mod tests {
         async fn get_agent_by_id(
             &self,
             _id: crate::typed_id::AgentId,
-        ) -> crate::Result<Option<crate::Agent>> {
+        ) -> crate::Result<Option<crate::AgentDefinition>> {
             Ok(None)
         }
         async fn add_agent_session_participant(

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -5,7 +5,7 @@
 // - Database implementations for production
 // - Channel-based implementations for streaming
 
-use crate::agent::Agent;
+use crate::agent_definition::AgentDefinition;
 use crate::harness::Harness;
 use crate::provider::DriverId;
 use crate::session_file::{
@@ -88,25 +88,52 @@ impl std::fmt::Debug for ReasoningEffortHandle {
 }
 
 // ============================================================================
-// AgentStore - For retrieving agent configurations
+// AgentStore - For retrieving agent execution configurations
 // ============================================================================
 
-/// Trait for retrieving agent configurations
+/// Narrow agent-loading seam for turn execution (EVE-872, EVE-877).
 ///
-/// Implementations can:
-/// - Load agents from a database
-/// - Keep agents in memory for testing
-/// - Load agents from a configuration file
+/// Implementations project their stored agent records into the portable
+/// [`AgentDefinition`] — the authored execution configuration. Stored
+/// `Agent`/`AgentVersion` persistence records live in `everruns-platform` and
+/// never cross this boundary.
+///
+/// Contract: records that exist but cannot execute (archived or deleted) must
+/// yield an error from [`AgentStore::get_agent`], so lifecycle validation is
+/// enforced at the loading seam before host execution begins.
 #[async_trait]
 pub trait AgentStore: Send + Sync {
-    /// Get an agent by ID
-    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>>;
+    /// Get the portable execution definition for an agent by public id.
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<AgentDefinition>>;
+
+    /// Execution-availability probe for dependency-blocker detection.
+    ///
+    /// Returns `None` when the agent exists and can execute. Hosted stores
+    /// override this to report [`DependencyBlocker::AgentArchived`] /
+    /// [`DependencyBlocker::AgentDeleted`] from the stored lifecycle status;
+    /// the default treats a missing record as deleted.
+    async fn get_agent_blocker(
+        &self,
+        agent_id: AgentId,
+    ) -> Result<Option<crate::dependency_blocker::DependencyBlocker>> {
+        Ok(match self.get_agent(agent_id).await? {
+            Some(_) => None,
+            None => Some(crate::dependency_blocker::DependencyBlocker::AgentDeleted),
+        })
+    }
 }
 
 #[async_trait]
 impl<T: AgentStore + ?Sized> AgentStore for std::sync::Arc<T> {
-    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<AgentDefinition>> {
         (**self).get_agent(agent_id).await
+    }
+
+    async fn get_agent_blocker(
+        &self,
+        agent_id: AgentId,
+    ) -> Result<Option<crate::dependency_blocker::DependencyBlocker>> {
+        (**self).get_agent_blocker(agent_id).await
     }
 }
 

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -596,8 +596,9 @@ impl Agent {
         let harness_id = harness.harness_id();
         let harness = harness.build();
 
+        // EVE-877: the builder produces a portable AgentDefinition; the
+        // harness link lives on the session, not the definition.
         let mut agent = RuntimeAgentBuilder::new(&self.name, &self.instructions)
-            .harness_id(harness_id)
             .capabilities(capabilities.clone());
         if let Some(parallel) = self.parallel_tool_calls {
             agent = agent.parallel_tool_calls(parallel);

--- a/crates/host/examples/inspect_context.rs
+++ b/crates/host/examples/inspect_context.rs
@@ -17,12 +17,11 @@ use everruns_test_support::TestMathCapability;
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::provider::DriverId;
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
+    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, Harness, HarnessStatus,
     PlatformDefinition, ResolvedModel, Session, SessionStatus,
 };
 use everruns_host::InProcessRuntimeBuilder;
 use everruns_test_support::llmsim_driver::LlmSimConfig;
-use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -66,33 +65,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             archived_at: None,
             deleted_at: None,
         })
-        .agent(Agent {
-            public_id: agent_id,
-            internal_id: Uuid::nil(),
-            name: "math-agent".into(),
+        .agent(AgentDefinition {
             display_name: Some("Math Agent".into()),
-            description: None,
-            system_prompt: "Use tools when needed.".into(),
-            default_model_id: None,
-            harness_id,
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
-            capabilities: vec![],
-            initial_files: vec![],
-            network_access: None,
             max_iterations: Some(8),
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(agent_id, "math-agent", "Use tools when needed.")
         })
         .session(Session {
             source: Default::default(),

--- a/crates/host/examples/real_disk_agent_instructions.rs
+++ b/crates/host/examples/real_disk_agent_instructions.rs
@@ -18,13 +18,12 @@ use chrono::Utc;
 use everruns_core::capabilities::AgentInstructionsCapability;
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, DriverId, Harness,
-    HarnessStatus, PlatformDefinition, ResolvedModel, Session, SessionStatus,
+    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, DriverId, Harness, HarnessStatus,
+    PlatformDefinition, ResolvedModel, Session, SessionStatus,
 };
 use everruns_host::{InProcessRuntimeBuilder, RealDiskSessionFileSystemFactory};
 use everruns_test_support::llmsim_driver::LlmSimConfig;
 use tempfile::TempDir;
-use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -86,33 +85,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             archived_at: None,
             deleted_at: None,
         })
-        .agent(Agent {
-            public_id: agent_id,
-            internal_id: Uuid::nil(),
-            name: "coding-agent".into(),
+        .agent(AgentDefinition {
             display_name: Some("Coding Agent".into()),
-            description: None,
-            system_prompt: "Use tools when needed.".into(),
-            default_model_id: None,
-            harness_id,
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
-            capabilities: vec![],
-            initial_files: vec![],
-            network_access: None,
             max_iterations: Some(8),
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(agent_id, "coding-agent", "Use tools when needed.")
         })
         .session(Session {
             source: Default::default(),

--- a/crates/host/examples/real_disk_file_system_tools.rs
+++ b/crates/host/examples/real_disk_file_system_tools.rs
@@ -21,13 +21,12 @@ use chrono::Utc;
 use everruns_core::capabilities::FileSystemCapability;
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, DriverId, Harness,
-    HarnessStatus, PlatformDefinition, ResolvedModel, Session, SessionStatus, ToolCall,
+    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, DriverId, Harness, HarnessStatus,
+    PlatformDefinition, ResolvedModel, Session, SessionStatus, ToolCall,
 };
 use everruns_host::{InProcessRuntimeBuilder, RealDiskSessionFileSystemFactory};
 use everruns_test_support::llmsim_driver::LlmSimConfig;
 use tempfile::TempDir;
-use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -106,33 +105,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             archived_at: None,
             deleted_at: None,
         })
-        .agent(Agent {
-            public_id: agent_id,
-            internal_id: Uuid::nil(),
-            name: "files-agent".into(),
+        .agent(AgentDefinition {
             display_name: Some("Files Agent".into()),
-            description: None,
-            system_prompt: "Use tools when needed.".into(),
-            default_model_id: None,
-            harness_id,
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
-            capabilities: vec![],
-            initial_files: vec![],
-            network_access: None,
             max_iterations: Some(8),
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(agent_id, "files-agent", "Use tools when needed.")
         })
         .session(Session {
             source: Default::default(),

--- a/crates/host/src/backends.rs
+++ b/crates/host/src/backends.rs
@@ -6,7 +6,7 @@
 use crate::events::{EventLog, EventSink, InMemoryEventLog, NoopEventSink};
 use crate::in_memory::{InMemorySessionStorageStore, InMemorySessionStore};
 use async_trait::async_trait;
-use everruns_core::agent::Agent;
+use everruns_core::agent_definition::AgentDefinition;
 use everruns_core::error::Result;
 use everruns_core::harness::Harness;
 use everruns_core::in_memory::{InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore};
@@ -31,10 +31,13 @@ pub type ScheduleStoreFactory = Arc<dyn Fn(i64) -> Arc<dyn SessionScheduleStore>
 pub type PlatformStoreFactory = Arc<dyn Fn(i64, SessionId) -> Arc<dyn PlatformStore> + Send + Sync>;
 
 /// Agent store contract for runtime seeding and lookup.
+///
+/// Seeds portable [`AgentDefinition`] values (EVE-877): the embedded host
+/// carries no stored Agent persistence records.
 #[async_trait]
 pub trait RuntimeAgentStore: AgentStore + Send + Sync {
     /// Insert or replace an agent definition.
-    async fn add_agent(&self, agent: Agent) -> Result<()>;
+    async fn add_agent(&self, agent: AgentDefinition) -> Result<()>;
 }
 
 /// Harness store contract for runtime seeding and lookup.
@@ -205,7 +208,7 @@ impl HostBackends {
 
 #[async_trait]
 impl RuntimeAgentStore for InMemoryAgentStore {
-    async fn add_agent(&self, agent: Agent) -> Result<()> {
+    async fn add_agent(&self, agent: AgentDefinition) -> Result<()> {
         InMemoryAgentStore::add_agent(self, agent).await;
         Ok(())
     }

--- a/crates/host/src/builders.rs
+++ b/crates/host/src/builders.rs
@@ -11,11 +11,10 @@ pub use everruns_core::driver_registry::{
 };
 use everruns_core::network_access::NetworkAccessList;
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentId, AgentStatus, DEFAULT_ORG_PUBLIC_ID, Harness, HarnessId,
+    AgentCapabilityConfig, AgentDefinition, AgentId, DEFAULT_ORG_PUBLIC_ID, Harness, HarnessId,
     HarnessStatus, ModelId, PrincipalId, ScopedMcpServers, Session, SessionId, SessionStatus,
     ToolDefinition, plugin_capability_id,
 };
-use uuid::Uuid;
 
 /// Builds a [`Harness`] with runtime-friendly defaults.
 ///
@@ -250,7 +249,11 @@ impl HarnessBuilder {
     }
 }
 
-/// Builds an [`Agent`] with runtime-friendly defaults.
+/// Builds a portable [`AgentDefinition`] with runtime-friendly defaults.
+///
+/// EVE-877: the embedded host seeds authored execution configuration only.
+/// Stored Agent persistence records (lifecycle status, versioning, timestamps)
+/// live in `everruns-platform` and are a hosted-control-plane concern.
 #[derive(Debug, Clone)]
 pub struct AgentBuilder {
     id: AgentId,
@@ -259,8 +262,6 @@ pub struct AgentBuilder {
     description: Option<String>,
     system_prompt: String,
     default_model_id: Option<ModelId>,
-    harness_id: HarnessId,
-    tags: Vec<String>,
     capabilities: Vec<AgentCapabilityConfig>,
     initial_files: Vec<everruns_core::InitialFile>,
     network_access: Option<NetworkAccessList>,
@@ -268,9 +269,6 @@ pub struct AgentBuilder {
     parallel_tool_calls: Option<bool>,
     tools: Vec<ToolDefinition>,
     mcp_servers: ScopedMcpServers,
-    status: AgentStatus,
-    created_at: Option<DateTime<Utc>>,
-    updated_at: Option<DateTime<Utc>>,
 }
 
 impl AgentBuilder {
@@ -283,8 +281,6 @@ impl AgentBuilder {
             description: None,
             system_prompt: system_prompt.into(),
             default_model_id: None,
-            harness_id: HarnessId::new(),
-            tags: Vec::new(),
             capabilities: Vec::new(),
             initial_files: Vec::new(),
             network_access: None,
@@ -292,9 +288,6 @@ impl AgentBuilder {
             parallel_tool_calls: None,
             tools: Vec::new(),
             mcp_servers: ScopedMcpServers::default(),
-            status: AgentStatus::Active,
-            created_at: None,
-            updated_at: None,
         }
     }
 
@@ -331,25 +324,6 @@ impl AgentBuilder {
 
     pub fn default_model_id(mut self, default_model_id: ModelId) -> Self {
         self.default_model_id = Some(default_model_id);
-        self
-    }
-
-    pub fn harness_id(mut self, harness_id: HarnessId) -> Self {
-        self.harness_id = harness_id;
-        self
-    }
-
-    pub fn tag(mut self, tag: impl Into<String>) -> Self {
-        self.tags.push(tag.into());
-        self
-    }
-
-    pub fn tags<I, S>(mut self, tags: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
-        self.tags.extend(tags.into_iter().map(Into::into));
         self
     }
 
@@ -411,40 +385,15 @@ impl AgentBuilder {
         self
     }
 
-    pub fn status(mut self, status: AgentStatus) -> Self {
-        self.status = status;
-        self
-    }
-
-    pub fn created_at(mut self, created_at: DateTime<Utc>) -> Self {
-        self.created_at = Some(created_at);
-        self
-    }
-
-    pub fn updated_at(mut self, updated_at: DateTime<Utc>) -> Self {
-        self.updated_at = Some(updated_at);
-        self
-    }
-
-    /// Build the agent. Builders do not validate domain invariants.
-    pub fn build(self) -> Agent {
-        let created_at = self.created_at.unwrap_or_else(Utc::now);
-        let updated_at = self.updated_at.unwrap_or(created_at);
-
-        Agent {
-            public_id: self.id,
-            internal_id: Uuid::nil(),
+    /// Build the agent definition. Builders do not validate domain invariants.
+    pub fn build(self) -> AgentDefinition {
+        AgentDefinition {
+            id: self.id,
             name: self.name,
             display_name: self.display_name,
             description: self.description,
             system_prompt: self.system_prompt,
             default_model_id: self.default_model_id,
-            harness_id: self.harness_id,
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: self.tags,
             capabilities: self.capabilities,
             initial_files: self.initial_files,
             network_access: self.network_access,
@@ -452,12 +401,6 @@ impl AgentBuilder {
             parallel_tool_calls: self.parallel_tool_calls,
             tools: self.tools,
             mcp_servers: self.mcp_servers,
-            status: self.status,
-            created_at,
-            updated_at,
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
         }
     }
 }
@@ -846,7 +789,8 @@ impl SingleSessionBuilder {
     pub fn tag(mut self, tag: impl Into<String>) -> Self {
         let tag = tag.into();
         self.harness = self.harness.tag(tag.clone());
-        self.agent = self.agent.tag(tag.clone());
+        // Agent definitions carry no tags (EVE-877); session tags drive
+        // execution metadata, harness tags stay for embedder bookkeeping.
         self.session = self.session.tag(tag);
         self
     }
@@ -935,7 +879,7 @@ impl SingleSessionBuilder {
         self
     }
 
-    pub(crate) fn build(self) -> (Harness, Agent, Session, SessionId) {
+    pub(crate) fn build(self) -> (Harness, AgentDefinition, Session, SessionId) {
         let session_id = self.session.session_id();
         (
             self.harness.build(),

--- a/crates/host/src/mcp.rs
+++ b/crates/host/src/mcp.rs
@@ -11,8 +11,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use everruns_core::capabilities::Capability;
 use everruns_core::{
-    Agent, Harness, McpCapability, McpServerTransportType, ScopedMcpServer, ScopedMcpServers,
-    Session, ToolDefinition, merge_scoped_mcp_servers,
+    AgentDefinition, Harness, McpCapability, McpServerTransportType, ScopedMcpServer,
+    ScopedMcpServers, Session, ToolDefinition, merge_scoped_mcp_servers,
 };
 use everruns_mcp::{McpClient, McpConnection, McpEndpoint, McpExecutor, StaticConnectionResolver};
 use futures::{StreamExt, stream};
@@ -26,7 +26,7 @@ const MAX_DISCOVERY_CONCURRENCY: usize = 16;
 /// Merge harness-chain → agent → session scoped MCP servers (last layer wins).
 pub(crate) fn merge_session_scoped_servers(
     harness_chain: &[Harness],
-    agent: Option<&Agent>,
+    agent: Option<&AgentDefinition>,
     session: &Session,
 ) -> ScopedMcpServers {
     let mut merged = ScopedMcpServers::default();

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -15,7 +15,7 @@ use crate::in_memory::{InMemorySessionFileStore, InMemorySessionFileSystemFactor
 use crate::turn_strategy::{RuntimeTurnPlan, RuntimeTurnState};
 use async_trait::async_trait;
 use chrono::Utc;
-use everruns_core::agent::Agent;
+use everruns_core::agent_definition::AgentDefinition;
 use everruns_core::atoms::{AtomContext, InputAtomInput, ReasonInput};
 use everruns_core::capabilities::{
     Capability, CapabilityRegistry, CapabilityStatus, collect_capability_mcp_servers,
@@ -320,7 +320,7 @@ pub struct InProcessRuntimeBuilder {
     workspace_policy: Option<everruns_core::WorkspacePolicy>,
     session_file_system_factory_context: SessionFileSystemFactoryContext,
     harnesses: Vec<Harness>,
-    agents: Vec<Agent>,
+    agents: Vec<AgentDefinition>,
     sessions: Vec<Session>,
     default_session_id: Option<SessionId>,
     seeded_files: Vec<(SessionId, InitialFile)>,
@@ -523,8 +523,8 @@ impl InProcessRuntimeBuilder {
         self
     }
 
-    /// Seed an agent into the runtime store.
-    pub fn agent(mut self, agent: Agent) -> Self {
+    /// Seed an agent definition into the runtime store.
+    pub fn agent(mut self, agent: AgentDefinition) -> Self {
         self.agents.push(agent);
         self
     }
@@ -918,7 +918,7 @@ impl InProcessRuntime {
     async fn session_mcp_servers(
         &self,
         session: &Session,
-        agent: Option<&Agent>,
+        agent: Option<&AgentDefinition>,
     ) -> everruns_core::ScopedMcpServers {
         let harness_chain = self
             .harness_store
@@ -1778,7 +1778,7 @@ impl RuntimeHostAdapter for InProcessRuntime {
 
 fn effective_overlay(
     harness_chain: &[Harness],
-    agent: Option<&Agent>,
+    agent: Option<&AgentDefinition>,
     session: &Session,
 ) -> AgentConfigOverlay {
     let harness_layers = harness_chain.iter().map(AgentConfigOverlay::from);

--- a/crates/host/tests/engine_planned_turn_test.rs
+++ b/crates/host/tests/engine_planned_turn_test.rs
@@ -13,7 +13,8 @@
 
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::{
-    Agent, CapabilityRegistry, DriverId, Harness, PlatformDefinition, ResolvedModel, Session,
+    AgentDefinition, CapabilityRegistry, DriverId, Harness, PlatformDefinition, ResolvedModel,
+    Session,
 };
 use everruns_engine::{
     ActOutcome, TurnPlan, TurnState, plan_after_act, plan_after_process_input, plan_after_reason,
@@ -41,7 +42,7 @@ fn harness(harness_id: everruns_core::HarnessId) -> Harness {
         .build()
 }
 
-fn agent(agent_id: everruns_core::AgentId, max_iterations: usize) -> Agent {
+fn agent(agent_id: everruns_core::AgentId, max_iterations: usize) -> AgentDefinition {
     AgentBuilder::new("math-agent", "Use tools when needed.")
         .id(agent_id)
         .display_name("Math Agent")

--- a/crates/host/tests/in_process_runtime_test.rs
+++ b/crates/host/tests/in_process_runtime_test.rs
@@ -5,7 +5,7 @@ use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::events::{EventContext, EventRequest, InputMessageData};
 use everruns_core::network_access::NetworkAccessList;
 use everruns_core::{
-    Agent, CapabilityRegistry, DriverId, Harness, InitialFile, Message, MessageRole,
+    AgentDefinition, CapabilityRegistry, DriverId, Harness, InitialFile, Message, MessageRole,
     PlatformDefinition, ResolvedModel, Session, SessionFileSystem, SessionFileSystemFactory,
     SessionFileSystemFactoryContext, ToolCall, WorkspacePolicy,
 };
@@ -33,7 +33,7 @@ fn harness(harness_id: everruns_core::HarnessId) -> Harness {
         .build()
 }
 
-fn agent(agent_id: everruns_core::AgentId) -> Agent {
+fn agent(agent_id: everruns_core::AgentId) -> AgentDefinition {
     AgentBuilder::new("math-agent", "Use tools when needed.")
         .id(agent_id)
         .display_name("Math Agent")
@@ -89,8 +89,6 @@ fn per_type_builders_accept_explicit_timestamps() {
         .build();
     let agent = AgentBuilder::new("math-agent", "prompt")
         .id(agent_id)
-        .created_at(timestamp)
-        .updated_at(timestamp)
         .build();
     let session = SessionBuilder::new(harness_id)
         .id(session_id)
@@ -101,8 +99,9 @@ fn per_type_builders_accept_explicit_timestamps() {
 
     assert_eq!(harness.created_at, timestamp);
     assert_eq!(harness.updated_at, timestamp);
-    assert_eq!(agent.created_at, timestamp);
-    assert_eq!(agent.updated_at, timestamp);
+    // Agent definitions are portable execution configuration (EVE-877); they
+    // carry no persistence timestamps.
+    assert_eq!(agent.id, agent_id);
     assert_eq!(session.created_at, timestamp);
     assert_eq!(session.updated_at, timestamp);
 }
@@ -732,7 +731,7 @@ async fn runtime_exposes_assembled_context() {
     assert!(initial_context.messages.is_empty());
     assert_eq!(initial_context.session.id, session_id);
     assert_eq!(
-        initial_context.agent.as_ref().map(|agent| agent.public_id),
+        initial_context.agent.as_ref().map(|agent| agent.id),
         Some(agent_id)
     );
 

--- a/crates/host/tests/resolved_snapshot_test.rs
+++ b/crates/host/tests/resolved_snapshot_test.rs
@@ -34,7 +34,7 @@ fn scoped_server_with_secret_header() -> ScopedMcpServer {
 struct Fixture {
     runtime: everruns_host::InProcessRuntime,
     harness: everruns_core::Harness,
-    agent: everruns_core::Agent,
+    agent: everruns_core::AgentDefinition,
     session: everruns_core::Session,
 }
 
@@ -48,7 +48,6 @@ async fn fixture() -> Fixture {
         .build();
     let agent = AgentBuilder::new("hosted-agent", "Agent instructions.")
         .id(agent_id)
-        .harness_id(harness_id)
         .max_iterations(7)
         .mcp_servers(
             [("docs".to_string(), scoped_server_with_secret_header())]
@@ -104,7 +103,7 @@ async fn framework_load_resolved_turn_matches_direct_projection() {
 
     assert_eq!(inputs.snapshot.session_id, fixture.session.id);
     assert_eq!(inputs.snapshot.harness_id, fixture.harness.id);
-    assert_eq!(inputs.snapshot.agent_id, Some(fixture.agent.public_id));
+    assert_eq!(inputs.snapshot.agent_id, Some(fixture.agent.id));
     assert_eq!(inputs.snapshot.max_iterations, Some(7));
     assert_eq!(
         inputs.snapshot.instructions.as_deref(),
@@ -157,50 +156,83 @@ async fn turn_execution_and_events_stay_free_of_secrets_and_platform_metadata() 
     }
 }
 
+/// EVE-877: archived/deleted lifecycle validation lives at the platform
+/// loading seam (`everruns_platform::Agent::execution_definition`), not in the
+/// portable definition the embedded host seeds. This adapter stands in for a
+/// hosted store whose stored record is archived: the loading seam errors and
+/// execution never starts.
+#[derive(Clone)]
+struct ArchivedAtSeamAgentStore;
+
+#[async_trait::async_trait]
+impl everruns_core::traits::AgentStore for ArchivedAtSeamAgentStore {
+    async fn get_agent(
+        &self,
+        agent_id: AgentId,
+    ) -> everruns_core::Result<Option<everruns_core::AgentDefinition>> {
+        Err(everruns_core::AgentLoopError::config(format!(
+            "agent {agent_id} is archived and cannot execute turns"
+        )))
+    }
+}
+
+#[async_trait::async_trait]
+impl everruns_host::RuntimeAgentStore for ArchivedAtSeamAgentStore {
+    async fn add_agent(&self, _agent: everruns_core::AgentDefinition) -> everruns_core::Result<()> {
+        Ok(())
+    }
+}
+
 #[tokio::test]
-async fn inactive_agent_fails_during_projection_before_execution() {
+async fn inactive_agent_fails_at_loading_seam_before_execution() {
+    use everruns_host::{EventReadLimit, EventReadRequest};
+
     let harness_id = HarnessId::from_seed(873);
     let agent_id = AgentId::from_seed(873);
     let session_id = SessionId::from_seed(873);
     let harness = HarnessBuilder::new("orphan", "Prompt.")
         .id(harness_id)
         .build();
-    let agent = AgentBuilder::new("archived-agent", "Prompt.")
-        .id(agent_id)
-        .harness_id(harness_id)
-        .status(everruns_core::AgentStatus::Archived)
-        .build();
     let session = SessionBuilder::new(harness_id)
         .id(session_id)
         .agent(agent_id)
         .build();
 
+    // Keep a handle on the session store so the session can be added after
+    // build: builder-time seeding also walks the agent loading seam, and this
+    // test wants the failure to surface at turn time.
+    let session_store = std::sync::Arc::new(everruns_host::InMemorySessionStore::new());
+    let backends = everruns_host::HostBackends::in_memory()
+        .with_agent_store(std::sync::Arc::new(ArchivedAtSeamAgentStore))
+        .with_session_store(session_store.clone());
     let runtime = InProcessRuntimeBuilder::new()
         .llm_sim(LlmSimConfig::fixed("unused"))
+        .backends(backends)
         .harness(harness)
-        .agent(agent)
-        .session(session)
         .build()
         .await
         .expect("runtime builds");
+    everruns_host::RuntimeSessionStore::add_session(session_store.as_ref(), session)
+        .await
+        .expect("session seeds");
 
     let error = runtime
         .run_text_turn(session_id, "hello")
         .await
-        .expect_err("projection fails before execution");
+        .expect_err("loading seam fails before execution");
     assert!(error.to_string().contains("archived"), "{error}");
 
-    // No turn events were emitted: the failure happened during platform
-    // projection, before host execution began.
-    let events = runtime.events().await.expect("events load");
+    // No turn events were emitted: the failure happened at the platform
+    // loading seam, before host execution began.
+    let page = runtime
+        .event_log()
+        .read_page(EventReadRequest::new(session_id, EventReadLimit::default()))
+        .await
+        .expect("events load");
     assert!(
-        events
+        page.events
             .iter()
             .all(|event| !event.event_type.starts_with("turn.")),
-        "no turn lifecycle events expected, got {:?}",
-        events
-            .iter()
-            .map(|e| e.event_type.clone())
-            .collect::<Vec<_>>()
+        "no turn lifecycle events expected"
     );
 }

--- a/crates/host/tests/runtime_host_test.rs
+++ b/crates/host/tests/runtime_host_test.rs
@@ -22,7 +22,7 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, DriverId, EventData, Harness,
+    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, DriverId, EventData, Harness,
     HarnessStatus, InputMessage, ResolvedModel, Session, SessionStatus, TokenUsage, Tool, ToolCall,
     ToolExecutionResult, ToolRegistry, ToolResult, inspect_turn_context, user_facing_error_codes,
 };
@@ -736,34 +736,12 @@ fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
     }
 }
 
-fn agent(agent_id: AgentId, capabilities: Vec<AgentCapabilityConfig>) -> Agent {
-    Agent {
-        public_id: agent_id,
-        internal_id: Uuid::nil(),
-        name: "test-agent".into(),
+fn agent(agent_id: AgentId, capabilities: Vec<AgentCapabilityConfig>) -> AgentDefinition {
+    AgentDefinition {
         display_name: Some("Test Agent".into()),
-        description: None,
-        system_prompt: "Use tools when needed.".into(),
-        default_model_id: None,
-        harness_id: HarnessId::from_uuid(Uuid::nil()),
-        default_version_id: None,
-        forked_from_agent_id: None,
-        forked_from_version_id: None,
-        root_agent_id: None,
-        tags: vec![],
         capabilities,
-        initial_files: vec![],
-        network_access: None,
         max_iterations: Some(8),
-        parallel_tool_calls: None,
-        tools: vec![],
-        mcp_servers: Default::default(),
-        status: AgentStatus::Active,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        archived_at: None,
-        deleted_at: None,
-        usage: None,
+        ..AgentDefinition::new(agent_id, "test-agent", "Use tools when needed.")
     }
 }
 

--- a/crates/host/tests/tool_scheduler_e2e_test.rs
+++ b/crates/host/tests/tool_scheduler_e2e_test.rs
@@ -17,8 +17,8 @@ use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::{
-    Agent, CapabilityRegistry, DriverId, Harness, PlatformDefinition, ResolvedModel, Session,
-    ToolCall,
+    AgentDefinition, CapabilityRegistry, DriverId, Harness, PlatformDefinition, ResolvedModel,
+    Session, ToolCall,
 };
 use everruns_host::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
 use everruns_test_support::LlmSimRuntimeExt;
@@ -159,7 +159,7 @@ fn harness(harness_id: everruns_core::HarnessId) -> Harness {
         .build()
 }
 
-fn agent(agent_id: everruns_core::AgentId) -> Agent {
+fn agent(agent_id: everruns_core::AgentId) -> AgentDefinition {
     AgentBuilder::new("sched-agent", "Use the tools provided.")
         .id(agent_id)
         .display_name("Scheduler Agent")

--- a/crates/internal-protocol/Cargo.toml
+++ b/crates/internal-protocol/Cargo.toml
@@ -32,6 +32,9 @@ prost-types.workspace = true
 
 # Internal dependencies
 everruns-core = { path = "../core" }
+# Stored Agent records moved to everruns-platform (EVE-877); the worker wire
+# still carries them between the two platform-side processes (server, worker).
+everruns-platform = { path = "../platform" }
 
 # Serialization (for JSON conversion)
 serde.workspace = true

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -427,8 +427,13 @@ fn serialize_event_data(data: &everruns_core::EventData) -> serde_json::Value {
 // Conversion to/from schemas types
 // ============================================================================
 
-/// Convert proto Agent to schemas Agent using JSON
-pub fn proto_agent_to_schema(value: proto::Agent) -> Result<everruns_core::Agent, ConversionError> {
+/// Convert proto Agent to the stored platform Agent record using JSON.
+///
+/// EVE-877: the stored record lives in `everruns-platform`; the proto shape is
+/// unchanged. Both endpoints of this wire (server, worker) are platform-side.
+pub fn proto_agent_to_schema(
+    value: proto::Agent,
+) -> Result<everruns_platform::Agent, ConversionError> {
     // Serialize proto to JSON, then deserialize to schema type
     // This is simpler and more maintainable than field-by-field conversion
     let tags: Vec<String> = vec![];
@@ -482,8 +487,8 @@ pub fn proto_agent_to_schema(value: proto::Agent) -> Result<everruns_core::Agent
     serde_json::from_value(json).map_err(ConversionError::from)
 }
 
-/// Convert schemas Agent to proto Agent
-pub fn schema_agent_to_proto(value: &everruns_core::Agent) -> proto::Agent {
+/// Convert the stored platform Agent record to proto Agent
+pub fn schema_agent_to_proto(value: &everruns_platform::Agent) -> proto::Agent {
     proto::Agent {
         id: Some(uuid_to_proto_uuid(value.internal_id)),
         name: value.name.clone(),
@@ -1898,7 +1903,7 @@ mod tests {
 
         // Create an Agent with capabilities
         let id = Uuid::now_v7();
-        let agent = everruns_core::Agent {
+        let agent = everruns_platform::Agent {
             public_id: everruns_core::AgentId::from_uuid(id),
             internal_id: id,
             name: "test-agent".to_string(),
@@ -1922,7 +1927,7 @@ mod tests {
             parallel_tool_calls: None,
             tools: vec![],
             mcp_servers: Default::default(),
-            status: everruns_core::AgentStatus::Active,
+            status: everruns_platform::AgentStatus::Active,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             archived_at: None,
@@ -1966,7 +1971,7 @@ mod tests {
 
         // Create an Agent without capabilities
         let id = Uuid::now_v7();
-        let agent = everruns_core::Agent {
+        let agent = everruns_platform::Agent {
             public_id: everruns_core::AgentId::from_uuid(id),
             internal_id: id,
             name: "test-agent".to_string(),
@@ -1987,7 +1992,7 @@ mod tests {
             parallel_tool_calls: None,
             tools: vec![],
             mcp_servers: Default::default(),
-            status: everruns_core::AgentStatus::Active,
+            status: everruns_platform::AgentStatus::Active,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             archived_at: None,

--- a/crates/llm-tests/examples/turn_based_execution.rs
+++ b/crates/llm-tests/examples/turn_based_execution.rs
@@ -24,8 +24,7 @@
 
 use chrono::Utc;
 use everruns_core::{
-    EnvCredentialProvider, Harness, HarnessStatus, InputMessage, MessageRetriever,
-    agent::{Agent, AgentStatus},
+    AgentDefinition, EnvCredentialProvider, Harness, HarnessStatus, InputMessage, MessageRetriever,
     atoms::{
         ActAtom, ActInput, Atom, AtomContext, InputAtom, InputAtomInput, ReasonAtom, ReasonInput,
     },
@@ -139,33 +138,14 @@ async fn main() -> anyhow::Result<()> {
     harness_store.add_harness(harness).await;
 
     // Create an agent in the store
-    let agent = Agent {
-        public_id: AgentId::from_uuid(agent_id),
-        internal_id: agent_id,
-        name: "weather-assistant".to_string(),
+    let agent = AgentDefinition {
         display_name: Some("Weather Assistant".to_string()),
         description: Some("A helpful weather assistant".to_string()),
-        system_prompt: "You are a helpful weather assistant. Use the get_weather tool to answer weather questions.".to_string(),
-        default_model_id: None,
-        harness_id,
-        default_version_id: None,
-        forked_from_agent_id: None,
-        forked_from_version_id: None,
-        root_agent_id: None,
-        tags: vec![],
-        capabilities: vec![],
-        initial_files: vec![],
-        network_access: None,
-        max_iterations: None,
-        parallel_tool_calls: None,
-        tools: vec![],
-        mcp_servers: Default::default(),
-        status: AgentStatus::Active,
-        created_at: now,
-        updated_at: now,
-        archived_at: None,
-        deleted_at: None,
-        usage: None,
+        ..AgentDefinition::new(
+            AgentId::from_uuid(agent_id),
+            "weather-assistant",
+            "You are a helpful weather assistant. Use the get_weather tool to answer weather questions.",
+        )
     };
     agent_store.add_agent(agent).await;
 

--- a/crates/local/src/platform_store.rs
+++ b/crates/local/src/platform_store.rs
@@ -11,7 +11,6 @@
 // manage those entities in code, not through this tool surface.
 
 use async_trait::async_trait;
-use everruns_core::agent::Agent;
 use everruns_core::capability_dto::CapabilityInfo;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::harness::Harness;
@@ -19,6 +18,7 @@ use everruns_core::session::{Session, SessionParticipant};
 use everruns_core::typed_id::{
     AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, SessionId,
 };
+use everruns_platform::Agent;
 use everruns_platform::app::{App, AppChannel, ChannelType};
 use everruns_platform::{PlatformCreateSessionRequest, PlatformMessage, PlatformStore};
 use std::sync::Arc;

--- a/crates/local/src/runtime_builder.rs
+++ b/crates/local/src/runtime_builder.rs
@@ -80,7 +80,7 @@ impl LocalRuntimeBuilder {
     }
 
     /// Seed an agent.
-    pub fn agent(mut self, agent: everruns_core::Agent) -> Self {
+    pub fn agent(mut self, agent: everruns_core::AgentDefinition) -> Self {
         self.inner = self.inner.agent(agent);
         self
     }

--- a/crates/platform/src/agent.rs
+++ b/crates/platform/src/agent.rs
@@ -1,23 +1,29 @@
-// Agent domain types
+// Stored Agent and AgentVersion persistence records (EVE-877).
+//
+// Decision: Agent persistence and lifecycle are a platform concern. These
+// records — lifecycle status, versioning and publication metadata, fork
+// lineage, timestamps, usage — moved here from `everruns-core`. The execution
+// kernel consumes only the portable `everruns_core::AgentDefinition`, produced
+// at the loading seam by [`Agent::execution_definition`], which enforces
+// archived/deleted validation before host execution.
 //
 // Design Decision: Dual-ID pattern (see knowledge/foundations/id-schema.md)
 // - public_id: AgentId (external, API-facing, client-supplied or auto-generated)
 // - internal_id: Uuid (internal PK, used for FK references, never exposed in API)
-//
-// These types represent the Agent entity and its status.
-// Used by both API and worker crates.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::capability_types::AgentCapabilityConfig;
-use crate::events::TokenUsage;
-use crate::mcp_server::{ScopedMcpServers, scoped_mcp_servers_is_empty};
-use crate::network_access::NetworkAccessList;
-use crate::session_file::InitialFile;
-use crate::tool_types::ToolDefinition;
-use crate::typed_id::{AgentId, AgentVersionId, HarnessId, ModelId, PrincipalId};
+use everruns_core::AgentDefinition;
+use everruns_core::capability_types::AgentCapabilityConfig;
+use everruns_core::error::AgentLoopError;
+use everruns_core::events::TokenUsage;
+use everruns_core::mcp_server::{ScopedMcpServers, scoped_mcp_servers_is_empty};
+use everruns_core::network_access::NetworkAccessList;
+use everruns_core::session_file::InitialFile;
+use everruns_core::tool_types::ToolDefinition;
+use everruns_core::typed_id::{AgentId, AgentVersionId, HarnessId, ModelId, PrincipalId};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -180,6 +186,10 @@ impl From<&str> for AgentStatus {
     }
 }
 
+// Stored Agent record: authored configuration plus platform persistence
+// metadata (lifecycle status, versioning, fork lineage, timestamps, usage).
+// The doc comment below is part of the public OpenAPI schema description and
+// intentionally unchanged by the EVE-877 move.
 /// Agent configuration for agentic loop.
 /// An agent defines the behavior and capabilities of an AI assistant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -250,7 +260,7 @@ pub struct Agent {
     #[serde(default)]
     #[cfg_attr(
         feature = "openapi",
-        schema(value_type = Vec<crate::capability_types::AgentCapabilityConfigSchema>)
+        schema(value_type = Vec<everruns_core::capability_types::AgentCapabilityConfigSchema>)
     )]
     pub capabilities: Vec<AgentCapabilityConfig>,
     /// Starter files copied into each new session for this agent.
@@ -306,6 +316,63 @@ pub struct Agent {
     pub usage: Option<TokenUsage>,
 }
 
+impl Agent {
+    /// Project this stored record into the portable authored execution
+    /// configuration, without lifecycle validation.
+    ///
+    /// Use [`Agent::execution_definition`] at execution loading seams; this
+    /// plain projection serves non-execution consumers (e.g. handoff target
+    /// overlay assembly) that historically saw the record regardless of
+    /// status.
+    pub fn definition(&self) -> AgentDefinition {
+        AgentDefinition {
+            id: self.public_id,
+            name: self.name.clone(),
+            display_name: self.display_name.clone(),
+            description: self.description.clone(),
+            system_prompt: self.system_prompt.clone(),
+            default_model_id: self.default_model_id,
+            capabilities: self.capabilities.clone(),
+            initial_files: self.initial_files.clone(),
+            network_access: self.network_access.clone(),
+            max_iterations: self.max_iterations,
+            parallel_tool_calls: self.parallel_tool_calls,
+            tools: self.tools.clone(),
+            mcp_servers: self.mcp_servers.clone(),
+        }
+    }
+
+    /// Project this stored record into the execution definition, enforcing
+    /// lifecycle validation at the platform loading seam (EVE-877).
+    ///
+    /// Archived and deleted records fail here — before host execution — with
+    /// the same error the snapshot projection historically produced.
+    pub fn execution_definition(&self) -> everruns_core::Result<AgentDefinition> {
+        match self.status {
+            AgentStatus::Active => Ok(self.definition()),
+            AgentStatus::Archived | AgentStatus::Deleted => Err(AgentLoopError::config(format!(
+                "agent {} is {} and cannot execute turns",
+                self.public_id, self.status
+            ))),
+        }
+    }
+
+    /// Dependency-blocker probe answer for this record's lifecycle status.
+    pub fn dependency_blocker(&self) -> Option<everruns_core::DependencyBlocker> {
+        match self.status {
+            AgentStatus::Active => None,
+            AgentStatus::Archived => Some(everruns_core::DependencyBlocker::AgentArchived),
+            AgentStatus::Deleted => Some(everruns_core::DependencyBlocker::AgentDeleted),
+        }
+    }
+}
+
+impl From<&Agent> for everruns_core::AgentConfigOverlay {
+    fn from(agent: &Agent) -> Self {
+        (&agent.definition()).into()
+    }
+}
+
 /// Maximum length for an addressable name (agent, harness, etc.).
 pub const MAX_ADDRESSABLE_NAME_LEN: usize = 64;
 
@@ -350,6 +417,37 @@ pub fn validate_agent_public_id(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_agent() -> Agent {
+        Agent {
+            public_id: "agent_01933b5a000070008000000000000001".parse().unwrap(),
+            internal_id: Uuid::nil(),
+            name: "test".to_string(),
+            display_name: Some("Test".to_string()),
+            description: None,
+            system_prompt: "test".to_string(),
+            default_model_id: None,
+            harness_id: "harness_01933b5a000070008000000000000001".parse().unwrap(),
+            default_version_id: None,
+            forked_from_agent_id: None,
+            forked_from_version_id: None,
+            root_agent_id: None,
+            tags: vec![],
+            capabilities: vec![],
+            initial_files: vec![],
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            tools: vec![],
+            mcp_servers: ScopedMcpServers::default(),
+            status: AgentStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            archived_at: None,
+            deleted_at: None,
+            usage: None,
+        }
+    }
 
     #[test]
     fn test_generate_agent_public_id() {
@@ -406,35 +504,7 @@ mod tests {
 
     #[test]
     fn test_agent_serde_public_id_as_id() {
-        let agent = Agent {
-            public_id: "agent_01933b5a000070008000000000000001".parse().unwrap(),
-            internal_id: Uuid::nil(),
-            name: "test".to_string(),
-            display_name: Some("Test".to_string()),
-            description: None,
-            system_prompt: "test".to_string(),
-            default_model_id: None,
-            harness_id: "harness_01933b5a000070008000000000000001".parse().unwrap(),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
-            capabilities: vec![],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: ScopedMcpServers::default(),
-            status: AgentStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
-        };
-
+        let agent = test_agent();
         let json = serde_json::to_value(&agent).unwrap();
         // public_id should serialize as "id"
         assert_eq!(json["id"], "agent_01933b5a000070008000000000000001");
@@ -463,5 +533,57 @@ mod tests {
         );
         // internal_id defaults to nil when not present in JSON
         assert_eq!(agent.internal_id, Uuid::nil());
+    }
+
+    #[test]
+    fn definition_projects_authored_execution_configuration() {
+        let mut agent = test_agent();
+        agent.max_iterations = Some(7);
+        agent.capabilities = vec![AgentCapabilityConfig::new("current_time")];
+
+        let definition = agent.definition();
+        assert_eq!(definition.id, agent.public_id);
+        assert_eq!(definition.name, "test");
+        assert_eq!(definition.system_prompt, "test");
+        assert_eq!(definition.max_iterations, Some(7));
+        assert_eq!(definition.capabilities.len(), 1);
+
+        // Persistence metadata never enters the portable definition.
+        let json = serde_json::to_value(&definition).unwrap();
+        for field in ["status", "created_at", "default_version_id", "usage"] {
+            assert!(json.get(field).is_none(), "{field} leaked into definition");
+        }
+    }
+
+    #[test]
+    fn execution_definition_fails_for_archived_and_deleted_records() {
+        // EVE-877: lifecycle validation moved from snapshot projection to this
+        // platform loading seam. The error text is unchanged.
+        for status in [AgentStatus::Archived, AgentStatus::Deleted] {
+            let mut agent = test_agent();
+            agent.status = status.clone();
+            let error = agent.execution_definition().unwrap_err().to_string();
+            assert!(
+                error.contains(&format!("is {status} and cannot execute turns")),
+                "unexpected error for {status:?}: {error}"
+            );
+        }
+        assert!(test_agent().execution_definition().is_ok());
+    }
+
+    #[test]
+    fn dependency_blocker_distinguishes_archived_from_deleted() {
+        let mut agent = test_agent();
+        assert!(agent.dependency_blocker().is_none());
+        agent.status = AgentStatus::Archived;
+        assert!(matches!(
+            agent.dependency_blocker(),
+            Some(everruns_core::DependencyBlocker::AgentArchived)
+        ));
+        agent.status = AgentStatus::Deleted;
+        assert!(matches!(
+            agent.dependency_blocker(),
+            Some(everruns_core::DependencyBlocker::AgentDeleted)
+        ));
     }
 }

--- a/crates/platform/src/audit.rs
+++ b/crates/platform/src/audit.rs
@@ -474,7 +474,7 @@ impl HasAuditTargetId for everruns_core::Harness {
     }
 }
 
-impl HasAuditTargetId for everruns_core::Agent {
+impl HasAuditTargetId for crate::agent::Agent {
     fn audit_target_id(&self) -> Option<String> {
         Some(self.public_id.to_string())
     }

--- a/crates/platform/src/capabilities/platform_management.rs
+++ b/crates/platform/src/capabilities/platform_management.rs
@@ -846,7 +846,7 @@ async fn manage_agents_impl(
     Ok(match operation {
         "create" => {
             let name = require_str(&arguments, "name")?;
-            if let Err(msg) = everruns_core::agent::validate_addressable_name(name) {
+            if let Err(msg) = crate::agent::validate_addressable_name(name) {
                 return Ok(ToolExecutionResult::tool_error(format!(
                     "Invalid agent name: {msg}"
                 )));
@@ -892,7 +892,7 @@ async fn manage_agents_impl(
             let id: everruns_core::typed_id::AgentId = parse_id(id_str, "agent_id")?;
             let name = get_str(&arguments, "name");
             if let Some(n) = name
-                && let Err(msg) = everruns_core::agent::validate_addressable_name(n)
+                && let Err(msg) = crate::agent::validate_addressable_name(n)
             {
                 return Ok(ToolExecutionResult::tool_error(format!(
                     "Invalid agent name: {msg}"

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -38,6 +38,15 @@ pub mod platform_store;
 pub mod agent_trigger;
 pub mod app;
 
+// Stored Agent/AgentVersion persistence records carved out of `everruns-core`
+// (EVE-877). Execution consumes only `everruns_core::AgentDefinition`, produced
+// by `Agent::execution_definition` at the platform loading seam.
+pub mod agent;
+
+pub use agent::{
+    Agent, AgentStatus, AgentVersion, AgentVersionChangeKind, MAX_ADDRESSABLE_NAME_LEN,
+    generate_agent_public_id, validate_addressable_name, validate_agent_public_id,
+};
 pub use organization::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, OrgMembership, Organization,
     generate_org_public_id, validate_org_public_id,

--- a/crates/platform/src/platform_store.rs
+++ b/crates/platform/src/platform_store.rs
@@ -5,10 +5,10 @@
 // Decision: Tool results include UI links via base_url()
 // Decision: PlatformMessage is a simplified view (role + text + timestamp)
 
+use crate::agent::Agent;
 use crate::app::{App, AppChannel, ChannelType};
 use async_trait::async_trait;
 use everruns_core::SessionContextReport;
-use everruns_core::agent::Agent;
 use everruns_core::capability_dto::CapabilityInfo;
 use everruns_core::error::Result;
 use everruns_core::harness::Harness;
@@ -357,8 +357,15 @@ pub struct PlatformStoreSubagentDelegate(pub std::sync::Arc<dyn PlatformStore>);
 
 #[async_trait]
 impl everruns_core::subagent_delegation::SubagentSessionDelegate for PlatformStoreSubagentDelegate {
-    async fn get_agent_by_id(&self, id: AgentId) -> Result<Option<Agent>> {
-        self.0.get_agent_by_id(id).await
+    async fn get_agent_by_id(&self, id: AgentId) -> Result<Option<everruns_core::AgentDefinition>> {
+        // Plain (status-agnostic) projection: handoff/spawn target validation
+        // historically saw the stored record regardless of lifecycle status;
+        // execution loading seams use `Agent::execution_definition` instead.
+        Ok(self
+            .0
+            .get_agent_by_id(id)
+            .await?
+            .map(|agent| agent.definition()))
     }
     async fn get_harness(&self, id: HarnessId) -> Result<Option<Harness>> {
         self.0.get_harness(id).await
@@ -406,9 +413,9 @@ impl everruns_core::subagent_delegation::SubagentSessionDelegate for PlatformSto
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::agent::{Agent, AgentStatus};
     use crate::app::{App, AppChannel, AppStatus, ChannelType};
     use everruns_core::AgentCapabilityConfig;
-    use everruns_core::agent::{Agent, AgentStatus};
     use everruns_core::harness::{Harness, HarnessStatus};
     use everruns_core::session::{Session, SessionStatus};
 

--- a/crates/server/examples/create_agent.rs
+++ b/crates/server/examples/create_agent.rs
@@ -6,7 +6,7 @@
 // 2. Run migrations: just migrate
 // 3. Start the API: just api (in another terminal)
 
-use everruns_core::Agent;
+use everruns_platform::Agent;
 use serde_json::json;
 
 const API_BASE_URL: &str = "http://localhost:9000";

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -15,9 +15,10 @@ use axum::{
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, AgentVersionId, HarnessId, ModelId};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, BuiltInHarnessRole, Caller, DeploymentGrade, InitialFile,
-    OrgRole, PlatformDefinition, ResourceConfigResponse, ScopedMcpServers, evaluate_policies_with,
+    AgentCapabilityConfig, BuiltInHarnessRole, Caller, DeploymentGrade, InitialFile, OrgRole,
+    PlatformDefinition, ResourceConfigResponse, ScopedMcpServers, evaluate_policies_with,
 };
+use everruns_platform::Agent;
 use futures::future::try_join_all;
 
 use super::common::{
@@ -779,7 +780,7 @@ pub async fn copy_agent(
         ("agent_id" = String, Path, description = "Agent ID (prefixed) or name")
     ),
     responses(
-        (status = 200, description = "Saved agent versions", body = Vec<everruns_core::AgentVersion>),
+        (status = 200, description = "Saved agent versions", body = Vec<everruns_platform::AgentVersion>),
         (status = 404, description = "Agent not found or agent_versions disabled", body = ErrorResponse),
     ),
     tag = "agents"
@@ -788,7 +789,7 @@ pub async fn list_agent_versions(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
-) -> ApiResult<Vec<everruns_core::AgentVersion>> {
+) -> ApiResult<Vec<everruns_platform::AgentVersion>> {
     require_agent_versions_enabled(&org)?;
     state
         .dispatcher(&org)
@@ -805,7 +806,7 @@ pub async fn list_agent_versions(
     ),
     request_body = CreateAgentVersionRequest,
     responses(
-        (status = 200, description = "Agent version created", body = everruns_core::AgentVersion),
+        (status = 200, description = "Agent version created", body = everruns_platform::AgentVersion),
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 404, description = "Agent not found or agent_versions disabled", body = ErrorResponse),
     ),
@@ -816,7 +817,7 @@ pub async fn create_agent_version(
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
     Json(req): Json<CreateAgentVersionRequest>,
-) -> ApiResult<everruns_core::AgentVersion> {
+) -> ApiResult<everruns_platform::AgentVersion> {
     require_agent_versions_enabled(&org)?;
     state
         .dispatcher(&org)

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -1235,10 +1235,10 @@ impl<T: ResourceUrlable + Serialize> ListResponse<T> {
 /// Hypermedia actions for an `Agent`. See `knowledge/execution/api-conventions.md`.
 pub fn agent_allowed_actions(
     id: &str,
-    status: &everruns_core::AgentStatus,
+    status: &everruns_platform::AgentStatus,
     api_base: &str,
 ) -> Vec<AllowedAction> {
-    use everruns_core::AgentStatus;
+    use everruns_platform::AgentStatus;
     let mut actions = vec![
         AllowedAction::new("self")
             .with_method("GET")
@@ -1276,7 +1276,7 @@ pub fn agent_allowed_actions(
     actions
 }
 
-impl ResourceUrlable for everruns_core::Agent {
+impl ResourceUrlable for everruns_platform::Agent {
     fn api_path() -> &'static str {
         "v1/agents"
     }
@@ -2350,7 +2350,7 @@ mod tests {
 
     #[test]
     fn agent_actions_offer_copy_only_when_active() {
-        use everruns_core::AgentStatus;
+        use everruns_platform::AgentStatus;
         let active = agent_allowed_actions("agent_01", &AgentStatus::Active, "https://api.example");
         let archived =
             agent_allowed_actions("agent_01", &AgentStatus::Archived, "https://api.example");

--- a/crates/server/src/api/mcp_endpoint/cards.rs
+++ b/crates/server/src/api/mcp_endpoint/cards.rs
@@ -9,7 +9,7 @@
 //   so the card itself is never the trust boundary
 
 use chrono::{DateTime, Utc};
-use everruns_core::Agent;
+use everruns_platform::Agent;
 use serde_json::{Value, json};
 use std::fmt::Write as _;
 
@@ -414,7 +414,7 @@ mod tests {
     use chrono::TimeZone;
     use everruns_core::events::TokenUsage;
     use everruns_core::typed_id::AgentId;
-    use everruns_core::{Agent, AgentStatus};
+    use everruns_platform::{Agent, AgentStatus};
 
     fn sample_agent() -> Agent {
         Agent {

--- a/crates/server/src/api/validation.rs
+++ b/crates/server/src/api/validation.rs
@@ -134,7 +134,7 @@ fn validate_harness_name_inner(name: &str) -> Result<(), (StatusCode, Json<Error
 /// Used for both harness and agent names. Delegates to core's shared
 /// `validate_addressable_name` and wraps the error as an HTTP 400.
 fn validate_name_format(entity: &str, name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    everruns_core::validate_addressable_name(name).map_err(|msg| {
+    everruns_platform::validate_addressable_name(name).map_err(|msg| {
         ErrorResponse::new(format!("{entity} {msg}")).into_response(StatusCode::BAD_REQUEST)
     })
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -25,11 +25,12 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
-    Agent, AgentStatus, Caller, ContentPart, DriverId, DriverRegistry, EgressRequest,
-    EgressRequestKind, EgressService, EventData, Harness, HarnessStatus, Message, MessageRole,
-    Session, SessionParticipant, SessionStatus, ToolDefinition, ToolResultContentPart,
-    UtilityLlmService, merge_harness, resolve_runtime_capabilities,
+    Caller, ContentPart, DriverId, DriverRegistry, EgressRequest, EgressRequestKind, EgressService,
+    EventData, Harness, HarnessStatus, Message, MessageRole, Session, SessionParticipant,
+    SessionStatus, ToolDefinition, ToolResultContentPart, UtilityLlmService, merge_harness,
+    resolve_runtime_capabilities,
 };
+use everruns_platform::{Agent, AgentStatus};
 use everruns_worker::mcp_executor::McpServerInfo;
 use everruns_worker::worker_adapters::{TurnContext, WorkerAdapters};
 use std::collections::HashMap;
@@ -344,8 +345,15 @@ impl DirectWorkerAdapters {
         harness: Option<&Harness>,
     ) -> Result<Vec<Message>> {
         let harness_chain: Vec<Harness> = harness.cloned().into_iter().collect();
-        let resolved =
-            resolve_runtime_capabilities(&harness_chain, agent, session, &self.capability_registry);
+        // Status-agnostic projection: message-filter resolution historically
+        // saw the stored record regardless of lifecycle status (EVE-877).
+        let agent_definition = agent.map(|a| a.definition());
+        let resolved = resolve_runtime_capabilities(
+            &harness_chain,
+            agent_definition.as_ref(),
+            session,
+            &self.capability_registry,
+        );
         let message_filters = collect_message_filters_only(
             &resolved.effective_overlay.capabilities,
             &self.capability_registry,

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -14,9 +14,9 @@ use crate::domains::common::*;
 use crate::max_iterations;
 use everruns_core::typed_id::{AgentId, AgentVersionId, HarnessId};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, AgentVersion, AgentVersionChangeKind, InitialFile,
-    OrgRole, Policy, ScopedMcpServers, ToolDefinition,
+    AgentCapabilityConfig, InitialFile, OrgRole, Policy, ScopedMcpServers, ToolDefinition,
 };
+use everruns_platform::{Agent, AgentStatus, AgentVersion, AgentVersionChangeKind};
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -1888,7 +1888,7 @@ impl Command for CheckAgentName {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<NameAvailability, CommandError> {
-        if everruns_core::validate_addressable_name(&self.name).is_err() {
+        if everruns_platform::validate_addressable_name(&self.name).is_err() {
             return Ok(NameAvailability { available: false });
         }
 

--- a/crates/server/src/domains/agents/queries.rs
+++ b/crates/server/src/domains/agents/queries.rs
@@ -6,10 +6,8 @@ use crate::domains::common::CommandError;
 use crate::max_iterations;
 use crate::storage::StorageBackend;
 use everruns_core::typed_id::{AgentId, AgentVersionId, HarnessId};
-use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, AgentVersion, AgentVersionChangeKind, InitialFile,
-    TokenUsage, is_declarative_capability,
-};
+use everruns_core::{AgentCapabilityConfig, InitialFile, TokenUsage, is_declarative_capability};
+use everruns_platform::{Agent, AgentStatus, AgentVersion, AgentVersionChangeKind};
 use uuid::Uuid;
 
 use super::types::AgentRow;

--- a/crates/server/src/domains/agents/types.rs
+++ b/crates/server/src/domains/agents/types.rs
@@ -4,9 +4,8 @@
 // has a single import path.
 
 use everruns_core::typed_id::{AgentId, AgentVersionId, HarnessId, ModelId};
-use everruns_core::{
-    AgentCapabilityConfig, AgentStatus, InitialFile, ScopedMcpServers, ToolDefinition,
-};
+use everruns_core::{AgentCapabilityConfig, InitialFile, ScopedMcpServers, ToolDefinition};
+use everruns_platform::AgentStatus;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
@@ -185,7 +184,7 @@ pub struct CreateAgentVersionRequest {
     /// Reason this version was created. See `AgentVersionChangeKind` for the allowed values.
     /// Defaults to `manual` when omitted.
     #[serde(default)]
-    pub change_kind: Option<everruns_core::AgentVersionChangeKind>,
+    pub change_kind: Option<everruns_platform::AgentVersionChangeKind>,
 }
 
 /// Request body for the `rollback_agent_version` operation.

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -1184,7 +1184,7 @@ pub fn catalog_entries_with_schemas(
 
 /// Validate an addressable name (agent, harness, etc.)
 pub fn validate_name(entity: &str, name: &str) -> Result<(), CommandError> {
-    everruns_core::validate_addressable_name(name)
+    everruns_platform::validate_addressable_name(name)
         .map_err(|msg| CommandError::bad_request(format!("{entity} {msg}")))
 }
 

--- a/crates/server/src/domains/harnesses/queries.rs
+++ b/crates/server/src/domains/harnesses/queries.rs
@@ -438,7 +438,7 @@ pub const RESERVED_HARNESS_NAMES: &[&str] = &["default"];
 /// Validate harness name for create/update — standard addressable name rules
 /// plus rejection of reserved names.
 pub fn validate_harness_name(name: &str) -> Result<(), CommandError> {
-    everruns_core::validate_addressable_name(name)
+    everruns_platform::validate_addressable_name(name)
         .map_err(|msg| CommandError::bad_request(format!("Harness {msg}")))?;
     if RESERVED_HARNESS_NAMES.contains(&name) {
         return Err(CommandError::bad_request(format!(

--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -10,10 +10,11 @@ use everruns_core::capabilities::{CapabilityRegistry, collect_capability_mcp_ser
 use everruns_core::mcp_server::sanitize_mcp_server_name;
 use everruns_core::traits::UserConnectionResolver;
 use everruns_core::{
-    Agent, Capability, EgressService, Harness, McpCapability, McpServerAuthMode, ScopedMcpServers,
+    Capability, EgressService, Harness, McpCapability, McpServerAuthMode, ScopedMcpServers,
     Session, SessionId, ToolDefinition, merge_scoped_mcp_servers, resolve_runtime_capabilities,
     validate_safe_url,
 };
+use everruns_platform::Agent;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -69,9 +70,12 @@ pub fn merge_effective_scoped_mcp_servers_with_capabilities(
     capability_registry: &CapabilityRegistry,
 ) -> ScopedMcpServers {
     let explicit = merge_effective_scoped_mcp_servers(harness, agent, session);
+    // Status-agnostic projection: scoped-MCP wiring historically saw the
+    // stored record regardless of lifecycle status (EVE-877).
+    let agent_definition = agent.map(|a| a.definition());
     let resolved = resolve_runtime_capabilities(
         std::slice::from_ref(harness),
-        agent,
+        agent_definition.as_ref(),
         session,
         capability_registry,
     );
@@ -311,9 +315,9 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use everruns_core::{
-        Agent, AgentStatus, Harness, HarnessId, HarnessStatus, ScopedMcpServer, Session, SessionId,
-        SessionStatus, generate_agent_public_id,
+        Harness, HarnessId, HarnessStatus, ScopedMcpServer, Session, SessionId, SessionStatus,
     };
+    use everruns_platform::{Agent, AgentStatus, generate_agent_public_id};
 
     struct MutableConnectionResolver {
         token: tokio::sync::RwLock<Option<String>>,

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -19,7 +19,9 @@ use everruns_core::command_host::StoreCommandHost;
 use everruns_core::runtime_context::resolve_runtime_capabilities;
 use everruns_core::traits::{AgentStore, HarnessStore, SessionStore};
 use everruns_core::typed_id::SessionId;
-use everruns_core::{Agent, AgentLoopError, Caller, CapabilityRegistry, DriverRegistry, Harness};
+use everruns_core::{
+    AgentDefinition, AgentLoopError, Caller, CapabilityRegistry, DriverRegistry, Harness,
+};
 use everruns_worker::worker_adapters::{
     AdapterAgentStore, AdapterHarnessStore, AdapterImageResolver, AdapterMessageRetriever,
     AdapterProviderStore, AdapterSessionFileStore, AdapterSessionStore,
@@ -195,7 +197,11 @@ impl SessionCommandService {
         &self,
         org_id: i64,
         session_id: SessionId,
-    ) -> Result<(Vec<Harness>, Option<Agent>, everruns_core::Session)> {
+    ) -> Result<(
+        Vec<Harness>,
+        Option<AgentDefinition>,
+        everruns_core::Session,
+    )> {
         let adapters = self.adapters();
         let session_store = AdapterSessionStore::new(adapters.clone(), org_id);
         let harness_store = AdapterHarnessStore::new(adapters.clone(), org_id);

--- a/crates/server/src/domains/session_tasks/queries.rs
+++ b/crates/server/src/domains/session_tasks/queries.rs
@@ -103,7 +103,8 @@ pub async fn tool_context_for_ctx(
     let harness_layers: Vec<Harness> = load_harness_chain(&ctx.db, org_id, harness_id).await?;
 
     // --- Load agent (if any) ---
-    let agent_layer: Option<everruns_core::Agent> = if let Some(agent_id) = session_row.agent_id {
+    let agent_layer: Option<everruns_platform::Agent> = if let Some(agent_id) = session_row.agent_id
+    {
         let agent_row = ctx
             .db
             .get_agent(org_id, agent_id)

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -913,7 +913,7 @@ impl WorkerServiceImpl {
     async fn build_mcp_tool_definitions(
         &self,
         org_id: i64,
-        agent: &everruns_core::Agent,
+        agent: &everruns_platform::Agent,
     ) -> Vec<McpToolDef> {
         use everruns_core::capabilities::mcp::parse_mcp_capability_id;
         use everruns_core::mcp_server::mcp_tool_name;

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -9,10 +9,10 @@ use crate::api::{ListResponse, PaginatedResponse};
 use crate::domains;
 use everruns_core::provider::{Provider, ProviderTraceConfig};
 use everruns_core::{
-    Agent, AgentStatus, CapabilityInfo, ContextReportContribution, ContextReportSection, DriverId,
-    Event, EventContext, EventData, FileInfo, FileStat, GrepMatch, GrepResult, LeasedResource,
-    McpServer, McpServerStatus, McpServerTransportType, Model, ModelWithProvider, ProviderStatus,
-    Session, SessionContextReport, SessionFile, SessionStatus, Skill, SkillContent, SkillFileEntry,
+    CapabilityInfo, ContextReportContribution, ContextReportSection, DriverId, Event, EventContext,
+    EventData, FileInfo, FileStat, GrepMatch, GrepResult, LeasedResource, McpServer,
+    McpServerStatus, McpServerTransportType, Model, ModelWithProvider, ProviderStatus, Session,
+    SessionContextReport, SessionFile, SessionStatus, Skill, SkillContent, SkillFileEntry,
     SkillSourceType, SkillStatus, SkillValidationResult, ToolCall,
     events::{
         ActCompletedData, ActStartedData, InputMessageData, LlmGenerationData,
@@ -22,6 +22,7 @@ use everruns_core::{
         TurnCompletedData, TurnFailedData, TurnSealedData, TurnStartedData,
     },
 };
+use everruns_platform::{Agent, AgentStatus};
 use serde_json::json;
 use utoipa::openapi::extensions::Extensions;
 use utoipa::openapi::{RefOr, Schema};
@@ -440,7 +441,7 @@ fn schema_extensions_mut(schema: &mut Schema) -> Option<&mut Option<Extensions>>
     ),
     components(
         schemas(
-            Agent, AgentStatus, everruns_core::AgentVersion, everruns_core::AgentVersionChangeKind,
+            Agent, AgentStatus, everruns_platform::AgentVersion, everruns_platform::AgentVersionChangeKind,
             Session, SessionStatus, Event, EventContext, EventData,
             everruns_core::typed_id::EventId,
             // Event data types

--- a/crates/server/src/storage/agent_store.rs
+++ b/crates/server/src/storage/agent_store.rs
@@ -1,7 +1,9 @@
 // Database-backed AgentStore implementation
 //
-// This module implements the core AgentStore trait for retrieving
-// agent configurations from the database.
+// This module implements the core AgentStore trait — the narrow agent-loading
+// seam for turn execution (EVE-872, EVE-877). The stored platform record is
+// hydrated here and projected into the portable execution definition;
+// archived/deleted agents fail at this seam, before host execution.
 //
 // Decision: org_id is baked into the struct at construction time,
 // matching the Grpc/Adapter store pattern. Callers must provide
@@ -10,11 +12,10 @@
 use crate::max_iterations;
 use async_trait::async_trait;
 use everruns_core::{
-    AgentCapabilityConfig, AgentId, Result, StoreResultExt,
-    agent::{Agent, AgentStatus},
-    from_json,
-    traits::AgentStore,
+    AgentCapabilityConfig, AgentDefinition, AgentId, DependencyBlocker, Result, StoreResultExt,
+    from_json, traits::AgentStore,
 };
+use everruns_platform::{Agent, AgentStatus};
 
 use super::repositories::Database;
 
@@ -36,11 +37,9 @@ impl DbAgentStore {
     pub fn new(db: Database, org_id: i64) -> Self {
         Self { db, org_id }
     }
-}
 
-#[async_trait]
-impl AgentStore for DbAgentStore {
-    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
+    /// Hydrate the stored platform record (row + capabilities).
+    async fn load_record(&self, agent_id: AgentId) -> Result<Option<Agent>> {
         let agent_row = self.db.get_agent(self.org_id, agent_id).await.store_err()?;
 
         match agent_row {
@@ -93,6 +92,25 @@ impl AgentStore for DbAgentStore {
             }
             None => Ok(None),
         }
+    }
+}
+
+#[async_trait]
+impl AgentStore for DbAgentStore {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<AgentDefinition>> {
+        // Loading seam (EVE-877): archived/deleted records fail here, before
+        // host execution.
+        self.load_record(agent_id)
+            .await?
+            .map(|agent| agent.execution_definition())
+            .transpose()
+    }
+
+    async fn get_agent_blocker(&self, agent_id: AgentId) -> Result<Option<DependencyBlocker>> {
+        Ok(match self.load_record(agent_id).await? {
+            Some(agent) => agent.dependency_blocker(),
+            None => Some(DependencyBlocker::AgentDeleted),
+        })
     }
 }
 

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -464,7 +464,7 @@ pub struct AgentRow {
     /// NULL until the agent first acts unattended (e.g. an agent trigger fire),
     /// at which point an `agent_identities` row is created and linked so the
     /// agent owns its unattended sessions as itself. Storage-only: intentionally
-    /// not surfaced on the public `everruns_core::Agent` API.
+    /// not surfaced on the public `everruns_platform::Agent` API.
     #[sqlx(default)]
     pub agent_identity_id: Option<AgentIdentityId>,
     #[sqlx(default)]

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -21,9 +21,10 @@ use test_harness::TestServer;
 use everruns_core::provider::Provider;
 use everruns_core::typed_id::ScheduleId;
 use everruns_core::{
-    Agent, DEFAULT_ORG_ID, Harness, Model, PrincipalId, Session, SessionContextReport, SessionFile,
+    DEFAULT_ORG_ID, Harness, Model, PrincipalId, Session, SessionContextReport, SessionFile,
 };
 use everruns_durable::UpdateField;
+use everruns_platform::Agent;
 use everruns_server::storage::models::{
     CreateAgentRow, CreatePrincipalRow, CreateSessionScheduleRow, UpdateOrganizationSettings,
     UpdateSession,
@@ -783,7 +784,10 @@ async fn test_delete_agent() {
         .await
         .assert_status(StatusCode::OK)
         .json();
-    assert_eq!(archived_agent.status, everruns_core::AgentStatus::Archived);
+    assert_eq!(
+        archived_agent.status,
+        everruns_platform::AgentStatus::Archived
+    );
 
     let default_list: Value = server
         .get("/v1/agents")

--- a/crates/server/tests/client_side_tools_test.rs
+++ b/crates/server/tests/client_side_tools_test.rs
@@ -38,7 +38,7 @@ fn test_agent_with_client_side_tools_serialization() {
         "updated_at": "2025-01-01T00:00:00Z"
     });
 
-    let agent: everruns_core::Agent = serde_json::from_value(agent_json).unwrap();
+    let agent: everruns_platform::Agent = serde_json::from_value(agent_json).unwrap();
     assert_eq!(
         agent.harness_id.to_string(),
         "harness_00000000000000000000000000000000"
@@ -79,7 +79,7 @@ fn test_agent_with_mixed_tools_serialization() {
         "updated_at": "2025-01-01T00:00:00Z"
     });
 
-    let agent: everruns_core::Agent = serde_json::from_value(agent_json).unwrap();
+    let agent: everruns_platform::Agent = serde_json::from_value(agent_json).unwrap();
     assert_eq!(
         agent.harness_id.to_string(),
         "harness_00000000000000000000000000000000"
@@ -116,7 +116,7 @@ fn test_agent_with_no_tools_omits_field() {
         "updated_at": "2025-01-01T00:00:00Z"
     });
 
-    let agent: everruns_core::Agent = serde_json::from_value(agent_json).unwrap();
+    let agent: everruns_platform::Agent = serde_json::from_value(agent_json).unwrap();
     assert_eq!(
         agent.harness_id.to_string(),
         "harness_00000000000000000000000000000000"

--- a/crates/server/tests/session_git_integration_test.rs
+++ b/crates/server/tests/session_git_integration_test.rs
@@ -11,7 +11,8 @@ use axum::http::StatusCode;
 use serde_json::{Value, json};
 use test_harness::TestServer;
 
-use everruns_core::{Agent, Session};
+use everruns_core::Session;
+use everruns_platform::Agent;
 
 /// Helper: create an agent + session + populate files, return session ID
 async fn setup_session_with_files(server: &TestServer) -> String {

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -16,7 +16,8 @@
 //! - Uses LlmSim for workflow tests, no real API keys needed
 
 use everruns_core::provider::Provider;
-use everruns_core::{Agent, Model, Session, SessionFile};
+use everruns_core::{Model, Session, SessionFile};
+use everruns_platform::Agent;
 use serde_json::{Value, json};
 
 const SERVER_BASE_URL: &str = "http://localhost:9000";

--- a/crates/test-support/src/in_memory_loop.rs
+++ b/crates/test-support/src/in_memory_loop.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 
 use crate::llmsim_driver::{LlmSimConfig, LlmSimDriver};
-use everruns_core::agent::{Agent, AgentStatus};
+use everruns_core::agent_definition::AgentDefinition;
 use everruns_core::atoms::{
     ActAtom, ActInput, Atom, AtomContext, InputAtom, InputAtomInput, ReasonAtom, ReasonInput,
 };
@@ -411,33 +411,12 @@ impl InMemoryAgenticLoopBuilder {
 
         // Create agent
         let agent_id = AgentId::new();
-        let agent = Agent {
-            public_id: agent_id,
-            internal_id: agent_id.uuid(),
-            name: "in-memory".to_string(),
+        let agent = AgentDefinition {
             display_name: Some(self.agent_name),
-            description: None,
-            system_prompt: self.system_prompt,
-            default_model_id: None,
-            harness_id,
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
             capabilities: agent_capability_configs,
-            mcp_servers: Default::default(),
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
             parallel_tool_calls: self.parallel_tool_calls,
             tools: explicit_tool_definitions,
-            status: AgentStatus::Active,
-            created_at: now,
-            updated_at: now,
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(agent_id, "in-memory", self.system_prompt)
         };
         agent_store.add_agent(agent).await;
 

--- a/crates/test-support/tests/command_host_test.rs
+++ b/crates/test-support/tests/command_host_test.rs
@@ -14,7 +14,7 @@ use everruns_test_support::TestMathCapability;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use everruns_core::agent::{Agent, AgentStatus};
+use everruns_core::AgentDefinition;
 
 use chrono::Utc;
 use everruns_core::driver_registry::LlmStreamEvent;
@@ -81,35 +81,10 @@ fn test_harness(harness_id: HarnessId) -> Harness {
     }
 }
 
-fn test_agent(agent_id: AgentId) -> Agent {
-    Agent {
-        public_id: agent_id,
-        internal_id: uuid::Uuid::nil(),
-        name: "a".into(),
-        display_name: None,
-        description: None,
-        system_prompt: "Use tools.".into(),
-        default_model_id: None,
-
-        harness_id: everruns_core::typed_id::HarnessId::from_uuid(uuid::Uuid::nil()),
-        default_version_id: None,
-        forked_from_agent_id: None,
-        forked_from_version_id: None,
-        root_agent_id: None,
-        tags: vec![],
-        capabilities: vec![],
-        initial_files: vec![],
-        network_access: None,
+fn test_agent(agent_id: AgentId) -> AgentDefinition {
+    AgentDefinition {
         max_iterations: Some(8),
-        parallel_tool_calls: None,
-        tools: vec![],
-        mcp_servers: Default::default(),
-        status: AgentStatus::Active,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        archived_at: None,
-        deleted_at: None,
-        usage: None,
+        ..AgentDefinition::new(agent_id, "a", "Use tools.")
     }
 }
 

--- a/crates/test-support/tests/reason_atom_test.rs
+++ b/crates/test-support/tests/reason_atom_test.rs
@@ -6,9 +6,9 @@
 // Run with: cargo test -p everruns-core --test reason_atom_test
 
 use async_trait::async_trait;
+use everruns_core::AgentDefinition;
 use everruns_core::AgentId;
 use everruns_core::MessageRetriever;
-use everruns_core::agent::{Agent, AgentStatus};
 use everruns_core::atoms::{Atom, AtomContext, ReasonAtom, ReasonInput};
 use everruns_core::capabilities::CapabilityRegistry;
 use everruns_core::driver_registry::{DriverId, DriverRegistry};
@@ -76,34 +76,13 @@ async fn setup_test_environment() -> (
 
     // Create a test agent
     let agent_id = Uuid::now_v7();
-    let agent = Agent {
-        public_id: AgentId::from_uuid(agent_id),
-        internal_id: agent_id,
-        name: "test-agent".to_string(),
+    let agent = AgentDefinition {
         display_name: Some("Test Agent".to_string()),
-        description: None,
-        system_prompt: "You are a helpful assistant.".to_string(),
-        default_model_id: None,
-
-        harness_id: HarnessId::from_uuid(uuid::Uuid::nil()),
-        default_version_id: None,
-        forked_from_agent_id: None,
-        forked_from_version_id: None,
-        root_agent_id: None,
-        capabilities: vec![],
-        initial_files: vec![],
-        network_access: None,
-        max_iterations: None,
-        parallel_tool_calls: None,
-        tools: vec![],
-        mcp_servers: Default::default(),
-        tags: vec![],
-        status: AgentStatus::Active,
-        created_at: now,
-        updated_at: now,
-        archived_at: None,
-        deleted_at: None,
-        usage: None,
+        ..AgentDefinition::new(
+            AgentId::from_uuid(agent_id),
+            "test-agent",
+            "You are a helpful assistant.",
+        )
     };
     agent_store.add_agent(agent).await;
 
@@ -923,38 +902,18 @@ async fn native_compact_retry_reuses_ordered_opaque_output_without_previous_resp
         })
         .await;
 
-    let now = chrono::Utc::now();
     agent_store
-        .add_agent(Agent {
-            public_id: AgentId::from_uuid(agent_id),
-            internal_id: agent_id,
-            name: "native-compact-test-agent".to_string(),
+        .add_agent(AgentDefinition {
             display_name: Some("Native Compact Test Agent".to_string()),
-            description: None,
-            system_prompt: "You are a helpful assistant.".to_string(),
-            default_model_id: None,
-            harness_id: HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
             capabilities: vec![AgentCapabilityConfig::with_config(
                 COMPACTION_CAPABILITY_ID,
                 json!({ "strategy": "native", "proactive": false }),
             )],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            tags: vec![],
-            status: AgentStatus::Active,
-            created_at: now,
-            updated_at: now,
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(
+                AgentId::from_uuid(agent_id),
+                "native-compact-test-agent",
+                "You are a helpful assistant.",
+            )
         })
         .await;
     message_retriever
@@ -4149,37 +4108,12 @@ async fn test_prompt_canary_guardrail_replaces_leaked_output() {
     {
         // Replace the agent so it has the leak-prone prompt + the canary
         // capability enabled.
-        let now = chrono::Utc::now();
-        let agent = Agent {
-            public_id: AgentId::from_uuid(agent_id),
-            internal_id: agent_id,
-            name: "leak-test-agent".to_string(),
+        let agent = AgentDefinition {
             display_name: Some("Leak Test Agent".to_string()),
-            description: None,
-            system_prompt: leak_prompt.to_string(),
-            default_model_id: None,
-
-            harness_id: HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
             capabilities: vec![AgentCapabilityConfig::new(
                 PROMPT_CANARY_GUARDRAIL_CAPABILITY_ID,
             )],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            tags: vec![],
-            status: AgentStatus::Active,
-            created_at: now,
-            updated_at: now,
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(AgentId::from_uuid(agent_id), "leak-test-agent", leak_prompt)
         };
         agent_store.add_agent(agent).await;
     }
@@ -4322,37 +4256,16 @@ async fn test_prompt_canary_guardrail_replaces_leaked_thinking() {
     let leak_prompt = "You are an internal pricing oracle that never discloses margins. \
          Refuse out-of-scope questions.";
     {
-        let now = chrono::Utc::now();
-        let agent = Agent {
-            public_id: AgentId::from_uuid(agent_id),
-            internal_id: agent_id,
-            name: "thinking-leak-test-agent".to_string(),
+        let agent = AgentDefinition {
             display_name: Some("Thinking Leak Test Agent".to_string()),
-            description: None,
-            system_prompt: leak_prompt.to_string(),
-            default_model_id: None,
-
-            harness_id: HarnessId::from_uuid(uuid::Uuid::nil()),
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
             capabilities: vec![AgentCapabilityConfig::new(
                 PROMPT_CANARY_GUARDRAIL_CAPABILITY_ID,
             )],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            mcp_servers: Default::default(),
-            tags: vec![],
-            status: AgentStatus::Active,
-            created_at: now,
-            updated_at: now,
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
+            ..AgentDefinition::new(
+                AgentId::from_uuid(agent_id),
+                "thinking-leak-test-agent",
+                leak_prompt,
+            )
         };
         agent_store.add_agent(agent).await;
     }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -25,14 +25,17 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, LeasedResourceId, MessageId, ModelId, SessionId};
 use everruns_core::{
-    Agent, Harness, HarnessStatus, Message, MessageFilter, MessageRole, Session,
+    AgentDefinition, Harness, HarnessStatus, Message, MessageFilter, MessageRole, Session,
     SessionParticipant, SessionStatus,
 };
+// EVE-877: the stored Agent record moved to `everruns-platform`; the gRPC wire
+// still carries it between server and worker (proto shape unchanged).
 use everruns_internal_protocol::proto;
 use everruns_internal_protocol::{
     WorkerServiceClient, json_to_proto_list, json_to_proto_struct, proto_list_to_json,
     proto_struct_to_json,
 };
+use everruns_platform::Agent;
 use std::sync::Arc;
 use tokio::sync::{Mutex, OnceCell};
 use tonic::service::interceptor::InterceptedService;
@@ -1328,7 +1331,30 @@ fn proto_message_to_message(proto_msg: proto::Message) -> Result<Message> {
 
 #[async_trait]
 impl AgentStore for GrpcOrgAdapter {
-    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<AgentDefinition>> {
+        // Loading seam (EVE-877): project the transported record into the
+        // portable execution definition; archived/deleted agents fail here.
+        self.fetch_agent_record(agent_id)
+            .await?
+            .map(|agent| agent.execution_definition())
+            .transpose()
+    }
+
+    async fn get_agent_blocker(
+        &self,
+        agent_id: AgentId,
+    ) -> Result<Option<everruns_core::DependencyBlocker>> {
+        Ok(match self.fetch_agent_record(agent_id).await? {
+            Some(agent) => agent.dependency_blocker(),
+            None => Some(everruns_core::DependencyBlocker::AgentDeleted),
+        })
+    }
+}
+
+impl GrpcOrgAdapter {
+    /// Fetch the stored agent record off the wire (platform-side transport;
+    /// projected to `AgentDefinition` before it reaches host execution).
+    pub(crate) async fn fetch_agent_record(&self, agent_id: AgentId) -> Result<Option<Agent>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::GetAgentRequest {
@@ -1366,10 +1392,10 @@ fn proto_agent_to_agent(proto_agent: proto::Agent) -> Result<Agent> {
         .ok_or_else(|| anyhow::anyhow!("proto Agent missing harness_id"))?;
 
     let status = match proto_agent.status.to_lowercase().as_str() {
-        "active" => everruns_core::AgentStatus::Active,
-        "archived" => everruns_core::AgentStatus::Archived,
-        "deleted" => everruns_core::AgentStatus::Deleted,
-        _ => everruns_core::AgentStatus::Active,
+        "active" => everruns_platform::AgentStatus::Active,
+        "archived" => everruns_platform::AgentStatus::Archived,
+        "deleted" => everruns_platform::AgentStatus::Deleted,
+        _ => everruns_platform::AgentStatus::Active,
     };
 
     let capabilities = if proto_agent.capabilities.is_empty() {

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -12,15 +12,16 @@ use everruns_core::session_file::{
     FileInfo, FileStat, GrepMatch, GrepOptions, GrepSearchResult, SessionFile,
 };
 use everruns_core::traits::{
-    AgentStore, ImageArtifactStore, ProviderCredentialStore, ResolvedImage, ResolvedModel,
+    ImageArtifactStore, ProviderCredentialStore, ResolvedImage, ResolvedModel,
 };
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
 use everruns_core::{
-    Agent, DriverRegistry, EgressService, Harness, Message, MessageHistory, MessageQuery,
+    DriverRegistry, EgressService, Harness, Message, MessageHistory, MessageQuery,
     PlatformDefinition, Session, UtilityLlmService,
 };
+use everruns_platform::Agent;
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -113,7 +114,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     async fn get_agent(&self, org_id: i64, agent_id: Uuid) -> Result<Option<Agent>> {
         let store = GrpcAgentStore::new(self.client.clone(), org_id);
-        store.get_agent(AgentId::from_uuid(agent_id)).await
+        store.fetch_agent_record(AgentId::from_uuid(agent_id)).await
     }
 
     async fn get_harness(&self, org_id: i64, harness_id: Uuid) -> Result<Option<Harness>> {

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -189,9 +189,17 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
             .await?
             .into_iter()
             .collect();
+        // Loading seam (EVE-877): project the stored record into the portable
+        // execution definition; archived/deleted agents fail here, before the
+        // snapshot is built.
+        let agent_definition = context
+            .agent
+            .as_ref()
+            .map(|agent| agent.execution_definition())
+            .transpose()?;
         let snapshot = ResolvedExecutionSnapshot::project(
             &harness_chain,
-            context.agent.as_ref(),
+            agent_definition.as_ref(),
             &context.session,
         )?;
         Ok(ResolvedTurnInputs {

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -1975,7 +1975,7 @@ mod tests {
                 &self,
                 _org_id: i64,
                 _agent_id: Uuid,
-            ) -> CoreResult<Option<everruns_core::Agent>> {
+            ) -> CoreResult<Option<everruns_platform::Agent>> {
                 unimplemented!()
             }
             async fn get_harness(

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -24,9 +24,13 @@ use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
 use everruns_core::{
-    Agent, DriverRegistry, EgressService, Harness, Message, MessageHistory, MessageQuery, Session,
-    ToolDefinition, UtilityLlmService,
+    AgentDefinition, DriverRegistry, EgressService, Harness, Message, MessageHistory, MessageQuery,
+    Session, ToolDefinition, UtilityLlmService,
 };
+// EVE-877: the stored Agent record moved to `everruns-platform`. WorkerAdapters
+// still transports it between control plane and worker; host/engine only ever
+// see the projected `AgentDefinition` / resolved execution snapshot.
+use everruns_platform::Agent;
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -49,7 +53,8 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     // Agent Operations
     // =========================================================================
 
-    /// Get agent by ID
+    /// Get the stored agent record by ID (platform-side transport; never
+    /// handed to host execution — see `AgentStore for OrgAdapter`).
     async fn get_agent(&self, org_id: i64, agent_id: Uuid) -> Result<Option<Agent>>;
 
     /// Get harness by ID
@@ -570,8 +575,31 @@ pub type AdapterSessionFileStore<A> = SessionAdapter<A>;
 
 #[async_trait]
 impl<A: WorkerAdapters> everruns_core::traits::AgentStore for OrgAdapter<A> {
-    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
-        self.adapters.get_agent(self.org_id, agent_id.uuid()).await
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<AgentDefinition>> {
+        // Loading seam (EVE-877): project the stored record into the portable
+        // execution definition; archived/deleted records fail here, before
+        // host execution.
+        self.adapters
+            .get_agent(self.org_id, agent_id.uuid())
+            .await?
+            .map(|agent| agent.execution_definition())
+            .transpose()
+    }
+
+    async fn get_agent_blocker(
+        &self,
+        agent_id: AgentId,
+    ) -> Result<Option<everruns_core::DependencyBlocker>> {
+        Ok(
+            match self
+                .adapters
+                .get_agent(self.org_id, agent_id.uuid())
+                .await?
+            {
+                Some(agent) => agent.dependency_blocker(),
+                None => Some(everruns_core::DependencyBlocker::AgentDeleted),
+            },
+        )
     }
 }
 

--- a/crates/worker/tests/resolved_turn_parity_test.rs
+++ b/crates/worker/tests/resolved_turn_parity_test.rs
@@ -9,8 +9,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use everruns_core::error::Result as CoreResult;
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
-use everruns_core::{Agent, DEFAULT_ORG_ID, Harness, ResolvedExecutionSnapshot, Session};
-use everruns_host::{AgentBuilder, HarnessBuilder, RuntimeHostAdapter, SessionBuilder};
+use everruns_core::{DEFAULT_ORG_ID, Harness, ResolvedExecutionSnapshot, Session};
+use everruns_host::{HarnessBuilder, RuntimeHostAdapter, SessionBuilder};
+// EVE-877: the hosted adapters transport the stored platform record; the
+// loading seam projects it into the portable execution definition.
+use everruns_platform::{Agent, AgentStatus};
 use everruns_worker::{WorkerAdapters, WorkerRuntimeHost, WorkerTurnContext};
 use uuid::Uuid;
 
@@ -22,11 +25,34 @@ fn fixture_records() -> (Harness, Agent, Session) {
     let harness = HarnessBuilder::new("hoster", "Harness instructions.")
         .id(harness_id)
         .build();
-    let agent = AgentBuilder::new("hosted-agent", "Agent instructions.")
-        .id(agent_id)
-        .harness_id(harness_id)
-        .max_iterations(9)
-        .build();
+    let agent = Agent {
+        public_id: agent_id,
+        internal_id: agent_id.uuid(),
+        name: "hosted-agent".into(),
+        display_name: None,
+        description: None,
+        system_prompt: "Agent instructions.".into(),
+        default_model_id: None,
+        harness_id,
+        default_version_id: None,
+        forked_from_agent_id: None,
+        forked_from_version_id: None,
+        root_agent_id: None,
+        tags: vec![],
+        capabilities: vec![],
+        initial_files: vec![],
+        network_access: None,
+        max_iterations: Some(9),
+        parallel_tool_calls: None,
+        tools: vec![],
+        mcp_servers: Default::default(),
+        status: AgentStatus::Active,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        archived_at: None,
+        deleted_at: None,
+        usage: None,
+    };
     let session = SessionBuilder::new(harness_id)
         .id(session_id)
         .agent(agent_id)
@@ -370,9 +396,12 @@ async fn direct_and_wire_adapters_project_the_same_snapshot() {
 
     // The canonical projection is the reference: hosted adapters built from
     // equivalent configuration produce equivalent snapshots.
-    let reference =
-        ResolvedExecutionSnapshot::project(std::slice::from_ref(&harness), Some(&agent), &session)
-            .expect("reference projection");
+    let reference = ResolvedExecutionSnapshot::project(
+        std::slice::from_ref(&harness),
+        Some(&agent.execution_definition().expect("active agent projects")),
+        &session,
+    )
+    .expect("reference projection");
 
     let direct_json = serde_json::to_value(&direct_inputs.snapshot).unwrap();
     let wire_json = serde_json::to_value(&wire_inputs.snapshot).unwrap();
@@ -398,6 +427,29 @@ async fn direct_and_wire_adapters_project_the_same_snapshot() {
 
     // Platform-only session metadata (UI title) never enters the snapshot.
     assert!(!wire_json.to_string().contains("UI-TITLE-MARKER"));
+}
+
+#[tokio::test]
+async fn worker_load_fails_for_archived_and_deleted_agents() {
+    // EVE-877: lifecycle validation happens at the worker loading seam, before
+    // the resolved snapshot is built and before host execution.
+    for status in [AgentStatus::Archived, AgentStatus::Deleted] {
+        let (harness, mut agent, session) = fixture_records();
+        agent.status = status.clone();
+        let host = WorkerRuntimeHost::new(DirectMockAdapters {
+            harness,
+            agent,
+            session: session.clone(),
+        });
+        let error = host
+            .load_resolved_turn(DEFAULT_ORG_ID, session.id)
+            .await
+            .expect_err("inactive agent must fail the loading seam");
+        assert!(
+            error.to_string().contains("cannot execute turns"),
+            "unexpected error for {status:?}: {error}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/knowledge/foundations/id-schema.md
+++ b/knowledge/foundations/id-schema.md
@@ -82,7 +82,7 @@ All entities use a **dual-ID pattern** with an internal UUID primary key and an 
 - FKs between tables use internal `UUID` columns
 - When auto-generating: derive `public_id` from the internal UUID for consistency (`{prefix}_{uuid_hex}`)
 
-**Domain struct convention:** See `crates/core/src/agent.rs` for the canonical example of the dual-ID pattern with `public_id` / `internal_id` fields.
+**Domain struct convention:** See `crates/platform/src/agent.rs` for the canonical example of the dual-ID pattern with `public_id` / `internal_id` fields.
 
 **Upsert semantics (PUT):**
 - `PUT /v1/{entity}/{public_id}` creates if not exists (201), updates if exists (200)

--- a/knowledge/foundations/models.md
+++ b/knowledge/foundations/models.md
@@ -18,7 +18,7 @@ This document defines the core data models for Everruns - a durable agentic harn
 
 Configuration for an agentic loop. An agent can have many concurrent sessions.
 
-See `crates/core/src/agent.rs` for full field definitions.
+See `crates/platform/src/agent.rs` for full field definitions.
 
 Key design points:
 - All entity IDs use the dual-ID pattern (internal UUID PK + external public_id). See `knowledge/foundations/id-schema.md`.
@@ -32,7 +32,7 @@ Key design points:
 
 Immutable snapshot of an Agent's authored and resolved configuration. AgentVersion is a pilot-specific model, not a generic entity versioning abstraction.
 
-See `crates/core/src/agent.rs` for full field definitions and `knowledge/runtime-resources/agent-versions.md` for behavior.
+See `crates/platform/src/agent.rs` for full field definitions and `knowledge/runtime-resources/agent-versions.md` for behavior.
 
 ### Building Block Lifecycle
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Everruns Knowledge Update Log
 
+## 2026-08-11
+
+* **Agent record extraction**: Moved the stored `Agent` and `AgentVersion`
+  persistence records — lifecycle status, versioning and publication metadata,
+  fork lineage, public-name validation, and persistence helpers — out of
+  `everruns-core` into `everruns-platform` (EVE-877, breaking for direct core
+  consumers in 0.18). Core keeps only the portable `AgentDefinition` (authored
+  execution configuration); the `AgentStore` loading seam projects stored
+  records into it and enforces archived/deleted validation before host
+  execution, which consumes the resolved execution snapshot only. REST/gRPC
+  and stored schema are unchanged, and a new architecture guard keeps kernel
+  crates (core, engine, provider, capability) free of platform record imports.
+
 ## 2026-08-10
 
 * **Observability extraction**: Moved telemetry initialization (OTLP exporter

--- a/knowledge/runtime-resources/agent-versions.md
+++ b/knowledge/runtime-resources/agent-versions.md
@@ -63,7 +63,7 @@ When disabled:
 
 ## References
 
-- Core types: `crates/core/src/agent.rs`, `crates/platform/src/app.rs`, `crates/core/src/session.rs`
+- Core types: `crates/platform/src/agent.rs`, `crates/platform/src/app.rs`, `crates/core/src/session.rs`
 - Storage models: `crates/server/src/storage/models.rs`
 - API commands: `crates/server/src/domains/agents/commands.rs`
 - Migration: `crates/server/migrations/037_agent_versions.sql`

--- a/scripts/lib/check-agent-record-isolation.sh
+++ b/scripts/lib/check-agent-record-isolation.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Architecture guard (EVE-877): stored Agent and AgentVersion persistence
+# records — lifecycle status, versioning/publication metadata, fork lineage —
+# live in crates/platform (`everruns-platform`). The execution kernel consumes
+# only the portable `everruns_core::AgentDefinition` and the resolved
+# execution snapshot:
+#
+# 1. Kernel crate sources (core, engine, provider, capability) must not
+#    reference `everruns_platform` at all — the platform Agent records must
+#    never flow back into the kernel.
+# 2. Kernel crates must carry no everruns-platform edge of any kind (normal,
+#    build, or dev), so `cargo tree` stays clean.
+# 3. Provider-only crates must ship no everruns-platform subtree on their
+#    normal (shipped) dependency edges.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+FAILED=0
+
+# 1. Kernel sources: no platform-crate references (src, tests, and examples —
+#    even kernel tests must not need the stored records).
+KERNEL_TREES=(
+  crates/core
+  crates/engine
+  crates/provider
+  crates/capability
+)
+if matches=$(grep -rnE 'everruns_platform(::|;)' "${KERNEL_TREES[@]}" --include='*.rs' 2>/dev/null); then
+  echo "Kernel crates must not reference everruns_platform (EVE-877):"
+  echo "$matches"
+  FAILED=1
+fi
+
+# 2. Kernel crates: no everruns-platform edge of any kind.
+KERNEL_CRATES=(
+  everruns-core
+  everruns-engine
+  everruns-provider
+  everruns-capability
+)
+for crate in "${KERNEL_CRATES[@]}"; do
+  tree=$(cargo tree -p "$crate" --edges normal,build,dev --prefix none 2>/dev/null)
+  if echo "$tree" | grep -qE '^everruns-platform '; then
+    echo "$crate must not depend on everruns-platform (any edge):"
+    echo "$tree" | grep -E '^everruns-platform '
+    FAILED=1
+  fi
+done
+
+# 3. Provider-only crates: shipped dependency tree free of platform records.
+PROVIDER_CRATES=(
+  everruns-openai
+  everruns-anthropic
+  everruns-openrouter
+  everruns-gemini
+  everruns-bedrock
+  everruns-mai
+  everruns-fireworks
+  everruns-meta
+)
+for crate in "${PROVIDER_CRATES[@]}"; do
+  tree=$(cargo tree -p "$crate" --edges normal --prefix none 2>/dev/null)
+  if echo "$tree" | grep -qE '^everruns-platform '; then
+    echo "$crate must not ship everruns-platform in its normal dependency tree:"
+    echo "$tree" | grep -E '^everruns-platform '
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "Agent-record isolation guard failed. Stored Agent/AgentVersion records belong in crates/platform (EVE-877)."
+  exit 1
+fi
+
+echo "Agent-record isolation guard passed: kernel crates consume AgentDefinition only; platform records stay in crates/platform."

--- a/scripts/lib/pre-push.sh
+++ b/scripts/lib/pre-push.sh
@@ -13,7 +13,7 @@ echo "🔒 Running pre-push checks..."
 echo ""
 
 # 1. Rust formatting
-echo "1/15 Rust formatting"
+echo "1/16 Rust formatting"
 if cargo fmt --check 2>/dev/null; then
   pass "cargo fmt"
 else
@@ -21,7 +21,7 @@ else
 fi
 
 # 2. Clippy
-echo "2/15 Rust linting"
+echo "2/16 Rust linting"
 if cargo clippy --all-targets --all-features -- -D warnings 2>/dev/null; then
   pass "clippy"
 else
@@ -29,7 +29,7 @@ else
 fi
 
 # 3. Cargo.lock freshness
-echo "3/15 Cargo.lock freshness"
+echo "3/16 Cargo.lock freshness"
 if cargo fetch --locked 2>/dev/null; then
   pass "Cargo.lock up to date"
 else
@@ -37,7 +37,7 @@ else
 fi
 
 # 4. UI formatting (skip if node_modules missing)
-echo "4/15 UI formatting"
+echo "4/16 UI formatting"
 if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && pnpm run format:check 2>/dev/null); then
     pass "UI format"
@@ -49,7 +49,7 @@ else
 fi
 
 # 5. UI linting (skip if node_modules missing)
-echo "5/15 UI linting"
+echo "5/16 UI linting"
 if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && pnpm run lint 2>/dev/null); then
     pass "UI lint"
@@ -61,7 +61,7 @@ else
 fi
 
 # 6. Migration ordering check
-echo "6/15 Migration ordering"
+echo "6/16 Migration ordering"
 if MIGRATION_ORDERING_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-migration-ordering.sh" 2>&1
 )"; then
@@ -72,7 +72,7 @@ else
 fi
 
 # 7. Migration immutability check
-echo "7/15 Migration immutability"
+echo "7/16 Migration immutability"
 if MIGRATION_IMMUTABILITY_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-migration-immutability.sh" 2>&1
 )"; then
@@ -83,7 +83,7 @@ else
 fi
 
 # 8. Server integration test enumeration
-echo "8/15 Server test enumeration"
+echo "8/16 Server test enumeration"
 if SERVER_TEST_ENUM_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-server-test-enumeration.sh" 2>&1
 )"; then
@@ -94,7 +94,7 @@ else
 fi
 
 # 9. Public everruns example inventory and compile check
-echo "9/15 Public everruns examples"
+echo "9/16 Public everruns examples"
 if EVERRUNS_EXAMPLES_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-everruns-examples.sh" 2>&1
 )"; then
@@ -105,7 +105,7 @@ else
 fi
 
 # 10. Knowledge bundle conformance
-echo "10/15 Knowledge bundle conformance"
+echo "10/16 Knowledge bundle conformance"
 if KNOWLEDGE_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/test-knowledge-okf.sh" 2>&1
 )"; then
@@ -116,7 +116,7 @@ else
 fi
 
 # 11. Published crate documentation contract
-echo "11/15 Published crate documentation"
+echo "11/16 Published crate documentation"
 if PUBLISHED_DOCS_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/test-published-crate-docs.sh" 2>&1
 )"; then
@@ -127,7 +127,7 @@ else
 fi
 
 # 12. Capability contract architecture guard (EVE-873)
-echo "12/15 Capability contract guard"
+echo "12/16 Capability contract guard"
 if CAPABILITY_CONTRACT_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-capability-contract.sh" 2>&1
 )"; then
@@ -138,7 +138,7 @@ else
 fi
 
 # 13. Test-support isolation guard (EVE-875)
-echo "13/15 Test-support isolation guard"
+echo "13/16 Test-support isolation guard"
 if TEST_SUPPORT_ISOLATION_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-test-support-isolation.sh" 2>&1
 )"; then
@@ -149,7 +149,7 @@ else
 fi
 
 # 14. Observability isolation guard (EVE-876)
-echo "14/15 Observability isolation guard"
+echo "14/16 Observability isolation guard"
 if OBSERVABILITY_ISOLATION_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-observability-isolation.sh" 2>&1
 )"; then
@@ -159,8 +159,19 @@ else
   fail "observability isolation guard failed"
 fi
 
-# 15. Commit author attribution check
-echo "15/15 Commit author attribution"
+# 15. Agent-record isolation guard (EVE-877)
+echo "15/16 Agent-record isolation guard"
+if AGENT_RECORD_ISOLATION_OUTPUT="$(
+  bash "$PROJECT_ROOT/scripts/lib/check-agent-record-isolation.sh" 2>&1
+)"; then
+  pass "$AGENT_RECORD_ISOLATION_OUTPUT"
+else
+  printf '%s\n' "$AGENT_RECORD_ISOLATION_OUTPUT" | sed 's/^/   /'
+  fail "agent-record isolation guard failed"
+fi
+
+# 16. Commit author attribution check
+echo "16/16 Commit author attribution"
 if ! resolve_commit_git_identity; then
   fail "commit identity invalid — fix git config or set GIT_USER_NAME/GIT_USER_EMAIL to a real user"
 elif OFFENDING_COMMIT="$(find_agent_like_outgoing_commit)"; then


### PR DESCRIPTION
## Summary

Agent persistence and lifecycle become a platform concern; the execution kernel receives the resolved execution snapshot, never a stored record.

- Stored `Agent`/`AgentVersion` records, `AgentStatus`, `AgentVersionChangeKind`, and name/ID validation move to `crates/platform/src/agent.rs`, with new seam methods: `Agent::definition()`, `Agent::execution_definition()` (fails archived/deleted), `Agent::dependency_blocker()`.
- New portable `AgentDefinition` in core (`agent_definition.rs`) carries authored execution configuration only. Core's `AgentStore` returns `AgentDefinition` plus a `get_agent_blocker` probe; agent lifecycle validation moves out of `ResolvedExecutionSnapshot::project` to the loading seam. Overlay, runtime-context, subagent-delegation and in-memory stores all consume `AgentDefinition`.
- Worker adapters (direct and gRPC) still transport the stored platform record between server and worker, but project via `execution_definition()` before anything reaches host/engine; `WorkerRuntimeHost::load_resolved_turn` projects before building the snapshot.
- Server: `DbAgentStore` hydrates then projects at the seam; ~25 files retarget to `everruns_platform` types; `session_commands` carries `AgentDefinition`; scoped-MCP and message-filter resolution use status-agnostic `definition()` projection, preserving historic behavior.
- `internal-protocol` retargets protobuf conversions to the platform record — wire shapes unchanged.

REST/gRPC JSON/protobuf shapes and stored schema are preserved; `docs/api/openapi.json` regenerates byte-identical. CHANGELOG carries the 0.18 breaking-change note for direct core consumers.

## Guards

New `scripts/lib/check-agent-record-isolation.sh` (pre-push step + `agent-record-isolation` CI job): source and `cargo tree` checks keep platform Agent records out of core/engine/provider/capability crates — kernel crates consume `AgentDefinition` only.

## Testing

`just pre-push` green (16/16). Core 2351 tests, server `--lib` 2117, plus platform, internal-protocol, host, worker (including a new archived/deleted-fails-at-loading-seam parity test), local, and facade suites green. Push-gated `workflow_test.rs` compiles with unchanged REST shapes. PostgreSQL-backed integration suites compile and run in CI.

Fixes EVE-877

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_