### PR TITLE
feat(models): use platform default fallback

### DIFF
--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -104,7 +104,7 @@ export default function ModelsPage() {
   const selectedDefaultModelName = org?.default_model_id
     ? (allEnabledModels.find((model) => model.id === org.default_model_id)?.display_name ??
       "Unknown model")
-    : undefined;
+    : "Platform default · GPT-5.6 Terra";
 
   // Provider usage counts across all models, for the rail facet.
   const providerFacets = useMemo(() => {
@@ -297,7 +297,7 @@ export default function ModelsPage() {
               <div className="mb-4">
                 <h2 className="text-xl font-semibold">Organization Settings</h2>
                 <p className="text-sm text-muted-foreground">
-                  Configure the default model for your organization. This is used when no model is
+                  Override the platform default for your organization. This is used when no model is
                   specified at the agent or session level.
                 </p>
               </div>
@@ -315,12 +315,12 @@ export default function ModelsPage() {
                       disabled={updateOrg.isPending}
                     >
                       <SelectTrigger className="w-full max-w-md" id="default-model">
-                        <SelectValue placeholder="No default model">
+                        <SelectValue placeholder="Platform default · GPT-5.6 Terra">
                           {selectedDefaultModelName}
                         </SelectValue>
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="none">No default model</SelectItem>
+                        <SelectItem value="none">Platform default · GPT-5.6 Terra</SelectItem>
                         {allEnabledModels.map((model) => (
                           <SelectItem key={model.id} value={model.id}>
                             <div className="flex items-center gap-2">

--- a/apps/ui/src/app/(main)/settings/organization/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organization/page.tsx
@@ -343,13 +343,13 @@ export default function OrganizationPage() {
 
             <SettingsGroup
               title="Models"
-              description="Model fallbacks applied when agents or sessions do not set their own model."
+              description="Override the platform model fallback used when agents or sessions do not set their own model."
               status={<AutoSaveBadge saveState={saveStates.models} />}
               error={saveStates.models.error}
             >
               <SettingsRow
                 label="Default Model"
-                description="Used when no model is specified at the agent or session level."
+                description="Leave empty to use the platform default, GPT-5.6 Terra."
                 htmlFor="default-model"
               >
                 <ModelPicker
@@ -360,7 +360,7 @@ export default function OrganizationPage() {
                     setDefaultModelId(value);
                     scheduleAutoSave("models", nextDraft);
                   }}
-                  placeholder="No default model"
+                  placeholder="Platform default · GPT-5.6 Terra"
                   className={CONTROL_CLASS_NAME}
                 />
               </SettingsRow>

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -9,10 +9,24 @@
 use everruns_core::connector::{ConnectorPlugin, ConnectorRegistry};
 use everruns_core::deployment::DeploymentGrade;
 use everruns_core::{
-    DirectEgressService, PlatformDefinition, SystemEmailConfig, SystemUtilityLlmConfig,
+    DEFAULT_ORG_ID, DirectEgressService, PlatformDefinition, SystemEmailConfig,
+    SystemUtilityLlmConfig,
 };
 use everruns_platform::BuiltInHarnessDefinition;
 use std::sync::Arc;
+use uuid::Uuid;
+
+/// The platform fallback when an organization has not selected a model.
+pub(crate) const PLATFORM_DEFAULT_MODEL_ID: Uuid =
+    Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000227);
+
+pub(crate) const fn platform_default_model_id(org_id: i64) -> Option<Uuid> {
+    if org_id == DEFAULT_ORG_ID {
+        Some(PLATFORM_DEFAULT_MODEL_ID)
+    } else {
+        None
+    }
+}
 
 /// Build the default OSS `PlatformDefinition` for the current deployment grade.
 pub fn oss_platform_definition() -> PlatformDefinition {

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1589,6 +1589,7 @@ const SEED_MODELS: &[SeedModel] = &[
         is_favorite: true, // Favorite model
     },
     SeedModel {
+        // Platform default model (see `platform::PLATFORM_DEFAULT_MODEL_ID`).
         id: seed_ids::GPT_5_6_TERRA,
         provider_id: seed_ids::OPENAI_PROVIDER,
         model_id: "gpt-5.6-terra",
@@ -1902,8 +1903,7 @@ const SEED_MODELS: &[SeedModel] = &[
     },
     // Anthropic current-gen (Opus 5, Sonnet 5, Opus 4.8)
     SeedModel {
-        // Platform default model (see `DEFAULT_MODEL_ID`). Opus 5 is the current
-        // Opus flagship — the recommended Anthropic model.
+        // Opus 5 is the current Opus flagship — the recommended Anthropic model.
         id: seed_ids::CLAUDE_OPUS_5,
         provider_id: seed_ids::ANTHROPIC_PROVIDER,
         model_id: "claude-opus-5",
@@ -2138,29 +2138,6 @@ const SEED_MODELS: &[SeedModel] = &[
         is_favorite: false,
     },
 ];
-
-/// Default model ID for org settings seeding (Claude Opus 5)
-const DEFAULT_MODEL_ID: Uuid = seed_ids::CLAUDE_OPUS_5;
-
-/// Seed organization settings (default model, etc.)
-async fn seed_organization_settings(db: &StorageBackend) -> anyhow::Result<SeedResult> {
-    let mut result = SeedResult::default();
-
-    match db.get_organization_settings(DEFAULT_ORG_ID).await? {
-        Some(existing) if existing.default_model_id.is_some() => {
-            tracing::debug!("Organization settings up to date");
-            result.unchanged += 1;
-        }
-        _ => {
-            db.upsert_organization_settings(DEFAULT_ORG_ID, Some(DEFAULT_MODEL_ID))
-                .await?;
-            tracing::info!("Seeded organization settings with default model");
-            result.created += 1;
-        }
-    }
-
-    Ok(result)
-}
 
 /// Seed default-org feature flag opt-ins when none exist (dev-friendly bootstrap).
 async fn seed_default_org_feature_flags(db: &StorageBackend) -> anyhow::Result<SeedResult> {
@@ -2662,16 +2639,6 @@ pub async fn seed_all_with_platform_definition(
         "Models seeded"
     );
     result.merge(model_result);
-
-    // Seed organization settings (depends on models for default_model_id)
-    let org_settings_result = seed_organization_settings(db).await?;
-    tracing::debug!(
-        created = org_settings_result.created,
-        updated = org_settings_result.updated,
-        unchanged = org_settings_result.unchanged,
-        "Organization settings seeded"
-    );
-    result.merge(org_settings_result);
 
     let org_flags_result = seed_default_org_feature_flags(db).await?;
     tracing::debug!(
@@ -3333,49 +3300,32 @@ mod tests {
             .id;
         assert_eq!(settings.default_harness_id, Some(generic_id));
         assert_eq!(settings.base_harness_id, Some(base_id));
-        assert_eq!(
-            settings.default_model_id,
-            Some(everruns_core::ModelId::from_uuid(DEFAULT_MODEL_ID))
-        );
+        assert_eq!(settings.default_model_id, None);
     }
 
     #[tokio::test]
-    async fn test_seed_all_sets_default_and_seeds_opus_5() {
+    async fn test_seed_all_leaves_the_org_model_override_unset() {
         let db = make_db();
         seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
             .await
             .unwrap();
 
-        // Platform default model is Claude Opus 5.
+        // GPT-5.6 Terra is platform-owned, not an organization override.
         let settings = db
             .get_organization_settings(DEFAULT_ORG_ID)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(
-            settings.default_model_id,
-            Some(everruns_core::ModelId::from_uuid(seed_ids::CLAUDE_OPUS_5)),
-        );
+        assert_eq!(settings.default_model_id, None);
 
-        // Claude Opus 5 is seeded for the Anthropic provider, enabled and marked
-        // favorite (the recommended Anthropic model, and the platform default).
-        let opus = db
-            .get_model(DEFAULT_ORG_ID, seed_ids::CLAUDE_OPUS_5)
+        let terra = db
+            .get_model(DEFAULT_ORG_ID, seed_ids::GPT_5_6_TERRA)
             .await
             .unwrap()
-            .expect("claude-opus-5 should be seeded");
-        assert_eq!(opus.model_id, "claude-opus-5");
-        assert!(opus.enabled, "claude-opus-5 should be enabled");
-        assert!(opus.is_favorite, "claude-opus-5 should be favorite");
-
-        // The 1M-context twin is seeded and enabled alongside the 200K base.
-        let opus_1m = db
-            .get_model(DEFAULT_ORG_ID, seed_ids::CLAUDE_OPUS_5_1M)
-            .await
-            .unwrap()
-            .expect("claude-opus-5[1m] should be seeded");
-        assert_eq!(opus_1m.model_id, "claude-opus-5[1m]");
-        assert!(opus_1m.enabled, "claude-opus-5[1m] should be enabled");
+            .expect("gpt-5.6-terra should be seeded");
+        assert_eq!(terra.model_id, "gpt-5.6-terra");
+        assert!(terra.enabled, "gpt-5.6-terra should be enabled");
+        assert!(terra.is_favorite, "gpt-5.6-terra should be favorite");
     }
 
     #[tokio::test]
@@ -3604,7 +3554,7 @@ mod tests {
         assert_eq!(
             anthropic.get("claude-opus-5"),
             Some(&(true, true)),
-            "Opus 5 must be the enabled favorite Opus (platform default)"
+            "Opus 5 must be the enabled favorite Opus"
         );
         assert_eq!(
             anthropic.get("claude-opus-5[1m]"),

--- a/crates/server/src/storage/memory/providers.rs
+++ b/crates/server/src/storage/memory/providers.rs
@@ -234,7 +234,10 @@ impl InMemoryDatabase {
 
     pub async fn get_default_model(&self, org_id: i64) -> Result<Option<ModelWithProviderRow>> {
         let org_settings = self.org_settings.read();
-        let default_model_id = org_settings.get(&org_id).and_then(|s| s.default_model_id);
+        let default_model_id = org_settings
+            .get(&org_id)
+            .and_then(|s| s.default_model_id)
+            .or_else(|| crate::platform::platform_default_model_id(org_id).map(ModelId::from_uuid));
         let default_model_id = match default_model_id {
             Some(id) => id,
             None => return Ok(None),

--- a/crates/server/src/storage/repositories/providers.rs
+++ b/crates/server/src/storage/repositories/providers.rs
@@ -202,7 +202,7 @@ impl Database {
     }
 
     /// Get the default LLM model with provider info.
-    /// Reads from organization_settings.default_model_id.
+    /// Uses the organization selection when present, otherwise the platform fallback.
     ///
     /// Fail-closed: filters to providers that are administratively active *and*
     /// to models with `enabled = TRUE`, so disabling a model — even if it is
@@ -215,13 +215,15 @@ impl Database {
             r#"
             SELECT m.id, m.org_id, m.provider_id, m.model_id, m.display_name, m.capabilities, m.is_favorite, m.enabled, m.source, m.last_seen_at, m.provider_metadata, m.created_at, m.updated_at,
                    p.name as provider_name, p.provider_type, p.api_key_set as provider_api_key_set, p.status as provider_status
-            FROM organization_settings os
-            JOIN models m ON m.id = os.default_model_id AND m.org_id = os.org_id
+            FROM models m
+            LEFT JOIN organization_settings os ON os.org_id = m.org_id
             JOIN providers p ON m.provider_id = p.id AND p.org_id = m.org_id
-            WHERE os.org_id = $1 AND p.status = 'active' AND m.enabled = TRUE
+            WHERE m.org_id = $1 AND m.id = COALESCE(os.default_model_id, $2)
+              AND p.status = 'active' AND m.enabled = TRUE
             "#,
         )
         .bind(org_id)
+        .bind(crate::platform::platform_default_model_id(org_id))
         .fetch_optional(&self.pool)
         .await?;
 


### PR DESCRIPTION
## What changed
Organization default-model settings now represent explicit overrides only. When unset, the platform falls back to GPT-5.6 Terra; the Models and Organization Settings UI makes that fallback visible.

## Why
The previous seed stored the platform choice as an organization-owned selection, making it impossible to distinguish a platform default from an administrator override.

## Before / After
Before: fresh default-org settings persisted a concrete default model ID.
After: the seed regression confirms `default_model_id = null`, while resolver storage selects the platform-owned GPT-5.6 Terra fallback. UI copy renders “Platform default · GPT-5.6 Terra” for the unset state.

## Risk
- Medium
- Default-model resolution now has an explicit fallback path. It remains scoped to the platform/default org and retains active-provider and enabled-model checks.

## Security
- Threat categories reviewed: TM-TENANT, TM-LLM, TM-WEB
- Findings and resolutions: Tenant scope remains in the model query; the fallback UUID is parameter-bound; provider/model eligibility checks remain fail-closed; UI renders static text only. No new threat-model entry required.

## Follow-ups
- Runtime UI smoke test is blocked locally: the canonical stack cannot obtain Doppler secrets because no project or fallback file is configured. CI must provide final UI runtime evidence.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)