### PR TITLE
refactor(providers): remove provider crates' direct dependency on core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,25 @@ jobs:
       - name: Check agent-record isolation
         run: bash scripts/lib/check-agent-record-isolation.sh
 
+  # Architecture guard (EVE-874): official wire-protocol provider crates build
+  # on the provider SPI (everruns-provider) alone — no direct core, host,
+  # platform, or server dependency on any edge kind, and no heavy core
+  # feature subtree in provider-only builds.
+  provider-isolation:
+    name: Provider Isolation Guard
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Check provider isolation
+        run: bash scripts/lib/check-provider-isolation.sh
+
   migration-immutability:
     name: Migration Immutability
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,7 +2426,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "eventsource-stream",
- "everruns-core",
  "everruns-provider",
  "futures",
  "reqwest 0.13.4",
@@ -2643,7 +2642,6 @@ version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-core",
  "everruns-provider",
  "futures",
  "reqwest 0.13.4",
@@ -2658,7 +2656,6 @@ name = "everruns-gemini"
 version = "0.17.26"
 dependencies = [
  "async-trait",
- "everruns-core",
  "everruns-provider",
  "futures",
  "reqwest 0.13.4",
@@ -2993,7 +2990,6 @@ version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-core",
  "everruns-provider",
  "futures",
  "reqwest 0.13.4",
@@ -3063,7 +3059,6 @@ version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-core",
  "everruns-provider",
  "reqwest 0.13.4",
  "serde",
@@ -3079,7 +3074,6 @@ version = "0.17.26"
 dependencies = [
  "async-trait",
  "chrono",
- "everruns-core",
  "everruns-provider",
  "futures",
  "reqwest 0.13.4",

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -1,5 +1,5 @@
 # Anthropic Provider Implementation
-# Decision: Implements the core LlmProvider trait for Claude API
+# Decision: Implements the everruns-provider ChatDriver contract for the Claude API
 # Decision: Uses Anthropic's messages API with streaming support
 
 [package]
@@ -40,14 +40,12 @@ chrono.workspace = true
 tracing.workspace = true
 
 # Internal dependencies
-# default-features = false sheds core's heavy optional subtrees
-# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
-# need, keeping the standalone crate's dependency tree small.
+# Provider SPI only (EVE-874): wire-protocol crates never depend on
+# everruns-core. Intentional optional features of everruns-provider (`openapi`
+# schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
 everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
-# Integration tests use core's in-memory runtime + llmsim harness.
-everruns-core = { path = "../core" }
 tokio = { workspace = true, features = ["full", "test-util"] }
 # wiremock serves the golden streaming SSE fixtures; futures drains the stream.
 wiremock = "0.6"

--- a/crates/anthropic/src/lib.rs
+++ b/crates/anthropic/src/lib.rs
@@ -1,10 +1,10 @@
 //! Anthropic Claude provider driver for Everruns.
 //!
 //! `everruns-anthropic` is part of the [Everruns](https://everruns.com)
-//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-core` and
+//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-provider` and
 //! registers Anthropic's Messages API driver into a [`DriverRegistry`].
 //!
-//! Provider crates depend on `everruns-core`; `everruns-core` does not depend on
+//! Provider crates depend on `everruns-provider`; the provider SPI does not depend on
 //! provider implementations. Hosts register whichever drivers they want to make
 //! available.
 //!

--- a/crates/anthropic/tests/chat_wire.rs
+++ b/crates/anthropic/tests/chat_wire.rs
@@ -11,7 +11,7 @@
 // cache-exclusive), so `prompt_tokens` passes through unchanged.
 
 use everruns_anthropic::AnthropicChatDriver;
-use everruns_core::driver_registry::{
+use everruns_provider::driver_registry::{
     LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole, LlmResponseStream,
     LlmStreamEvent,
 };

--- a/crates/anthropic/tests/parallel_tool_calls_live.rs
+++ b/crates/anthropic/tests/parallel_tool_calls_live.rs
@@ -11,8 +11,8 @@
 //!   `doppler run -- cargo test -p everruns-anthropic --test parallel_tool_calls_live -- --ignored --nocapture`
 
 use everruns_anthropic::provider;
-use everruns_core::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole};
-use everruns_core::tool_types::{
+use everruns_provider::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole};
+use everruns_provider::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
 };
 

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -36,9 +36,9 @@ tracing.workspace = true
 
 # Internal dependencies
 base64.workspace = true
-# default-features = false sheds core's heavy optional subtrees
-# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
-# need, keeping the standalone crate's dependency tree small.
+# Provider SPI only (EVE-874): wire-protocol crates never depend on
+# everruns-core. Intentional optional features of everruns-provider (`openapi`
+# schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
 everruns-provider = { path = "../provider", version = "0.17.26" }
 
 # AWS SDK for Bedrock Runtime

--- a/crates/bedrock/src/lib.rs
+++ b/crates/bedrock/src/lib.rs
@@ -1,6 +1,6 @@
 //! AWS Bedrock Runtime provider driver for Everruns.
 //!
-//! `everruns-bedrock` implements the [`ChatDriver`] contract from `everruns-core`
+//! `everruns-bedrock` implements the [`ChatDriver`] contract from `everruns-provider`
 //! using the AWS Bedrock Runtime `ConverseStream` API.
 //! It is part of the [Everruns](https://everruns.com) ecosystem and pairs with
 //! the application-facing `everruns` crate.

--- a/crates/fireworks/Cargo.toml
+++ b/crates/fireworks/Cargo.toml
@@ -1,8 +1,8 @@
 # Fireworks AI Provider Implementation
 # Decision: Fireworks AI serves open models (Llama, Qwen, DeepSeek, GLM, Kimi,
 # gpt-oss, ...) behind an OpenAI-compatible Chat Completions API. This crate
-# wraps the core Chat Completions protocol driver and adds Fireworks-specific
-# model discovery, which advertises rich capability metadata (supports_chat,
+# wraps the shared everruns-provider Chat Completions protocol driver and adds
+# Fireworks-specific model discovery, which advertises rich capability metadata (supports_chat,
 # supports_tools, supports_image_input, context_length).
 
 [package]
@@ -32,15 +32,14 @@ serde_json.workspace = true
 chrono.workspace = true
 
 # Internal dependencies
-# default-features = false sheds core's heavy optional subtrees
-# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
-# need, keeping the dependency tree small. No version pin: this crate is not in
-# the publish set, so it follows the unpublished-crate convention (path only).
+# Provider SPI only (EVE-874): wire-protocol crates never depend on
+# everruns-core. Intentional optional features of everruns-provider (`openapi`
+# schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
+# No version pin: this crate is not in the publish set, so it follows the
+# unpublished-crate convention (path only).
 everruns-provider = { path = "../provider" }
 
 [dev-dependencies]
-# Integration tests use core's in-memory runtime + llmsim harness.
-everruns-core = { path = "../core" }
 # tokio powers `#[tokio::test]`; wiremock captures discovery requests;
 # futures drains the chat stream.
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/fireworks/src/lib.rs
+++ b/crates/fireworks/src/lib.rs
@@ -1,7 +1,7 @@
 //! Fireworks AI provider driver for Everruns.
 //!
 //! `everruns-fireworks` is part of the [Everruns](https://everruns.com)
-//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-core`
+//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-provider`
 //! and registers the Fireworks AI provider into a [`DriverRegistry`].
 //!
 //! [Fireworks AI](https://fireworks.ai) serves open models (Llama, Qwen,

--- a/crates/fireworks/tests/chat_live.rs
+++ b/crates/fireworks/tests/chat_live.rs
@@ -8,8 +8,10 @@
 //! Ignored by default (requires network + `FIREWORKS_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-fireworks --test chat_live -- --ignored --nocapture`
 
-use everruns_core::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent};
 use everruns_fireworks::provider;
+use everruns_provider::driver_registry::{
+    LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent,
+};
 use futures::StreamExt;
 
 const LIVE_MODEL: &str = "accounts/fireworks/models/gpt-oss-120b";

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -1,5 +1,5 @@
 # Google Gemini Provider Implementation
-# Decision: Implements the core LlmDriver trait for Google Gemini API
+# Decision: Implements the everruns-provider ChatDriver contract for the Google Gemini API
 # Decision: Uses Gemini's generateContent API with streaming support
 
 [package]
@@ -36,15 +36,12 @@ serde_json.workspace = true
 tracing.workspace = true
 
 # Internal dependencies
-# default-features = false sheds core's heavy optional subtrees
-# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
-# need, keeping the standalone crate's dependency tree small.
+# Provider SPI only (EVE-874): wire-protocol crates never depend on
+# everruns-core. Intentional optional features of everruns-provider (`openapi`
+# schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
 everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
-# Integration tests + the inline driver test use core's runtime harness
-# and FileSystemCapability tool definitions.
-everruns-core = { path = "../core" }
 tokio = { workspace = true, features = ["full", "test-util"] }
 # wiremock serves the golden streaming SSE fixtures; futures drains the stream.
 wiremock = "0.6"

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -1112,8 +1112,6 @@ struct GeminiModelInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::FileSystemCapability;
-    use everruns_core::capabilities::Capability;
     use everruns_provider::driver_registry::ChatDriver;
 
     #[test]
@@ -1366,9 +1364,90 @@ mod tests {
         assert_eq!(prop["type"], "boolean");
     }
 
+    /// Builds filesystem-style tool definitions mirroring the schema shapes the
+    /// session filesystem capability produces (nested `additionalProperties`
+    /// inside array items and sub-objects). Kept as an in-crate fixture so this
+    /// wire-protocol crate stays decoupled from capability implementations
+    /// (EVE-874); capability identity/authoring lives in `everruns-capability`.
+    fn filesystem_style_tools() -> Vec<ToolDefinition> {
+        use everruns_provider::tool_types::{BuiltinTool, DeferrablePolicy, ToolHints, ToolPolicy};
+
+        let builtin = |name: &str, parameters: Value| {
+            ToolDefinition::Builtin(BuiltinTool {
+                name: name.to_string(),
+                display_name: None,
+                description: format!("{name} tool"),
+                parameters,
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
+                hints: ToolHints::default(),
+                full_parameters: None,
+            })
+        };
+
+        vec![
+            builtin(
+                "read_file",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string" },
+                        "offset": { "type": "integer", "default": 0, "minimum": 0 },
+                        "limit": { "type": "integer", "default": 2000, "minimum": 1 }
+                    },
+                    "required": ["path"],
+                    "additionalProperties": false
+                }),
+            ),
+            builtin(
+                "edit_file",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string" },
+                        "expected_hash": { "type": "string" },
+                        "edits": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "old_text": { "type": "string" },
+                                    "new_text": { "type": "string" }
+                                },
+                                "required": ["old_text", "new_text"],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": ["path", "expected_hash", "edits"],
+                    "additionalProperties": false
+                }),
+            ),
+            builtin(
+                "grep_files",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "pattern": { "type": "string" },
+                        "options": {
+                            "type": "object",
+                            "properties": {
+                                "case_insensitive": { "type": "boolean" }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": ["pattern"],
+                    "additionalProperties": false
+                }),
+            ),
+        ]
+    }
+
     #[test]
-    fn test_convert_file_system_capability_strips_nested_additional_properties() {
-        let tools = FileSystemCapability.tool_definitions();
+    fn test_convert_filesystem_style_tools_strips_nested_additional_properties() {
+        let tools = filesystem_style_tools();
         let gemini_tools = GeminiChatDriver::convert_tools(&tools).unwrap();
 
         fn assert_no_additional_properties(v: &Value) {

--- a/crates/gemini/src/lib.rs
+++ b/crates/gemini/src/lib.rs
@@ -1,7 +1,7 @@
 //! Google Gemini LLM provider driver for Everruns.
 //!
 //! `everruns-gemini` is part of the [Everruns](https://everruns.com) ecosystem.
-//! It implements the `ChatDriver` contract from `everruns-core`, so the agent
+//! It implements the `ChatDriver` contract from `everruns-provider`, so the agent
 //! loop can run against Google's Gemini API, and registers itself through
 //! [`register_driver`].
 //!

--- a/crates/gemini/tests/chat_wire.rs
+++ b/crates/gemini/tests/chat_wire.rs
@@ -11,11 +11,11 @@
 // stream by closing the connection (no `[DONE]` marker), which the driver's
 // finish handling collapses into a single terminal `Done` event.
 
-use everruns_core::driver_registry::{
+use everruns_gemini::GeminiChatDriver;
+use everruns_provider::driver_registry::{
     LlmCallConfig, LlmCompletionMetadata, LlmMessage, LlmMessageRole, LlmResponseStream,
     LlmStreamEvent,
 };
-use everruns_gemini::GeminiChatDriver;
 use everruns_provider::{Provider, StaticHeaderAuth};
 use futures::StreamExt;
 use wiremock::matchers::{method, path_regex};

--- a/crates/mai/Cargo.toml
+++ b/crates/mai/Cargo.toml
@@ -1,8 +1,9 @@
 # Microsoft MAI Provider Implementation
 # Decision: Microsoft MAI models (e.g. MAI-Code-1-Flash) are served via Azure AI
 # Foundry behind an OpenAI-compatible Chat Completions API. This crate wraps the
-# core Chat Completions protocol driver and adds a pluggable, OAuth-capable auth
-# layer (Azure AI Foundry API key or Microsoft Entra ID client-credentials).
+# shared everruns-provider Chat Completions protocol driver and adds a pluggable,
+# OAuth-capable auth layer (Azure AI Foundry API key or Microsoft Entra ID
+# client-credentials).
 
 [package]
 name = "everruns-mai"
@@ -37,15 +38,14 @@ chrono.workspace = true
 tracing.workspace = true
 
 # Internal dependencies
-# default-features = false sheds core's heavy optional subtrees
-# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
-# need, keeping the dependency tree small. No version pin: this crate is not in
-# the publish set, so it follows the unpublished-crate convention (path only).
+# Provider SPI only (EVE-874): wire-protocol crates never depend on
+# everruns-core. Intentional optional features of everruns-provider (`openapi`
+# schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
+# No version pin: this crate is not in the publish set, so it follows the
+# unpublished-crate convention (path only).
 everruns-provider = { path = "../provider" }
 
 [dev-dependencies]
-# Integration tests use core's in-memory runtime + llmsim harness.
-everruns-core = { path = "../core" }
 # tokio powers `#[tokio::test]`; wiremock captures driver/token requests;
 # futures drains the chat stream.
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/mai/src/lib.rs
+++ b/crates/mai/src/lib.rs
@@ -1,7 +1,7 @@
 //! Microsoft MAI provider driver for Everruns.
 //!
 //! `everruns-mai` is part of the [Everruns](https://everruns.com) ecosystem. It
-//! implements the [`ChatDriver`] contract from `everruns-core` and registers a
+//! implements the [`ChatDriver`] contract from `everruns-provider` and registers a
 //! Microsoft MAI provider (e.g. `mai-code-1-flash`) into a [`DriverRegistry`].
 //!
 //! Microsoft MAI models are served via [Azure AI Foundry](https://ai.azure.com)

--- a/crates/mai/tests/chat_wire.rs
+++ b/crates/mai/tests/chat_wire.rs
@@ -11,12 +11,12 @@
 //   2. Microsoft Entra ID OAuth  -> a token is minted from the (mocked) token
 //      endpoint and applied as `Authorization: Bearer <token>`.
 
-use everruns_core::DriverRegistry;
-use everruns_core::driver_registry::{
+use everruns_mai::{EntraOAuthConfig, MaiAuth, provider, register_driver};
+use everruns_provider::DriverRegistry;
+use everruns_provider::ProviderEndpoint;
+use everruns_provider::driver_registry::{
     ChatDriver, DriverId, LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent, ProviderConfig,
 };
-use everruns_mai::{EntraOAuthConfig, MaiAuth, provider, register_driver};
-use everruns_provider::ProviderEndpoint;
 use futures::StreamExt;
 use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -55,7 +55,7 @@ fn sse_chat_response() -> String {
     .join("\n")
 }
 
-async fn drain_text(mut stream: everruns_core::driver_registry::LlmResponseStream) -> String {
+async fn drain_text(mut stream: everruns_provider::driver_registry::LlmResponseStream) -> String {
     let mut text = String::new();
     while let Some(event) = stream.next().await {
         match event.expect("stream item should not be a transport error") {

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -21,6 +21,9 @@ async-trait.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+# Provider SPI only (EVE-874): wire-protocol crates never depend on
+# everruns-core. Intentional optional features of everruns-provider (`openapi`
+# schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
 everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -1,5 +1,5 @@
 # OpenAI Provider Implementation
-# Decision: Implements the core LlmProvider trait for OpenAI API
+# Decision: Implements the everruns-provider ChatDriver contract for the OpenAI API
 # Decision: Uses OpenAI's chat completion API with streaming support
 
 [package]
@@ -38,13 +38,11 @@ chrono.workspace = true
 tracing.workspace = true
 
 # Internal dependencies
-# default-features = false sheds core's heavy optional subtrees
-# (telemetry/OTLP, a2a gRPC, web-fetch/fetchkit) that this provider does not
-# need, keeping the standalone crate's dependency tree small.
+# Provider SPI only (EVE-874): wire-protocol crates never depend on
+# everruns-core. Intentional optional features of everruns-provider (`openapi`
+# schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
 everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
-# Integration tests use core's in-memory runtime + llmsim harness.
-everruns-core = { path = "../core" }
 tokio = { workspace = true, features = ["full", "test-util"] }
 wiremock = "0.6"

--- a/crates/openai/src/lib.rs
+++ b/crates/openai/src/lib.rs
@@ -1,7 +1,7 @@
 //! OpenAI provider drivers for Everruns.
 //!
 //! `everruns-openai` is part of the [Everruns](https://everruns.com)
-//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-core` and
+//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-provider` and
 //! registers OpenAI providers into a [`DriverRegistry`].
 //!
 //! The crate exposes two drivers:

--- a/crates/openai/src/types.rs
+++ b/crates/openai/src/types.rs
@@ -1,7 +1,7 @@
 // OpenAI Protocol Types
 //
 // These types are kept for backward compatibility with existing code.
-// The actual implementation is now in everruns-core/src/openai.rs.
+// The actual implementation is now in everruns-provider/src/openai_protocol.rs.
 
 use everruns_provider::{ToolCall, ToolDefinition};
 use serde::{Deserialize, Serialize};

--- a/crates/openai/tests/parallel_tool_calls_live.rs
+++ b/crates/openai/tests/parallel_tool_calls_live.rs
@@ -9,11 +9,11 @@
 //! Ignored by default (requires network + `OPENAI_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-openai --test parallel_tool_calls_live -- --ignored --nocapture`
 
-use everruns_core::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole};
-use everruns_core::tool_types::{
+use everruns_openai::provider;
+use everruns_provider::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole};
+use everruns_provider::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
 };
-use everruns_openai::provider;
 
 const LIVE_MODEL: &str = "gpt-4o-mini";
 

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -1,5 +1,5 @@
 # OpenRouter Provider Implementation
-# Decision: Wraps the core Open Responses protocol driver with OpenRouter's
+# Decision: Wraps the shared everruns-provider Open Responses protocol driver with OpenRouter's
 # OpenAI-compatible Responses API and richer `/models` discovery metadata.
 
 [package]
@@ -31,14 +31,12 @@ serde_json.workspace = true
 chrono.workspace = true
 
 # Internal dependencies
-# default-features = false sheds core's heavy optional subtrees (telemetry/OTLP,
-# a2a gRPC, web-fetch/fetchkit) that an OpenRouter provider does not need. This
-# is what keeps the standalone `everruns-openrouter` dependency tree small.
+# Provider SPI only (EVE-874): wire-protocol crates never depend on
+# everruns-core. Intentional optional features of everruns-provider (`openapi`
+# schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
 everruns-provider = { path = "../provider", version = "0.17.26" }
 
 [dev-dependencies]
-# Integration tests use core's in-memory runtime + llmsim harness.
-everruns-core = { path = "../core" }
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures
 # drains the live chat stream.
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/src/lib.rs
+++ b/crates/openrouter/src/lib.rs
@@ -1,7 +1,7 @@
 //! OpenRouter provider driver for Everruns.
 //!
 //! `everruns-openrouter` is part of the [Everruns](https://everruns.com)
-//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-core`
+//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-provider`
 //! and registers the OpenRouter provider into a [`DriverRegistry`].
 //!
 //! OpenRouter exposes an OpenAI-compatible Responses API, so [`OpenRouterChatDriver`]

--- a/crates/openrouter/tests/chat_live.rs
+++ b/crates/openrouter/tests/chat_live.rs
@@ -9,11 +9,11 @@
 //! Ignored by default (requires network + `OPENROUTER_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-openrouter --test chat_live -- --ignored --nocapture`
 
-use everruns_core::driver_registry::{
+use everruns_openrouter::provider;
+use everruns_provider::driver_registry::{
     LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent, OpenRouterRoute,
     OpenRouterRoutingConfig,
 };
-use everruns_openrouter::provider;
 use futures::StreamExt;
 
 #[tokio::test]

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -6,14 +6,14 @@
 // fields onto the outgoing body. A wiremock server captures the request so we can
 // assert the exact JSON sent.
 
-use everruns_core::driver_registry::{
+use everruns_openrouter::OpenRouterChatDriver;
+use everruns_provider::driver_registry::{
     LlmCallConfig, LlmMessage, LlmMessageRole, OpenRouterDataCollection, OpenRouterMaxPrice,
     OpenRouterPluginConfig, OpenRouterProviderRouting, OpenRouterProviderSort,
     OpenRouterProviderSortBy, OpenRouterProviderSortOptions, OpenRouterRoute,
     OpenRouterRoutingConfig, OpenRouterServerTool, OpenRouterServerToolKind,
     OpenRouterSortPartition, OpenRouterWebSearchPlugin,
 };
-use everruns_openrouter::OpenRouterChatDriver;
 use everruns_provider::{BearerAuth, Provider};
 use serde_json::json;
 use wiremock::matchers::method;
@@ -349,10 +349,10 @@ async fn retries_after_openrouter_rate_limit_reset() {
     let mut text = String::new();
     while let Some(event) = stream.next().await {
         match event.expect("stream item") {
-            everruns_core::driver_registry::LlmStreamEvent::TextDelta(delta) => {
+            everruns_provider::driver_registry::LlmStreamEvent::TextDelta(delta) => {
                 text.push_str(&delta)
             }
-            everruns_core::driver_registry::LlmStreamEvent::Error(error) => {
+            everruns_provider::driver_registry::LlmStreamEvent::Error(error) => {
                 panic!("retry success stream should not emit an error: {error}")
             }
             _ => {}

--- a/crates/worker/src/adapters.rs
+++ b/crates/worker/src/adapters.rs
@@ -115,3 +115,37 @@ pub fn create_chat_driver(
     let registry = create_driver_registry();
     registry.create_chat_driver(&config)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The product's default platform composition must register every official
+    /// provider driver (EVE-874). Protocol drivers live in provider crates on
+    /// the everruns-provider SPI; the worker is the composition point that
+    /// assembles them into the default product registry, so a provider crate
+    /// dropping out of the assembly fails here.
+    #[test]
+    fn default_registry_registers_all_official_providers() {
+        let registry = create_driver_registry();
+        let official = [
+            DriverId::OpenAI,
+            DriverId::OpenAICompletions,
+            DriverId::OpenRouter,
+            DriverId::Mai,
+            DriverId::Fireworks,
+            DriverId::Meta,
+            DriverId::Anthropic,
+            DriverId::Gemini,
+            DriverId::Bedrock,
+            // Seeded simulation driver (test-support `sim` surface).
+            DriverId::LlmSim,
+        ];
+        for id in official {
+            assert!(
+                registry.has_driver(&id),
+                "default product registry is missing official driver {id:?}"
+            );
+        }
+    }
+}

--- a/knowledge/foundations/code-organization.md
+++ b/knowledge/foundations/code-organization.md
@@ -68,10 +68,17 @@ protocol drivers, model profiles, retry/stream helpers, typed IDs, the
 credential form schema, and the LLM error taxonomy). It carries none of core's
 heavy subtrees (`a2a` gRPC, web-fetch/fetchkit), so a
 standalone provider build never pulls them in. A provider is therefore a pure
-`ChatDriver` implementation with no dependency on core's agent-loop runtime;
-provider crates keep `everruns-core` (and, where needed,
-`everruns-test-support` for the in-memory runtime + `llmsim` harness) only as
-**dev-dependencies**.
+`ChatDriver` implementation with no dependency on core's agent-loop runtime.
+Since EVE-874 provider crates carry **no** `everruns-core` edge at all — not
+even as a dev-dependency; wire-level tests build their fixtures in-crate, and
+`scripts/lib/check-provider-isolation.sh` (pre-push + CI) rejects a direct
+core/host/platform/server dependency on any edge kind, plus any heavy core
+feature subtree (sqlx/utoipa/inventory/axum/tonic) in provider-only shipped
+trees. Default-product registration stays a composition concern: the worker
+(`crates/worker/src/adapters.rs`) assembles all official drivers into the
+product registry, and downstream providers register through the open
+`DriverRegistry` seams alone (see
+`tests/fixtures/external-consumer/provider-pack/`).
 
 Deterministic simulation and demo fixtures live in `everruns-test-support`
 (EVE-875): the `llmsim` driver, the in-memory agentic loop, mock test doubles,

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,16 @@
 
 ## 2026-08-11
 
+* **Provider SPI separation completed**: Official wire-protocol provider
+  crates no longer depend on `everruns-core` on any edge kind — the last
+  dev-dependencies were removed and their tests now build fixtures in-crate
+  (EVE-874). A new architecture guard
+  (`scripts/lib/check-provider-isolation.sh`, pre-push + CI) forbids direct
+  core/host/platform/server dependencies from provider crates and keeps heavy
+  core feature subtrees out of provider-only builds; a downstream provider
+  fixture proves custom drivers compile against `everruns-provider` alone.
+  Updated code-organization.
+
 * **Agent record extraction**: Moved the stored `Agent` and `AgentVersion`
   persistence records — lifecycle status, versioning and publication metadata,
   fork lineage, public-name validation, and persistence helpers — out of

--- a/scripts/lib/check-provider-isolation.sh
+++ b/scripts/lib/check-provider-isolation.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Architecture guard (EVE-874): official wire-protocol provider crates build on
+# the provider SPI (`everruns-provider`) and the neutral capability contract
+# alone — never on the monolithic kernel or product composition crates:
+#
+# 1. Provider crate sources (src/ AND tests/ — dev code included) must not
+#    import everruns_core, everruns_host, everruns_platform, or
+#    everruns_server.
+# 2. Provider crate manifests must not declare a direct everruns-core /
+#    everruns-host / everruns-platform / everruns-server dependency on any
+#    edge kind (normal, build, or dev).
+# 3. `cargo tree` for each provider crate must be free of those crates on
+#    every edge kind, so provider-only builds never compile the kernel.
+# 4. Provider-only shipped trees must not pull core's heavy feature subtrees:
+#    no sqlx, utoipa, inventory, axum, or tonic in normal edges. (The
+#    provider SPI's `sqlx`/`openapi` features are intentional, documented
+#    opt-ins that provider crates leave off.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+FAILED=0
+
+PROVIDER_DIRS=(
+  crates/openai
+  crates/anthropic
+  crates/openrouter
+  crates/gemini
+  crates/bedrock
+  crates/mai
+  crates/fireworks
+  crates/meta
+)
+PROVIDER_CRATES=(
+  everruns-openai
+  everruns-anthropic
+  everruns-openrouter
+  everruns-gemini
+  everruns-bedrock
+  everruns-mai
+  everruns-fireworks
+  everruns-meta
+)
+FORBIDDEN_TREE='^(everruns-core|everruns-host|everruns-platform|everruns-server) '
+HEAVY_TREE='^(sqlx|utoipa|inventory|axum|tonic) '
+
+# 1. No kernel/product imports anywhere in provider crates (tests included —
+#    dev-only coupling is exactly what EVE-874 removed).
+SOURCE_PATTERN='(everruns_core|everruns_host|everruns_platform|everruns_server)::'
+if matches=$(grep -rnE "$SOURCE_PATTERN" "${PROVIDER_DIRS[@]}" --include='*.rs' 2>/dev/null); then
+  echo "Provider protocol crates must not import core/host/platform/server (EVE-874):"
+  echo "$matches"
+  FAILED=1
+fi
+
+# 2. Manifests: no direct dependency declarations on the forbidden crates
+#    (any section — [dependencies], [dev-dependencies], [build-dependencies]).
+for dir in "${PROVIDER_DIRS[@]}"; do
+  if matches=$(grep -nE '^[[:space:]]*everruns-(core|host|platform|server)[[:space:]]*[.=]' "$dir/Cargo.toml" 2>/dev/null); then
+    echo "$dir/Cargo.toml must not declare a core/host/platform/server dependency (EVE-874):"
+    echo "$matches"
+    FAILED=1
+  fi
+done
+
+# 3. Dependency trees: forbidden crates absent on every edge kind, so
+#    `cargo test -p <provider>` never builds the kernel.
+for crate in "${PROVIDER_CRATES[@]}"; do
+  tree=$(cargo tree -p "$crate" --edges normal,build,dev --prefix none 2>/dev/null)
+  if echo "$tree" | grep -qE "$FORBIDDEN_TREE"; then
+    echo "$crate must not depend on core/host/platform/server (any edge kind):"
+    echo "$tree" | grep -E "$FORBIDDEN_TREE" | sort -u
+    FAILED=1
+  fi
+done
+
+# 4. Shipped (normal-edge) trees: no heavy core feature subtree leaks into
+#    provider-only builds.
+for crate in "${PROVIDER_CRATES[@]}"; do
+  tree=$(cargo tree -p "$crate" --edges normal --prefix none 2>/dev/null)
+  if echo "$tree" | grep -qE "$HEAVY_TREE"; then
+    echo "$crate must not ship heavy core feature subtrees (sqlx/utoipa/inventory/axum/tonic):"
+    echo "$tree" | grep -E "$HEAVY_TREE" | sort -u
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "Provider isolation guard failed. Wire-protocol crates build on everruns-provider alone (EVE-874)."
+  exit 1
+fi
+
+echo "Provider isolation guard passed: provider crates depend on the provider SPI, not core/host/platform/server."

--- a/scripts/lib/pre-push.sh
+++ b/scripts/lib/pre-push.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Pre-push checks: fast local validation to catch CI failures early (~30s).
-# Runs formatting, linting, lockfile, migration, test/example enumeration, knowledge, capability-contract, test-support-isolation, observability-isolation, and attribution checks.
+# Runs formatting, linting, lockfile, migration, test/example enumeration, knowledge, capability-contract, test-support-isolation, observability-isolation, agent-record-isolation, provider-isolation, and attribution checks.
 # Usage: just pre-push (or: bash scripts/lib/pre-push.sh)
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
@@ -13,7 +13,7 @@ echo "🔒 Running pre-push checks..."
 echo ""
 
 # 1. Rust formatting
-echo "1/16 Rust formatting"
+echo "1/17 Rust formatting"
 if cargo fmt --check 2>/dev/null; then
   pass "cargo fmt"
 else
@@ -21,7 +21,7 @@ else
 fi
 
 # 2. Clippy
-echo "2/16 Rust linting"
+echo "2/17 Rust linting"
 if cargo clippy --all-targets --all-features -- -D warnings 2>/dev/null; then
   pass "clippy"
 else
@@ -29,7 +29,7 @@ else
 fi
 
 # 3. Cargo.lock freshness
-echo "3/16 Cargo.lock freshness"
+echo "3/17 Cargo.lock freshness"
 if cargo fetch --locked 2>/dev/null; then
   pass "Cargo.lock up to date"
 else
@@ -37,7 +37,7 @@ else
 fi
 
 # 4. UI formatting (skip if node_modules missing)
-echo "4/16 UI formatting"
+echo "4/17 UI formatting"
 if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && pnpm run format:check 2>/dev/null); then
     pass "UI format"
@@ -49,7 +49,7 @@ else
 fi
 
 # 5. UI linting (skip if node_modules missing)
-echo "5/16 UI linting"
+echo "5/17 UI linting"
 if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && pnpm run lint 2>/dev/null); then
     pass "UI lint"
@@ -61,7 +61,7 @@ else
 fi
 
 # 6. Migration ordering check
-echo "6/16 Migration ordering"
+echo "6/17 Migration ordering"
 if MIGRATION_ORDERING_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-migration-ordering.sh" 2>&1
 )"; then
@@ -72,7 +72,7 @@ else
 fi
 
 # 7. Migration immutability check
-echo "7/16 Migration immutability"
+echo "7/17 Migration immutability"
 if MIGRATION_IMMUTABILITY_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-migration-immutability.sh" 2>&1
 )"; then
@@ -83,7 +83,7 @@ else
 fi
 
 # 8. Server integration test enumeration
-echo "8/16 Server test enumeration"
+echo "8/17 Server test enumeration"
 if SERVER_TEST_ENUM_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-server-test-enumeration.sh" 2>&1
 )"; then
@@ -94,7 +94,7 @@ else
 fi
 
 # 9. Public everruns example inventory and compile check
-echo "9/16 Public everruns examples"
+echo "9/17 Public everruns examples"
 if EVERRUNS_EXAMPLES_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-everruns-examples.sh" 2>&1
 )"; then
@@ -105,7 +105,7 @@ else
 fi
 
 # 10. Knowledge bundle conformance
-echo "10/16 Knowledge bundle conformance"
+echo "10/17 Knowledge bundle conformance"
 if KNOWLEDGE_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/test-knowledge-okf.sh" 2>&1
 )"; then
@@ -116,7 +116,7 @@ else
 fi
 
 # 11. Published crate documentation contract
-echo "11/16 Published crate documentation"
+echo "11/17 Published crate documentation"
 if PUBLISHED_DOCS_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/test-published-crate-docs.sh" 2>&1
 )"; then
@@ -127,7 +127,7 @@ else
 fi
 
 # 12. Capability contract architecture guard (EVE-873)
-echo "12/16 Capability contract guard"
+echo "12/17 Capability contract guard"
 if CAPABILITY_CONTRACT_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-capability-contract.sh" 2>&1
 )"; then
@@ -138,7 +138,7 @@ else
 fi
 
 # 13. Test-support isolation guard (EVE-875)
-echo "13/16 Test-support isolation guard"
+echo "13/17 Test-support isolation guard"
 if TEST_SUPPORT_ISOLATION_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-test-support-isolation.sh" 2>&1
 )"; then
@@ -149,7 +149,7 @@ else
 fi
 
 # 14. Observability isolation guard (EVE-876)
-echo "14/16 Observability isolation guard"
+echo "14/17 Observability isolation guard"
 if OBSERVABILITY_ISOLATION_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-observability-isolation.sh" 2>&1
 )"; then
@@ -160,7 +160,7 @@ else
 fi
 
 # 15. Agent-record isolation guard (EVE-877)
-echo "15/16 Agent-record isolation guard"
+echo "15/17 Agent-record isolation guard"
 if AGENT_RECORD_ISOLATION_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-agent-record-isolation.sh" 2>&1
 )"; then
@@ -170,8 +170,19 @@ else
   fail "agent-record isolation guard failed"
 fi
 
-# 16. Commit author attribution check
-echo "16/16 Commit author attribution"
+# 16. Provider isolation guard (EVE-874)
+echo "16/17 Provider isolation guard"
+if PROVIDER_ISOLATION_OUTPUT="$(
+  bash "$PROJECT_ROOT/scripts/lib/check-provider-isolation.sh" 2>&1
+)"; then
+  pass "$PROVIDER_ISOLATION_OUTPUT"
+else
+  printf '%s\n' "$PROVIDER_ISOLATION_OUTPUT" | sed 's/^/   /'
+  fail "provider isolation guard failed"
+fi
+
+# 17. Commit author attribution check
+echo "17/17 Commit author attribution"
 if ! resolve_commit_git_identity; then
   fail "commit identity invalid — fix git config or set GIT_USER_NAME/GIT_USER_EMAIL to a real user"
 elif OFFENDING_COMMIT="$(find_agent_like_outgoing_commit)"; then

--- a/scripts/test-external-consumer.sh
+++ b/scripts/test-external-consumer.sh
@@ -9,6 +9,11 @@
 #                             `everruns-capability` contract ALONE (EVE-873),
 #                             so the open capability seams fail here if they
 #                             stop being usable without core/host access.
+#   external-provider-pack    implements the `ChatDriver` contract and driver
+#                             registration against the provider SPI
+#                             (`everruns-provider`) ALONE (EVE-874), so custom
+#                             downstream providers fail here if they stop
+#                             compiling without core/host access.
 #   external-event-log        implements the canonical `EventLog`/`EventReader`
 #                             SPI from `everruns-host` and supplies it to host
 #                             composition, so the SPI fails here if it stops
@@ -42,6 +47,11 @@ CARGO_TARGET_DIR="$TARGET_DIR" RUSTFLAGS="-D warnings" \
   cargo test --quiet --locked --manifest-path "$FIXTURE" -p external-capability-pack
 
 echo "External capability pack builds on the neutral everruns-capability contract under -D warnings."
+
+CARGO_TARGET_DIR="$TARGET_DIR" RUSTFLAGS="-D warnings" \
+  cargo test --quiet --locked --manifest-path "$FIXTURE" -p external-provider-pack
+
+echo "External provider pack builds on the provider SPI (everruns-provider) alone under -D warnings."
 
 CARGO_TARGET_DIR="$TARGET_DIR" RUSTFLAGS="-D warnings" \
   cargo test --quiet --locked --manifest-path "$FIXTURE" -p external-event-log

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -1333,6 +1333,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "external-provider-pack"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "everruns-provider",
+ "futures",
+ "tokio",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/fixtures/external-consumer/Cargo.toml
+++ b/tests/fixtures/external-consumer/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["app", "capability-pack", "event-log"]
+members = ["app", "capability-pack", "event-log", "provider-pack"]

--- a/tests/fixtures/external-consumer/provider-pack/Cargo.toml
+++ b/tests/fixtures/external-consumer/provider-pack/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "external-provider-pack"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# A third-party provider driver built against the provider SPI ALONE
+# (EVE-874): no everruns, no everruns-core, no everruns-host. It implements
+# the `ChatDriver` contract, registers under an external `DriverId`, and
+# streams a scripted completion — proving custom providers need nothing but
+# `everruns-provider`.
+[dependencies]
+async-trait = "0.1"
+everruns-provider = { path = "../../../../crates/provider" }
+futures = "0.3"
+
+[dev-dependencies]
+tokio = { version = "1.50", features = ["macros", "rt-multi-thread"] }

--- a/tests/fixtures/external-consumer/provider-pack/src/lib.rs
+++ b/tests/fixtures/external-consumer/provider-pack/src/lib.rs
@@ -1,0 +1,98 @@
+//! External provider package: implements the `ChatDriver` contract and driver
+//! registration against the provider SPI (`everruns-provider`) only — no
+//! `everruns`, `everruns-core`, or `everruns-host` imports (EVE-874).
+
+use async_trait::async_trait;
+use everruns_provider::driver_registry::{
+    ChatDriver, DriverRegistry, LlmCallConfig, LlmCompletionMetadata, LlmMessage,
+    LlmResponseStream, LlmStreamEvent,
+};
+use everruns_provider::runtime_provider::{Provider, ProviderEndpoint};
+
+/// Canonical wire id of the fixture's external driver.
+pub const ACME_DRIVER_ID: &str = "acme_llm";
+
+/// A scripted downstream chat driver: echoes the last user message back as a
+/// streamed completion. Stands in for a real vendor wire protocol.
+pub struct AcmeChatDriver;
+
+#[async_trait]
+impl ChatDriver for AcmeChatDriver {
+    async fn chat_completion_stream(
+        &self,
+        _endpoint: &ProviderEndpoint,
+        messages: Vec<LlmMessage>,
+        _config: &LlmCallConfig,
+    ) -> everruns_provider::Result<LlmResponseStream> {
+        let last = messages
+            .last()
+            .map(|message| message.content.to_text())
+            .unwrap_or_default();
+        let events = vec![
+            Ok(LlmStreamEvent::TextDelta(format!("acme:{last}"))),
+            Ok(LlmStreamEvent::Done(Box::new(
+                LlmCompletionMetadata::default(),
+            ))),
+        ];
+        Ok(Box::pin(futures::stream::iter(events)))
+    }
+}
+
+/// Register the external driver into a [`DriverRegistry`] through the open
+/// `register_external` seam — the same descriptor machinery the official
+/// provider crates use, with no vendor/service branching in the SPI.
+pub fn register_driver(registry: &mut DriverRegistry) {
+    registry.register_external(ACME_DRIVER_ID, |config| {
+        Provider::new(config.provider.clone(), AcmeChatDriver)
+            .base_url(config.base_url.as_deref().unwrap_or("https://acme.test"))
+            .into_boxed_driver()
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_provider::driver_registry::{DriverId, LlmMessageRole, ProviderConfig};
+
+    fn call_config() -> LlmCallConfig {
+        LlmCallConfig {
+            model: "acme-1".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            speed: None,
+            verbosity: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            provider_opaque_context: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: None,
+            parallel_tool_calls: None,
+            volatile_suffix_len: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn external_driver_registers_and_completes() {
+        let mut registry = DriverRegistry::new();
+        register_driver(&mut registry);
+
+        let id = DriverId::external(ACME_DRIVER_ID);
+        assert!(registry.has_driver(&id));
+
+        let driver = registry
+            .create_chat_driver(&ProviderConfig::new(id))
+            .expect("external driver must be constructible without an api key");
+        let response = driver
+            .chat_completion(
+                &ProviderEndpoint::default(),
+                vec![LlmMessage::text(LlmMessageRole::User, "ping")],
+                &call_config(),
+            )
+            .await
+            .expect("scripted completion succeeds");
+        assert_eq!(response.text, "acme:ping");
+    }
+}


### PR DESCRIPTION
## Summary

Completes the provider SPI separation: all eight official wire-protocol provider crates (OpenAI, Anthropic, OpenRouter, Gemini, Fireworks, MAI, Meta, Bedrock) build on `everruns-provider` alone, with no `everruns-core` dependency on any edge kind.

- The remaining coupling was dev-dependencies and doc drift: openai/anthropic/openrouter/fireworks/mai/gemini drop the `everruns-core` dev-dependency; tests import `everruns_provider::driver_registry`/`tool_types` directly. Meta and Bedrock were already core-free.
- Gemini's `additionalProperties`-stripping test no longer imports `everruns_core::FileSystemCapability` — an in-crate `filesystem_style_tools()` fixture mirrors the session filesystem schemas (same nested shapes), keeping identical coverage; the wire crate carries no capability implementation edge.
- All eight manifests document why `everruns-provider`'s optional features (`openapi`, `sqlx`) stay off. Registration stays per-crate (`register_driver`) with composition in `crates/worker/src/adapters.rs` — no vendor/service branching reintroduced.

## Guards

New `scripts/lib/check-provider-isolation.sh` (pre-push step + `provider-isolation` CI job): forbids `everruns_core/host/platform/server` imports and manifest declarations in provider crates on every dependency section, asserts `cargo tree --edges normal,build,dev` per crate is clean of forbidden edges, and keeps heavy core feature subtrees (sqlx/utoipa/inventory/axum/tonic) out of provider-only shipped trees.

## Testing

All 8 provider crates pass `cargo test -p <crate>` independently. New worker test `default_registry_registers_all_official_providers` covers product composition (9 official drivers + LlmSim). New downstream fixture `tests/fixtures/external-consumer/provider-pack/` proves a custom `ChatDriver` compiles against `everruns-provider` alone under `-D warnings --locked`; the fixture lockfile is regenerated and verified. Multi-identity coverage confirmed via the existing `one_protocol_serves_distinct_provider_identities` test. Rebased onto the EVE-877 merge (guard step/CI job renumbering resolved); `just pre-push` green (17/17).

Fixes EVE-874

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_