### PR TITLE
feat(ui): separate session recording projections

### DIFF
--- a/apps/ui/src/__tests__/chats-page.test.tsx
+++ b/apps/ui/src/__tests__/chats-page.test.tsx
@@ -177,7 +177,7 @@ describe("Thread surface", () => {
     expect(screen.getByText("chat-panel:Scout")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open session/ })).toHaveAttribute(
       "href",
-      "/sessions/sess_1",
+      "/sessions/sess_1/transcript",
     );
     fireEvent.click(screen.getByRole("button", { name: "Pin chat" }));
     expect(mockPinMutate).toHaveBeenCalledWith({ sessionId: "sess_1" });

--- a/apps/ui/src/__tests__/eval-run-detail-page.test.tsx
+++ b/apps/ui/src/__tests__/eval-run-detail-page.test.tsx
@@ -101,7 +101,7 @@ describe("EvalRunDetailPage", () => {
     await renderWithSuspense({ evalId: "eval_123", runId: "evalrun_123" });
 
     const link = screen.getByLabelText("Open session for Case with session in new tab");
-    expect(link).toHaveAttribute("href", "/sessions/session_123");
+    expect(link).toHaveAttribute("href", "/sessions/session_123/transcript");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });

--- a/apps/ui/src/__tests__/run-timeline.test.tsx
+++ b/apps/ui/src/__tests__/run-timeline.test.tsx
@@ -29,6 +29,7 @@ const events: Event[] = [
       model: "gpt-4",
       success: true,
       usage: { input_tokens: 1200, output_tokens: 80 },
+      retry: { attempts: 2, total_wait_ms: 500 },
     },
   }),
   event(4, "tool.completed", {
@@ -81,10 +82,19 @@ describe("RunTimeline", () => {
     expect(screen.getByText("1.2K prompt")).toBeInTheDocument();
   });
 
-  it("names the durable-execution worker that ran each step", () => {
+  it("keeps durable-execution worker IDs behind details", () => {
     render(<RunTimeline events={events} tasks={[]} />);
 
-    expect(screen.getAllByText("worker exec_alpha").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Worker: exec_alpha")).not.toBeInTheDocument();
+    const modelStep = screen.getByText("Model call").closest("li")!;
+    fireEvent.click(within(modelStep).getByRole("button", { name: /show details/i }));
+    expect(screen.getByText("Worker: exec_alpha")).toBeInTheDocument();
+  });
+
+  it("surfaces model retries as a curated fact", () => {
+    render(<RunTimeline events={events} tasks={[]} />);
+
+    expect(screen.getByText("3 attempts")).toBeInTheDocument();
   });
 
   it("shows a tool call's result payload inline, behind an expander", () => {
@@ -94,7 +104,7 @@ describe("RunTimeline", () => {
     expect(screen.queryByText("the file body")).not.toBeInTheDocument();
 
     const toolStep = screen.getByText("Read file").closest("li")!;
-    fireEvent.click(within(toolStep).getByRole("button", { name: /show payload/i }));
+    fireEvent.click(within(toolStep).getByRole("button", { name: /show details/i }));
     expect(screen.getByText("the file body")).toBeInTheDocument();
   });
 
@@ -108,7 +118,10 @@ describe("RunTimeline", () => {
     render(<RunTimeline events={events} tasks={tasks} />);
 
     expect(screen.getByText("Doc reviewer")).toBeInTheDocument();
-    expect(screen.getByText("worker worker_7")).toBeInTheDocument();
+    expect(screen.queryByText("Worker: worker_7")).not.toBeInTheDocument();
+    const subagentStep = screen.getByText("Doc reviewer").closest("li")!;
+    fireEvent.click(within(subagentStep).getByRole("button", { name: /show details/i }));
+    expect(screen.getByText("Worker: worker_7")).toBeInTheDocument();
 
     const titles = screen.getAllByRole("listitem").map((item) => item.textContent ?? "");
     const subagentIndex = titles.findIndex((title) => title.includes("Doc reviewer"));
@@ -121,5 +134,11 @@ describe("RunTimeline", () => {
     render(<RunTimeline events={[]} tasks={[]} />);
 
     expect(screen.getByText(/Nothing has run in this session yet/)).toBeInTheDocument();
+  });
+
+  it("shows a loading state while live history is being hydrated", () => {
+    render(<RunTimeline events={[]} tasks={[]} loading />);
+
+    expect(screen.getByText("Loading the run…")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/session-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-model.test.tsx
@@ -84,7 +84,7 @@ describe("SessionCard - LLM Model Display", () => {
 
     // Check that the link points to the org-level session path
     const link = screen.getByTestId("session-link");
-    expect(link).toHaveAttribute("data-href", "/sessions/session-1");
+    expect(link).toHaveAttribute("data-href", "/sessions/session-1/transcript");
   });
 
   it("displays agent name when provided", async () => {

--- a/apps/ui/src/__tests__/session-detail-read-only.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-read-only.test.tsx
@@ -3,7 +3,7 @@
 //
 // Every network call the UI makes goes through `@/lib/api/client` or `fetch`.
 // Both are replaced here with recorders that fail loudly on anything other than
-// GET, then each of the five tabs is rendered and every control on it is
+// GET, then every tab is rendered and every control on it is
 // exercised — buttons clicked, text fields typed into and submitted. A tab that
 // grows a composer, a save button or a delete affordance fails this test.
 
@@ -185,6 +185,8 @@ jest.mock("../app/(main)/sessions/[sessionId]/session-context", () => ({
 }));
 
 // eslint-disable-next-line import/first
+import TranscriptPage from "../app/(main)/sessions/[sessionId]/transcript/page";
+// eslint-disable-next-line import/first
 import TimelinePage from "../app/(main)/sessions/[sessionId]/timeline/page";
 // eslint-disable-next-line import/first
 import WorkPage from "../app/(main)/sessions/[sessionId]/work/page";
@@ -196,6 +198,7 @@ import WorkspacePage from "../app/(main)/sessions/[sessionId]/files/page";
 import CostPage from "../app/(main)/sessions/[sessionId]/cost/page";
 
 const TABS: Array<[string, React.ComponentType]> = [
+  ["Transcript", TranscriptPage],
   ["Timeline", TimelinePage],
   ["Work", WorkPage],
   ["Events", EventsPage],

--- a/apps/ui/src/__tests__/session-layout.test.tsx
+++ b/apps/ui/src/__tests__/session-layout.test.tsx
@@ -173,7 +173,7 @@ import SessionLayout from "@/app/(main)/sessions/[sessionId]/layout";
 describe("SessionLayout", () => {
   beforeEach(() => {
     mockPush.mockReset();
-    mockPathname.mockReturnValue("/sessions/ses-abc12345/chat");
+    mockPathname.mockReturnValue("/sessions/ses-abc12345/transcript");
     mockSessionContext.sessionLoading = false;
     mockSessionContext.effectiveStatus = "idle";
     mockSessionContext.liveUsage = null;
@@ -221,21 +221,32 @@ describe("SessionLayout", () => {
     });
   });
 
-  it("renders the five recording tabs", async () => {
+  it("renders the recording tabs in information-architecture order", async () => {
     await renderLayout();
 
     await waitFor(() => {
-      expect(screen.getByRole("link", { name: /timeline/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /transcript/i })).toBeInTheDocument();
     });
-    for (const label of [/timeline/i, /events/i, /workspace/i, /cost/i]) {
-      expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
-    }
+    expect(
+      screen
+        .getAllByRole("link")
+        .filter((link) =>
+          ["Transcript", "Timeline", "Work", "Events", "Workspace", "Cost"].includes(
+            link.textContent ?? "",
+          ),
+        )
+        .map((link) => link.textContent),
+    ).toEqual(["Transcript", "Timeline", "Work", "Events", "Workspace", "Cost"]);
   });
 
   it("points each tab at its route", async () => {
     await renderLayout();
 
     await waitFor(() => {
+      expect(screen.getByRole("link", { name: /transcript/i })).toHaveAttribute(
+        "href",
+        "/sessions/ses-abc12345/transcript",
+      );
       expect(screen.getByRole("link", { name: /timeline/i })).toHaveAttribute(
         "href",
         "/sessions/ses-abc12345/timeline",
@@ -270,6 +281,15 @@ describe("SessionLayout", () => {
       expect(screen.getByRole("link", { name: /workspace/i })).toHaveClass("border-primary");
     });
     expect(screen.getByRole("link", { name: /timeline/i })).not.toHaveClass("border-primary");
+  });
+
+  it("highlights Transcript and uses it in the page title", async () => {
+    await renderLayout();
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /transcript/i })).toHaveClass("border-primary");
+      expect(document.title).toContain("Transcript · Test Session · Session");
+    });
   });
 
   it("offers the three escape hatches and no session-editing control", async () => {
@@ -359,8 +379,9 @@ describe("SessionLayout", () => {
     await renderLayout();
 
     await waitFor(() => {
-      expect(screen.getByRole("link", { name: /timeline/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /transcript/i })).toBeInTheDocument();
     });
+    expect(screen.getByRole("link", { name: /timeline/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /events/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /cost/i })).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /workspace/i })).not.toBeInTheDocument();

--- a/apps/ui/src/__tests__/session-navigation.test.ts
+++ b/apps/ui/src/__tests__/session-navigation.test.ts
@@ -1,15 +1,19 @@
 import { buildSessionNavigation } from "@/components/session/session-header";
 
 describe("buildSessionNavigation", () => {
-  // A session is a recording (EVE-854): five tabs, no more, and the ones that
-  // depend on a capability stay gated on the session's features.
-  it("always offers timeline, events and cost", () => {
+  // A session is a recording: Transcript, Timeline, Events, and Cost are
+  // unconditional; the views that depend on capabilities stay feature-gated.
+  it("always offers transcript first, followed by timeline, events and cost", () => {
     const items = buildSessionNavigation({
       basePath: "/sessions/session_123",
       features: new Set(),
     });
 
-    expect(items.map((item) => item.key)).toEqual(["timeline", "events", "cost"]);
+    expect(items.map((item) => item.key)).toEqual(["transcript", "timeline", "events", "cost"]);
+    expect(items[0]).toMatchObject({
+      label: "Transcript",
+      href: "/sessions/session_123/transcript",
+    });
     expect(items.find((item) => item.key === "timeline")?.href).toBe(
       "/sessions/session_123/timeline",
     );
@@ -21,7 +25,14 @@ describe("buildSessionNavigation", () => {
       features: new Set(["file_system", "leased_resources"]),
     });
 
-    expect(items.map((item) => item.key)).toEqual(["timeline", "work", "events", "files", "cost"]);
+    expect(items.map((item) => item.key)).toEqual([
+      "transcript",
+      "timeline",
+      "work",
+      "events",
+      "files",
+      "cost",
+    ]);
     expect(items.find((item) => item.key === "files")?.label).toBe("Workspace");
   });
 

--- a/apps/ui/src/__tests__/session-recording-pages.test.tsx
+++ b/apps/ui/src/__tests__/session-recording-pages.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import type { Event } from "@/lib/api/types";
+
+const mockSessionContext = {
+  sessionId: "session_123",
+  events: [] as Event[],
+  eventsLoading: false,
+};
+
+jest.mock("@/app/(main)/sessions/[sessionId]/session-context", () => ({
+  useSessionContext: () => mockSessionContext,
+}));
+
+jest.mock("@/hooks/use-session-tasks", () => ({
+  useSessionTasks: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock("@/components/session/session-transcript", () => ({
+  SessionTranscript: () => <div data-testid="session-transcript">conversation</div>,
+}));
+
+jest.mock("@/components/session/run-timeline", () => ({
+  RunTimeline: ({ events }: { events: Event[] }) => (
+    <div data-testid="run-timeline">{events.map((event) => event.type).join(",")}</div>
+  ),
+}));
+
+jest.mock("@/components/events/event-filter", () => ({
+  EventFilter: () => <div>event filters</div>,
+}));
+
+import EventsPage from "@/app/(main)/sessions/[sessionId]/events/page";
+import TimelinePage from "@/app/(main)/sessions/[sessionId]/timeline/page";
+import TranscriptPage from "@/app/(main)/sessions/[sessionId]/transcript/page";
+
+function rawEvent(type: string, sequence: number): Event {
+  return {
+    id: `event_${sequence}`,
+    session_id: "session_123",
+    type,
+    sequence,
+    ts: "2026-08-10T12:00:00Z",
+    context: { exec_id: "exec_abc" },
+    data: { raw_worker_id: "worker_abc", nested: { complete: true } },
+  } as unknown as Event;
+}
+
+describe("session recording projections", () => {
+  beforeEach(() => {
+    mockSessionContext.events = [];
+    mockSessionContext.eventsLoading = false;
+  });
+
+  it("renders Transcript as the full conversation projection", () => {
+    render(<TranscriptPage />);
+
+    expect(screen.getByTestId("session-transcript")).toBeInTheDocument();
+    expect(screen.queryByTestId("run-timeline")).not.toBeInTheDocument();
+  });
+
+  it("renders Timeline full-width without a transcript rail", () => {
+    mockSessionContext.events = [rawEvent("turn.started", 1)];
+    const { container } = render(<TimelinePage />);
+
+    expect(screen.getByRole("region", { name: "Execution timeline" })).toHaveClass("flex-1");
+    expect(screen.getByTestId("run-timeline")).toHaveTextContent("turn.started");
+    expect(screen.queryByTestId("session-transcript")).not.toBeInTheDocument();
+    expect(container.querySelector("aside")).not.toBeInTheDocument();
+  });
+
+  it("updates Timeline when live events arrive and replays completed history", () => {
+    const { rerender } = render(<TimelinePage />);
+    expect(screen.getByTestId("run-timeline")).toBeEmptyDOMElement();
+
+    mockSessionContext.events = [
+      rawEvent("turn.started", 1),
+      rawEvent("llm.generation", 2),
+      rawEvent("turn.completed", 3),
+    ];
+    rerender(<TimelinePage />);
+
+    expect(screen.getByTestId("run-timeline")).toHaveTextContent(
+      "turn.started,llm.generation,turn.completed",
+    );
+  });
+
+  it("keeps Events as the exact raw ledger rather than either projection", () => {
+    mockSessionContext.events = [rawEvent("custom.debug", 42)];
+    render(<EventsPage />);
+
+    expect(screen.getByText("custom.debug")).toBeInTheDocument();
+    expect(screen.getByText(/raw_worker_id/)).toBeInTheDocument();
+    expect(screen.getByText(/worker_abc/)).toBeInTheDocument();
+    expect(screen.getByText(/exec_abc/)).toBeInTheDocument();
+    expect(screen.getByText(/event_42/)).toBeInTheDocument();
+    expect(screen.queryByTestId("session-transcript")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("run-timeline")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/session-route-redirects.test.ts
+++ b/apps/ui/src/__tests__/session-route-redirects.test.ts
@@ -1,0 +1,26 @@
+const mockRedirect = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  redirect: (href: string) => mockRedirect(href),
+}));
+
+import LegacySessionChatPage from "@/app/(main)/sessions/[sessionId]/chat/page";
+import SessionPage from "@/app/(main)/sessions/[sessionId]/page";
+
+describe("session recording redirects", () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+  });
+
+  it("lands the base session route on Transcript", async () => {
+    await SessionPage({ params: Promise.resolve({ sessionId: "session_123" }) });
+
+    expect(mockRedirect).toHaveBeenCalledWith("/sessions/session_123/transcript");
+  });
+
+  it("preserves legacy session chat bookmarks as Transcript", async () => {
+    await LegacySessionChatPage({ params: Promise.resolve({ sessionId: "session_123" }) });
+
+    expect(mockRedirect).toHaveBeenCalledWith("/sessions/session_123/transcript");
+  });
+});

--- a/apps/ui/src/__tests__/session-transcript.test.tsx
+++ b/apps/ui/src/__tests__/session-transcript.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import type { Event } from "@/lib/api/types";
+
+function event(type: string, sequence: number, text: string): Event {
+  return {
+    id: `event_${sequence}`,
+    session_id: "session_123",
+    type,
+    sequence,
+    ts: "2026-08-10T12:00:00Z",
+    data: {
+      message: { content: [{ type: "text", text }] },
+    },
+  } as Event;
+}
+
+const completedEvents = [
+  event("input.message", 1, "What happened?"),
+  event("output.message.completed", 2, "The run completed."),
+];
+
+const mockContext = {
+  events: completedEvents as Event[],
+  sessionId: "session_123",
+  chatEvents: completedEvents as Event[],
+  toolResultsMap: new Map(),
+  toolProgressMap: new Map(),
+  toolOutputMap: new Map(),
+  eventsLoading: false,
+  isThinking: false,
+  streamingText: null as string | null,
+  streamingMessageId: null as string | null,
+  streamingIteration: null as number | null,
+  hasMoreEvents: false,
+  loadingOlderEvents: false,
+  loadOlderEvents: jest.fn(),
+  getMessageText: (data: { message?: { content?: Array<{ text?: string }> } }) =>
+    data.message?.content?.[0]?.text ?? "",
+  getToolCalls: () => [],
+};
+
+jest.mock("@/app/(main)/sessions/[sessionId]/session-context", () => ({
+  useSessionContext: () => mockContext,
+}));
+
+jest.mock("@/hooks", () => ({
+  useMessageScrollerVisibility: () => ({ currentAnchorId: null, scrollToAnchor: jest.fn() }),
+  useScrollManager: () => ({
+    scrollContainerRef: { current: null },
+    messagesEndRef: { current: null },
+    hasNewMessages: false,
+    dismissNewMessages: jest.fn(),
+    handleScrollUp: jest.fn(),
+  }),
+  useSessionParticipants: () => ({ data: [] }),
+  useTurnKeyboardNavigation: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-thread-runs", () => ({
+  useThreadRuns: () => [],
+}));
+
+jest.mock("@/components/chat/chat-message-list", () => ({
+  ChatMessageList: ({ chatEvents }: { chatEvents: Event[] }) => (
+    <div data-testid="completed-transcript">{chatEvents.map((item) => item.type).join(",")}</div>
+  ),
+}));
+
+jest.mock("@/components/chat/chat-nav-rail", () => ({
+  ChatNavRail: () => <nav aria-label="Conversation turns" />,
+}));
+
+jest.mock("@/components/streaming-message", () => ({
+  StreamingMessage: ({ text }: { text: string }) => <div data-testid="streaming-text">{text}</div>,
+}));
+
+jest.mock("@/components/thinking-indicator", () => ({
+  ThinkingIndicator: () => <div>Thinking</div>,
+}));
+
+jest.mock("@/providers/locale-provider", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+import { SessionTranscript } from "@/components/session/session-transcript";
+
+describe("SessionTranscript replay and streaming", () => {
+  beforeEach(() => {
+    mockContext.events = completedEvents;
+    mockContext.chatEvents = completedEvents;
+    mockContext.isThinking = false;
+    mockContext.streamingText = null;
+    mockContext.streamingMessageId = null;
+    mockContext.streamingIteration = null;
+  });
+
+  it("replays the completed human-readable conversation", () => {
+    render(<SessionTranscript />);
+
+    expect(screen.getByTestId("completed-transcript")).toHaveTextContent(
+      "input.message,output.message.completed",
+    );
+    expect(screen.queryByTestId("streaming-text")).not.toBeInTheDocument();
+  });
+
+  it("shows live output and settles back to completed replay", () => {
+    mockContext.events = [completedEvents[0]];
+    mockContext.chatEvents = [completedEvents[0]];
+    mockContext.isThinking = true;
+    mockContext.streamingText = "The run is still";
+    mockContext.streamingMessageId = "message_live";
+
+    const { rerender } = render(<SessionTranscript />);
+    expect(screen.getByTestId("streaming-text")).toHaveTextContent("The run is still");
+
+    mockContext.events = completedEvents;
+    mockContext.chatEvents = completedEvents;
+    mockContext.isThinking = false;
+    mockContext.streamingText = null;
+    mockContext.streamingMessageId = null;
+    rerender(<SessionTranscript />);
+
+    expect(screen.queryByTestId("streaming-text")).not.toBeInTheDocument();
+    expect(screen.getByTestId("completed-transcript")).toHaveTextContent(
+      "output.message.completed",
+    );
+  });
+});

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -7,8 +7,9 @@ const mockUseAgents = jest.fn((_options?: { enabled?: boolean }) => ({ data: [] 
 jest.mock("@/hooks/use-agents", () => ({
   useAgents: (options?: { enabled?: boolean }) => mockUseAgents(options),
 }));
+const mockUseSessions = jest.fn(() => ({ data: { data: [] as Array<Record<string, unknown>> } }));
 jest.mock("@/hooks/use-sessions", () => ({
-  useSessions: () => ({ data: { data: [] } }),
+  useSessions: () => mockUseSessions(),
 }));
 jest.mock("@/hooks/use-harnesses", () => ({
   useHarnesses: () => ({ data: [] }),
@@ -134,6 +135,8 @@ describe("useGlobalSearch", () => {
   beforeEach(() => {
     mockSetCurrentOrg.mockClear();
     mockUseAgents.mockClear();
+    mockUseSessions.mockReset();
+    mockUseSessions.mockReturnValue({ data: { data: [] } });
     mockUseSkills.mockClear();
     mockUseEvals.mockClear();
     mockUseMemories.mockClear();
@@ -227,6 +230,29 @@ describe("useGlobalSearch", () => {
       subtitle: "Current organization > org_current",
     });
     expect(orgResult?.onSelect).toBeUndefined();
+  });
+
+  it("opens session search results on the transcript", () => {
+    mockUseSessions.mockReturnValue({
+      data: {
+        data: [
+          {
+            id: "session_123",
+            title: "Recorded deployment",
+            preview: "Deploy the service",
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useGlobalSearch("recorded deployment"));
+
+    expect(result.current).toContainEqual(
+      expect.objectContaining({
+        id: "session:session_123",
+        href: "/sessions/session_123/transcript",
+      }),
+    );
   });
 
   it.each([

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -128,7 +128,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
       const session = await createSession.mutateAsync({
         request: { agent_id: agentId, ...(title ? { title } : {}) },
       });
-      router.push(`/sessions/${session.id}`);
+      router.push(`/sessions/${session.id}/transcript`);
       return session;
     },
     [agentId, createSession, router],
@@ -176,7 +176,11 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
         webMcpSessionPendingRef.current = true;
         try {
           const session = await createAgentSession(title || undefined);
-          return { created: true, session_id: session.id, path: `/sessions/${session.id}` };
+          return {
+            created: true,
+            session_id: session.id,
+            path: `/sessions/${session.id}/transcript`,
+          };
         } finally {
           webMcpSessionPendingRef.current = false;
         }

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -45,7 +45,7 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
       const session = await createSession.mutateAsync({
         request: { agent_id: agentId },
       });
-      router.push(`/sessions/${session.id}`);
+      router.push(`/sessions/${session.id}/transcript`);
     } catch (error) {
       console.error("Failed to create session:", error);
     }

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -75,7 +75,7 @@ export default function DashboardPage() {
         },
       });
       setNewSessionDialogOpen(false);
-      router.push(`/sessions/${session.id}`);
+      router.push(`/sessions/${session.id}/transcript`);
     } catch (error) {
       console.error("Failed to create session:", error);
     }

--- a/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/[workflowId]/page.tsx
@@ -294,7 +294,7 @@ export default function WorkflowDetailPage({
                   <div>
                     <p className="text-sm text-muted-foreground mb-1">Linked Session</p>
                     <Link
-                      href={`/sessions/${workflow.session_id}`}
+                      href={`/sessions/${workflow.session_id}/transcript`}
                       className="inline-flex items-center gap-1 text-primary hover:underline"
                     >
                       <ExternalLink className="h-4 w-4" />

--- a/apps/ui/src/app/(main)/durable/workflows/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/page.tsx
@@ -128,7 +128,7 @@ function WorkflowRow({
       <TableCell>
         {workflow.session_id ? (
           <Link
-            href={`/sessions/${workflow.session_id}`}
+            href={`/sessions/${workflow.session_id}/transcript`}
             className="flex items-center gap-1 text-sm text-primary hover:underline"
           >
             <ExternalLink className="h-3 w-3" />

--- a/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
@@ -128,7 +128,7 @@ function ResultRow({ result, columns }: { result: EvalCaseResult; columns: numbe
             <span className="text-sm font-medium">{result.case_name ?? result.eval_case_id}</span>
             {result.session_id && (
               <Link
-                href={`/sessions/${result.session_id}`}
+                href={`/sessions/${result.session_id}/transcript`}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`Open session for ${result.case_name ?? result.eval_case_id} in new tab`}

--- a/apps/ui/src/app/(main)/observers/[observerId]/page.tsx
+++ b/apps/ui/src/app/(main)/observers/[observerId]/page.tsx
@@ -179,7 +179,10 @@ function ScoreRow({ score }: { score: TraceScore }) {
         {new Date(score.created_at).toLocaleString()}
       </TableCell>
       <TableCell>
-        <Link href={`/sessions/${score.session_id}`} className="text-primary hover:underline">
+        <Link
+          href={`/sessions/${score.session_id}/transcript`}
+          className="text-primary hover:underline"
+        >
           View
         </Link>
       </TableCell>

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/chat/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/chat/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+
+interface LegacySessionChatPageProps {
+  params: Promise<{ sessionId: string }>;
+}
+
+// Preserve bookmarks from the former read-only session chat route. Mutable
+// conversations live under /chats; a session recording's equivalent is Transcript.
+export default async function LegacySessionChatPage({ params }: LegacySessionChatPageProps) {
+  const { sessionId } = await params;
+  redirect(`/sessions/${sessionId}/transcript`);
+}

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/cost/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/cost/page.tsx
@@ -190,7 +190,7 @@ export default function CostPage() {
           {session?.forked_from_session_id ? (
             <DefinitionRow icon={RefreshCcw} label="Forked from">
               <Link
-                href={`/sessions/${session.forked_from_session_id}`}
+                href={`/sessions/${session.forked_from_session_id}/transcript`}
                 className="font-mono text-xs hover:underline"
               >
                 {session.forked_from_session_id}

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
@@ -176,7 +176,7 @@ export default function EventsPage() {
                   <TableHead className="w-[80px]">Seq</TableHead>
                   <TableHead className="w-[180px]">Type</TableHead>
                   <TableHead className="w-[200px]">Timestamp</TableHead>
-                  <TableHead>Data</TableHead>
+                  <TableHead>Raw event</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -205,10 +205,10 @@ export default function EventsPage() {
                               View
                             </Button>
                           )}
-                          <CopyButton data={event.data} />
+                          <CopyButton data={event} />
                         </div>
                         <pre className="whitespace-pre-wrap break-all text-xs bg-muted p-2 rounded max-h-[200px] overflow-y-auto">
-                          {JSON.stringify(event.data, null, 2)}
+                          {JSON.stringify(event, null, 2)}
                         </pre>
                       </div>
                     </TableCell>

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -17,6 +17,7 @@ import { getDisplayName } from "@/lib/entity-lifecycle";
 import { useLocale } from "@/providers/locale-provider";
 
 const SESSION_TAB_LABELS: Record<SessionNavKey, string> = {
+  transcript: "Transcript",
   timeline: "Timeline",
   work: "Work",
   events: "Events",
@@ -51,11 +52,13 @@ export function SessionLayoutContent({ children, sessionId }: SessionLayoutConte
 
   // Determine active tab from pathname
   const getActiveTab = (): SessionNavKey => {
+    if (pathname.endsWith("/transcript")) return "transcript";
     if (pathname.endsWith("/files")) return "files";
     if (pathname.endsWith("/events")) return "events";
     if (pathname.endsWith("/work")) return "work";
     if (pathname.endsWith("/cost")) return "cost";
-    return "timeline"; // Default (includes /timeline and the base path)
+    if (pathname.endsWith("/timeline")) return "timeline";
+    return "transcript"; // Default while the base route redirects.
   };
   const activeTab = getActiveTab();
 

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/page.tsx
@@ -6,5 +6,5 @@ interface SessionPageProps {
 
 export default async function SessionPage({ params }: SessionPageProps) {
   const { sessionId } = await params;
-  redirect(`/sessions/${sessionId}/timeline`);
+  redirect(`/sessions/${sessionId}/transcript`);
 }

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/timeline/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/timeline/page.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-// Timeline — the default view of a session recording (EVE-854): the structural
-// run on the left, the transcript on the right. Both are read-only and both
-// stream: a live session appends to each as events arrive, a finished one
-// replays entirely from history.
+// Timeline is the curated execution history of a session recording. It streams
+// live and replays from durable history, but never duplicates the conversation
+// transcript or exposes mutation controls.
 
 import { useSessionTasks } from "@/hooks/use-session-tasks";
 import { RunTimeline } from "@/components/session/run-timeline";
-import { SessionTranscript } from "@/components/session/session-transcript";
 import { useSessionContext } from "../session-context";
 
 export default function TimelinePage() {
@@ -15,19 +13,17 @@ export default function TimelinePage() {
   const { data: tasks, isLoading: tasksLoading } = useSessionTasks(sessionId);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-      <aside className="flex min-h-0 shrink-0 flex-col overflow-y-auto border-b border-border/70 px-4 lg:w-96 lg:border-b-0 lg:border-r">
-        <h2 className="pt-4 text-sm font-medium text-muted-foreground">Run</h2>
+    <section
+      aria-label="Execution timeline"
+      className="min-h-0 flex-1 overflow-y-auto px-4 sm:px-6"
+    >
+      <div className="w-full">
         <RunTimeline
           events={events ?? []}
           tasks={tasks ?? []}
           loading={eventsLoading || tasksLoading}
         />
-      </aside>
-
-      <div className="flex min-h-0 flex-1 flex-col">
-        <SessionTranscript />
       </div>
-    </div>
+    </section>
   );
 }

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/transcript/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/transcript/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+// Transcript is the default human-readable view of a session recording. It
+// intentionally reuses the chat transcript so completed replay and live output
+// stay identical to Chats, but it never renders a composer or mutation controls.
+
+import { SessionTranscript } from "@/components/session/session-transcript";
+
+export default function TranscriptPage() {
+  return <SessionTranscript />;
+}

--- a/apps/ui/src/components/agents/agent-health-check.tsx
+++ b/apps/ui/src/components/agents/agent-health-check.tsx
@@ -188,7 +188,7 @@ function CaseRow({ result }: { result: HealthCheckCaseResult }) {
           )}
           {result.session_id && (
             <Link
-              href={`/sessions/${result.session_id}`}
+              href={`/sessions/${result.session_id}/transcript`}
               target="_blank"
               className="text-muted-foreground hover:text-foreground"
               aria-label="Open session"

--- a/apps/ui/src/components/chat/chat-thread-header.tsx
+++ b/apps/ui/src/components/chat/chat-thread-header.tsx
@@ -129,7 +129,7 @@ export function ChatThreadHeader({
         <ChatPinButton session={session} showLabel />
         <ShareButton />
         <Link
-          href={`/sessions/${session.id}`}
+          href={`/sessions/${session.id}/transcript`}
           aria-label="Open session"
           className="inline-flex items-center gap-1.5 border border-border/70 px-2.5 py-1.5 text-[13px] font-medium transition-colors hover:bg-muted/40 max-sm:size-7 max-sm:justify-center max-sm:px-0"
         >

--- a/apps/ui/src/components/chat/run-card.tsx
+++ b/apps/ui/src/components/chat/run-card.tsx
@@ -42,7 +42,9 @@ function kindIcon(kind: string) {
  *  otherwise the owning session's task list. */
 function runHref(task: SessionTask): string {
   const childSessionId = task.links?.child_session_id;
-  return childSessionId ? `/sessions/${childSessionId}` : `/sessions/${task.session_id}/resources`;
+  return childSessionId
+    ? `/sessions/${childSessionId}/transcript`
+    : `/sessions/${task.session_id}/resources`;
 }
 
 export function RunCard({ run, now }: { run: ChatRun; now: number }) {

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -88,7 +88,7 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                 <EntityCard
                   key={session.id}
                   variant="row"
-                  href={`/sessions/${session.id}`}
+                  href={`/sessions/${session.id}/transcript`}
                   title={session.title || `Session ${shortenId(session.id)}`}
                   copyValue={session.id}
                   icon={

--- a/apps/ui/src/components/session/run-timeline.tsx
+++ b/apps/ui/src/components/session/run-timeline.tsx
@@ -40,8 +40,10 @@ interface TimelineStep {
   icon: ComponentType<{ className?: string }>;
   tone: StepTone;
   title: string;
-  /** Short facts rendered as a badge row (model, tokens, duration, worker). */
+  /** Short user-facing facts rendered as a badge row (model, tokens, duration). */
   facts: string[];
+  /** Raw correlation and storage fields hidden behind the details disclosure. */
+  technicalDetails?: string[];
   /** Expandable payload — a tool result, a subagent return, an error. */
   payload?: string;
 }
@@ -74,9 +76,9 @@ function stringifyPayload(value: unknown): string | undefined {
  * correlation `exec_id`; when the runtime does not attach one, we say nothing
  * rather than inventing a name.
  */
-function workerFact(event: Event): string[] {
+function workerDetails(event: Event): string[] {
   const execId = event.context?.exec_id;
-  return execId ? [`worker ${execId}`] : [];
+  return execId ? [`Worker: ${execId}`] : [];
 }
 
 function eventSteps(events: Event[]): TimelineStep[] {
@@ -93,9 +95,10 @@ function eventSteps(events: Event[]): TimelineStep[] {
         icon: Play,
         tone: "accent",
         title: "Session started",
-        facts: [started.model_id ? `model ${started.model_id}` : null, ...workerFact(event)].filter(
+        facts: [started.model_id ? `model ${started.model_id}` : null].filter(
           (fact): fact is string => !!fact,
         ),
+        technicalDetails: workerDetails(event),
       });
       return;
     }
@@ -107,7 +110,8 @@ function eventSteps(events: Event[]): TimelineStep[] {
         icon: CircleDot,
         tone: "accent",
         title: "Agent turn started",
-        facts: workerFact(event),
+        facts: [],
+        technicalDetails: workerDetails(event),
         payload: stringifyPayload(turnStarted.input_content),
       });
       return;
@@ -126,8 +130,11 @@ function eventSteps(events: Event[]): TimelineStep[] {
           usage ? `${formatTokens(usage.input_tokens)} prompt` : null,
           usage ? `${formatTokens(usage.output_tokens)} completion` : null,
           formatDuration(generation.metadata.duration_ms),
-          ...workerFact(event),
+          generation.metadata.retry && generation.metadata.retry.attempts > 0
+            ? `${generation.metadata.retry.attempts + 1} attempts`
+            : null,
         ].filter((fact): fact is string => !!fact),
+        technicalDetails: workerDetails(event),
         payload: generation.metadata.error,
       });
       return;
@@ -141,11 +148,10 @@ function eventSteps(events: Event[]): TimelineStep[] {
         icon: Wrench,
         tone: toolCompleted.success ? "neutral" : "danger",
         title: toolCompleted.display_name || toolCompleted.tool_name,
-        facts: [
-          toolCompleted.status,
-          formatDuration(toolCompleted.duration_ms),
-          ...workerFact(event),
-        ].filter((fact): fact is string => !!fact),
+        facts: [toolCompleted.status, formatDuration(toolCompleted.duration_ms)].filter(
+          (fact): fact is string => !!fact,
+        ),
+        technicalDetails: workerDetails(event),
         payload:
           toolCompleted.error ??
           stringifyPayload(resultText || (toolCompleted.result as unknown)) ??
@@ -161,9 +167,8 @@ function eventSteps(events: Event[]): TimelineStep[] {
         icon: AlertTriangle,
         tone: "danger",
         title: "Turn failed",
-        facts: [turnFailed.error_code ?? null, ...workerFact(event)].filter(
-          (fact): fact is string => !!fact,
-        ),
+        facts: [turnFailed.error_code ?? null].filter((fact): fact is string => !!fact),
+        technicalDetails: workerDetails(event),
         payload: turnFailed.error,
       });
       return;
@@ -183,8 +188,8 @@ function eventSteps(events: Event[]): TimelineStep[] {
             ? `${formatTokens(turnCompleted.usage.input_tokens + turnCompleted.usage.output_tokens)} tokens`
             : null,
           formatDuration(turnCompleted.duration_ms),
-          ...workerFact(event),
         ].filter((fact): fact is string => !!fact),
+        technicalDetails: workerDetails(event),
       });
       return;
     }
@@ -200,8 +205,8 @@ function eventSteps(events: Event[]): TimelineStep[] {
           idled.usage
             ? `${formatTokens(idled.usage.input_tokens + idled.usage.output_tokens)} cumulative tokens`
             : null,
-          ...workerFact(event),
         ].filter((fact): fact is string => !!fact),
+        technicalDetails: workerDetails(event),
       });
     }
   });
@@ -239,12 +244,13 @@ function taskSteps(tasks: SessionTask[], events: Event[]): TimelineStep[] {
     icon: task.kind === "subagent" ? Bot : ListTodo,
     tone: task.state === "failed" ? ("danger" as const) : ("neutral" as const),
     title: task.display_name || task.kind,
-    facts: [
-      task.kind,
-      task.state,
-      task.worker_id ? `worker ${task.worker_id}` : null,
-      task.result_path ?? null,
-    ].filter((fact): fact is string => !!fact),
+    facts: [task.kind, task.state, task.attempt > 1 ? `${task.attempt} attempts` : null].filter(
+      (fact): fact is string => !!fact,
+    ),
+    technicalDetails: [
+      task.worker_id ? `Worker: ${task.worker_id}` : null,
+      task.result_path ? `Result path: ${task.result_path}` : null,
+    ].filter((detail): detail is string => !!detail),
     payload: task.error ? `${task.error.kind}: ${task.error.message}` : (task.summary ?? undefined),
   }));
 }
@@ -281,7 +287,7 @@ function TimelineRow({ step }: { step: TimelineStep }) {
         </div>
       )}
 
-      {step.payload && (
+      {(step.payload || (step.technicalDetails?.length ?? 0) > 0) && (
         <div className="mt-1.5">
           <button
             type="button"
@@ -290,12 +296,23 @@ function TimelineRow({ step }: { step: TimelineStep }) {
             aria-expanded={expanded}
           >
             {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-            {expanded ? "Hide payload" : "Show payload"}
+            {expanded ? "Hide details" : "Show details"}
           </button>
           {expanded && (
-            <pre className="mt-1 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded border border-border/70 bg-card px-3 py-2 text-xs text-foreground">
-              {step.payload}
-            </pre>
+            <div className="mt-1 max-h-64 overflow-auto rounded border border-border/70 bg-card px-3 py-2 text-xs text-foreground">
+              {step.technicalDetails && step.technicalDetails.length > 0 && (
+                <ul className="space-y-1 text-muted-foreground">
+                  {step.technicalDetails.map((detail) => (
+                    <li key={detail}>{detail}</li>
+                  ))}
+                </ul>
+              )}
+              {step.payload && (
+                <pre className="mt-2 whitespace-pre-wrap break-words border-t border-border/70 pt-2">
+                  {step.payload}
+                </pre>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -160,7 +160,7 @@ export function SessionCard({
   // Show output preview from session (last assistant message)
   const outputPreview = session.output_preview;
   // Sessions are org-level entities
-  const sessionUrl = `/sessions/${session.id}`;
+  const sessionUrl = `/sessions/${session.id}/transcript`;
   const isPinned = session.is_pinned === true;
 
   return (

--- a/apps/ui/src/components/session/session-header.tsx
+++ b/apps/ui/src/components/session/session-header.tsx
@@ -45,11 +45,11 @@ import {
 } from "lucide-react";
 
 /**
- * A session is a recording, not a workspace (EVE-854), so its tabs are the five
- * views a recording actually has. `files` keeps its route id — the label is
+ * A session is a recording, not a workspace, so its tabs are the views a
+ * recording actually has. `files` keeps its route id — the label is
  * "Workspace" and renaming the route would break existing links.
  */
-export type SessionNavKey = "timeline" | "work" | "events" | "files" | "cost";
+export type SessionNavKey = "transcript" | "timeline" | "work" | "events" | "files" | "cost";
 
 export interface SessionNavItem {
   key: SessionNavKey;
@@ -155,6 +155,12 @@ export function buildSessionNavigation({
   const hasWork = hasFeature("leased_resources") || hasFeature("schedules");
 
   return [
+    {
+      key: "transcript",
+      label: "Transcript",
+      href: `${basePath}/transcript`,
+      icon: MessageSquare,
+    },
     {
       key: "timeline",
       label: "Timeline",

--- a/apps/ui/src/components/session/session-row.tsx
+++ b/apps/ui/src/components/session/session-row.tsx
@@ -58,7 +58,7 @@ export function SessionRow({ session, agentName }: SessionRowProps) {
 
   return (
     <Link
-      href={`/sessions/${session.id}`}
+      href={`/sessions/${session.id}/transcript`}
       className="flex items-start gap-3 border bg-card px-4 py-3 transition-colors hover:border-foreground/20 hover:bg-accent/10"
     >
       <span

--- a/apps/ui/src/components/session/task-detail.tsx
+++ b/apps/ui/src/components/session/task-detail.tsx
@@ -282,7 +282,7 @@ export function TaskCard({
         {childSessionId ? (
           <div>
             <Link
-              href={`/sessions/${childSessionId}`}
+              href={`/sessions/${childSessionId}/transcript`}
               className="text-primary underline-offset-4 hover:underline"
             >
               View child session

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -563,7 +563,7 @@ export function useGlobalSearch(query: string) {
           icon: MessageSquare,
           title: title,
           subtitle: `Sessions > ${title.length > 40 ? title.slice(0, 40) + "..." : title}`,
-          href: `/sessions/${session.id}`,
+          href: `/sessions/${session.id}/transcript`,
         });
         sessionCount++;
       }

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -2,7 +2,7 @@
 
 // Enums that stay generated (closed sets the server owns) while the entity they
 // annotate is still hand-maintained here.
-import type { SessionActivity, SessionSource } from "./schema-types";
+import type { LlmRetryInfo, SessionActivity, SessionSource } from "./schema-types";
 
 // Agent Identity types
 export type AgentIdentityStatus = "active" | "archived" | "deleted";
@@ -2492,6 +2492,7 @@ export interface LlmGenerationMetadata {
   time_to_first_token_ms?: number;
   success: boolean;
   error?: string;
+  retry?: LlmRetryInfo | null;
   compaction?: LlmCompactionInfo;
 }
 

--- a/apps/ui/src/providers/webmcp-provider.tsx
+++ b/apps/ui/src/providers/webmcp-provider.tsx
@@ -205,7 +205,7 @@ function WebMcpShellTools({ enabled }: { enabled: boolean }) {
             throw new TypeError("resource_id must be a session ID");
           }
           await getSession(resourceId);
-          href = `/sessions/${resourceId}`;
+          href = `/sessions/${resourceId}/transcript`;
         } else {
           throw new TypeError("target_type must be page, agent, or session");
         }

--- a/knowledge/ui/information-architecture.md
+++ b/knowledge/ui/information-architecture.md
@@ -76,10 +76,11 @@ policy and dev-mode gating and stay out of the five groups for the same reason.
   same twice, so the Chats entry lists only the few most recently active threads and hands
   the rest to the all-threads page. It also holds its order steady while the pointer is
   inside it, so an arriving turn cannot re-sort a row out from under a click.
-* **A session is a read-only recording.** Session detail inspects, it does not edit. The
-  inspector pattern lives inside session detail rather than in the shell. It carries five
-  views — Timeline, Work, Events, Workspace, Cost — each showing something a recording
-  actually has; watching a live session stream is not editing it. Anything that would
+* **A session is a read-only recording.** Session detail inspects, it does not edit. Its default
+  Transcript preserves the human-readable conversation; Timeline curates how the run executed;
+  Events remains the exact emitted ledger. Work, Workspace, and Cost appear when applicable to the
+  recording and its enabled capabilities. Watching any of these views stream live is not editing
+  the session. Anything that would
   change the session (composing a message, editing a file, writing a secret, steering or
   cancelling a task, enabling a schedule) is absent rather than disabled, including the
   WebMCP tools a browser agent could otherwise reach. The tab set is built by

--- a/test_cases/ui/sessions/TC002_session_recording_projections.md
+++ b/test_cases/ui/sessions/TC002_session_recording_projections.md
@@ -1,0 +1,52 @@
+## Description
+
+Verifies that a session recording separates the human-readable Transcript, curated execution
+Timeline, and exact raw Events ledger while remaining read-only and responsive.
+
+## Preconditions
+
+- The API, worker, UI, and reverse proxy are running with `AUTH_MODE=none` or an authenticated user.
+- A completed session exists with several user/agent turns and model-call events.
+- An empty session exists.
+- A latency-enabled local test model is available for a live turn.
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Completed session | At least three turns |
+| Empty session | No messages or execution events |
+| Desktop viewport | 1280 × 800 or wider |
+| Narrow viewport | 390 × 844 |
+
+## Steps
+
+1. Open `/sessions/<completed-session-id>` and inspect the resulting URL, title, tabs, and active tab.
+2. Inspect Transcript, then start a latency-enabled turn and observe output while it streams and
+   after it completes.
+3. Confirm Transcript contains conversation messages and compact completed work narration but no
+   composer, send, edit, cancel, or other mutation control.
+4. Open Timeline and inspect the same live and completed turn.
+5. Expand one model or tool detail and inspect its worker correlation or payload.
+6. Open Events and inspect one raw event payload.
+7. Use browser Back and Forward across Transcript, Timeline, and Events.
+8. Open the legacy `/sessions/<completed-session-id>/chat` URL.
+9. Repeat Transcript and Timeline inspection at the narrow viewport.
+10. Open Transcript and Timeline for the empty session.
+11. Open an unknown session ID and observe the error state; reload a known session and observe the
+    loading skeleton before data settles.
+
+## Expected Result
+
+- The base and legacy chat routes redirect to `/sessions/<id>/transcript`.
+- Navigation order is Transcript, Timeline, optional Work, Events, optional Workspace, Cost.
+- Transcript is active by default, has the Transcript page title, fills the recording content area,
+  replays completed conversation, and appends live output without a composer or mutation controls.
+- Timeline fills the recording content area without a transcript rail, streams/replays curated
+  execution steps, and keeps raw worker IDs and payloads collapsed behind details.
+- Events shows event sequence, type, timestamp/metadata, and the complete raw payload rather than
+  either curated projection.
+- Back/Forward restores the correct route and active tab.
+- Empty, loading, and missing-session states are clear and do not expose mutation controls.
+- Desktop and narrow layouts remain readable without side-by-side independent transcript/timeline
+  scrollers.


### PR DESCRIPTION
## What changed
Session recordings now have three distinct projections:
- **Transcript** is the default, full-width, read-only conversation replay.
- **Timeline** is a full-width curated execution history with noisy worker details collapsed.
- **Events** remains the complete raw emitted-event ledger.

Session entry points, global search, page titles, tab state, and the existing **Fork into chat** escape hatch now target Transcript. Work, Workspace, and Cost retain their existing feature-gated behavior.

## Why
The old Timeline combined an execution rail and an independently scrolling transcript, presenting duplicate projections as if they were master-detail views. This obscured the distinction between conversation replay and execution debugging.

## Before / After
Before: Timeline rendered the Run rail beside an unlabeled read-only transcript with no selection relationship.

After: Transcript and Timeline are separate full-width views, while Events clearly exposes the exact raw event envelope.

Before/after desktop and narrow-viewport screenshots are attached in the PR conversation and are not part of the repository.

Manual evidence:
- Completed replay: 23-turn session, including Transcript pagination and a 253-event Timeline.
- Live streaming: Transcript and Timeline both observed while running and after completion.
- Empty, loading, and missing-session states verified.
- Desktop (1280 px) and narrow (390 px) layouts verified.
- Transcript DOM verified with zero textareas, forms, or send buttons.
- Base and legacy chat URLs redirect to Transcript; browser back/forward and hydrated page titles remain correct.

Validation:
- `pnpm exec jest --runInBand`: 181 suites, 1469 tests passed.
- UI format, lint, typecheck, and production build passed.
- `just check-okf` passed.
- `just pre-push` passed all 17 checks.
- Manual UI case `TC002_session_recording_projections.md` passed.
- PR CI: 14 affected checks passed, 24 unaffected checks skipped, 0 failures.

## Risk
- **Low**
- Session navigation and presentation change, but no API, persistence, authorization, or mutation behavior changes.
- Legacy `/sessions/:id/chat` links intentionally redirect to Transcript.

## Security
- Threat categories reviewed: TM-WEB and TM-DOS.
- Findings and resolutions: No findings. Redirects are same-origin and relative; React escapes raw event JSON; no authentication, authorization, storage, dependency, or mutating-control changes were introduced; existing event pagination bounds remain in place.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)