### PR TITLE
feat(chats): add chat pinning

### DIFF
--- a/apps/ui/src/__tests__/chat-threads.test.ts
+++ b/apps/ui/src/__tests__/chat-threads.test.ts
@@ -48,6 +48,19 @@ describe("selectChatThreads", () => {
     expect(threads.map((thread) => thread.id)).toEqual(["newest", "middle", "old"]);
   });
 
+  it("keeps pinned threads ahead of newer unpinned threads", () => {
+    const threads = selectChatThreads(
+      [
+        session({ id: "newest", updated_at: "2026-08-09T12:00:00Z" }),
+        session({ id: "pinned-old", updated_at: "2026-08-01T00:00:00Z", is_pinned: true }),
+        session({ id: "pinned-new", updated_at: "2026-08-05T00:00:00Z", is_pinned: true }),
+      ],
+      "user_1",
+    );
+
+    expect(threads.map((thread) => thread.id)).toEqual(["pinned-new", "pinned-old", "newest"]);
+  });
+
   it("drops threads owned by someone else", () => {
     const threads = selectChatThreads(
       [

--- a/apps/ui/src/__tests__/chats-page.test.tsx
+++ b/apps/ui/src/__tests__/chats-page.test.tsx
@@ -5,6 +5,9 @@ import ChatThreadPage from "@/app/(main)/chats/[threadId]/page";
 import { useChatThreads } from "@/hooks/use-chat-threads";
 import type { Session } from "@/lib/api/types";
 
+const mockPinMutate = jest.fn();
+const mockUnpinMutate = jest.fn();
+
 jest.mock("next/link", () => ({
   __esModule: true,
   default: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
@@ -18,6 +21,8 @@ jest.mock("@/hooks/use-chat-threads", () => ({
 
 jest.mock("@/hooks/use-sessions", () => ({
   useUpdateSession: () => ({ mutate: jest.fn() }),
+  usePinSession: () => ({ mutate: mockPinMutate, isPending: false }),
+  useUnpinSession: () => ({ mutate: mockUnpinMutate, isPending: false }),
 }));
 
 jest.mock("@/hooks", () => ({
@@ -97,6 +102,24 @@ describe("Chats surface", () => {
     expect(screen.getByRole("link", { name: /Latency/ })).toHaveAttribute("href", "/chats/sess_2");
   });
 
+  it("pins and unpins chats from the list", () => {
+    mockUseChatThreads.mockReturnValue({
+      threads: [
+        thread({ id: "sess_1" }),
+        thread({ id: "sess_2", title: "Pinned", is_pinned: true }),
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ChatsPageClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Pin chat" }));
+    fireEvent.click(screen.getByRole("button", { name: "Unpin chat" }));
+
+    expect(mockPinMutate).toHaveBeenCalledWith({ sessionId: "sess_1" });
+    expect(mockUnpinMutate).toHaveBeenCalledWith({ sessionId: "sess_2" });
+  });
+
   it("keeps the starting form mounted when the new thread lands in the list", () => {
     const { rerender } = render(<ChatsPageClient />);
     fireEvent.click(screen.getByText("new-chat-form"));
@@ -156,6 +179,8 @@ describe("Thread surface", () => {
       "href",
       "/sessions/sess_1",
     );
+    fireEvent.click(screen.getByRole("button", { name: "Pin chat" }));
+    expect(mockPinMutate).toHaveBeenCalledWith({ sessionId: "sess_1" });
   });
 
   it("names the harness for a thread bound to one instead of an agent", async () => {

--- a/apps/ui/src/__tests__/sidebar-chat-threads.test.tsx
+++ b/apps/ui/src/__tests__/sidebar-chat-threads.test.tsx
@@ -58,6 +58,18 @@ describe("SidebarChatThreads", () => {
     expect(screen.getByRole("link", { name: /New chat/ })).toHaveAttribute("href", "/chats/new");
   });
 
+  it("marks pinned threads", () => {
+    mockUseChatThreads.mockReturnValue({
+      threads: [{ ...thread("sess_pinned", "Pinned thread"), is_pinned: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SidebarChatThreads pathname="/chats" />);
+
+    expect(screen.getByLabelText("Pinned")).toBeInTheDocument();
+  });
+
   it("holds the order steady while the pointer is inside the list", () => {
     const first = thread("sess_a", "Alpha");
     const second = thread("sess_b", "Beta");

--- a/apps/ui/src/app/(main)/chats/chats-page-client.tsx
+++ b/apps/ui/src/app/(main)/chats/chats-page-client.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { MessageCircle, Plus } from "lucide-react";
 import { AgentAvatar } from "@/components/chat/agent-avatar";
+import { ChatPinButton } from "@/components/chat/chat-pin-button";
 import { NewChatForm } from "@/components/chat/new-chat-form";
 import { EmptyState, PageContainer, PageMasthead } from "@/components/layout";
 import { buttonVariants } from "@/components/ui/button";
@@ -22,21 +23,26 @@ import type { Session } from "@/lib/api/types";
 
 function ThreadRow({ thread, counterpart }: { thread: Session; counterpart?: string }) {
   return (
-    <Link
-      href={`/chats/${thread.id}`}
-      className="flex items-center gap-3 border border-border/70 bg-card/80 px-4 py-3 transition-colors hover:bg-muted/40"
-    >
-      <AgentAvatar name={counterpart} size="sm" />
-      <div className="flex min-w-0 flex-col">
-        <span className="truncate text-sm font-medium text-foreground">{threadTitle(thread)}</span>
-        {thread.output_preview && (
-          <span className="truncate text-xs text-muted-foreground">{thread.output_preview}</span>
-        )}
-      </div>
-      <span className="ml-auto flex-none text-xs text-muted-foreground">
-        {formatRelativeTime(thread.updated_at)}
-      </span>
-    </Link>
+    <div className="flex items-center border border-border/70 bg-card/80 transition-colors hover:bg-muted/40">
+      <Link
+        href={`/chats/${thread.id}`}
+        className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3"
+      >
+        <AgentAvatar name={counterpart} size="sm" />
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate text-sm font-medium text-foreground">
+            {threadTitle(thread)}
+          </span>
+          {thread.output_preview && (
+            <span className="truncate text-xs text-muted-foreground">{thread.output_preview}</span>
+          )}
+        </div>
+        <span className="ml-auto flex-none text-xs text-muted-foreground">
+          {formatRelativeTime(thread.updated_at)}
+        </span>
+      </Link>
+      <ChatPinButton session={thread} className="mr-3" />
+    </div>
   );
 }
 

--- a/apps/ui/src/components/chat/chat-pin-button.tsx
+++ b/apps/ui/src/components/chat/chat-pin-button.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Pin, PinOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { usePinSession, useUnpinSession } from "@/hooks/use-sessions";
+import { cn } from "@/lib/utils";
+import type { Session } from "@/lib/api/types";
+
+export function ChatPinButton({
+  session,
+  showLabel = false,
+  className,
+}: {
+  session: Pick<Session, "id" | "is_pinned">;
+  showLabel?: boolean;
+  className?: string;
+}) {
+  const pinSession = usePinSession();
+  const unpinSession = useUnpinSession();
+  const isPinned = session.is_pinned === true;
+  const isPending = pinSession.isPending || unpinSession.isPending;
+  const label = isPinned ? "Unpin chat" : "Pin chat";
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size={showLabel ? "sm" : "icon-sm"}
+      className={cn(showLabel && "max-sm:w-7 max-sm:px-0", isPinned && "text-primary", className)}
+      aria-label={label}
+      aria-pressed={isPinned}
+      title={label}
+      disabled={isPending}
+      onClick={() => {
+        const mutation = isPinned ? unpinSession : pinSession;
+        mutation.mutate({ sessionId: session.id });
+      }}
+    >
+      {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
+      {showLabel && <span className="max-sm:hidden">{label}</span>}
+    </Button>
+  );
+}

--- a/apps/ui/src/components/chat/chat-thread-header.tsx
+++ b/apps/ui/src/components/chat/chat-thread-header.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { Check, Copy, ExternalLink, Pencil } from "lucide-react";
 import type { Session } from "@/lib/api/types";
 import { AgentAvatar } from "@/components/chat/agent-avatar";
+import { ChatPinButton } from "@/components/chat/chat-pin-button";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useUpdateSession } from "@/hooks/use-sessions";
@@ -88,13 +89,15 @@ function ShareButton() {
       type="button"
       variant="outline"
       size="sm"
+      className="max-sm:w-7 max-sm:px-0"
+      aria-label={copied ? "Link copied" : "Share"}
       onClick={async () => {
         await navigator.clipboard?.writeText(window.location.href);
         setCopied(true);
       }}
     >
       {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-      {copied ? "Link copied" : "Share"}
+      <span className="max-sm:hidden">{copied ? "Link copied" : "Share"}</span>
     </Button>
   );
 }
@@ -123,13 +126,15 @@ export function ChatThreadHeader({
         </span>
       </div>
       <div className="ml-auto flex items-center gap-2">
+        <ChatPinButton session={session} showLabel />
         <ShareButton />
         <Link
           href={`/sessions/${session.id}`}
-          className="inline-flex items-center gap-1.5 border border-border/70 px-2.5 py-1.5 text-[13px] font-medium transition-colors hover:bg-muted/40"
+          aria-label="Open session"
+          className="inline-flex items-center gap-1.5 border border-border/70 px-2.5 py-1.5 text-[13px] font-medium transition-colors hover:bg-muted/40 max-sm:size-7 max-sm:justify-center max-sm:px-0"
         >
           <ExternalLink className="size-3.5" />
-          Open session
+          <span className="max-sm:hidden">Open session</span>
         </Link>
       </div>
     </div>

--- a/apps/ui/src/components/layout/sidebar-chat-threads.tsx
+++ b/apps/ui/src/components/layout/sidebar-chat-threads.tsx
@@ -11,7 +11,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Plus } from "lucide-react";
+import { Pin, Plus } from "lucide-react";
 import { useChatThreads } from "@/hooks/use-chat-threads";
 import { SIDEBAR_THREAD_LIMIT, threadTitle } from "@/lib/chat-threads";
 import type { Session } from "@/lib/api/types";
@@ -65,6 +65,9 @@ export function SidebarChatThreads({ pathname }: { pathname: string }) {
             )}
           >
             <span className="truncate">{threadTitle(thread)}</span>
+            {thread.is_pinned === true && (
+              <Pin className="ml-auto size-3 shrink-0 text-primary" aria-label="Pinned" />
+            )}
           </Link>
         );
       })}

--- a/apps/ui/src/hooks/use-chat-threads.ts
+++ b/apps/ui/src/hooks/use-chat-threads.ts
@@ -23,7 +23,7 @@ export interface UseChatThreadsResult {
   error: Error | null;
 }
 
-/** This user's chat threads, most recently active first. */
+/** This user's chat threads, pinned first and then ordered by recent activity. */
 export function useChatThreads(options: { enabled?: boolean } = {}): UseChatThreadsResult {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const { user } = useAuth();

--- a/apps/ui/src/lib/chat-threads.ts
+++ b/apps/ui/src/lib/chat-threads.ts
@@ -57,9 +57,10 @@ export function threadActivityAt(session: Session): number {
 }
 
 /**
- * Pick this user's chat threads out of a session page, most recently active
- * first. `userId` is undefined when auth is off (local development, single
- * anonymous user) — every thread is then "mine".
+ * Pick this user's chat threads out of a session page. Pinned threads come
+ * first, with each group ordered by most recent activity. `userId` is undefined
+ * when auth is off (local development, single anonymous user) — every thread is
+ * then "mine".
  */
 export function selectChatThreads(sessions: Session[], userId?: string): Session[] {
   return sessions
@@ -68,7 +69,10 @@ export function selectChatThreads(sessions: Session[], userId?: string): Session
       (session) =>
         !userId || !session.resolved_owner_user_id || session.resolved_owner_user_id === userId,
     )
-    .sort((a, b) => threadActivityAt(b) - threadActivityAt(a));
+    .sort((a, b) => {
+      const pinOrder = Number(b.is_pinned === true) - Number(a.is_pinned === true);
+      return pinOrder || threadActivityAt(b) - threadActivityAt(a);
+    });
 }
 
 /** Title to show for a thread that has not been named yet. */

--- a/test_cases/ui/chats/TC001_chats_landing_and_new_thread.md
+++ b/test_cases/ui/chats/TC001_chats_landing_and_new_thread.md
@@ -31,7 +31,7 @@ None.
 | Landing | `/` redirects to `/chats` |
 | Empty state | Shows "No chats yet" with an agent picker and **Start chat** — never a bare spinner |
 | Thread created | `POST /v1/sessions` returns 200/201 with the picked agent, and the browser lands on `/chats/{sessionId}` |
-| Thread header | Shows the agent avatar, the thread title, **Share**, and **Open session** |
+| Thread header | Shows the agent avatar, the thread title, **Pin chat**, **Share**, and **Open session** |
 | Composer | Placeholder names the bound agent; the model control shows the model in use |
 | Agent binding | Shown as text, with no control to change the agent on an existing thread |
 | Thread list | The new thread appears in `/chats` and under **Chats** in the sidebar |

--- a/test_cases/ui/chats/TC013_pin_chat.md
+++ b/test_cases/ui/chats/TC013_pin_chat.md
@@ -1,0 +1,36 @@
+# TC013: Chats - Pin Chat
+
+## Description
+
+Verify that a chat can be pinned or unpinned from both the Chats list and the open thread, and that
+pinned chats stay ahead of more recently active unpinned chats.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- At least two chat threads exist for the current user
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Open `/chats` and identify an older unpinned chat
+2. Press its **Pin chat** button
+3. Observe the Chats list and the sidebar
+4. Open the pinned chat and press **Unpin chat** in the thread header
+5. Return to `/chats`
+6. Open a different unpinned chat, press **Pin chat** in the thread header, then return to `/chats`
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| List action | The row action changes from **Pin chat** to **Unpin chat** after pinning |
+| Pinned order | The pinned chat moves above every unpinned chat; activity time orders chats within each group |
+| Sidebar | The pinned chat appears first among available threads and carries a pin indicator |
+| Header action | The open thread exposes the same pin/unpin state and action as the list |
+| Persistence | Reloading `/chats` preserves the pin state and ordering |
+| Unpin | The chat returns to activity-time ordering after it is unpinned |


### PR DESCRIPTION
## What changed

- Added pin/unpin actions to chat rows and open chat headers.
- Ordered pinned chats before unpinned chats while retaining recent-activity ordering within each group.
- Marked pinned sidebar entries and kept header actions responsive on narrow screens.
- Added automated coverage and manual TC013 acceptance criteria.

## Why

Chats reused session pinning in the API but did not expose it, so important conversations could not be kept at the top of the Chats surface.

## Before / After

Before: Chats exposed no pin action and always ordered every thread only by activity.

After: the PostgreSQL-backed TC013 smoke test confirmed list and header pin/unpin, pinned-first ordering, sidebar indication, reload persistence, and a 375px responsive layout. Desktop and mobile screenshots are attached in the PR conversation.

## Risk

- Low
- The change is limited to Chats UI state and ordering; the existing session pin API and authorization remain unchanged.
- The bounded 100-session client list retains its existing O(n log n) sorting profile.

## Security

- Threat categories reviewed: TM-WEB, TM-AUTHZ
- Findings and resolutions: no new trust boundary or unsafe rendering sink. Mutations use the existing authenticated, org-scoped session pin endpoints; React continues to escape chat metadata. No findings.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
