### PR TITLE
fix(llm-tests): skip subagent live test on provider quota exhaustion

### DIFF
--- a/crates/llm-tests/tests/subagent_live_test.rs
+++ b/crates/llm-tests/tests/subagent_live_test.rs
@@ -200,6 +200,7 @@ async fn background_spawn_agent_subagent_live_end_to_end() {
         )
         .await
         .expect("parent turn runs");
+    skip_if_quota!(turn, config.label());
     assert!(turn.success, "parent turn failed: {:?}", turn.error);
 
     let parent_messages = runtime.messages(parent_id).await.expect("parent messages");
@@ -237,6 +238,19 @@ async fn background_spawn_agent_subagent_live_end_to_end() {
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
     let settled = settled.expect("subagent task should settle within 120s");
+    // The child's turn is a second live call; out-of-quota there is the same
+    // provider condition as on the parent turn, not a subagent regression.
+    if settled.state != SessionTaskState::Succeeded
+        && let Some(err) = settled.error.as_ref()
+        && is_quota_exhausted(&err.message)
+    {
+        eprintln!(
+            "SKIP: provider {} out of quota: {}",
+            config.label(),
+            err.message
+        );
+        return;
+    }
     assert_eq!(
         settled.state,
         SessionTaskState::Succeeded,


### PR DESCRIPTION
## Summary

Main CI went red on `background_spawn_agent_subagent_live_end_to_end`: the Anthropic account is currently out of API credits, and the provider returns `400 "Your credit balance is too low to access the Anthropic API"`. The rest of the live suite already routes provider-quota conditions through `is_quota_exhausted`/`skip_if_quota!` (which explicitly documents this exact Anthropic 400), but this test asserted turn success directly — so a billing condition failed main instead of skipping.

The fix protects both live seams with the existing convention:
- the parent turn gets `skip_if_quota!(turn, config.label())` before the success assert;
- the child task's settled state checks `settled.error` against `is_quota_exhausted` before asserting `Succeeded`, since the child's turn is a second live call hitting the same provider.

Auth/permission failures remain unswallowed — `is_quota_exhausted` deliberately rejects 401/403/invalid-key signatures.

## Testing

`cargo check` and `cargo clippy` on the test target pass; `cargo fmt --check` clean. The skip path is exercised by the current CI environment itself (the account is out of credits), and the quota detector's signature matching is covered by the existing `matches_provider_quota_signatures` unit test.

Note: main stays functionally degraded for live-LLM coverage until Anthropic credits are topped up — this PR only stops billing state from reading as a code regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_