### PR TITLE
refactor(platform): move the persisted Session aggregate out of core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **Moved the persisted `Session` aggregate and product lifecycle enums out of
+  `everruns-core`.** The database/API record — `Session`, `SessionStatus`,
+  `SessionSource`, `SessionActivity`, `SessionParticipant`,
+  `SessionParticipantKind`, `SessionParticipantRole` — now lives in
+  `everruns-platform`. Core keeps only the portable
+  `everruns_core::ExecutionSession` (session correlation values plus the
+  per-session configuration overlay a turn consumes) and the neutral
+  `everruns_core::SessionExecutionState` the host lifecycle drives;
+  `SessionStore`/`SessionMutator` implementations now return the execution
+  view, and status mutation acknowledges without exposing a stored record.
+  The stored record projects into the execution view via
+  `everruns_platform::Session::execution_session()` at the platform loading
+  seam (server repositories, worker adapters); `SessionId`, turn/message
+  correlation IDs, and portable event/message values stay in core. Framework
+  hosts seed `ExecutionSession` values (`SessionBuilder` now builds one, and
+  no longer takes owner/timestamp fields). Direct core consumers that touch
+  the stored record should depend on `everruns-platform` and import it from
+  there. REST/gRPC shapes and stored schema are unchanged.
+
 - **Moved the stored `Harness` record and built-in provisioning templates out
   of `everruns-core`.** The persistence record — `Harness`, `HarnessStatus`,
   `merge_harness`, `merge_harness_chain` — and the provisioning templates —

--- a/crates/core/src/ard_attachment.rs
+++ b/crates/core/src/ard_attachment.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::capability_types::AgentCapabilityConfig;
 use crate::mcp_server::ScopedMcpServer;
-use crate::session::Session;
+use crate::session::ExecutionSession;
 use crate::traits::SessionStorageStore;
 use crate::typed_id::SessionId;
 
@@ -95,7 +95,7 @@ pub fn urn_slug(urn: &str) -> String {
 /// Merge a single attachment into a session's config layer. Idempotent: an MCP
 /// server with the same logical name, or an A2A agent with the same `id`, is
 /// not duplicated (the attachment wins on conflict, matching last-layer-wins).
-pub fn merge_attachment_into_session(session: &mut Session, attachment: &ArdAttachment) {
+pub fn merge_attachment_into_session(session: &mut ExecutionSession, attachment: &ArdAttachment) {
     match &attachment.target {
         ArdAttachmentTarget::McpServer { name, server } => {
             session.mcp_servers.insert(name.clone(), server.clone());
@@ -110,7 +110,7 @@ pub fn merge_attachment_into_session(session: &mut Session, attachment: &ArdAtta
 /// capability config (creating the capability entry if absent). Adding the
 /// capability at the session layer makes `spawn_agent` available scoped to this
 /// session even when the base agent was not provisioned with A2A delegation.
-fn merge_external_agent(session: &mut Session, agent: &serde_json::Value) {
+fn merge_external_agent(session: &mut ExecutionSession, agent: &serde_json::Value) {
     let Some(agent_id) = agent.get("id").and_then(|v| v.as_str()) else {
         return;
     };
@@ -190,7 +190,10 @@ pub async fn load_session_attachments(
 /// config layer. Called during turn-context assembly (server `GetTurnContext`
 /// and the in-process runtime) after the session record is loaded and before
 /// scoped MCP servers / capabilities are resolved into the live tool set.
-pub async fn apply_session_attachments(storage: &dyn SessionStorageStore, session: &mut Session) {
+pub async fn apply_session_attachments(
+    storage: &dyn SessionStorageStore,
+    session: &mut ExecutionSession,
+) {
     let attachments = load_session_attachments(storage, session.id).await;
     for attachment in &attachments {
         merge_attachment_into_session(session, attachment);
@@ -201,55 +204,9 @@ pub async fn apply_session_attachments(storage: &dyn SessionStorageStore, sessio
 mod tests {
     use super::*;
     use crate::mcp_server::McpServerTransportType;
-    use crate::session::SessionStatus;
 
-    fn test_session() -> Session {
-        let session_id = SessionId::new();
-        Session {
-            source: Default::default(),
-            activity: Default::default(),
-            id: session_id,
-            workspace_id: crate::WorkspaceId::from_uuid(session_id.uuid()),
-            organization_id: crate::DEFAULT_ORG_PUBLIC_ID.to_string(),
-            harness_id: crate::typed_id::HarnessId::new(),
-            agent_id: None,
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: crate::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
-            title: None,
-            goal: None,
-            locale: None,
-            preview: None,
-            output_preview: None,
-            tags: vec![],
-            model_id: None,
-            capabilities: vec![],
-            tools: vec![],
-            mcp_servers: Default::default(),
-            system_prompt: None,
-            initial_files: vec![],
-            hints: None,
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            started_at: None,
-            finished_at: None,
-            usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
-            parent_session_id: None,
-            forked_from_session_id: None,
-            forked_from_sequence: None,
-            blueprint_id: None,
-            blueprint_config: None,
-        }
+    fn test_session() -> ExecutionSession {
+        ExecutionSession::with_own_workspace(SessionId::new(), crate::typed_id::HarnessId::new())
     }
 
     fn mcp_attachment(urn: &str, name: &str) -> ArdAttachment {

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -493,7 +493,7 @@ async fn harness_chain_overlay(
 
 async fn invite_mode_overlays(
     store: &dyn crate::subagent_delegation::SubagentSessionDelegate,
-    parent_session: &crate::session::Session,
+    parent_session: &crate::session::ExecutionSession,
     target: &AgentHandoffTargetConfig,
 ) -> Result<(AgentConfigOverlay, AgentConfigOverlay), ToolExecutionResult> {
     let mut host_layers = vec![harness_chain_overlay(store, parent_session.harness_id).await?];
@@ -1012,16 +1012,16 @@ impl Tool for SpawnAgentHandoffTool {
                 ));
             }
 
-            let participant = match store
+            let participant_id = match store
                 .add_agent_session_participant(context.session_id, target.agent_id)
                 .await
             {
-                Ok(participant) => participant,
+                Ok(participant_id) => participant_id,
                 Err(error) => return ToolExecutionResult::internal_error(error),
             };
 
             return ToolExecutionResult::success(json!({
-                "participant_id": participant.id,
+                "participant_id": participant_id,
                 "target": target.id,
                 "target_agent_id": target.agent_id,
                 "name": name,
@@ -1796,11 +1796,7 @@ mod tests {
             .expect("participants lock")
             .clone();
         assert_eq!(participants.len(), 1);
-        assert_eq!(participants[0].agent_id, Some(store.agent.id));
-        assert_eq!(
-            participants[0].role,
-            crate::session::SessionParticipantRole::Member
-        );
+        assert_eq!(participants[0].1, Some(store.agent.id));
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/btw.rs
+++ b/crates/core/src/capabilities/btw.rs
@@ -131,7 +131,7 @@ mod tests {
     use crate::command_host::{
         CommandHost, CommandTurnContext, SessionCompletion, SessionCompletionError,
     };
-    use crate::session::{Session, SessionStatus};
+    use crate::session::ExecutionSession;
     use crate::typed_id::{HarnessId, SessionId};
     use crate::user_facing_error::UserFacingErrorContext;
     use std::sync::{Arc, Mutex};
@@ -150,52 +150,8 @@ mod tests {
         assert!(commands[0].args[0].required);
     }
 
-    fn test_session(session_id: SessionId) -> Session {
-        Session {
-            source: Default::default(),
-            activity: Default::default(),
-            id: session_id,
-            workspace_id: crate::WorkspaceId::from_uuid((session_id).uuid()),
-            organization_id: crate::DEFAULT_ORG_PUBLIC_ID.to_string(),
-            harness_id: HarnessId::new(),
-            agent_id: None,
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: crate::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
-            title: None,
-            goal: None,
-            locale: None,
-            preview: None,
-            output_preview: None,
-            tags: vec![],
-            model_id: None,
-            capabilities: vec![],
-            tools: vec![],
-            mcp_servers: Default::default(),
-            system_prompt: None,
-            initial_files: vec![],
-            hints: None,
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-            started_at: None,
-            finished_at: None,
-            usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
-            parent_session_id: None,
-            forked_from_session_id: None,
-            forked_from_sequence: None,
-            blueprint_id: None,
-            blueprint_config: None,
-        }
+    fn test_session(session_id: SessionId) -> ExecutionSession {
+        ExecutionSession::with_own_workspace(session_id, HarnessId::new())
     }
 
     struct StubHost {

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -7,7 +7,7 @@
 use super::{Capability, CapabilityLocalization, CapabilityStatus};
 use crate::error::{AgentLoopError, Result};
 use crate::events::{EventContext, EventRequest, SessionTitleUpdatedData, TokenUsage};
-use crate::session::Session;
+use crate::session::ExecutionSession;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{EventEmitter, SessionMutator, SessionStore, ToolContext};
@@ -37,7 +37,7 @@ impl SessionCapabilityConfig {
 #[derive(Debug, Clone)]
 pub struct SessionTitleMutation {
     /// Current session snapshot.
-    pub session: Session,
+    pub session: ExecutionSession,
     /// Whether the stored title changed and an event was emitted.
     pub changed: bool,
 }
@@ -387,28 +387,27 @@ mod tests {
     use super::*;
     use crate::AgentDefinition;
     use crate::events::{Event, EventRequest};
-    use crate::session::{Session, SessionStatus};
+    use crate::session::{ExecutionSession, SessionExecutionState};
     use crate::typed_id::{AgentId, EventId, HarnessId, MessageId, ModelId, SessionId, TurnId};
     use crate::{AgentCapabilityConfig, Tool};
     use async_trait::async_trait;
-    use chrono::Utc;
     use std::sync::{Arc, Mutex};
 
     #[derive(Clone)]
     struct MockSessionStore {
-        session: Arc<Mutex<Option<Session>>>,
+        session: Arc<Mutex<Option<ExecutionSession>>>,
     }
 
     #[async_trait]
     impl crate::traits::SessionStore for MockSessionStore {
-        async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+        async fn get_session(&self, _session_id: SessionId) -> Result<Option<ExecutionSession>> {
             Ok(self.session.lock().expect("poisoned").clone())
         }
     }
 
     #[derive(Clone)]
     struct MockSessionMutator {
-        session: Arc<Mutex<Session>>,
+        session: Arc<Mutex<ExecutionSession>>,
     }
 
     #[async_trait]
@@ -417,7 +416,7 @@ mod tests {
             &self,
             _session_id: SessionId,
             title: String,
-        ) -> Result<Session> {
+        ) -> Result<ExecutionSession> {
             let mut session = self.session.lock().expect("poisoned");
             session.title = Some(title);
             Ok(session.clone())
@@ -451,53 +450,13 @@ mod tests {
         }
     }
 
-    fn build_session(agent_id: Option<AgentId>) -> Session {
-        let session_id = SessionId::new();
-        Session {
-            source: Default::default(),
-            activity: Default::default(),
-            id: session_id,
-            // Default 1:1 session<->workspace: workspace.id mirrors the session id.
-            workspace_id: crate::WorkspaceId::from_uuid(session_id.uuid()),
-            organization_id: "org_00000000000000000000000000000001".to_string(),
-            harness_id: HarnessId::new(),
+    fn build_session(agent_id: Option<AgentId>) -> ExecutionSession {
+        ExecutionSession {
             agent_id,
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: crate::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
             title: Some("Old title".to_string()),
-            goal: None,
-            locale: None,
-            preview: None,
-            output_preview: None,
-            tags: vec![],
             model_id: Some(ModelId::new()),
-            capabilities: vec![],
-            tools: vec![],
-            mcp_servers: Default::default(),
-            system_prompt: None,
-            initial_files: vec![],
-            hints: None,
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            status: SessionStatus::Idle,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            started_at: None,
-            finished_at: None,
-            usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
-            parent_session_id: None,
-            forked_from_session_id: None,
-            forked_from_sequence: None,
-            blueprint_id: None,
-            blueprint_config: None,
+            status: SessionExecutionState::Idle,
+            ..ExecutionSession::with_own_workspace(SessionId::new(), HarnessId::new())
         }
     }
 

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -387,7 +387,7 @@ fn get_session_store(
 
 async fn current_subagent_depth(
     session_store: &dyn SessionStore,
-    session: &crate::session::Session,
+    session: &crate::session::ExecutionSession,
     max_subagent_depth: u32,
 ) -> Result<u32, ToolExecutionResult> {
     let mut depth = 0_u32;
@@ -416,7 +416,7 @@ async fn current_subagent_depth(
 
 async fn root_session_for_subagent_tree(
     session_store: &dyn SessionStore,
-    session: &crate::session::Session,
+    session: &crate::session::ExecutionSession,
 ) -> Result<SessionId, ToolExecutionResult> {
     let mut root_id = session.id;
     let mut cursor = session.parent_session_id;
@@ -497,7 +497,7 @@ async fn descendant_subagent_task_counts(
 
 async fn enforce_subagent_task_caps(
     session_store: &dyn SessionStore,
-    session: &crate::session::Session,
+    session: &crate::session::ExecutionSession,
     context: &ToolContext,
 ) -> Result<(), ToolExecutionResult> {
     let Some(registry) = context.session_task_registry.as_ref() else {
@@ -613,7 +613,7 @@ async fn enforce_detached_spawn_caps(
 
 async fn enforce_subagent_depth_cap(
     session_store: &dyn SessionStore,
-    session: &crate::session::Session,
+    session: &crate::session::ExecutionSession,
     context: &ToolContext,
 ) -> Result<(), ToolExecutionResult> {
     let max_subagent_depth = context.subagent_nesting_policy.max_subagent_depth();
@@ -1151,7 +1151,7 @@ fn background_running_result(
 async fn spawn_create_and_wait(
     store: &dyn SubagentSessionDelegate,
     context: &ToolContext,
-    parent_session: &crate::session::Session,
+    parent_session: &crate::session::ExecutionSession,
     name: &str,
     goal: Option<&str>,
     instructions: &str,
@@ -2106,7 +2106,7 @@ mod tests {
         async fn get_session(
             &self,
             session_id: crate::typed_id::SessionId,
-        ) -> crate::error::Result<Option<crate::session::Session>> {
+        ) -> crate::error::Result<Option<crate::session::ExecutionSession>> {
             self.0.get_session_by_id(session_id).await
         }
     }

--- a/crates/core/src/command_host.rs
+++ b/crates/core/src/command_host.rs
@@ -21,7 +21,7 @@ use crate::error::{AgentLoopError, Result};
 use crate::message::{Controls, Message, MessageRole, patch_dangling_tool_calls};
 use crate::message_retriever::MessageRetriever;
 use crate::runtime_context::{AssembledTurnContext, inspect_turn_context};
-use crate::session::Session;
+use crate::session::ExecutionSession;
 use crate::traits::{
     AgentStore, HarnessStore, ImageResolver, ProviderStore, ResolvedImage, ResolvedModel,
     SessionFileSystem, SessionStore,
@@ -44,7 +44,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone)]
 pub struct CommandTurnContext {
     /// Session the command is executing against.
-    pub session: Session,
+    pub session: ExecutionSession,
     /// Conversation messages after capability message filters.
     pub messages: Vec<Message>,
     /// Merged system prompt including capability contributions.

--- a/crates/core/src/config_layer.rs
+++ b/crates/core/src/config_layer.rs
@@ -28,7 +28,7 @@ use crate::capability_types::AgentCapabilityConfig;
 use crate::harness_definition::HarnessDefinition;
 use crate::mcp_server::{ScopedMcpServers, merge_scoped_mcp_servers};
 use crate::network_access::{self, NetworkAccessList};
-use crate::session::Session;
+use crate::session::ExecutionSession;
 use crate::session_file::InitialFile;
 use crate::tool_types::ToolDefinition;
 use crate::typed_id::ModelId;
@@ -215,8 +215,8 @@ impl From<&AgentDefinition> for AgentConfigOverlay {
     }
 }
 
-impl From<&Session> for AgentConfigOverlay {
-    fn from(s: &Session) -> Self {
+impl From<&ExecutionSession> for AgentConfigOverlay {
+    fn from(s: &ExecutionSession) -> Self {
         let goal_prompt = s
             .goal
             .as_ref()

--- a/crates/core/src/execution_snapshot.rs
+++ b/crates/core/src/execution_snapshot.rs
@@ -1,7 +1,7 @@
 // Canonical resolved execution snapshot (EVE-872).
 //
 // Decision: host turn execution consumes this neutral, value-first projection
-// instead of stored Agent/Harness/Session aggregates. Both the Framework
+// instead of stored Agent/Harness/Session aggregates (the session arrives as the portable `ExecutionSession` projection, EVE-882). Both the Framework
 // in-process runtime and the hosted workers build the same value here, so
 // harness → agent → session precedence is applied by one code path
 // (`AgentConfigOverlay` merge semantics) regardless of which host executes the
@@ -22,7 +22,7 @@ use crate::mcp_server::{
     McpProtocolMode, McpServerAuthMode, McpServerTransportType, ScopedMcpServer,
 };
 use crate::network_access::NetworkAccessList;
-use crate::session::Session;
+use crate::session::ExecutionSession;
 use crate::session_file::InitialFile;
 use crate::tool_types::ToolDefinition;
 use crate::traits::{AgentStore, HarnessStore, SessionStore};
@@ -140,7 +140,7 @@ impl ResolvedExecutionSnapshot {
     pub fn project(
         harness: &HarnessDefinition,
         agent: Option<&AgentDefinition>,
-        session: &Session,
+        session: &ExecutionSession,
     ) -> Result<Self> {
         let agent = match (session.agent_id, agent) {
             (Some(agent_id), Some(agent)) => {
@@ -227,7 +227,7 @@ pub async fn load_execution_snapshot(
 pub async fn load_execution_snapshot_for_session(
     harness_store: &dyn HarnessStore,
     agent_store: &dyn AgentStore,
-    session: &Session,
+    session: &ExecutionSession,
 ) -> Result<ResolvedExecutionSnapshot> {
     let harness = harness_store
         .get_harness(session.harness_id)
@@ -245,8 +245,6 @@ mod tests {
     use super::*;
     use crate::in_memory::{InMemoryAgentStore, InMemoryHarnessStore};
     use crate::network_access::NetworkAccessList;
-    use crate::session::SessionStatus;
-    use chrono::Utc;
     use std::collections::HashMap;
 
     fn harness() -> HarnessDefinition {
@@ -264,51 +262,17 @@ mod tests {
         }
     }
 
-    fn session(session_id: SessionId, harness_id: HarnessId, agent_id: Option<AgentId>) -> Session {
-        Session {
-            source: Default::default(),
-            activity: Default::default(),
-            id: session_id,
-            workspace_id: crate::WorkspaceId::from_uuid(session_id.uuid()),
-            organization_id: crate::DEFAULT_ORG_PUBLIC_ID.to_string(),
-            harness_id,
+    fn session(
+        session_id: SessionId,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+    ) -> ExecutionSession {
+        ExecutionSession {
             agent_id,
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: crate::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
             title: Some("UI-TITLE-MARKER".into()),
-            goal: None,
             locale: Some("en-US".into()),
-            preview: Some("UI-PREVIEW-MARKER".into()),
-            output_preview: None,
             tags: vec!["tag-a".into()],
-            model_id: None,
-            capabilities: vec![],
-            tools: vec![],
-            mcp_servers: Default::default(),
-            system_prompt: None,
-            initial_files: vec![],
-            hints: None,
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            started_at: None,
-            finished_at: None,
-            usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
-            parent_session_id: None,
-            forked_from_session_id: None,
-            forked_from_sequence: None,
-            blueprint_id: None,
-            blueprint_config: None,
+            ..ExecutionSession::with_own_workspace(session_id, harness_id)
         }
     }
 

--- a/crates/core/src/in_memory.rs
+++ b/crates/core/src/in_memory.rs
@@ -12,7 +12,7 @@ use crate::agent_definition::AgentDefinition;
 use crate::credential_provider::CredentialProvider;
 use crate::harness_definition::HarnessDefinition;
 use crate::provider::DriverId;
-use crate::session::Session;
+use crate::session::ExecutionSession;
 
 use crate::traits::ResolvedModel;
 use crate::typed_id::{AgentId, EventId, HarnessId, MessageId, ModelId, SessionId};
@@ -295,7 +295,7 @@ impl HarnessStore for InMemoryHarnessStore {
 /// Useful for testing and examples where you want to configure sessions without a database.
 #[derive(Debug, Default, Clone)]
 pub struct InMemorySessionStore {
-    sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
+    sessions: Arc<RwLock<HashMap<SessionId, ExecutionSession>>>,
 }
 
 impl InMemorySessionStore {
@@ -307,7 +307,7 @@ impl InMemorySessionStore {
     }
 
     /// Add a session to the store
-    pub async fn add_session(&self, session: Session) {
+    pub async fn add_session(&self, session: ExecutionSession) {
         self.sessions.write().await.insert(session.id, session);
     }
 
@@ -324,7 +324,7 @@ impl InMemorySessionStore {
 
 #[async_trait]
 impl SessionStore for InMemorySessionStore {
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         Ok(self.sessions.read().await.get(&session_id).cloned())
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -540,10 +540,11 @@ pub use runtime_provider::{
     ProviderRegistry, ResolvedProviderRequest, RuntimeProvider, RuntimeProviderRegistry,
     StaticHeaderAuth,
 };
-pub use session::{
-    Session, SessionActivity, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
-    SessionSeedMode, SessionSource, SessionStatus, SubagentStatus,
-};
+// EVE-882: the persisted `Session` aggregate and its product lifecycle enums
+// (`SessionStatus`, `SessionSource`, `SessionActivity`, participants) moved to
+// the `everruns-platform` crate. Core keeps only the portable execution view
+// and the neutral execution state consumed during a turn.
+pub use session::{ExecutionSession, SessionExecutionState, SessionSeedMode, SubagentStatus};
 pub use session_file::{
     FileInfo, FileStat, GREP_MAX_CONTEXT_LINES, GREP_MAX_RETURN_BYTES, GrepContextBlock,
     GrepContextLine, GrepMatch, GrepOptions, GrepResult, GrepSearchResult, InitialFile,

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -20,7 +20,7 @@ use crate::message_filter::MessageQuery;
 use crate::message_retriever::MessageRetriever;
 use crate::runtime_agent::RuntimeAgent;
 use crate::runtime_agent::RuntimeAgentBuilder;
-use crate::session::Session;
+use crate::session::ExecutionSession;
 use crate::tool_types::ToolDefinition;
 use crate::traits::{
     AgentStore, HarnessStore, ProviderStore, ResolvedModel, SessionFileSystem, SessionStore,
@@ -35,8 +35,8 @@ pub struct AssembledTurnContext {
     pub harness: HarnessDefinition,
     /// Optional agent execution definition attached to the session.
     pub agent: Option<AgentDefinition>,
-    /// Session being executed.
-    pub session: Session,
+    /// Portable execution view of the session being executed (EVE-882).
+    pub session: ExecutionSession,
     /// Effective overlay after merging harness chain → agent → session.
     pub effective_overlay: AgentConfigOverlay,
     /// Capability configs after dependency resolution.
@@ -271,7 +271,7 @@ async fn assemble_turn_context_with_mode(
 pub fn resolve_runtime_capabilities(
     harness: &HarnessDefinition,
     agent: Option<&AgentDefinition>,
-    session: &Session,
+    session: &ExecutionSession,
     capability_registry: &CapabilityRegistry,
 ) -> ResolvedRuntimeCapabilities {
     let agent_layers = agent.into_iter().map(AgentConfigOverlay::from);
@@ -299,7 +299,7 @@ pub fn resolve_runtime_capabilities(
 }
 
 async fn build_runtime_agent(
-    session: &Session,
+    session: &ExecutionSession,
     effective_overlay: &AgentConfigOverlay,
     capability_registry: &CapabilityRegistry,
     prompt_ctx: &SystemPromptContext,
@@ -405,10 +405,9 @@ mod tests {
     use crate::message::Controls;
     use crate::message_retriever::InputMessage;
     use crate::network_access::NetworkAccessList;
-    use crate::session::{Session, SessionStatus};
+    use crate::session::ExecutionSession;
     use crate::tools::{Tool, ToolExecutionResult};
     use crate::typed_id::{AgentId, HarnessId};
-    use chrono::Utc;
 
     /// Local stand-in for the `test_math` fixture capability, which lives in
     /// `everruns-test-support` (EVE-875). These tests only need a registered
@@ -473,51 +472,16 @@ mod tests {
         }
     }
 
-    fn session(session_id: SessionId, harness_id: HarnessId, agent_id: AgentId) -> Session {
-        Session {
-            source: Default::default(),
-            activity: Default::default(),
-            id: session_id,
-            workspace_id: crate::WorkspaceId::from_uuid((session_id).uuid()),
-            organization_id: crate::DEFAULT_ORG_PUBLIC_ID.to_string(),
-            harness_id,
+    fn session(
+        session_id: SessionId,
+        harness_id: HarnessId,
+        agent_id: AgentId,
+    ) -> ExecutionSession {
+        ExecutionSession {
             agent_id: Some(agent_id),
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: crate::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
             title: Some("ctx".into()),
-            goal: None,
             locale: Some("en-US".into()),
-            preview: None,
-            output_preview: None,
-            tags: vec![],
-            model_id: None,
-            capabilities: vec![],
-            tools: vec![],
-            mcp_servers: Default::default(),
-            system_prompt: None,
-            initial_files: vec![],
-            hints: None,
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            started_at: None,
-            finished_at: None,
-            usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
-            parent_session_id: None,
-            forked_from_session_id: None,
-            forked_from_sequence: None,
-            blueprint_id: None,
-            blueprint_config: None,
+            ..ExecutionSession::with_own_workspace(session_id, harness_id)
         }
     }
 

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,28 +1,30 @@
-// Session domain types
+// Neutral session identity and turn execution state (EVE-882).
 //
-// These types represent the Session entity and its status.
-// Used by both API and worker crates.
+// Decision: the persisted `Session` database/API aggregate — source/facet
+// classifications, participants and ownership references, UI/list activity
+// projections, timestamps, catalog relationships — lives in
+// `everruns-platform`. Core keeps only this portable, execution-facing view:
+// the session correlation values and effective per-session configuration a
+// turn consumes, plus the small neutral execution state the host lifecycle
+// drives. The platform loading seam (server repositories, worker adapters,
+// hosted stores) projects stored records into these values before host
+// execution begins — the host never requests or receives a stored Session.
 
-use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::capability_types::AgentCapabilityConfig;
 use crate::events::TokenUsage;
 use crate::mcp_server::{ScopedMcpServers, scoped_mcp_servers_is_empty};
 use crate::network_access::NetworkAccessList;
-use crate::principal::PrincipalSummary;
+use crate::session_file::InitialFile;
 use crate::tool_types::ToolDefinition;
-use crate::typed_id::{
-    AgentId, AgentIdentityId, AgentVersionId, HarnessId, ModelId, PrincipalId, SessionId,
-    SessionParticipantId, WorkspaceId,
-};
-
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
+use crate::typed_id::{AgentId, HarnessId, ModelId, SessionId, WorkspaceId};
 
 /// Subagent lifecycle status.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum SubagentStatus {
     Spawning,
@@ -68,15 +70,21 @@ impl From<&str> for SubagentStatus {
     }
 }
 
-/// Session execution status.
-/// - `started`: Session just created, no turn executed yet
-/// - `active`: A turn is currently running
-/// - `idle`: Turn completed, session waiting for next input
-/// - `paused`: Budget limit reached, waiting for user to increase limit or resume
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[serde(rename_all = "lowercase")]
-pub enum SessionStatus {
+/// Neutral session execution state (EVE-882).
+///
+/// The small value host planning and lifecycle transitions operate on:
+/// - `started`: session created, no turn executed yet
+/// - `active`: a turn is currently running
+/// - `idle`: turn completed, session waiting for next input
+/// - `waiting_for_tool_results`: waiting for the client to submit tool results
+/// - `paused`: budget limit reached, waiting for the user to resume
+///
+/// The persisted product status enum lives in `everruns-platform`
+/// (`SessionStatus`) and maps to/from this value at the adapter boundary; its
+/// wire strings are the [`SessionExecutionState::as_str`] values below.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionExecutionState {
     /// Session just created, no turn executed yet.
     Started,
     /// A turn is currently running (session is active).
@@ -89,400 +97,79 @@ pub enum SessionStatus {
     Paused,
 }
 
-impl std::fmt::Display for SessionStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl SessionExecutionState {
+    pub fn as_str(self) -> &'static str {
         match self {
-            SessionStatus::Started => write!(f, "started"),
-            SessionStatus::Active => write!(f, "active"),
-            SessionStatus::Idle => write!(f, "idle"),
-            SessionStatus::WaitingForToolResults => write!(f, "waiting_for_tool_results"),
-            SessionStatus::Paused => write!(f, "paused"),
+            SessionExecutionState::Started => "started",
+            SessionExecutionState::Active => "active",
+            SessionExecutionState::Idle => "idle",
+            SessionExecutionState::WaitingForToolResults => "waiting_for_tool_results",
+            SessionExecutionState::Paused => "paused",
         }
     }
 }
 
-impl From<&str> for SessionStatus {
+impl std::fmt::Display for SessionExecutionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for SessionExecutionState {
     fn from(s: &str) -> Self {
         match s {
-            "active" => SessionStatus::Active,
-            "idle" => SessionStatus::Idle,
-            "waiting_for_tool_results" => SessionStatus::WaitingForToolResults,
-            "paused" => SessionStatus::Paused,
+            "active" => SessionExecutionState::Active,
+            "idle" => SessionExecutionState::Idle,
+            "waiting_for_tool_results" => SessionExecutionState::WaitingForToolResults,
+            "paused" => SessionExecutionState::Paused,
             // Handle legacy values during migration
-            "running" => SessionStatus::Active,
-            "pending" | "completed" | "failed" => SessionStatus::Idle,
-            _ => SessionStatus::Started,
+            "running" => SessionExecutionState::Active,
+            "pending" | "completed" | "failed" => SessionExecutionState::Idle,
+            _ => SessionExecutionState::Started,
         }
     }
 }
 
-/// How a session came into existence.
+/// Portable execution view of one session (EVE-882).
 ///
-/// Closed set: the sessions facet rail enumerates every variant, so the value
-/// is typed rather than a free-form string. Ingress paths set it server-side —
-/// clients may only declare the two variants they can legitimately be
-/// (`Chat` and `Api`), which keeps a facet like "started by a schedule"
-/// trustworthy. Rows that predate the column, or whose origin could not be
-/// inferred at backfill time, carry `Unknown`.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum SessionSource {
-    /// Interactive chat thread (UI chat surface, global chat, public chat).
-    Chat,
-    /// Direct `POST /v1/sessions` from the API, CLI, or an SDK.
-    Api,
-    /// Slack channel ingress.
-    Slack,
-    /// AG-UI channel ingress.
-    AgUi,
-    /// FCP channel ingress.
-    Fcp,
-    /// Fired by a schedule (app schedule channel or agent trigger).
-    Schedule,
-    /// Inbound webhook or app API endpoint.
-    Webhook,
-    /// Inbound A2A request.
-    A2a,
-    /// Created by an eval run.
-    Eval,
-    /// Spawned as a subagent / delegated peer of another session.
-    Subagent,
-    /// Origin not recorded (pre-migration rows that could not be inferred).
-    #[default]
-    Unknown,
-}
-
-impl SessionSource {
-    pub const ALL: &'static [SessionSource] = &[
-        SessionSource::Chat,
-        SessionSource::Api,
-        SessionSource::Slack,
-        SessionSource::AgUi,
-        SessionSource::Fcp,
-        SessionSource::Schedule,
-        SessionSource::Webhook,
-        SessionSource::A2a,
-        SessionSource::Eval,
-        SessionSource::Subagent,
-        SessionSource::Unknown,
-    ];
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            SessionSource::Chat => "chat",
-            SessionSource::Api => "api",
-            SessionSource::Slack => "slack",
-            SessionSource::AgUi => "ag_ui",
-            SessionSource::Fcp => "fcp",
-            SessionSource::Schedule => "schedule",
-            SessionSource::Webhook => "webhook",
-            SessionSource::A2a => "a2a",
-            SessionSource::Eval => "eval",
-            SessionSource::Subagent => "subagent",
-            SessionSource::Unknown => "unknown",
-        }
-    }
-
-    pub fn parse(s: &str) -> Option<Self> {
-        Self::ALL.iter().copied().find(|v| v.as_str() == s)
-    }
-
-    /// Whether a client may declare this source on `POST /v1/sessions`.
-    /// Everything else is server-owned so facets cannot be spoofed.
-    pub fn is_client_declarable(self) -> bool {
-        matches!(self, SessionSource::Chat | SessionSource::Api)
-    }
-}
-
-impl std::fmt::Display for SessionSource {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl From<&str> for SessionSource {
-    fn from(s: &str) -> Self {
-        Self::parse(s).unwrap_or(SessionSource::Unknown)
-    }
-}
-
-/// Outcome-oriented view of a session, as the sessions list and facet rail
-/// present it. Derived from the session's execution status plus the outcome of
-/// its most recent turn — `SessionStatus` alone has no notion of failure.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum SessionActivity {
-    /// A turn is executing, or the session is waiting on client tool results.
-    Running,
-    /// Budget limit reached; waiting for the user to resume.
-    Paused,
-    /// Last completed turn failed or was cancelled.
-    Failed,
-    /// Last completed turn succeeded and nothing is running.
-    Completed,
-    /// Created but idle with no completed turn yet.
-    #[default]
-    Idle,
-}
-
-impl SessionActivity {
-    pub const ALL: &'static [SessionActivity] = &[
-        SessionActivity::Running,
-        SessionActivity::Paused,
-        SessionActivity::Failed,
-        SessionActivity::Completed,
-        SessionActivity::Idle,
-    ];
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            SessionActivity::Running => "running",
-            SessionActivity::Paused => "paused",
-            SessionActivity::Failed => "failed",
-            SessionActivity::Completed => "completed",
-            SessionActivity::Idle => "idle",
-        }
-    }
-
-    pub fn parse(s: &str) -> Option<Self> {
-        Self::ALL.iter().copied().find(|v| v.as_str() == s)
-    }
-
-    /// Single source of truth for the derivation, mirrored by
-    /// `session_activity_sql` in the sessions repository so the list, the facet
-    /// counts, and the in-memory backend cannot drift apart.
-    pub fn derive(status: &SessionStatus, last_turn_status: Option<&str>) -> Self {
-        match status {
-            SessionStatus::Active | SessionStatus::WaitingForToolResults => {
-                SessionActivity::Running
-            }
-            SessionStatus::Paused => SessionActivity::Paused,
-            _ => match last_turn_status {
-                Some("failed") | Some("cancelled") => SessionActivity::Failed,
-                Some("completed") => SessionActivity::Completed,
-                _ => SessionActivity::Idle,
-            },
-        }
-    }
-}
-
-impl std::fmt::Display for SessionActivity {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-/// Kind of actor participating in a session.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum SessionParticipantKind {
-    Agent,
-    User,
-}
-
-impl std::fmt::Display for SessionParticipantKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SessionParticipantKind::Agent => write!(f, "agent"),
-            SessionParticipantKind::User => write!(f, "user"),
-        }
-    }
-}
-
-impl From<&str> for SessionParticipantKind {
-    fn from(s: &str) -> Self {
-        match s {
-            "agent" => SessionParticipantKind::Agent,
-            "user" => SessionParticipantKind::User,
-            _ => SessionParticipantKind::User,
-        }
-    }
-}
-
-/// Role a participant has inside a session.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum SessionParticipantRole {
-    Host,
-    Member,
-}
-
-impl std::fmt::Display for SessionParticipantRole {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SessionParticipantRole::Host => write!(f, "host"),
-            SessionParticipantRole::Member => write!(f, "member"),
-        }
-    }
-}
-
-impl From<&str> for SessionParticipantRole {
-    fn from(s: &str) -> Self {
-        match s {
-            "host" => SessionParticipantRole::Host,
-            "member" => SessionParticipantRole::Member,
-            _ => SessionParticipantRole::Member,
-        }
-    }
-}
-
-/// Session participant - an agent or user that has joined a session.
+/// Carries exactly what turn execution consumes: the typed correlation
+/// values, the session's own configuration overlay layer (leaf of the
+/// harness → agent → session chain), the neutral execution state, and
+/// cumulative usage accounting. It is not a persistence record — origin
+/// facets, activity projections, participants, ownership summaries,
+/// timestamps, and list/UI metadata stay in `everruns-platform`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub struct SessionParticipant {
-    /// Unique identifier for the participant row (format: part_{32-hex}).
-    #[cfg_attr(
-        feature = "openapi",
-        schema(
-            value_type = String,
-            example = "part_01933b5a00007000800000000000001"
-        )
-    )]
-    pub id: SessionParticipantId,
-    /// Session this participant belongs to.
-    #[cfg_attr(
-        feature = "openapi",
-        schema(
-            value_type = String,
-            example = "session_01933b5a00007000800000000000001"
-        )
-    )]
-    pub session_id: SessionId,
-    pub kind: SessionParticipantKind,
-    /// Present for agent participants.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(
-            value_type = Option<String>,
-            example = "agent_01933b5a00007000800000000000001"
-        )
-    )]
-    pub agent_id: Option<AgentId>,
-    /// Immutable agent version captured for an agent participant when known.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(
-            value_type = Option<String>,
-            example = "agentver_01933b5a00007000800000000000001"
-        )
-    )]
-    pub agent_version_id: Option<AgentVersionId>,
-    /// Principal that joined the session.
-    #[cfg_attr(
-        feature = "openapi",
-        schema(
-            value_type = String,
-            example = "principal_01933b5a000070008000000000000001"
-        )
-    )]
-    pub principal_id: PrincipalId,
-    /// Human-readable name captured for this participant.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
-    pub role: SessionParticipantRole,
-    pub joined_at: DateTime<Utc>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub left_at: Option<DateTime<Utc>>,
-}
-
-/// Session - instance of agentic loop execution.
-/// A session represents a single conversation with an agent.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub struct Session {
-    /// Unique identifier for the session (format: session_{32-hex}).
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "session_01933b5a00007000800000000000001"))]
+pub struct ExecutionSession {
+    /// Session identity (correlation value).
     pub id: SessionId,
-    /// Organization this session belongs to (format: org_{32-hex}).
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "org_00000000000000000000000000000001"))]
+    /// Public (`org_…`) organization id used for execution scoping. This is a
+    /// correlation value, not the organization record.
     pub organization_id: String,
-    /// Workspace this session is attached to (format: wsp_{32-hex}). Owns the
-    /// session's virtual filesystem. For the default 1:1 case this mirrors the
-    /// session id, but clients should read it here rather than deriving it.
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "wsp_01933b5a00007000800000000000001"))]
+    /// Workspace owning the session's virtual filesystem. For the default 1:1
+    /// case this mirrors the session id.
     pub workspace_id: WorkspaceId,
-    /// ID of the harness for this session (format: harness_{32-hex}).
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "harness_01933b5a00007000800000000000001"))]
+    /// Harness providing the base environment configuration layer.
     pub harness_id: HarnessId,
-    /// ID of the agent working in this session (format: agent_{32-hex}). Optional.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001"))]
+    /// Optional agent working in this session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<AgentId>,
-    /// Immutable agent version captured when the session was created or rebound.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "agentver_01933b5a00007000800000000000001"))]
-    pub agent_version_id: Option<AgentVersionId>,
-    /// Optional resident agent identity for unattended/background execution.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "identity_01933b5a00007000800000000000001"))]
-    pub agent_identity_id: Option<AgentIdentityId>,
-    /// Owning principal for this session.
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "principal_01933b5a000070008000000000000001"))]
-    pub owner_principal_id: PrincipalId,
-    /// Denormalized effective human owner of the owning principal lineage.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(example = "550e8400-e29b-41d4-a716-446655440000")
-    )]
-    pub resolved_owner_user_id: Option<uuid::Uuid>,
-    /// Owning principal summary.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub owner: Option<PrincipalSummary>,
-    /// Effective human owner summary.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub effective_owner: Option<PrincipalSummary>,
-    /// Human-readable title for the session.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = "Q3 marketing brief"))]
+    /// Human-readable title (readable/writable through the session capability).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// Session objective visible to the runtime agent at system-prompt level.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(example = "Investigate the queue latency regression")
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub goal: Option<String>,
-    /// Locale for localized agent behavior and formatting (BCP 47, e.g. `uk-UA`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = "en-US"))]
+    /// Locale for localized agent behavior and formatting (BCP 47).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
-    /// Preview text from the first user message (truncated).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(example = "Help me draft the Q3 marketing plan")
-    )]
-    pub preview: Option<String>,
-    /// Preview text from the last assistant response (truncated).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(example = "Here is a Q3 plan covering the three pillars we discussed...")
-    )]
-    pub output_preview: Option<String>,
-    /// Tags for organizing and filtering sessions.
-    #[serde(default)]
-    #[cfg_attr(feature = "openapi", schema(example = json!(["marketing", "q3", "draft"])))]
+    /// Tags consulted by execution modes (e.g. progress reporting).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
-    /// LLM model ID to use for this session (format: model_{32-hex}).
-    /// Overrides the agent's default model if set.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001"))]
+    /// Session-level model override (higher priority than agent/harness).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<ModelId>,
     /// Session-level capabilities (additive to agent capabilities).
-    /// Applied after agent capabilities when building RuntimeAgent.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(
-        feature = "openapi",
-        schema(value_type = Vec<crate::capability_types::AgentCapabilityConfigSchema>)
-    )]
     pub capabilities: Vec<AgentCapabilityConfig>,
     /// Client-side tools for this session (additive to agent tools).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -496,117 +183,88 @@ pub struct Session {
     )]
     pub mcp_servers: ScopedMcpServers,
     /// Session-level system prompt override.
-    /// Prepended to the agent's system prompt when building RuntimeAgent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
     /// Session-level initial files (additive to agent initial_files).
-    /// Files with matching paths override agent/harness files; new paths are appended.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub initial_files: Vec<crate::session_file::InitialFile>,
-    /// Session-level client hints — arbitrary key-value pairs declared by the
-    /// client at session creation time. These are defaults for every turn;
-    /// per-message `controls.hints` override these key-by-key (shallow merge).
-    ///
-    /// Examples: `{"setup_connection": true, "rich_media": true}`
+    pub initial_files: Vec<InitialFile>,
+    /// Session-level client hints; per-message `controls.hints` override these
+    /// key-by-key (shallow merge).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub hints: Option<std::collections::HashMap<String, serde_json::Value>>,
-    /// Network access list controlling which hosts/URLs this session can reach.
-    /// Merged with harness and agent layers (allowed: intersect, blocked: union).
+    pub hints: Option<HashMap<String, serde_json::Value>>,
+    /// Network access list merged with harness and agent layers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub network_access: Option<NetworkAccessList>,
     /// Maximum number of LLM iterations per turn for this session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = 50))]
     pub max_iterations: Option<usize>,
     /// Request-level parallel tool calling preference (EVE-598).
-    ///
-    /// `None` (default) preserves provider defaults. `Some(true)` signals the
-    /// provider that parallel tool calls are wanted; `Some(false)` requests at
-    /// most one tool call per turn and forces serial execution. Merged across
-    /// harness/agent/session layers (overlay wins).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = true))]
     pub parallel_tool_calls: Option<bool>,
-    /// Current execution status of the session.
-    pub status: SessionStatus,
-    /// How this session was started. Server-owned for every ingress path.
-    #[serde(default)]
-    pub source: SessionSource,
-    /// Outcome-oriented status derived from `status` and the last turn result.
-    /// This is the value the sessions list groups by and the facet rail counts.
-    #[serde(default)]
-    pub activity: SessionActivity,
-    /// Timestamp when the session was created.
-    #[cfg_attr(feature = "openapi", schema(example = "2026-05-25T10:00:00Z"))]
-    pub created_at: DateTime<Utc>,
-    /// Timestamp when the session was last updated.
-    #[cfg_attr(feature = "openapi", schema(example = "2026-05-25T10:14:32Z"))]
-    pub updated_at: DateTime<Utc>,
-    /// Timestamp when the session started executing.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = "2026-05-25T10:00:01Z"))]
-    pub started_at: Option<DateTime<Utc>>,
-    /// Timestamp when the session finished (completed or failed).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = "2026-05-25T10:14:32Z"))]
-    pub finished_at: Option<DateTime<Utc>>,
+    /// Neutral execution state driven by the host lifecycle.
+    pub status: SessionExecutionState,
     /// Cumulative token usage for all LLM calls in this session.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<TokenUsage>,
-    /// Whether this session is pinned by the current user.
-    /// Only populated when the request has an authenticated user context.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = false))]
-    pub is_pinned: Option<bool>,
-    /// Number of active (enabled) schedules for this session.
-    /// Populated when the session is fetched for API responses.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = 2))]
-    pub active_schedule_count: Option<u32>,
-    /// Aggregated UI features from all active capabilities (harness + agent + session).
-    /// Computed at read time from the capability registry.
-    /// Known features: "file_system", "schedules", "secrets", "key_value",
-    /// "sql_database", "leased_resources".
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[cfg_attr(feature = "openapi", schema(example = json!(["file_system", "secrets"])))]
-    pub features: Vec<String>,
-
-    // -- Subagent nesting fields --
-    /// Parent session that spawned this subagent. NULL for top-level sessions.
-    /// Used to compute governed subagent delegation depth.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+    /// Parent session that spawned this subagent (subagent nesting depth).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_session_id: Option<SessionId>,
-
-    // -- Fork lineage fields (knowledge/runtime-resources/forking-sessions.md) --
-    /// Session this one was forked from. NULL for sessions that were not forked.
-    /// Distinct from `parent_session_id` (subagent nesting): forking is a
-    /// user-initiated "branch from here" relationship.
+    /// Session this one was forked from (delegation-result correlation).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub forked_from_session_id: Option<SessionId>,
-    /// Parent event sequence the fork was taken at (the fork point). NULL unless
-    /// this session is a fork.
+    /// Blueprint ID. When set, execution builds the RuntimeAgent from the
+    /// blueprint definition instead of harness/agent configuration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = 42))]
-    pub forked_from_sequence: Option<i32>,
-
-    // -- Blueprint fields (only set when this session runs a blueprint agent) --
-    /// Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent
-    /// from the blueprint definition instead of from harness_id/agent_id.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = "blueprint_research_pack"))]
     pub blueprint_id: Option<String>,
     /// Validated config passed by host at blueprint spawn time.
-    /// Example: `{"target_repo": "acme/everruns"}`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blueprint_config: Option<serde_json::Value>,
+}
+
+impl ExecutionSession {
+    /// Create an execution session with the given correlation identity; all
+    /// configuration starts empty, status starts at `started`, and the
+    /// organization defaults to the single-tenant default org.
+    pub fn new(id: SessionId, workspace_id: WorkspaceId, harness_id: HarnessId) -> Self {
+        Self {
+            id,
+            organization_id: crate::DEFAULT_ORG_PUBLIC_ID.to_string(),
+            workspace_id,
+            harness_id,
+            agent_id: None,
+            title: None,
+            goal: None,
+            locale: None,
+            tags: Vec::new(),
+            model_id: None,
+            capabilities: Vec::new(),
+            tools: Vec::new(),
+            mcp_servers: ScopedMcpServers::default(),
+            system_prompt: None,
+            initial_files: Vec::new(),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            status: SessionExecutionState::Started,
+            usage: None,
+            parent_session_id: None,
+            forked_from_session_id: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        }
+    }
+
+    /// Create an execution session under the default 1:1 workspace identity
+    /// (`workspace.id == session.id`).
+    pub fn with_own_workspace(id: SessionId, harness_id: HarnessId) -> Self {
+        Self::new(id, WorkspaceId::from_uuid(id.uuid()), harness_id)
+    }
 }
 
 /// Seed mode used when creating a peer session from an existing session.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum SessionSeedMode {
     /// Create an empty session and only record lineage when provided.
@@ -632,67 +290,60 @@ impl SessionSeedMode {
 mod tests {
     use super::*;
 
-    /// The list filters activity in SQL and the in-memory backend filters it in
-    /// Rust, so this truth table is the contract both sides implement. It is
-    /// duplicated verbatim as a comment beside `ACTIVITY_SQL` in
-    /// `crates/server/src/storage/repositories/sessions.rs`.
     #[test]
-    fn activity_derivation_truth_table() {
-        use SessionActivity as A;
-        use SessionStatus as S;
+    fn execution_state_round_trips_through_its_wire_string() {
+        for state in [
+            SessionExecutionState::Started,
+            SessionExecutionState::Active,
+            SessionExecutionState::Idle,
+            SessionExecutionState::WaitingForToolResults,
+            SessionExecutionState::Paused,
+        ] {
+            assert_eq!(SessionExecutionState::from(state.as_str()), state);
+        }
+        // Legacy values degrade the same way the stored status column does.
+        assert_eq!(
+            SessionExecutionState::from("running"),
+            SessionExecutionState::Active
+        );
+        assert_eq!(
+            SessionExecutionState::from("completed"),
+            SessionExecutionState::Idle
+        );
+        assert_eq!(
+            SessionExecutionState::from("garbage"),
+            SessionExecutionState::Started
+        );
+    }
 
-        let cases: &[(SessionStatus, Option<&str>, SessionActivity)] = &[
-            // Execution state wins: a running turn is running whatever the
-            // previous turn did.
-            (S::Active, None, A::Running),
-            (S::Active, Some("failed"), A::Running),
-            (S::WaitingForToolResults, Some("completed"), A::Running),
-            (S::Paused, Some("failed"), A::Paused),
-            // Otherwise the last terminal turn decides.
-            (S::Idle, Some("completed"), A::Completed),
-            (S::Idle, Some("failed"), A::Failed),
-            (S::Idle, Some("cancelled"), A::Failed),
-            (S::Started, Some("completed"), A::Completed),
-            // No completed turn yet, or an unrecognized outcome.
-            (S::Started, None, A::Idle),
-            (S::Idle, None, A::Idle),
-            (S::Idle, Some("weird"), A::Idle),
-        ];
-
-        for (status, last_turn, expected) in cases {
-            assert_eq!(
-                SessionActivity::derive(status, *last_turn),
-                *expected,
-                "status={status} last_turn={last_turn:?}"
+    #[test]
+    fn execution_session_carries_no_persistence_metadata() {
+        let session = ExecutionSession::with_own_workspace(SessionId::new(), HarnessId::new());
+        let json = serde_json::to_value(&session).unwrap();
+        for persistence_field in [
+            "source",
+            "activity",
+            "owner_principal_id",
+            "resolved_owner_user_id",
+            "owner",
+            "effective_owner",
+            "agent_version_id",
+            "agent_identity_id",
+            "preview",
+            "output_preview",
+            "created_at",
+            "updated_at",
+            "started_at",
+            "finished_at",
+            "is_pinned",
+            "active_schedule_count",
+            "features",
+            "forked_from_sequence",
+        ] {
+            assert!(
+                json.get(persistence_field).is_none(),
+                "portable execution session must not expose {persistence_field}"
             );
         }
-    }
-
-    #[test]
-    fn session_source_round_trips_through_its_wire_string() {
-        for source in SessionSource::ALL {
-            assert_eq!(SessionSource::parse(source.as_str()), Some(*source));
-        }
-        // Unknown text degrades to the explicit unknown bucket rather than
-        // inventing a facet.
-        assert_eq!(SessionSource::from("not_a_source"), SessionSource::Unknown);
-    }
-
-    #[test]
-    fn only_chat_and_api_are_client_declarable() {
-        let declarable: Vec<_> = SessionSource::ALL
-            .iter()
-            .filter(|s| s.is_client_declarable())
-            .copied()
-            .collect();
-        assert_eq!(declarable, vec![SessionSource::Chat, SessionSource::Api]);
-    }
-
-    #[test]
-    fn session_activity_round_trips_through_its_wire_string() {
-        for activity in SessionActivity::ALL {
-            assert_eq!(SessionActivity::parse(activity.as_str()), Some(*activity));
-        }
-        assert_eq!(SessionActivity::parse("nope"), None);
     }
 }

--- a/crates/core/src/subagent_delegation.rs
+++ b/crates/core/src/subagent_delegation.rs
@@ -13,8 +13,8 @@
 use crate::agent_definition::AgentDefinition;
 use crate::error::Result;
 use crate::harness_definition::HarnessDefinition;
-use crate::session::{Session, SessionParticipant, SessionSeedMode};
-use crate::typed_id::{AgentId, HarnessId, SessionId};
+use crate::session::{ExecutionSession, SessionSeedMode};
+use crate::typed_id::{AgentId, HarnessId, SessionId, SessionParticipantId};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -62,20 +62,24 @@ pub trait SubagentSessionDelegate: Send + Sync {
     async fn get_harness(&self, id: HarnessId) -> Result<Option<HarnessDefinition>>;
 
     /// Add an agent as a member participant in an existing session.
+    ///
+    /// Returns the new participant row's id (a neutral correlation value);
+    /// the stored participant record stays behind the platform seam (EVE-882).
     async fn add_agent_session_participant(
         &self,
         session_id: SessionId,
         agent_id: AgentId,
-    ) -> Result<SessionParticipant>;
+    ) -> Result<SessionParticipantId>;
 
-    /// Create a child session with the given options.
+    /// Create a child session with the given options. Returns the portable
+    /// execution view of the new session (EVE-882).
     async fn create_session_with_options(
         &self,
         request: PlatformCreateSessionRequest,
-    ) -> Result<Session>;
+    ) -> Result<ExecutionSession>;
 
-    /// Get a session by id.
-    async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>>;
+    /// Get a session's portable execution view by id.
+    async fn get_session_by_id(&self, id: SessionId) -> Result<Option<ExecutionSession>>;
 
     /// Send a user message to a session, triggering a turn.
     async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()>;
@@ -99,7 +103,7 @@ pub trait SubagentSessionDelegate: Send + Sync {
 pub mod tests {
     use super::*;
     use crate::AgentCapabilityConfig;
-    use crate::session::{SessionParticipant, SessionStatus};
+    use crate::session::SessionExecutionState;
 
     /// Mock [`SubagentSessionDelegate`] for portable subagent/handoff tests.
     ///
@@ -111,9 +115,10 @@ pub mod tests {
         pub extra_harnesses:
             std::sync::Mutex<std::collections::HashMap<HarnessId, HarnessDefinition>>,
         pub agent: AgentDefinition,
-        pub session: Session,
-        pub extra_sessions: std::sync::Mutex<std::collections::HashMap<SessionId, Session>>,
-        pub joined_participants: std::sync::Mutex<Vec<SessionParticipant>>,
+        pub session: ExecutionSession,
+        pub extra_sessions:
+            std::sync::Mutex<std::collections::HashMap<SessionId, ExecutionSession>>,
+        pub joined_participants: std::sync::Mutex<Vec<(SessionId, Option<AgentId>)>>,
         pub created_session_harness_ids: std::sync::Mutex<Vec<HarnessId>>,
         pub created_session_budget_roots: std::sync::Mutex<Vec<Option<SessionId>>>,
         pub wait_for_idle_status: std::sync::Mutex<String>,
@@ -143,53 +148,10 @@ pub mod tests {
                         "You are helpful.",
                     )
                 },
-                session: {
-                    let session_id = SessionId::new();
-                    Session {
-                        source: Default::default(),
-                        activity: Default::default(),
-                        id: session_id,
-                        workspace_id: crate::WorkspaceId::from_uuid(session_id.uuid()),
-                        organization_id: "org_00000000000000000000000000000001".to_string(),
-                        harness_id: HarnessId::new(),
-                        agent_id: None,
-                        agent_version_id: None,
-                        agent_identity_id: None,
-                        owner_principal_id: crate::PrincipalId::from_seed(1),
-                        resolved_owner_user_id: None,
-                        owner: None,
-                        effective_owner: None,
-                        title: Some("Test Session".to_string()),
-                        goal: None,
-                        locale: None,
-                        preview: None,
-                        output_preview: None,
-                        tags: vec![],
-                        model_id: None,
-                        capabilities: vec![],
-                        tools: vec![],
-                        mcp_servers: Default::default(),
-                        system_prompt: None,
-                        initial_files: vec![],
-                        hints: None,
-                        network_access: None,
-                        max_iterations: None,
-                        parallel_tool_calls: None,
-                        status: SessionStatus::Idle,
-                        created_at: chrono::Utc::now(),
-                        updated_at: chrono::Utc::now(),
-                        started_at: None,
-                        finished_at: None,
-                        usage: None,
-                        is_pinned: None,
-                        active_schedule_count: None,
-                        features: vec![],
-                        parent_session_id: None,
-                        forked_from_session_id: None,
-                        forked_from_sequence: None,
-                        blueprint_id: None,
-                        blueprint_config: None,
-                    }
+                session: ExecutionSession {
+                    title: Some("Test Session".to_string()),
+                    status: SessionExecutionState::Idle,
+                    ..ExecutionSession::with_own_workspace(SessionId::new(), HarnessId::new())
                 },
                 extra_sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
                 joined_participants: std::sync::Mutex::new(Vec::new()),
@@ -210,7 +172,7 @@ pub mod tests {
             blueprint_id: Option<&str>,
             blueprint_config: Option<&serde_json::Value>,
             parent_session_id: Option<SessionId>,
-        ) -> Result<Session> {
+        ) -> Result<ExecutionSession> {
             if let Ok(mut recorder) = self.created_session_harness_ids.lock() {
                 recorder.push(hid);
             }
@@ -243,23 +205,11 @@ pub mod tests {
             &self,
             session_id: SessionId,
             agent_id: AgentId,
-        ) -> Result<SessionParticipant> {
-            let participant = SessionParticipant {
-                id: crate::typed_id::SessionParticipantId::new(),
-                session_id,
-                kind: crate::session::SessionParticipantKind::Agent,
-                agent_id: Some(agent_id),
-                agent_version_id: None,
-                principal_id: self.session.owner_principal_id,
-                display_name: None,
-                role: crate::session::SessionParticipantRole::Member,
-                joined_at: chrono::Utc::now(),
-                left_at: None,
-            };
+        ) -> Result<SessionParticipantId> {
             if let Ok(mut participants) = self.joined_participants.lock() {
-                participants.push(participant.clone());
+                participants.push((session_id, Some(agent_id)));
             }
-            Ok(participant)
+            Ok(SessionParticipantId::new())
         }
 
         async fn get_harness(&self, id: HarnessId) -> Result<Option<HarnessDefinition>> {
@@ -272,7 +222,7 @@ pub mod tests {
         async fn create_session_with_options(
             &self,
             request: PlatformCreateSessionRequest,
-        ) -> Result<Session> {
+        ) -> Result<ExecutionSession> {
             self.created_session_budget_roots
                 .lock()
                 .expect("budget root recorder")
@@ -296,7 +246,7 @@ pub mod tests {
             Ok(session)
         }
 
-        async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>> {
+        async fn get_session_by_id(&self, id: SessionId) -> Result<Option<ExecutionSession>> {
             if id == self.session.id {
                 return Ok(Some(self.session.clone()));
             }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -2495,7 +2495,7 @@ mod tests {
             &self,
             _session_id: SessionId,
             _agent_id: crate::typed_id::AgentId,
-        ) -> crate::Result<crate::session::SessionParticipant> {
+        ) -> crate::Result<crate::typed_id::SessionParticipantId> {
             Err(crate::error::AgentLoopError::tool(
                 "test store does not add participants",
             ))
@@ -2509,12 +2509,15 @@ mod tests {
         async fn create_session_with_options(
             &self,
             _request: crate::subagent_delegation::PlatformCreateSessionRequest,
-        ) -> crate::Result<crate::Session> {
+        ) -> crate::Result<crate::ExecutionSession> {
             Err(crate::error::AgentLoopError::tool(
                 "test store does not create sessions",
             ))
         }
-        async fn get_session_by_id(&self, _id: SessionId) -> crate::Result<Option<crate::Session>> {
+        async fn get_session_by_id(
+            &self,
+            _id: SessionId,
+        ) -> crate::Result<Option<crate::ExecutionSession>> {
             Ok(None)
         }
         async fn send_message(&self, _session_id: SessionId, content: &str) -> crate::Result<()> {

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -199,31 +199,41 @@ impl<T: HarnessStore + ?Sized> HarnessStore for std::sync::Arc<T> {
 
 use crate::capability_types::AgentCapabilityConfig;
 use crate::leased_resource::{LeasedResource, UpsertLeasedResource};
-use crate::session::Session;
+use crate::session::ExecutionSession;
 
-/// Trait for retrieving session configurations
+/// Narrow session-loading seam for turn execution (EVE-872, EVE-882).
 ///
-/// Implementations can:
-/// - Load sessions from a database
-/// - Keep sessions in memory for testing
+/// Implementations project their stored session records into the portable
+/// [`ExecutionSession`] — the session correlation values, per-session
+/// configuration layer, and neutral execution state a turn consumes. The
+/// persisted `Session` aggregate (facets, participants, ownership summaries,
+/// timestamps, UI metadata) lives in `everruns-platform` and never crosses
+/// this boundary.
 #[async_trait]
 pub trait SessionStore: Send + Sync {
-    /// Get a session by ID
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>>;
+    /// Get the portable execution view for a session by ID.
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>>;
 }
 
 #[async_trait]
 impl<T: SessionStore + ?Sized> SessionStore for std::sync::Arc<T> {
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         (**self).get_session(session_id).await
     }
 }
 
 /// Trait for updating mutable session metadata.
+///
+/// Mutations acknowledge with the refreshed portable execution view, never a
+/// stored platform record (EVE-882).
 #[async_trait]
 pub trait SessionMutator: Send + Sync {
     /// Update a session's human-readable title.
-    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session>;
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> Result<ExecutionSession>;
 
     /// Add or replace a session-scoped capability atomically.
     ///
@@ -234,7 +244,7 @@ pub trait SessionMutator: Send + Sync {
         &self,
         _session_id: SessionId,
         _capability: AgentCapabilityConfig,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         Err(crate::error::AgentLoopError::store(
             "session backend does not support live capability reconfiguration",
         ))
@@ -245,7 +255,7 @@ pub trait SessionMutator: Send + Sync {
         &self,
         _session_id: SessionId,
         _capability_id: &str,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         Err(crate::error::AgentLoopError::store(
             "session backend does not support live capability reconfiguration",
         ))
@@ -254,7 +264,11 @@ pub trait SessionMutator: Send + Sync {
 
 #[async_trait]
 impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
-    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> Result<ExecutionSession> {
         (**self).update_session_title(session_id, title).await
     }
 
@@ -262,7 +276,7 @@ impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
         &self,
         session_id: SessionId,
         capability: AgentCapabilityConfig,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         (**self)
             .upsert_session_capability(session_id, capability)
             .await
@@ -272,7 +286,7 @@ impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
         &self,
         session_id: SessionId,
         capability_id: &str,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         (**self)
             .remove_session_capability(session_id, capability_id)
             .await

--- a/crates/host/examples/inspect_context.rs
+++ b/crates/host/examples/inspect_context.rs
@@ -10,15 +10,14 @@
 //! cargo run -p everruns-host --example inspect_context
 //! ```
 
-use chrono::Utc;
 use everruns_test_support::LlmSimRuntimeExt;
 use everruns_test_support::TestMathCapability;
 
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::provider::DriverId;
 use everruns_core::{
-    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, HarnessDefinition,
-    PlatformDefinition, ResolvedModel, Session, SessionStatus,
+    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, ExecutionSession,
+    HarnessDefinition, PlatformDefinition, ResolvedModel, SessionExecutionState,
 };
 use everruns_host::InProcessRuntimeBuilder;
 use everruns_test_support::llmsim_driver::LlmSimConfig;
@@ -55,25 +54,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             max_iterations: Some(8),
             ..AgentDefinition::new(agent_id, "math-agent", "Use tools when needed.")
         })
-        .session(Session {
-            source: Default::default(),
-            activity: Default::default(),
+        .session(ExecutionSession {
             id: session_id,
             workspace_id: everruns_core::WorkspaceId::from_uuid((session_id).uuid()),
             organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
             harness_id,
             agent_id: Some(agent_id),
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
-            title: Some("Context Session".into()),
+            title: Some("Context ExecutionSession".into()),
             goal: None,
             locale: Some("en-US".into()),
-            preview: None,
-            output_preview: None,
             tags: vec![],
             model_id: None,
             capabilities: vec![],
@@ -85,18 +74,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            started_at: None,
-            finished_at: None,
+            status: SessionExecutionState::Started,
             usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
             parent_session_id: None,
             forked_from_session_id: None,
-            forked_from_sequence: None,
             blueprint_id: None,
             blueprint_config: None,
         })

--- a/crates/host/examples/real_disk_agent_instructions.rs
+++ b/crates/host/examples/real_disk_agent_instructions.rs
@@ -14,12 +14,11 @@
 use everruns_test_support::LlmSimRuntimeExt;
 use std::sync::Arc;
 
-use chrono::Utc;
 use everruns_core::capabilities::AgentInstructionsCapability;
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::{
-    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, DriverId, HarnessDefinition,
-    PlatformDefinition, ResolvedModel, Session, SessionStatus,
+    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, DriverId, ExecutionSession,
+    HarnessDefinition, PlatformDefinition, ResolvedModel, SessionExecutionState,
 };
 use everruns_host::{InProcessRuntimeBuilder, RealDiskSessionFileSystemFactory};
 use everruns_test_support::llmsim_driver::LlmSimConfig;
@@ -75,25 +74,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             max_iterations: Some(8),
             ..AgentDefinition::new(agent_id, "coding-agent", "Use tools when needed.")
         })
-        .session(Session {
-            source: Default::default(),
-            activity: Default::default(),
+        .session(ExecutionSession {
             id: session_id,
             workspace_id: everruns_core::WorkspaceId::from_uuid((session_id).uuid()),
             organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
             harness_id,
             agent_id: Some(agent_id),
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
-            title: Some("Coding Session".into()),
+            title: Some("Coding ExecutionSession".into()),
             goal: None,
             locale: None,
-            preview: None,
-            output_preview: None,
             tags: vec![],
             model_id: None,
             capabilities: vec![],
@@ -105,18 +94,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            started_at: None,
-            finished_at: None,
+            status: SessionExecutionState::Started,
             usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
             parent_session_id: None,
             forked_from_session_id: None,
-            forked_from_sequence: None,
             blueprint_id: None,
             blueprint_config: None,
         })

--- a/crates/host/examples/real_disk_file_system_tools.rs
+++ b/crates/host/examples/real_disk_file_system_tools.rs
@@ -17,12 +17,11 @@
 use everruns_test_support::LlmSimRuntimeExt;
 use std::sync::Arc;
 
-use chrono::Utc;
 use everruns_core::capabilities::FileSystemCapability;
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::{
-    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, DriverId, HarnessDefinition,
-    PlatformDefinition, ResolvedModel, Session, SessionStatus, ToolCall,
+    AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, DriverId, ExecutionSession,
+    HarnessDefinition, PlatformDefinition, ResolvedModel, SessionExecutionState, ToolCall,
 };
 use everruns_host::{InProcessRuntimeBuilder, RealDiskSessionFileSystemFactory};
 use everruns_test_support::llmsim_driver::LlmSimConfig;
@@ -95,25 +94,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             max_iterations: Some(8),
             ..AgentDefinition::new(agent_id, "files-agent", "Use tools when needed.")
         })
-        .session(Session {
-            source: Default::default(),
-            activity: Default::default(),
+        .session(ExecutionSession {
             id: session_id,
             workspace_id: everruns_core::WorkspaceId::from_uuid((session_id).uuid()),
             organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
             harness_id,
             agent_id: Some(agent_id),
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
-            title: Some("Files Session".into()),
+            title: Some("Files ExecutionSession".into()),
             goal: None,
             locale: None,
-            preview: None,
-            output_preview: None,
             tags: vec![],
             model_id: None,
             capabilities: vec![],
@@ -125,18 +114,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            started_at: None,
-            finished_at: None,
+            status: SessionExecutionState::Started,
             usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
             parent_session_id: None,
             forked_from_session_id: None,
-            forked_from_sequence: None,
             blueprint_id: None,
             blueprint_config: None,
         })

--- a/crates/host/src/backends.rs
+++ b/crates/host/src/backends.rs
@@ -10,7 +10,7 @@ use everruns_core::agent_definition::AgentDefinition;
 use everruns_core::error::Result;
 use everruns_core::harness_definition::HarnessDefinition;
 use everruns_core::in_memory::{InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore};
-use everruns_core::session::Session;
+use everruns_core::session::ExecutionSession;
 use everruns_core::session_task::SessionTaskRegistry;
 use everruns_core::traits::{
     AgentStore, HarnessStore, ProviderStore, ResolvedModel, SessionMutator, SessionScheduleStore,
@@ -51,10 +51,13 @@ pub trait RuntimeHarnessStore: HarnessStore + Send + Sync {
 }
 
 /// Session store contract for runtime seeding, lookup, and mutation.
+///
+/// Seeds portable [`ExecutionSession`] values (EVE-882): the embedded host
+/// carries no stored Session persistence records.
 #[async_trait]
 pub trait RuntimeSessionStore: SessionStore + SessionMutator + Send + Sync {
-    /// Insert or replace a session definition.
-    async fn add_session(&self, session: Session) -> Result<()>;
+    /// Insert or replace a session's portable execution view.
+    async fn add_session(&self, session: ExecutionSession) -> Result<()>;
 }
 
 /// Provider store contract for runtime lookup and default-model configuration.
@@ -227,7 +230,7 @@ impl RuntimeHarnessStore for InMemoryHarnessStore {
 
 #[async_trait]
 impl RuntimeSessionStore for InMemorySessionStore {
-    async fn add_session(&self, session: Session) -> Result<()> {
+    async fn add_session(&self, session: ExecutionSession) -> Result<()> {
         InMemorySessionStore::add_session(self, session).await;
         Ok(())
     }

--- a/crates/host/src/builders.rs
+++ b/crates/host/src/builders.rs
@@ -5,14 +5,13 @@
 
 use std::collections::HashMap;
 
-use chrono::{DateTime, Utc};
 pub use everruns_core::driver_registry::{
     OPENROUTER_HTTP_REFERER_METADATA_KEY, OPENROUTER_X_TITLE_METADATA_KEY,
 };
 use everruns_core::network_access::NetworkAccessList;
 use everruns_core::{
-    AgentCapabilityConfig, AgentDefinition, AgentId, DEFAULT_ORG_PUBLIC_ID, HarnessDefinition,
-    HarnessId, ModelId, PrincipalId, ScopedMcpServers, Session, SessionId, SessionStatus,
+    AgentCapabilityConfig, AgentDefinition, AgentId, DEFAULT_ORG_PUBLIC_ID, ExecutionSession,
+    HarnessDefinition, HarnessId, ModelId, ScopedMcpServers, SessionExecutionState, SessionId,
     ToolDefinition, plugin_capability_id,
 };
 
@@ -345,14 +344,18 @@ impl AgentBuilder {
     }
 }
 
-/// Builds a [`Session`] with runtime-friendly defaults.
+/// Builds a portable [`ExecutionSession`] with runtime-friendly defaults.
+///
+/// EVE-882: the embedded host seeds the neutral execution view only. The
+/// stored Session persistence record (source facets, participants, ownership
+/// summaries, timestamps, UI metadata) lives in `everruns-platform` and is a
+/// hosted control-plane concern.
 #[derive(Debug, Clone)]
 pub struct SessionBuilder {
     id: SessionId,
     organization_id: String,
     harness_id: HarnessId,
     agent_id: Option<AgentId>,
-    owner_principal_id: PrincipalId,
     title: Option<String>,
     goal: Option<String>,
     locale: Option<String>,
@@ -366,9 +369,7 @@ pub struct SessionBuilder {
     network_access: Option<NetworkAccessList>,
     max_iterations: Option<usize>,
     parallel_tool_calls: Option<bool>,
-    status: SessionStatus,
-    created_at: Option<DateTime<Utc>>,
-    updated_at: Option<DateTime<Utc>>,
+    status: SessionExecutionState,
 }
 
 impl SessionBuilder {
@@ -379,7 +380,6 @@ impl SessionBuilder {
             organization_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
             harness_id,
             agent_id: None,
-            owner_principal_id: PrincipalId::from_seed(1),
             title: None,
             goal: None,
             locale: None,
@@ -393,9 +393,7 @@ impl SessionBuilder {
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: None,
-            updated_at: None,
+            status: SessionExecutionState::Started,
         }
     }
 
@@ -422,11 +420,6 @@ impl SessionBuilder {
 
     pub fn agent(mut self, agent_id: AgentId) -> Self {
         self.agent_id = Some(agent_id);
-        self
-    }
-
-    pub fn owner_principal_id(mut self, owner_principal_id: PrincipalId) -> Self {
-        self.owner_principal_id = owner_principal_id;
         self
     }
 
@@ -527,45 +520,22 @@ impl SessionBuilder {
         self
     }
 
-    pub fn status(mut self, status: SessionStatus) -> Self {
+    pub fn status(mut self, status: SessionExecutionState) -> Self {
         self.status = status;
         self
     }
 
-    pub fn created_at(mut self, created_at: DateTime<Utc>) -> Self {
-        self.created_at = Some(created_at);
-        self
-    }
-
-    pub fn updated_at(mut self, updated_at: DateTime<Utc>) -> Self {
-        self.updated_at = Some(updated_at);
-        self
-    }
-
     /// Build the session. Builders do not validate domain invariants.
-    pub fn build(self) -> Session {
-        let created_at = self.created_at.unwrap_or_else(Utc::now);
-        let updated_at = self.updated_at.unwrap_or(created_at);
-
-        Session {
-            source: Default::default(),
-            activity: Default::default(),
+    pub fn build(self) -> ExecutionSession {
+        ExecutionSession {
             id: self.id,
             workspace_id: everruns_core::WorkspaceId::from_uuid((self.id).uuid()),
             organization_id: self.organization_id,
             harness_id: self.harness_id,
             agent_id: self.agent_id,
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: self.owner_principal_id,
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
             title: self.title,
             goal: self.goal,
             locale: self.locale,
-            preview: None,
-            output_preview: None,
             tags: self.tags,
             model_id: self.model_id,
             capabilities: self.capabilities,
@@ -578,17 +548,9 @@ impl SessionBuilder {
             max_iterations: self.max_iterations,
             parallel_tool_calls: self.parallel_tool_calls,
             status: self.status,
-            created_at,
-            updated_at,
-            started_at: None,
-            finished_at: None,
             usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: Vec::new(),
             parent_session_id: None,
             forked_from_session_id: None,
-            forked_from_sequence: None,
             blueprint_id: None,
             blueprint_config: None,
         }
@@ -807,7 +769,7 @@ impl SingleSessionBuilder {
         self
     }
 
-    pub(crate) fn build(self) -> (SeededHarness, AgentDefinition, Session, SessionId) {
+    pub(crate) fn build(self) -> (SeededHarness, AgentDefinition, ExecutionSession, SessionId) {
         let session_id = self.session.session_id();
         (
             self.harness.build(),

--- a/crates/host/src/host.rs
+++ b/crates/host/src/host.rs
@@ -18,7 +18,7 @@ use everruns_core::events::{
 };
 use everruns_core::message::{ContentPart, Message};
 use everruns_core::message_retriever::MessageRetriever;
-use everruns_core::session::SessionStatus;
+use everruns_core::session::SessionExecutionState;
 use everruns_core::tools::Tool;
 use everruns_core::traits::{
     AgentStore, BudgetChecker, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver,
@@ -73,7 +73,7 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
         &self,
         org_id: i64,
         session_id: SessionId,
-        status: SessionStatus,
+        status: SessionExecutionState,
     ) -> everruns_core::error::Result<()>;
 
     /// Load and resolve the turn's execution inputs.
@@ -667,7 +667,7 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         }
     }
 
-    async fn set_session_status(&self, status: SessionStatus, action: &'static str) {
+    async fn set_session_status(&self, status: SessionExecutionState, action: &'static str) {
         if let Err(error) = self
             .adapter
             .set_session_status(self.org_id, self.session_id, status)
@@ -706,7 +706,7 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
             .flatten()
             .map(|message| message.content_to_llm_string());
 
-        self.set_session_status(SessionStatus::Active, "turn_started")
+        self.set_session_status(SessionExecutionState::Active, "turn_started")
             .await;
 
         self.emit_event(EventRequest::new(
@@ -748,7 +748,7 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         iterations: Option<u32>,
         usage: Option<TokenUsage>,
     ) {
-        self.set_session_status(SessionStatus::Idle, "emit_session_idled")
+        self.set_session_status(SessionExecutionState::Idle, "emit_session_idled")
             .await;
 
         self.emit_event(EventRequest::new(
@@ -928,7 +928,7 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         user_error: Option<&UserFacingError>,
         disclosure: Option<ErrorDisclosure>,
     ) {
-        self.set_session_status(SessionStatus::Idle, "turn_failed")
+        self.set_session_status(SessionExecutionState::Idle, "turn_failed")
             .await;
 
         self.emit_event(EventRequest::new(
@@ -964,7 +964,7 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
 
     pub async fn waiting_for_tool_results(&self) {
         self.set_session_status(
-            SessionStatus::WaitingForToolResults,
+            SessionExecutionState::WaitingForToolResults,
             "waiting_for_tool_results",
         )
         .await;

--- a/crates/host/src/in_memory.rs
+++ b/crates/host/src/in_memory.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use everruns_core::AgentCapabilityConfig;
 use everruns_core::error::{AgentLoopError, Result};
-use everruns_core::session::Session;
+use everruns_core::session::ExecutionSession;
 use everruns_core::session_file::{
     FileInfo, FileStat, GrepMatch, GrepOptions, GrepSearchResult, InitialFile, SessionFile,
     build_grep_search_result,
@@ -24,9 +24,11 @@ use uuid::Uuid;
 /// In-memory `SessionStore` + `SessionMutator` for embedded runtimes.
 ///
 /// This is the default session backend used by [`crate::InProcessRuntime`].
+/// Holds portable [`ExecutionSession`] values (EVE-882): no stored Session
+/// persistence records exist in the embedded host.
 #[derive(Debug, Default, Clone)]
 pub struct InMemorySessionStore {
-    sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
+    sessions: Arc<RwLock<HashMap<SessionId, ExecutionSession>>>,
 }
 
 impl InMemorySessionStore {
@@ -38,27 +40,30 @@ impl InMemorySessionStore {
     }
 
     /// Insert or replace a session in the store.
-    pub async fn add_session(&self, session: Session) {
+    pub async fn add_session(&self, session: ExecutionSession) {
         self.sessions.write().await.insert(session.id, session);
     }
 }
 
 #[async_trait]
 impl SessionStore for InMemorySessionStore {
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         Ok(self.sessions.read().await.get(&session_id).cloned())
     }
 }
 
 #[async_trait]
 impl SessionMutator for InMemorySessionStore {
-    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> Result<ExecutionSession> {
         let mut sessions = self.sessions.write().await;
         let session = sessions
             .get_mut(&session_id)
             .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
         session.title = Some(title);
-        session.updated_at = Utc::now();
         Ok(session.clone())
     }
 
@@ -66,7 +71,7 @@ impl SessionMutator for InMemorySessionStore {
         &self,
         session_id: SessionId,
         capability: AgentCapabilityConfig,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         let mut sessions = self.sessions.write().await;
         let session = sessions
             .get_mut(&session_id)
@@ -80,7 +85,6 @@ impl SessionMutator for InMemorySessionStore {
         } else {
             session.capabilities.push(capability);
         }
-        session.updated_at = Utc::now();
         Ok(session.clone())
     }
 
@@ -88,7 +92,7 @@ impl SessionMutator for InMemorySessionStore {
         &self,
         session_id: SessionId,
         capability_id: &str,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         let mut sessions = self.sessions.write().await;
         let session = sessions
             .get_mut(&session_id)
@@ -96,7 +100,6 @@ impl SessionMutator for InMemorySessionStore {
         session
             .capabilities
             .retain(|capability| capability.capability_id() != capability_id);
-        session.updated_at = Utc::now();
         Ok(session.clone())
     }
 }

--- a/crates/host/src/mcp.rs
+++ b/crates/host/src/mcp.rs
@@ -11,8 +11,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use everruns_core::capabilities::Capability;
 use everruns_core::{
-    AgentDefinition, HarnessDefinition, McpCapability, McpServerTransportType, ScopedMcpServer,
-    ScopedMcpServers, Session, ToolDefinition, merge_scoped_mcp_servers,
+    AgentDefinition, ExecutionSession, HarnessDefinition, McpCapability, McpServerTransportType,
+    ScopedMcpServer, ScopedMcpServers, ToolDefinition, merge_scoped_mcp_servers,
 };
 use everruns_mcp::{McpClient, McpConnection, McpEndpoint, McpExecutor, StaticConnectionResolver};
 use futures::{StreamExt, stream};
@@ -28,7 +28,7 @@ const MAX_DISCOVERY_CONCURRENCY: usize = 16;
 pub(crate) fn merge_session_scoped_servers(
     harness: &HarnessDefinition,
     agent: Option<&AgentDefinition>,
-    session: &Session,
+    session: &ExecutionSession,
 ) -> ScopedMcpServers {
     let mut merged = merge_scoped_mcp_servers(&ScopedMcpServers::default(), &harness.mcp_servers);
     if let Some(agent) = agent {

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -32,7 +32,7 @@ use everruns_core::message::Message;
 use everruns_core::platform_definition::PlatformDefinition;
 use everruns_core::plugins::{PluginFileSet, compile_plugin};
 use everruns_core::runtime_context::{AssembledTurnContext, inspect_turn_context};
-use everruns_core::session::{Session, SessionStatus};
+use everruns_core::session::{ExecutionSession, SessionExecutionState};
 use everruns_core::session_file::{InitialFile, SessionFile};
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, ProviderStore, ResolvedModel, SessionMutator,
@@ -61,7 +61,7 @@ use std::sync::{Arc, Mutex};
 const HASH_INPUT_CAP_BYTES: usize = 128;
 
 /// Derive an internal `i64` org id from the public `org_<32hex>` form on a
-/// [`Session`].
+/// [`ExecutionSession`].
 ///
 /// Round-trip with [`everruns_core::org_public_id_from_internal`]: when the
 /// public id was produced by that helper (i.e. the upper bits are zero and
@@ -321,7 +321,7 @@ pub struct InProcessRuntimeBuilder {
     session_file_system_factory_context: SessionFileSystemFactoryContext,
     harnesses: Vec<crate::builders::SeededHarness>,
     agents: Vec<AgentDefinition>,
-    sessions: Vec<Session>,
+    sessions: Vec<ExecutionSession>,
     default_session_id: Option<SessionId>,
     seeded_files: Vec<(SessionId, InitialFile)>,
     mcp_auth_provider: Option<Arc<dyn everruns_mcp::McpAuthProvider>>,
@@ -531,7 +531,7 @@ impl InProcessRuntimeBuilder {
     }
 
     /// Seed a session into the runtime store.
-    pub fn session(mut self, session: Session) -> Self {
+    pub fn session(mut self, session: ExecutionSession) -> Self {
         self.sessions.push(session);
         self
     }
@@ -876,7 +876,7 @@ pub struct InProcessRuntime {
 }
 
 impl InProcessRuntime {
-    async fn ensure_session_started(&self, session: &Session) -> Result<()> {
+    async fn ensure_session_started(&self, session: &ExecutionSession) -> Result<()> {
         if self
             .event_history
             .contains_event_type(session.id, everruns_core::events::SESSION_STARTED)
@@ -924,7 +924,7 @@ impl InProcessRuntime {
     /// Resolve the effective scoped MCP servers for a session.
     async fn session_mcp_servers(
         &self,
-        session: &Session,
+        session: &ExecutionSession,
         agent: Option<&AgentDefinition>,
     ) -> everruns_core::ScopedMcpServers {
         let harness = self
@@ -1560,7 +1560,7 @@ impl InProcessRuntime {
     /// Load a session record and fold runtime ARD attachments into its config
     /// layer before capabilities / scoped MCP servers are resolved
     /// (resource_discovery).
-    async fn attached_session(&self, session_id: SessionId) -> Result<Session> {
+    async fn attached_session(&self, session_id: SessionId) -> Result<ExecutionSession> {
         let mut session = self
             .session_store
             .get_session(session_id)
@@ -1620,7 +1620,7 @@ impl RuntimeHostAdapter for InProcessRuntime {
         &self,
         _org_id: i64,
         session_id: SessionId,
-        _status: SessionStatus,
+        _status: SessionExecutionState,
     ) -> Result<()> {
         // The in-process runtime does not persist status. Lifecycle callers
         // still emit their events; downstream consumers in-process don't
@@ -1788,7 +1788,7 @@ impl RuntimeHostAdapter for InProcessRuntime {
 fn effective_overlay(
     harness: &HarnessDefinition,
     agent: Option<&AgentDefinition>,
-    session: &Session,
+    session: &ExecutionSession,
 ) -> AgentConfigOverlay {
     let agent_layers = agent.into_iter().map(AgentConfigOverlay::from);
     AgentConfigOverlay::fold(
@@ -1835,7 +1835,7 @@ async fn seed_runtime_initial_files(
     harness_store: &dyn RuntimeHarnessStore,
     agent_store: &dyn RuntimeAgentStore,
     file_store: &dyn SessionFileSystem,
-    session: &Session,
+    session: &ExecutionSession,
 ) -> Result<()> {
     let harness = harness_store
         .get_harness(session.harness_id)

--- a/crates/host/tests/engine_planned_turn_test.rs
+++ b/crates/host/tests/engine_planned_turn_test.rs
@@ -13,7 +13,8 @@
 
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::{
-    AgentDefinition, CapabilityRegistry, DriverId, PlatformDefinition, ResolvedModel, Session,
+    AgentDefinition, CapabilityRegistry, DriverId, ExecutionSession, PlatformDefinition,
+    ResolvedModel,
 };
 use everruns_engine::{
     ActOutcome, TurnPlan, TurnState, plan_after_act, plan_after_process_input, plan_after_reason,
@@ -52,11 +53,11 @@ fn session(
     session_id: everruns_core::SessionId,
     harness_id: everruns_core::HarnessId,
     agent_id: everruns_core::AgentId,
-) -> Session {
+) -> ExecutionSession {
     SessionBuilder::new(harness_id)
         .id(session_id)
         .agent(agent_id)
-        .title("Engine Planned Session")
+        .title("Engine Planned ExecutionSession")
         .build()
 }
 

--- a/crates/host/tests/filesystem_narration_paths_test.rs
+++ b/crates/host/tests/filesystem_narration_paths_test.rs
@@ -2,7 +2,6 @@
 // display_path contract so transcript paths match tool results.
 
 use async_trait::async_trait;
-use chrono::Utc;
 use everruns_core::MessageRetriever;
 use everruns_core::atoms::{ActInput, AtomContext};
 use everruns_core::capabilities::{
@@ -23,8 +22,8 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
-    AgentCapabilityConfig, EventData, HarnessDefinition, MountFs, Session, SessionStatus, ToolCall,
-    WorkspaceRootSet,
+    AgentCapabilityConfig, EventData, ExecutionSession, HarnessDefinition, MountFs,
+    SessionExecutionState, ToolCall, WorkspaceRootSet,
 };
 use everruns_host::{
     InMemorySessionFileStore, RealDiskFileStore, ResolvedTurnInputs, RuntimeHostAdapter,
@@ -39,19 +38,22 @@ use uuid::Uuid;
 
 #[derive(Clone, Default)]
 struct TestSessionStore {
-    sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
+    sessions: Arc<RwLock<HashMap<SessionId, ExecutionSession>>>,
 }
 
 impl TestSessionStore {
-    async fn insert(&self, session: Session) {
+    async fn insert(&self, session: ExecutionSession) {
         self.sessions.write().await.insert(session.id, session);
     }
 
-    async fn set_status(&self, session_id: SessionId, status: SessionStatus) -> Session {
+    async fn set_status(
+        &self,
+        session_id: SessionId,
+        status: SessionExecutionState,
+    ) -> ExecutionSession {
         let mut sessions = self.sessions.write().await;
         let session = sessions.get_mut(&session_id).expect("session exists");
         session.status = status;
-        session.updated_at = Utc::now();
         session.clone()
     }
 }
@@ -61,7 +63,7 @@ impl SessionStore for TestSessionStore {
     async fn get_session(
         &self,
         session_id: SessionId,
-    ) -> everruns_core::error::Result<Option<Session>> {
+    ) -> everruns_core::error::Result<Option<ExecutionSession>> {
         Ok(self.sessions.read().await.get(&session_id).cloned())
     }
 }
@@ -72,7 +74,7 @@ impl SessionMutator for TestSessionStore {
         &self,
         session_id: SessionId,
         title: String,
-    ) -> everruns_core::error::Result<Session> {
+    ) -> everruns_core::error::Result<ExecutionSession> {
         let mut sessions = self.sessions.write().await;
         let session = sessions.get_mut(&session_id).expect("session exists");
         session.title = Some(title);
@@ -97,7 +99,7 @@ impl RuntimeHostAdapter for NarrationTestHost {
         &self,
         _org_id: i64,
         session_id: SessionId,
-        status: SessionStatus,
+        status: SessionExecutionState,
     ) -> everruns_core::error::Result<()> {
         self.session_store.set_status(session_id, status).await;
         Ok(())
@@ -174,26 +176,16 @@ fn harness() -> HarnessDefinition {
     }
 }
 
-fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
-    Session {
-        source: Default::default(),
-        activity: Default::default(),
+fn session(session_id: SessionId, harness_id: HarnessId) -> ExecutionSession {
+    ExecutionSession {
         id: session_id,
         workspace_id: everruns_core::WorkspaceId::from_uuid(session_id.uuid()),
         organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
         harness_id,
         agent_id: None,
-        agent_version_id: None,
-        agent_identity_id: None,
-        owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-        resolved_owner_user_id: None,
-        owner: None,
-        effective_owner: None,
         title: None,
         goal: None,
         locale: None,
-        preview: None,
-        output_preview: None,
         tags: vec![],
         model_id: None,
         capabilities: vec![],
@@ -205,18 +197,10 @@ fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
         network_access: None,
         max_iterations: None,
         parallel_tool_calls: None,
-        status: SessionStatus::Started,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        started_at: None,
-        finished_at: None,
+        status: SessionExecutionState::Started,
         usage: None,
-        is_pinned: None,
-        active_schedule_count: None,
-        features: vec![],
         parent_session_id: None,
         forked_from_session_id: None,
-        forked_from_sequence: None,
         blueprint_id: None,
         blueprint_config: None,
     }

--- a/crates/host/tests/in_process_runtime_test.rs
+++ b/crates/host/tests/in_process_runtime_test.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
-use chrono::{TimeZone, Utc};
 use everruns_core::capabilities::{InfinityContextCapability, SessionTasksCapability};
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::events::{EventContext, EventRequest, InputMessageData};
 use everruns_core::network_access::NetworkAccessList;
 use everruns_core::{
-    AgentDefinition, CapabilityRegistry, DriverId, InitialFile, Message, MessageRole,
-    PlatformDefinition, ResolvedModel, Session, SessionFileSystem, SessionFileSystemFactory,
+    AgentDefinition, CapabilityRegistry, DriverId, ExecutionSession, InitialFile, Message,
+    MessageRole, PlatformDefinition, ResolvedModel, SessionFileSystem, SessionFileSystemFactory,
     SessionFileSystemFactoryContext, ToolCall, WorkspacePolicy,
 };
 use everruns_host::{
@@ -44,10 +43,10 @@ fn session(
     session_id: everruns_core::SessionId,
     harness_id: everruns_core::HarnessId,
     agent_id: Option<everruns_core::AgentId>,
-) -> Session {
+) -> ExecutionSession {
     let builder = SessionBuilder::new(harness_id)
         .id(session_id)
-        .title("Embedded Session");
+        .title("Embedded ExecutionSession");
     match agent_id {
         Some(agent_id) => builder.agent(agent_id).build(),
         None => builder.build(),
@@ -75,8 +74,7 @@ impl SessionFileSystemFactory for ContextRealDiskFactory {
 }
 
 #[test]
-fn per_type_builders_accept_explicit_timestamps() {
-    let timestamp = Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap();
+fn per_type_builders_produce_portable_execution_values() {
     let harness_id = everruns_core::HarnessId::from_seed(51);
     let agent_id = everruns_core::AgentId::from_seed(51);
     let session_id = everruns_core::SessionId::from_seed(51);
@@ -88,16 +86,14 @@ fn per_type_builders_accept_explicit_timestamps() {
     let session = SessionBuilder::new(harness_id)
         .id(session_id)
         .agent(agent_id)
-        .created_at(timestamp)
-        .updated_at(timestamp)
         .build();
 
-    // Harness/agent definitions are portable execution configuration
-    // (EVE-877, EVE-881); they carry no persistence timestamps.
+    // Harness/agent/session values are portable execution configuration
+    // (EVE-877, EVE-881, EVE-882); they carry no persistence timestamps.
     assert_eq!(harness.id, harness_id);
     assert_eq!(agent.id, agent_id);
-    assert_eq!(session.created_at, timestamp);
-    assert_eq!(session.updated_at, timestamp);
+    assert_eq!(session.id, session_id);
+    assert_eq!(session.agent_id, Some(agent_id));
 }
 
 #[tokio::test]
@@ -404,7 +400,7 @@ async fn single_session_builder_seeds_runnable_runtime() {
                 .with_capability("test_math")
                 .agent("math-agent", "Use tools when needed.")
                 .agent_max_iterations(8)
-                .session_title("Embedded Session")
+                .session_title("Embedded ExecutionSession")
         })
         .build()
         .await

--- a/crates/host/tests/resolved_snapshot_test.rs
+++ b/crates/host/tests/resolved_snapshot_test.rs
@@ -35,7 +35,7 @@ struct Fixture {
     runtime: everruns_host::InProcessRuntime,
     harness: everruns_host::SeededHarness,
     agent: everruns_core::AgentDefinition,
-    session: everruns_core::Session,
+    session: everruns_core::ExecutionSession,
 }
 
 async fn fixture() -> Fixture {

--- a/crates/host/tests/runtime_host_test.rs
+++ b/crates/host/tests/runtime_host_test.rs
@@ -23,9 +23,9 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
     AgentCapabilityConfig, AgentDefinition, CapabilityRegistry, DriverId, EventData,
-    HarnessDefinition, InputMessage, ResolvedModel, Session, SessionStatus, TokenUsage, Tool,
-    ToolCall, ToolExecutionResult, ToolRegistry, ToolResult, inspect_turn_context,
-    user_facing_error_codes,
+    ExecutionSession, HarnessDefinition, InputMessage, ResolvedModel, SessionExecutionState,
+    TokenUsage, Tool, ToolCall, ToolExecutionResult, ToolRegistry, ToolResult,
+    inspect_turn_context, user_facing_error_codes,
 };
 use everruns_host::{
     InMemorySessionFileStore, ResolvedTurnInputs, RuntimeHostAdapter, RuntimeSessionLifecycle,
@@ -41,19 +41,22 @@ use uuid::Uuid;
 
 #[derive(Clone, Default)]
 struct TestSessionStore {
-    sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
+    sessions: Arc<RwLock<HashMap<SessionId, ExecutionSession>>>,
 }
 
 impl TestSessionStore {
-    async fn insert(&self, session: Session) {
+    async fn insert(&self, session: ExecutionSession) {
         self.sessions.write().await.insert(session.id, session);
     }
 
-    async fn set_status(&self, session_id: SessionId, status: SessionStatus) -> Session {
+    async fn set_status(
+        &self,
+        session_id: SessionId,
+        status: SessionExecutionState,
+    ) -> ExecutionSession {
         let mut sessions = self.sessions.write().await;
         let session = sessions.get_mut(&session_id).expect("session exists");
         session.status = status;
-        session.updated_at = Utc::now();
         session.clone()
     }
 }
@@ -63,7 +66,7 @@ impl SessionStore for TestSessionStore {
     async fn get_session(
         &self,
         session_id: SessionId,
-    ) -> everruns_core::error::Result<Option<Session>> {
+    ) -> everruns_core::error::Result<Option<ExecutionSession>> {
         Ok(self.sessions.read().await.get(&session_id).cloned())
     }
 }
@@ -74,7 +77,7 @@ impl SessionMutator for TestSessionStore {
         &self,
         session_id: SessionId,
         title: String,
-    ) -> everruns_core::error::Result<Session> {
+    ) -> everruns_core::error::Result<ExecutionSession> {
         let mut sessions = self.sessions.write().await;
         let session = sessions.get_mut(&session_id).expect("session exists");
         session.title = Some(title);
@@ -102,7 +105,7 @@ impl RuntimeHostAdapter for MockHostAdapter {
         &self,
         _org_id: i64,
         session_id: SessionId,
-        status: SessionStatus,
+        status: SessionExecutionState,
     ) -> everruns_core::error::Result<()> {
         self.session_store.set_status(session_id, status).await;
         Ok(())
@@ -669,26 +672,16 @@ fn harness() -> HarnessDefinition {
     }
 }
 
-fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
-    Session {
-        source: Default::default(),
-        activity: Default::default(),
+fn session(session_id: SessionId, harness_id: HarnessId) -> ExecutionSession {
+    ExecutionSession {
         id: session_id,
         workspace_id: everruns_core::WorkspaceId::from_uuid((session_id).uuid()),
         organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
         harness_id,
         agent_id: None,
-        agent_version_id: None,
-        agent_identity_id: None,
-        owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-        resolved_owner_user_id: None,
-        owner: None,
-        effective_owner: None,
         title: Some("Runtime Host".into()),
         goal: None,
         locale: None,
-        preview: None,
-        output_preview: None,
         tags: vec![],
         model_id: None,
         capabilities: vec![],
@@ -700,18 +693,10 @@ fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
         network_access: None,
         max_iterations: None,
         parallel_tool_calls: None,
-        status: SessionStatus::Started,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        started_at: None,
-        finished_at: None,
+        status: SessionExecutionState::Started,
         usage: None,
-        is_pinned: None,
-        active_schedule_count: None,
-        features: vec![],
         parent_session_id: None,
         forked_from_session_id: None,
-        forked_from_sequence: None,
         blueprint_id: None,
         blueprint_config: None,
     }
@@ -839,7 +824,7 @@ async fn input_activity_emits_lifecycle_events_and_marks_session_active() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(session.status, SessionStatus::Active);
+    assert_eq!(session.status, SessionExecutionState::Active);
 
     let event_types: Vec<_> = adapter
         .event_emitter
@@ -1170,7 +1155,7 @@ async fn act_activity_agent_session_executes_harness_overlay_tools_from_reason_p
     adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
     adapter
         .session_store
-        .insert(Session {
+        .insert(ExecutionSession {
             agent_id: Some(agent_id),
             ..session(session_id, harness_id)
         })
@@ -1241,7 +1226,7 @@ async fn act_activity_agent_session_resolves_transitive_overlay_capabilities() {
     adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
     adapter
         .session_store
-        .insert(Session {
+        .insert(ExecutionSession {
             agent_id: Some(agent_id),
             ..session(session_id, harness_id)
         })
@@ -1311,7 +1296,7 @@ async fn act_activity_agent_session_runs_post_tool_hooks_from_merged_overlay() {
     adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
     adapter
         .session_store
-        .insert(Session {
+        .insert(ExecutionSession {
             agent_id: Some(agent_id),
             ..session(session_id, harness_id)
         })
@@ -1385,7 +1370,7 @@ async fn act_activity_runs_capability_pre_tool_hook_and_blocks() {
     adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
     adapter
         .session_store
-        .insert(Session {
+        .insert(ExecutionSession {
             agent_id: Some(agent_id),
             ..session(session_id, harness_id)
         })
@@ -1472,7 +1457,7 @@ async fn act_activity_skips_pre_tool_hooks_from_unavailable_capability() {
     adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
     adapter
         .session_store
-        .insert(Session {
+        .insert(ExecutionSession {
             agent_id: Some(agent_id),
             ..session(session_id, harness_id)
         })
@@ -1544,7 +1529,7 @@ async fn lifecycle_helper_sets_waiting_for_tool_results_status() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(session.status, SessionStatus::WaitingForToolResults);
+    assert_eq!(session.status, SessionExecutionState::WaitingForToolResults);
 }
 
 #[tokio::test]
@@ -1763,7 +1748,7 @@ async fn plan_next_host_turn_schedules_act_with_session_blueprint_id() {
         .await;
     adapter
         .session_store
-        .insert(Session {
+        .insert(ExecutionSession {
             blueprint_id: Some("blueprint.private".into()),
             ..session(session_id, harness_id)
         })
@@ -2167,7 +2152,7 @@ async fn plan_next_host_turn_waits_for_tool_results_when_session_hint_requests_i
                 .await
                 .unwrap()
                 .unwrap();
-            assert_eq!(session.status, SessionStatus::WaitingForToolResults);
+            assert_eq!(session.status, SessionExecutionState::WaitingForToolResults);
         }
         other => panic!("expected WaitForToolResults, got {other:?}"),
     }

--- a/crates/host/tests/tool_scheduler_e2e_test.rs
+++ b/crates/host/tests/tool_scheduler_e2e_test.rs
@@ -17,8 +17,8 @@ use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::{
-    AgentDefinition, CapabilityRegistry, DriverId, PlatformDefinition, ResolvedModel, Session,
-    ToolCall,
+    AgentDefinition, CapabilityRegistry, DriverId, ExecutionSession, PlatformDefinition,
+    ResolvedModel, ToolCall,
 };
 use everruns_host::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
 use everruns_test_support::LlmSimRuntimeExt;
@@ -170,11 +170,11 @@ fn session(
     session_id: everruns_core::SessionId,
     harness_id: everruns_core::HarnessId,
     agent_id: everruns_core::AgentId,
-) -> Session {
+) -> ExecutionSession {
     SessionBuilder::new(harness_id)
         .id(session_id)
         .agent(agent_id)
-        .title("Scheduler Session")
+        .title("Scheduler ExecutionSession")
         .build()
 }
 

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -604,10 +604,11 @@ pub fn proto_harness_to_schema(
     serde_json::from_value(json).map_err(ConversionError::from)
 }
 
-/// Convert proto Session to schemas Session using JSON
+/// Convert proto Session to the stored platform Session record using JSON
+/// (EVE-882: the persisted aggregate lives in `everruns-platform`).
 pub fn proto_session_to_schema(
     value: proto::Session,
-) -> Result<everruns_core::Session, ConversionError> {
+) -> Result<everruns_platform::Session, ConversionError> {
     let tags = value.tags.clone();
     let started_at: Option<String> = None;
     let finished_at: Option<String> = None;
@@ -726,7 +727,7 @@ pub fn proto_session_to_schema(
 }
 
 /// Convert schemas Session to proto Session
-pub fn schema_session_to_proto(value: &everruns_core::Session) -> proto::Session {
+pub fn schema_session_to_proto(value: &everruns_platform::Session) -> proto::Session {
     proto::Session {
         id: Some(uuid_to_proto_uuid(value.id.uuid())),
         agent_id: value.agent_id.map(|id| uuid_to_proto_uuid(id.uuid())),
@@ -2169,7 +2170,7 @@ mod tests {
 
         let now = Utc::now();
         let session_id = everruns_core::SessionId::new();
-        let session = everruns_core::Session {
+        let session = everruns_platform::Session {
             source: Default::default(),
             activity: Default::default(),
             id: session_id,
@@ -2200,7 +2201,7 @@ mod tests {
             max_iterations: None,
             parallel_tool_calls: Some(true),
             mcp_servers: Default::default(),
-            status: everruns_core::SessionStatus::Idle,
+            status: everruns_platform::SessionStatus::Idle,
             created_at: now,
             updated_at: now,
             started_at: None,
@@ -2378,7 +2379,7 @@ mod tests {
 
         let now = Utc::now();
         let session_id = everruns_core::SessionId::new();
-        let session = everruns_core::Session {
+        let session = everruns_platform::Session {
             source: Default::default(),
             activity: Default::default(),
             id: session_id,
@@ -2408,7 +2409,7 @@ mod tests {
             max_iterations: None,
             parallel_tool_calls: None,
             mcp_servers: Default::default(),
-            status: everruns_core::SessionStatus::Idle,
+            status: everruns_platform::SessionStatus::Idle,
             created_at: now,
             updated_at: now,
             started_at: None,

--- a/crates/llm-tests/examples/turn_based_execution.rs
+++ b/crates/llm-tests/examples/turn_based_execution.rs
@@ -22,7 +22,6 @@
 //!
 //! Run with: cargo run -p everruns-llm-tests --example turn_based_execution
 
-use chrono::Utc;
 use everruns_core::{
     AgentDefinition, EnvCredentialProvider, HarnessDefinition, InputMessage, MessageRetriever,
     atoms::{
@@ -34,9 +33,9 @@ use everruns_core::{
         InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryMessageRetriever,
         InMemoryProviderStore, InMemorySessionStore,
     },
-    session::{Session, SessionStatus},
+    session::{ExecutionSession, SessionExecutionState},
     tools::{Tool, ToolExecutionResult, ToolRegistry, ToolRegistryBuilder},
-    typed_id::{AgentId, HarnessId, PrincipalId, TurnId},
+    typed_id::{AgentId, HarnessId, TurnId},
 };
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -112,7 +111,6 @@ async fn main() -> anyhow::Result<()> {
     let harness_id = HarnessId::new();
     let agent_id = Uuid::now_v7();
     let session_id = Uuid::now_v7();
-    let now = Utc::now();
     let harness = HarnessDefinition::new("default", "You are a helpful assistant.");
     harness_store.add_harness(harness_id, harness).await;
 
@@ -129,25 +127,15 @@ async fn main() -> anyhow::Result<()> {
     agent_store.add_agent(agent).await;
 
     // Create a session in the store
-    let session = Session {
-        source: Default::default(),
-        activity: Default::default(),
+    let session = ExecutionSession {
         id: session_id.into(),
         workspace_id: everruns_core::WorkspaceId::from_uuid(session_id),
         organization_id: "default".to_string(),
         harness_id,
         agent_id: Some(AgentId::from_uuid(agent_id)),
-        agent_version_id: None,
-        agent_identity_id: None,
-        owner_principal_id: PrincipalId::from_seed(1),
-        resolved_owner_user_id: None,
-        owner: None,
-        effective_owner: None,
         title: Some("Weather Query".to_string()),
         goal: None,
         locale: None,
-        preview: None,
-        output_preview: None,
         tags: vec![],
         model_id: None,
         capabilities: vec![],
@@ -159,18 +147,10 @@ async fn main() -> anyhow::Result<()> {
         network_access: None,
         max_iterations: None,
         parallel_tool_calls: None,
-        status: SessionStatus::Started,
-        created_at: now,
-        updated_at: now,
-        started_at: None,
-        finished_at: None,
+        status: SessionExecutionState::Started,
         usage: None,
-        is_pinned: None,
-        active_schedule_count: None,
-        features: vec![],
         parent_session_id: None,
         forked_from_session_id: None,
-        forked_from_sequence: None,
         blueprint_id: None,
         blueprint_config: None,
     };
@@ -189,7 +169,7 @@ async fn main() -> anyhow::Result<()> {
     // Setup: Add user message to store (simulating API layer)
     // =========================================================================
     let user_question = "What's the weather like in Paris?";
-    println!("Session: {}", session_id);
+    println!("ExecutionSession: {}", session_id);
     println!("User: {}\n", user_question);
 
     // Add user message to store (this would be done by the API layer)

--- a/crates/llm-tests/tests/subagent_live_test.rs
+++ b/crates/llm-tests/tests/subagent_live_test.rs
@@ -21,7 +21,7 @@ use llm_test_matrix::*;
 use async_trait::async_trait;
 use everruns_core::capabilities::SubagentCapability;
 use everruns_core::error::Result;
-use everruns_core::session::Session;
+use everruns_core::session::ExecutionSession;
 use everruns_core::session_task::{SessionTaskRegistry, SessionTaskState};
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_core::{CapabilityRegistry, MessageRole, PlatformDefinition};
@@ -62,7 +62,7 @@ impl LocalSessionRunner for RuntimeRunner {
         title: Option<&str>,
         _locale: Option<&str>,
         parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         let mut session = SessionBuilder::new(harness_id)
             .id(SessionId::new())
             .title(title.unwrap_or("subagent"))
@@ -89,11 +89,11 @@ impl LocalSessionRunner for RuntimeRunner {
         &self,
         _limit: Option<usize>,
         _agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
+    ) -> Result<Vec<ExecutionSession>> {
         Ok(vec![])
     }
 
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         self.sessions.get_session(session_id).await
     }
 

--- a/crates/local/src/platform_store.rs
+++ b/crates/local/src/platform_store.rs
@@ -13,7 +13,8 @@
 use async_trait::async_trait;
 use everruns_core::capability_dto::CapabilityInfo;
 use everruns_core::error::{AgentLoopError, Result};
-use everruns_core::session::{Session, SessionParticipant};
+use everruns_core::session::ExecutionSession;
+use everruns_core::typed_id::PrincipalId;
 use everruns_core::typed_id::{
     AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, SessionId,
 };
@@ -21,6 +22,7 @@ use everruns_platform::Agent;
 use everruns_platform::Harness;
 use everruns_platform::app::{App, AppChannel, ChannelType};
 use everruns_platform::{PlatformCreateSessionRequest, PlatformMessage, PlatformStore};
+use everruns_platform::{Session, SessionParticipant};
 use std::sync::Arc;
 
 /// Drives real local sessions for the platform store. An embedder implements
@@ -40,6 +42,9 @@ pub trait LocalSessionRunner: Send + Sync {
     }
 
     /// Create a child/local session and persist it in the session catalog.
+    ///
+    /// Returns the portable execution view (EVE-882): embedded runners carry
+    /// no stored Session persistence records.
     async fn create_session(
         &self,
         harness_id: HarnessId,
@@ -47,12 +52,12 @@ pub trait LocalSessionRunner: Send + Sync {
         title: Option<&str>,
         locale: Option<&str>,
         parent_session_id: Option<SessionId>,
-    ) -> Result<Session>;
+    ) -> Result<ExecutionSession>;
 
     async fn create_session_with_options(
         &self,
         request: PlatformCreateSessionRequest,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         if request.forked_from_session_id.is_some()
             || request.budget_root_session_id.is_some()
             || request.seed != everruns_core::session::SessionSeedMode::Fresh
@@ -80,10 +85,10 @@ pub trait LocalSessionRunner: Send + Sync {
         &self,
         limit: Option<usize>,
         agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>>;
+    ) -> Result<Vec<ExecutionSession>>;
 
     /// Look up a single session by id.
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>>;
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>>;
 
     /// Read recent messages (most recent first) as platform messages.
     async fn get_messages(
@@ -118,6 +123,14 @@ impl LocalPlatformStore {
             base_url: base_url.into(),
         }
     }
+
+    /// Lift the runner's portable execution view into the stored platform
+    /// record the `PlatformStore` seam speaks (EVE-882). The local host has no
+    /// real session ownership catalog, so the record carries the fixed local
+    /// principal and neutral product defaults.
+    fn lift(&self, session: ExecutionSession) -> Session {
+        Session::from_execution_session(session, PrincipalId::from_seed(1))
+    }
 }
 
 #[async_trait]
@@ -137,9 +150,11 @@ impl PlatformStore for LocalPlatformStore {
         if blueprint_id.is_some() {
             return Err(unsupported("create_session(blueprint)"));
         }
-        self.runner
-            .create_session(harness_id, agent_id, title, locale, parent_session_id)
-            .await
+        Ok(self.lift(
+            self.runner
+                .create_session(harness_id, agent_id, title, locale, parent_session_id)
+                .await?,
+        ))
     }
 
     async fn create_session_with_options(
@@ -149,11 +164,15 @@ impl PlatformStore for LocalPlatformStore {
         if request.blueprint_id.is_some() {
             return Err(unsupported("create_session(blueprint)"));
         }
-        self.runner.create_session_with_options(request).await
+        Ok(self.lift(self.runner.create_session_with_options(request).await?))
     }
 
     async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>> {
-        self.runner.get_session(id).await
+        Ok(self
+            .runner
+            .get_session(id)
+            .await?
+            .map(|session| self.lift(session)))
     }
 
     async fn add_agent_session_participant(
@@ -169,7 +188,13 @@ impl PlatformStore for LocalPlatformStore {
         limit: Option<usize>,
         agent_id: Option<AgentId>,
     ) -> Result<Vec<Session>> {
-        self.runner.list_sessions(limit, agent_id).await
+        Ok(self
+            .runner
+            .list_sessions(limit, agent_id)
+            .await?
+            .into_iter()
+            .map(|session| self.lift(session))
+            .collect())
     }
 
     async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {

--- a/crates/local/src/runtime_builder.rs
+++ b/crates/local/src/runtime_builder.rs
@@ -86,7 +86,7 @@ impl LocalRuntimeBuilder {
     }
 
     /// Seed a session.
-    pub fn session(mut self, session: everruns_core::Session) -> Self {
+    pub fn session(mut self, session: everruns_core::ExecutionSession) -> Self {
         self.inner = self.inner.session(session);
         self
     }

--- a/crates/local/src/session_store.rs
+++ b/crates/local/src/session_store.rs
@@ -4,10 +4,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use chrono::Utc;
 use everruns_core::AgentCapabilityConfig;
 use everruns_core::error::{AgentLoopError, Result};
-use everruns_core::session::Session;
+use everruns_core::session::ExecutionSession;
 use everruns_core::traits::{SessionMutator, SessionStore};
 use everruns_core::typed_id::{HarnessId, SessionId};
 use everruns_host::{RuntimeSessionStore, SessionBuilder};
@@ -26,7 +25,7 @@ use crate::SqliteDb;
 #[derive(Clone)]
 pub struct LocalSessionStore {
     db: SqliteDb,
-    sessions: Arc<Mutex<HashMap<SessionId, Session>>>,
+    sessions: Arc<Mutex<HashMap<SessionId, ExecutionSession>>>,
 }
 
 impl LocalSessionStore {
@@ -46,7 +45,7 @@ impl LocalSessionStore {
         })
     }
 
-    fn load(&self, session_id: SessionId) -> Result<Option<Session>> {
+    fn load(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         if let Some(session) = self
             .sessions
             .lock()
@@ -71,12 +70,15 @@ impl LocalSessionStore {
         Ok(exists.then(|| SessionBuilder::new(HarnessId::new()).id(session_id).build()))
     }
 
-    fn mutate(&self, session_id: SessionId, update: impl FnOnce(&mut Session)) -> Result<Session> {
+    fn mutate(
+        &self,
+        session_id: SessionId,
+        update: impl FnOnce(&mut ExecutionSession),
+    ) -> Result<ExecutionSession> {
         let mut session = self
             .load(session_id)?
             .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
         update(&mut session);
-        session.updated_at = Utc::now();
         self.sessions
             .lock()
             .map_err(|_| AgentLoopError::store("local session catalog lock poisoned"))?
@@ -87,14 +89,18 @@ impl LocalSessionStore {
 
 #[async_trait]
 impl SessionStore for LocalSessionStore {
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         self.load(session_id)
     }
 }
 
 #[async_trait]
 impl SessionMutator for LocalSessionStore {
-    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> Result<ExecutionSession> {
         self.mutate(session_id, |session| session.title = Some(title))
     }
 
@@ -102,7 +108,7 @@ impl SessionMutator for LocalSessionStore {
         &self,
         session_id: SessionId,
         capability: AgentCapabilityConfig,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         self.mutate(session_id, |session| {
             if let Some(existing) = session
                 .capabilities
@@ -120,7 +126,7 @@ impl SessionMutator for LocalSessionStore {
         &self,
         session_id: SessionId,
         capability_id: &str,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         self.mutate(session_id, |session| {
             session
                 .capabilities
@@ -131,7 +137,7 @@ impl SessionMutator for LocalSessionStore {
 
 #[async_trait]
 impl RuntimeSessionStore for LocalSessionStore {
-    async fn add_session(&self, session: Session) -> Result<()> {
+    async fn add_session(&self, session: ExecutionSession) -> Result<()> {
         let session_id = session.id;
         self.db
             .with_conn(|conn| {

--- a/crates/local/src/wake_routing.rs
+++ b/crates/local/src/wake_routing.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use everruns_core::error::Result;
-use everruns_core::session::Session;
+use everruns_core::session::ExecutionSession;
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_platform::{PlatformCreateSessionRequest, PlatformMessage};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
@@ -145,7 +145,7 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
         title: Option<&str>,
         locale: Option<&str>,
         parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         self.inner
             .create_session(harness_id, agent_id, title, locale, parent_session_id)
             .await
@@ -154,7 +154,7 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
     async fn create_session_with_options(
         &self,
         request: PlatformCreateSessionRequest,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         self.inner.create_session_with_options(request).await
     }
 
@@ -162,11 +162,11 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
         &self,
         limit: Option<usize>,
         agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
+    ) -> Result<Vec<ExecutionSession>> {
         self.inner.list_sessions(limit, agent_id).await
     }
 
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         self.inner.get_session(session_id).await
     }
 
@@ -204,7 +204,7 @@ mod tests {
             _title: Option<&str>,
             _locale: Option<&str>,
             _parent_session_id: Option<SessionId>,
-        ) -> Result<Session> {
+        ) -> Result<ExecutionSession> {
             let _ = harness_id;
             Err(AgentLoopError::tool("create_session unused in these tests"))
         }
@@ -223,11 +223,11 @@ mod tests {
             &self,
             _limit: Option<usize>,
             _agent_id: Option<AgentId>,
-        ) -> Result<Vec<Session>> {
+        ) -> Result<Vec<ExecutionSession>> {
             Ok(vec![])
         }
 
-        async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+        async fn get_session(&self, _session_id: SessionId) -> Result<Option<ExecutionSession>> {
             Ok(None)
         }
 
@@ -343,7 +343,7 @@ mod tests {
                 _title: Option<&str>,
                 _locale: Option<&str>,
                 _parent: Option<SessionId>,
-            ) -> Result<Session> {
+            ) -> Result<ExecutionSession> {
                 let _ = harness_id;
                 Err(AgentLoopError::tool("create_session unused in these tests"))
             }
@@ -354,10 +354,13 @@ mod tests {
                 &self,
                 _limit: Option<usize>,
                 _agent_id: Option<AgentId>,
-            ) -> Result<Vec<Session>> {
+            ) -> Result<Vec<ExecutionSession>> {
                 Ok(vec![])
             }
-            async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+            async fn get_session(
+                &self,
+                _session_id: SessionId,
+            ) -> Result<Option<ExecutionSession>> {
                 Ok(None)
             }
             async fn get_messages(

--- a/crates/local/tests/platform_store_test.rs
+++ b/crates/local/tests/platform_store_test.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use everruns_core::error::Result;
-use everruns_core::session::Session;
+use everruns_core::session::ExecutionSession;
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_local::{LocalPlatformStore, LocalSessionRunner};
 use everruns_platform::{PlatformMessage, PlatformStore};
@@ -23,7 +23,7 @@ impl LocalSessionRunner for FakeRunner {
         title: Option<&str>,
         _locale: Option<&str>,
         parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         let id = SessionId::new();
         let mut s = everruns_host::SessionBuilder::new(harness_id)
             .id(id)
@@ -46,11 +46,11 @@ impl LocalSessionRunner for FakeRunner {
         &self,
         _limit: Option<usize>,
         _agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
+    ) -> Result<Vec<ExecutionSession>> {
         Ok(vec![])
     }
 
-    async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, _session_id: SessionId) -> Result<Option<ExecutionSession>> {
         Ok(None)
     }
 

--- a/crates/local/tests/schedule_runner_test.rs
+++ b/crates/local/tests/schedule_runner_test.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use everruns_core::error::{AgentLoopError, Result};
-use everruns_core::session::Session;
+use everruns_core::session::ExecutionSession;
 use everruns_core::session_schedule::{ScheduleType, SessionSchedule};
 use everruns_core::traits::SessionScheduleStore;
 use everruns_core::typed_id::{AgentId, HarnessId, PrincipalId, ScheduleId, SessionId};
@@ -64,14 +64,14 @@ impl LocalSessionRunner for RecordingRunner {
         _title: Option<&str>,
         _locale: Option<&str>,
         _parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
     async fn create_session_with_options(
         &self,
         _request: PlatformCreateSessionRequest,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
@@ -98,11 +98,11 @@ impl LocalSessionRunner for RecordingRunner {
         &self,
         _limit: Option<usize>,
         _agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
+    ) -> Result<Vec<ExecutionSession>> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
-    async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, _session_id: SessionId) -> Result<Option<ExecutionSession>> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
@@ -171,7 +171,7 @@ impl LocalSessionRunner for RoutingRunner {
         _title: Option<&str>,
         _locale: Option<&str>,
         _parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
@@ -192,11 +192,11 @@ impl LocalSessionRunner for RoutingRunner {
         &self,
         _limit: Option<usize>,
         _agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
+    ) -> Result<Vec<ExecutionSession>> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
-    async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, _session_id: SessionId) -> Result<Option<ExecutionSession>> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
@@ -232,7 +232,7 @@ impl LocalSessionRunner for BlockingRunner {
         _title: Option<&str>,
         _locale: Option<&str>,
         _parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
@@ -247,11 +247,11 @@ impl LocalSessionRunner for BlockingRunner {
         &self,
         _limit: Option<usize>,
         _agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
+    ) -> Result<Vec<ExecutionSession>> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 
-    async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, _session_id: SessionId) -> Result<Option<ExecutionSession>> {
         Err(AgentLoopError::tool("unused in schedule runner test"))
     }
 

--- a/crates/local/tests/spawn_agent_runtime_test.rs
+++ b/crates/local/tests/spawn_agent_runtime_test.rs
@@ -33,7 +33,7 @@ use async_trait::async_trait;
 use everruns_core::capabilities::{AgentHandoffCapability, SubagentCapability};
 use everruns_core::driver_registry::DriverRegistry;
 use everruns_core::error::Result;
-use everruns_core::session::Session;
+use everruns_core::session::ExecutionSession;
 use everruns_core::session_task::{
     SessionTaskRegistry, SessionTaskState, TASK_KIND_AGENT_HANDOFF, TASK_KIND_SUBAGENT,
 };
@@ -90,7 +90,7 @@ impl LocalSessionRunner for RuntimeRunner {
         title: Option<&str>,
         _locale: Option<&str>,
         parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         let mut session = SessionBuilder::new(harness_id)
             .id(SessionId::new())
             .title(title.unwrap_or("child"))
@@ -117,11 +117,11 @@ impl LocalSessionRunner for RuntimeRunner {
         &self,
         _limit: Option<usize>,
         _agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
+    ) -> Result<Vec<ExecutionSession>> {
         Ok(vec![])
     }
 
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         self.sessions.get_session(session_id).await
     }
 

--- a/crates/platform/src/audit.rs
+++ b/crates/platform/src/audit.rs
@@ -480,7 +480,7 @@ impl HasAuditTargetId for crate::agent::Agent {
     }
 }
 
-impl HasAuditTargetId for everruns_core::Session {
+impl HasAuditTargetId for crate::session::Session {
     fn audit_target_id(&self) -> Option<String> {
         Some(self.id.to_string())
     }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -50,6 +50,13 @@ pub mod agent;
 // loading seam.
 pub mod harness;
 
+// Stored Session persistence record and product lifecycle enums carved out of
+// `everruns-core` (EVE-882). Execution consumes only the portable
+// `everruns_core::ExecutionSession`, produced by `Session::execution_session`
+// at the platform loading seam; the neutral `SessionExecutionState` maps
+// to/from the stored `SessionStatus` at the adapter boundary.
+pub mod session;
+
 pub use agent::{
     Agent, AgentStatus, AgentVersion, AgentVersionChangeKind, MAX_ADDRESSABLE_NAME_LEN,
     generate_agent_public_id, validate_addressable_name, validate_agent_public_id,
@@ -67,6 +74,10 @@ pub use platform_store::{
     PlatformStoreSubagentDelegate,
 };
 pub use principal::{Principal, PrincipalStatus};
+pub use session::{
+    Session, SessionActivity, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
+    SessionSource, SessionStatus,
+};
 
 // Hosted control-plane orchestration records (EVE-841).
 pub use agent_trigger::{AgentTrigger, AgentTriggerType, ScheduleTriggerConfig};

--- a/crates/platform/src/platform_store.rs
+++ b/crates/platform/src/platform_store.rs
@@ -12,7 +12,10 @@ use async_trait::async_trait;
 use everruns_core::SessionContextReport;
 use everruns_core::capability_dto::CapabilityInfo;
 use everruns_core::error::Result;
-use everruns_core::session::{Session, SessionParticipant, SessionSeedMode};
+use everruns_core::session::SessionSeedMode;
+use everruns_core::typed_id::SessionParticipantId;
+
+use crate::session::{Session, SessionParticipant};
 use everruns_core::typed_id::{
     AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, SessionId,
 };
@@ -380,19 +383,36 @@ impl everruns_core::subagent_delegation::SubagentSessionDelegate for PlatformSto
         &self,
         session_id: SessionId,
         agent_id: AgentId,
-    ) -> Result<SessionParticipant> {
-        self.0
+    ) -> Result<SessionParticipantId> {
+        // The stored participant record stays behind this adapter (EVE-882);
+        // portable orchestration only needs the correlation id.
+        Ok(self
+            .0
             .add_agent_session_participant(session_id, agent_id)
-            .await
+            .await?
+            .id)
     }
     async fn create_session_with_options(
         &self,
         request: PlatformCreateSessionRequest,
-    ) -> Result<Session> {
-        self.0.create_session_with_options(request).await
+    ) -> Result<everruns_core::ExecutionSession> {
+        // Project the stored aggregate into the portable execution view at
+        // the platform seam (EVE-882).
+        Ok(self
+            .0
+            .create_session_with_options(request)
+            .await?
+            .execution_session())
     }
-    async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>> {
-        self.0.get_session_by_id(id).await
+    async fn get_session_by_id(
+        &self,
+        id: SessionId,
+    ) -> Result<Option<everruns_core::ExecutionSession>> {
+        Ok(self
+            .0
+            .get_session_by_id(id)
+            .await?
+            .map(|session| session.execution_session()))
     }
     async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
         self.0.send_message(session_id, content).await
@@ -419,8 +439,8 @@ pub mod tests {
     use crate::agent::{Agent, AgentStatus};
     use crate::app::{App, AppChannel, AppStatus, ChannelType};
     use crate::harness::HarnessStatus;
+    use crate::session::{Session, SessionStatus};
     use everruns_core::AgentCapabilityConfig;
-    use everruns_core::session::{Session, SessionStatus};
 
     /// Mock PlatformStore for unit tests.
     ///
@@ -934,12 +954,12 @@ pub mod tests {
             let participant = SessionParticipant {
                 id: everruns_core::typed_id::SessionParticipantId::new(),
                 session_id,
-                kind: everruns_core::session::SessionParticipantKind::Agent,
+                kind: crate::session::SessionParticipantKind::Agent,
                 agent_id: Some(agent_id),
                 agent_version_id: self.agent.default_version_id,
                 principal_id: self.session.owner_principal_id,
                 display_name: None,
-                role: everruns_core::session::SessionParticipantRole::Member,
+                role: crate::session::SessionParticipantRole::Member,
                 joined_at: chrono::Utc::now(),
                 left_at: None,
             };

--- a/crates/platform/src/session.rs
+++ b/crates/platform/src/session.rs
@@ -1,0 +1,813 @@
+// Stored Session persistence record and product lifecycle enums (EVE-882).
+//
+// Decision: the hosted Session database/API aggregate is a platform concern.
+// This record — source/facet classifications, participants and ownership
+// references, UI/list activity projections, timestamps, catalog
+// relationships — moved here from `everruns-core`. The execution kernel
+// consumes only the portable `everruns_core::ExecutionSession`, produced at
+// the loading seam by [`Session::execution_session`]; the neutral
+// [`SessionExecutionState`] maps to/from the stored [`SessionStatus`] at the
+// adapter boundary.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use everruns_core::capability_types::AgentCapabilityConfig;
+use everruns_core::events::TokenUsage;
+use everruns_core::mcp_server::{ScopedMcpServers, scoped_mcp_servers_is_empty};
+use everruns_core::network_access::NetworkAccessList;
+use everruns_core::principal::PrincipalSummary;
+use everruns_core::session::{ExecutionSession, SessionExecutionState};
+use everruns_core::tool_types::ToolDefinition;
+use everruns_core::typed_id::{
+    AgentId, AgentIdentityId, AgentVersionId, HarnessId, ModelId, PrincipalId, SessionId,
+    SessionParticipantId, WorkspaceId,
+};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// Session execution status.
+/// - `started`: Session just created, no turn executed yet
+/// - `active`: A turn is currently running
+/// - `idle`: Turn completed, session waiting for next input
+/// - `paused`: Budget limit reached, waiting for user to increase limit or resume
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum SessionStatus {
+    /// Session just created, no turn executed yet.
+    Started,
+    /// A turn is currently running (session is active).
+    Active,
+    /// Turn completed, session waiting for next input (idle).
+    Idle,
+    /// Waiting for client to submit tool results.
+    WaitingForToolResults,
+    /// Budget limit reached — session paused until user resumes or increases limit.
+    Paused,
+}
+
+impl SessionStatus {
+    /// Project the stored status into the neutral execution state consumed by
+    /// the kernel (EVE-882). The variants correspond one-to-one today; the
+    /// mapping keeps the boundary explicit so they can diverge independently.
+    pub fn execution_state(&self) -> SessionExecutionState {
+        match self {
+            SessionStatus::Started => SessionExecutionState::Started,
+            SessionStatus::Active => SessionExecutionState::Active,
+            SessionStatus::Idle => SessionExecutionState::Idle,
+            SessionStatus::WaitingForToolResults => SessionExecutionState::WaitingForToolResults,
+            SessionStatus::Paused => SessionExecutionState::Paused,
+        }
+    }
+}
+
+impl From<SessionExecutionState> for SessionStatus {
+    fn from(state: SessionExecutionState) -> Self {
+        match state {
+            SessionExecutionState::Started => SessionStatus::Started,
+            SessionExecutionState::Active => SessionStatus::Active,
+            SessionExecutionState::Idle => SessionStatus::Idle,
+            SessionExecutionState::WaitingForToolResults => SessionStatus::WaitingForToolResults,
+            SessionExecutionState::Paused => SessionStatus::Paused,
+        }
+    }
+}
+
+impl From<&SessionStatus> for SessionExecutionState {
+    fn from(status: &SessionStatus) -> Self {
+        status.execution_state()
+    }
+}
+
+impl std::fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionStatus::Started => write!(f, "started"),
+            SessionStatus::Active => write!(f, "active"),
+            SessionStatus::Idle => write!(f, "idle"),
+            SessionStatus::WaitingForToolResults => write!(f, "waiting_for_tool_results"),
+            SessionStatus::Paused => write!(f, "paused"),
+        }
+    }
+}
+
+impl From<&str> for SessionStatus {
+    fn from(s: &str) -> Self {
+        match s {
+            "active" => SessionStatus::Active,
+            "idle" => SessionStatus::Idle,
+            "waiting_for_tool_results" => SessionStatus::WaitingForToolResults,
+            "paused" => SessionStatus::Paused,
+            // Handle legacy values during migration
+            "running" => SessionStatus::Active,
+            "pending" | "completed" | "failed" => SessionStatus::Idle,
+            _ => SessionStatus::Started,
+        }
+    }
+}
+
+/// How a session came into existence.
+///
+/// Closed set: the sessions facet rail enumerates every variant, so the value
+/// is typed rather than a free-form string. Ingress paths set it server-side —
+/// clients may only declare the two variants they can legitimately be
+/// (`Chat` and `Api`), which keeps a facet like "started by a schedule"
+/// trustworthy. Rows that predate the column, or whose origin could not be
+/// inferred at backfill time, carry `Unknown`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SessionSource {
+    /// Interactive chat thread (UI chat surface, global chat, public chat).
+    Chat,
+    /// Direct `POST /v1/sessions` from the API, CLI, or an SDK.
+    Api,
+    /// Slack channel ingress.
+    Slack,
+    /// AG-UI channel ingress.
+    AgUi,
+    /// FCP channel ingress.
+    Fcp,
+    /// Fired by a schedule (app schedule channel or agent trigger).
+    Schedule,
+    /// Inbound webhook or app API endpoint.
+    Webhook,
+    /// Inbound A2A request.
+    A2a,
+    /// Created by an eval run.
+    Eval,
+    /// Spawned as a subagent / delegated peer of another session.
+    Subagent,
+    /// Origin not recorded (pre-migration rows that could not be inferred).
+    #[default]
+    Unknown,
+}
+
+impl SessionSource {
+    pub const ALL: &'static [SessionSource] = &[
+        SessionSource::Chat,
+        SessionSource::Api,
+        SessionSource::Slack,
+        SessionSource::AgUi,
+        SessionSource::Fcp,
+        SessionSource::Schedule,
+        SessionSource::Webhook,
+        SessionSource::A2a,
+        SessionSource::Eval,
+        SessionSource::Subagent,
+        SessionSource::Unknown,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SessionSource::Chat => "chat",
+            SessionSource::Api => "api",
+            SessionSource::Slack => "slack",
+            SessionSource::AgUi => "ag_ui",
+            SessionSource::Fcp => "fcp",
+            SessionSource::Schedule => "schedule",
+            SessionSource::Webhook => "webhook",
+            SessionSource::A2a => "a2a",
+            SessionSource::Eval => "eval",
+            SessionSource::Subagent => "subagent",
+            SessionSource::Unknown => "unknown",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|v| v.as_str() == s)
+    }
+
+    /// Whether a client may declare this source on `POST /v1/sessions`.
+    /// Everything else is server-owned so facets cannot be spoofed.
+    pub fn is_client_declarable(self) -> bool {
+        matches!(self, SessionSource::Chat | SessionSource::Api)
+    }
+}
+
+impl std::fmt::Display for SessionSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for SessionSource {
+    fn from(s: &str) -> Self {
+        Self::parse(s).unwrap_or(SessionSource::Unknown)
+    }
+}
+
+/// Outcome-oriented view of a session, as the sessions list and facet rail
+/// present it. Derived from the session's execution status plus the outcome of
+/// its most recent turn — `SessionStatus` alone has no notion of failure.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SessionActivity {
+    /// A turn is executing, or the session is waiting on client tool results.
+    Running,
+    /// Budget limit reached; waiting for the user to resume.
+    Paused,
+    /// Last completed turn failed or was cancelled.
+    Failed,
+    /// Last completed turn succeeded and nothing is running.
+    Completed,
+    /// Created but idle with no completed turn yet.
+    #[default]
+    Idle,
+}
+
+impl SessionActivity {
+    pub const ALL: &'static [SessionActivity] = &[
+        SessionActivity::Running,
+        SessionActivity::Paused,
+        SessionActivity::Failed,
+        SessionActivity::Completed,
+        SessionActivity::Idle,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SessionActivity::Running => "running",
+            SessionActivity::Paused => "paused",
+            SessionActivity::Failed => "failed",
+            SessionActivity::Completed => "completed",
+            SessionActivity::Idle => "idle",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|v| v.as_str() == s)
+    }
+
+    /// Single source of truth for the derivation, mirrored by
+    /// `session_activity_sql` in the sessions repository so the list, the facet
+    /// counts, and the in-memory backend cannot drift apart.
+    pub fn derive(status: &SessionStatus, last_turn_status: Option<&str>) -> Self {
+        match status {
+            SessionStatus::Active | SessionStatus::WaitingForToolResults => {
+                SessionActivity::Running
+            }
+            SessionStatus::Paused => SessionActivity::Paused,
+            _ => match last_turn_status {
+                Some("failed") | Some("cancelled") => SessionActivity::Failed,
+                Some("completed") => SessionActivity::Completed,
+                _ => SessionActivity::Idle,
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for SessionActivity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Kind of actor participating in a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SessionParticipantKind {
+    Agent,
+    User,
+}
+
+impl std::fmt::Display for SessionParticipantKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionParticipantKind::Agent => write!(f, "agent"),
+            SessionParticipantKind::User => write!(f, "user"),
+        }
+    }
+}
+
+impl From<&str> for SessionParticipantKind {
+    fn from(s: &str) -> Self {
+        match s {
+            "agent" => SessionParticipantKind::Agent,
+            "user" => SessionParticipantKind::User,
+            _ => SessionParticipantKind::User,
+        }
+    }
+}
+
+/// Role a participant has inside a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SessionParticipantRole {
+    Host,
+    Member,
+}
+
+impl std::fmt::Display for SessionParticipantRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionParticipantRole::Host => write!(f, "host"),
+            SessionParticipantRole::Member => write!(f, "member"),
+        }
+    }
+}
+
+impl From<&str> for SessionParticipantRole {
+    fn from(s: &str) -> Self {
+        match s {
+            "host" => SessionParticipantRole::Host,
+            "member" => SessionParticipantRole::Member,
+            _ => SessionParticipantRole::Member,
+        }
+    }
+}
+
+/// Session participant - an agent or user that has joined a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct SessionParticipant {
+    /// Unique identifier for the participant row (format: part_{32-hex}).
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = String,
+            example = "part_01933b5a00007000800000000000001"
+        )
+    )]
+    pub id: SessionParticipantId,
+    /// Session this participant belongs to.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = String,
+            example = "session_01933b5a00007000800000000000001"
+        )
+    )]
+    pub session_id: SessionId,
+    pub kind: SessionParticipantKind,
+    /// Present for agent participants.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = Option<String>,
+            example = "agent_01933b5a00007000800000000000001"
+        )
+    )]
+    pub agent_id: Option<AgentId>,
+    /// Immutable agent version captured for an agent participant when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = Option<String>,
+            example = "agentver_01933b5a00007000800000000000001"
+        )
+    )]
+    pub agent_version_id: Option<AgentVersionId>,
+    /// Principal that joined the session.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(
+            value_type = String,
+            example = "principal_01933b5a000070008000000000000001"
+        )
+    )]
+    pub principal_id: PrincipalId,
+    /// Human-readable name captured for this participant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    pub role: SessionParticipantRole,
+    pub joined_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left_at: Option<DateTime<Utc>>,
+}
+
+/// Session - instance of agentic loop execution.
+/// A session represents a single conversation with an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct Session {
+    /// Unique identifier for the session (format: session_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "session_01933b5a00007000800000000000001"))]
+    pub id: SessionId,
+    /// Organization this session belongs to (format: org_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "org_00000000000000000000000000000001"))]
+    pub organization_id: String,
+    /// Workspace this session is attached to (format: wsp_{32-hex}). Owns the
+    /// session's virtual filesystem. For the default 1:1 case this mirrors the
+    /// session id, but clients should read it here rather than deriving it.
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "wsp_01933b5a00007000800000000000001"))]
+    pub workspace_id: WorkspaceId,
+    /// ID of the harness for this session (format: harness_{32-hex}).
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "harness_01933b5a00007000800000000000001"))]
+    pub harness_id: HarnessId,
+    /// ID of the agent working in this session (format: agent_{32-hex}). Optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001"))]
+    pub agent_id: Option<AgentId>,
+    /// Immutable agent version captured when the session was created or rebound.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "agentver_01933b5a00007000800000000000001"))]
+    pub agent_version_id: Option<AgentVersionId>,
+    /// Optional resident agent identity for unattended/background execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "identity_01933b5a00007000800000000000001"))]
+    pub agent_identity_id: Option<AgentIdentityId>,
+    /// Owning principal for this session.
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "principal_01933b5a000070008000000000000001"))]
+    pub owner_principal_id: PrincipalId,
+    /// Denormalized effective human owner of the owning principal lineage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "550e8400-e29b-41d4-a716-446655440000")
+    )]
+    pub resolved_owner_user_id: Option<uuid::Uuid>,
+    /// Owning principal summary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<PrincipalSummary>,
+    /// Effective human owner summary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_owner: Option<PrincipalSummary>,
+    /// Human-readable title for the session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = "Q3 marketing brief"))]
+    pub title: Option<String>,
+    /// Session objective visible to the runtime agent at system-prompt level.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "Investigate the queue latency regression")
+    )]
+    pub goal: Option<String>,
+    /// Locale for localized agent behavior and formatting (BCP 47, e.g. `uk-UA`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = "en-US"))]
+    pub locale: Option<String>,
+    /// Preview text from the first user message (truncated).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "Help me draft the Q3 marketing plan")
+    )]
+    pub preview: Option<String>,
+    /// Preview text from the last assistant response (truncated).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "Here is a Q3 plan covering the three pillars we discussed...")
+    )]
+    pub output_preview: Option<String>,
+    /// Tags for organizing and filtering sessions.
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(example = json!(["marketing", "q3", "draft"])))]
+    pub tags: Vec<String>,
+    /// LLM model ID to use for this session (format: model_{32-hex}).
+    /// Overrides the agent's default model if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001"))]
+    pub model_id: Option<ModelId>,
+    /// Session-level capabilities (additive to agent capabilities).
+    /// Applied after agent capabilities when building RuntimeAgent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(value_type = Vec<everruns_core::capability_types::AgentCapabilityConfigSchema>)
+    )]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Client-side tools for this session (additive to agent tools).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolDefinition>,
+    /// Remote MCP servers scoped to this session only.
+    #[serde(
+        default,
+        rename = "mcpServers",
+        alias = "mcp_servers",
+        skip_serializing_if = "scoped_mcp_servers_is_empty"
+    )]
+    pub mcp_servers: ScopedMcpServers,
+    /// Session-level system prompt override.
+    /// Prepended to the agent's system prompt when building RuntimeAgent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
+    /// Session-level initial files (additive to agent initial_files).
+    /// Files with matching paths override agent/harness files; new paths are appended.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub initial_files: Vec<everruns_core::session_file::InitialFile>,
+    /// Session-level client hints — arbitrary key-value pairs declared by the
+    /// client at session creation time. These are defaults for every turn;
+    /// per-message `controls.hints` override these key-by-key (shallow merge).
+    ///
+    /// Examples: `{"setup_connection": true, "rich_media": true}`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hints: Option<std::collections::HashMap<String, serde_json::Value>>,
+    /// Network access list controlling which hosts/URLs this session can reach.
+    /// Merged with harness and agent layers (allowed: intersect, blocked: union).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_access: Option<NetworkAccessList>,
+    /// Maximum number of LLM iterations per turn for this session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = 50))]
+    pub max_iterations: Option<usize>,
+    /// Request-level parallel tool calling preference (EVE-598).
+    ///
+    /// `None` (default) preserves provider defaults. `Some(true)` signals the
+    /// provider that parallel tool calls are wanted; `Some(false)` requests at
+    /// most one tool call per turn and forces serial execution. Merged across
+    /// harness/agent/session layers (overlay wins).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = true))]
+    pub parallel_tool_calls: Option<bool>,
+    /// Current execution status of the session.
+    pub status: SessionStatus,
+    /// How this session was started. Server-owned for every ingress path.
+    #[serde(default)]
+    pub source: SessionSource,
+    /// Outcome-oriented status derived from `status` and the last turn result.
+    /// This is the value the sessions list groups by and the facet rail counts.
+    #[serde(default)]
+    pub activity: SessionActivity,
+    /// Timestamp when the session was created.
+    #[cfg_attr(feature = "openapi", schema(example = "2026-05-25T10:00:00Z"))]
+    pub created_at: DateTime<Utc>,
+    /// Timestamp when the session was last updated.
+    #[cfg_attr(feature = "openapi", schema(example = "2026-05-25T10:14:32Z"))]
+    pub updated_at: DateTime<Utc>,
+    /// Timestamp when the session started executing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = "2026-05-25T10:00:01Z"))]
+    pub started_at: Option<DateTime<Utc>>,
+    /// Timestamp when the session finished (completed or failed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = "2026-05-25T10:14:32Z"))]
+    pub finished_at: Option<DateTime<Utc>>,
+    /// Cumulative token usage for all LLM calls in this session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<TokenUsage>,
+    /// Whether this session is pinned by the current user.
+    /// Only populated when the request has an authenticated user context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = false))]
+    pub is_pinned: Option<bool>,
+    /// Number of active (enabled) schedules for this session.
+    /// Populated when the session is fetched for API responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = 2))]
+    pub active_schedule_count: Option<u32>,
+    /// Aggregated UI features from all active capabilities (harness + agent + session).
+    /// Computed at read time from the capability registry.
+    /// Known features: "file_system", "schedules", "secrets", "key_value",
+    /// "sql_database", "leased_resources".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(example = json!(["file_system", "secrets"])))]
+    pub features: Vec<String>,
+
+    // -- Subagent nesting fields --
+    /// Parent session that spawned this subagent. NULL for top-level sessions.
+    /// Used to compute governed subagent delegation depth.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+    pub parent_session_id: Option<SessionId>,
+
+    // -- Fork lineage fields (knowledge/runtime-resources/forking-sessions.md) --
+    /// Session this one was forked from. NULL for sessions that were not forked.
+    /// Distinct from `parent_session_id` (subagent nesting): forking is a
+    /// user-initiated "branch from here" relationship.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+    pub forked_from_session_id: Option<SessionId>,
+    /// Parent event sequence the fork was taken at (the fork point). NULL unless
+    /// this session is a fork.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = 42))]
+    pub forked_from_sequence: Option<i32>,
+
+    // -- Blueprint fields (only set when this session runs a blueprint agent) --
+    /// Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent
+    /// from the blueprint definition instead of from harness_id/agent_id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = "blueprint_research_pack"))]
+    pub blueprint_id: Option<String>,
+    /// Validated config passed by host at blueprint spawn time.
+    /// Example: `{"target_repo": "acme/everruns"}`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    pub blueprint_config: Option<serde_json::Value>,
+}
+
+impl Session {
+    /// Lift a portable execution view into a minimal stored record (EVE-882).
+    ///
+    /// The inverse of [`Session::execution_session`], for embedded/local hosts
+    /// that implement platform seams (e.g. `PlatformStore`) over a runtime that
+    /// only carries `ExecutionSession` values. Product-only fields get neutral
+    /// defaults: `source` is [`SessionSource::Unknown`], `activity` derives
+    /// from the execution state with no last-turn outcome, timestamps are now,
+    /// and ownership references beyond the supplied principal stay empty.
+    pub fn from_execution_session(
+        execution: ExecutionSession,
+        owner_principal_id: PrincipalId,
+    ) -> Self {
+        let status = SessionStatus::from(execution.status);
+        let activity = SessionActivity::derive(&status, None);
+        let now = Utc::now();
+        Self {
+            id: execution.id,
+            organization_id: execution.organization_id,
+            workspace_id: execution.workspace_id,
+            harness_id: execution.harness_id,
+            agent_id: execution.agent_id,
+            agent_version_id: None,
+            agent_identity_id: None,
+            owner_principal_id,
+            resolved_owner_user_id: None,
+            owner: None,
+            effective_owner: None,
+            title: execution.title,
+            goal: execution.goal,
+            locale: execution.locale,
+            preview: None,
+            output_preview: None,
+            tags: execution.tags,
+            model_id: execution.model_id,
+            capabilities: execution.capabilities,
+            tools: execution.tools,
+            mcp_servers: execution.mcp_servers,
+            system_prompt: execution.system_prompt,
+            initial_files: execution.initial_files,
+            hints: execution.hints,
+            network_access: execution.network_access,
+            max_iterations: execution.max_iterations,
+            parallel_tool_calls: execution.parallel_tool_calls,
+            status,
+            source: SessionSource::Unknown,
+            activity,
+            created_at: now,
+            updated_at: now,
+            started_at: None,
+            finished_at: None,
+            usage: execution.usage,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: Vec::new(),
+            parent_session_id: execution.parent_session_id,
+            forked_from_session_id: execution.forked_from_session_id,
+            forked_from_sequence: None,
+            blueprint_id: execution.blueprint_id,
+            blueprint_config: execution.blueprint_config,
+        }
+    }
+
+    /// Project this stored record into the portable execution view consumed by
+    /// the kernel (EVE-882).
+    ///
+    /// Sessions have no archived/deleted lifecycle, so — unlike
+    /// `Agent::execution_definition` / `Harness::execution_definition` — this
+    /// projection cannot fail; the stored status maps onto the neutral
+    /// execution state. Product facets, participants, ownership summaries,
+    /// timestamps, and UI metadata are excluded by construction.
+    pub fn execution_session(&self) -> ExecutionSession {
+        ExecutionSession {
+            id: self.id,
+            organization_id: self.organization_id.clone(),
+            workspace_id: self.workspace_id,
+            harness_id: self.harness_id,
+            agent_id: self.agent_id,
+            title: self.title.clone(),
+            goal: self.goal.clone(),
+            locale: self.locale.clone(),
+            tags: self.tags.clone(),
+            model_id: self.model_id,
+            capabilities: self.capabilities.clone(),
+            tools: self.tools.clone(),
+            mcp_servers: self.mcp_servers.clone(),
+            system_prompt: self.system_prompt.clone(),
+            initial_files: self.initial_files.clone(),
+            hints: self.hints.clone(),
+            network_access: self.network_access.clone(),
+            max_iterations: self.max_iterations,
+            parallel_tool_calls: self.parallel_tool_calls,
+            status: self.status.execution_state(),
+            usage: self.usage.clone(),
+            parent_session_id: self.parent_session_id,
+            forked_from_session_id: self.forked_from_session_id,
+            blueprint_id: self.blueprint_id.clone(),
+            blueprint_config: self.blueprint_config.clone(),
+        }
+    }
+}
+
+impl From<&Session> for everruns_core::AgentConfigOverlay {
+    fn from(session: &Session) -> Self {
+        (&session.execution_session()).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The list filters activity in SQL and the in-memory backend filters it in
+    /// Rust, so this truth table is the contract both sides implement. It is
+    /// duplicated verbatim as a comment beside `ACTIVITY_SQL` in
+    /// `crates/server/src/storage/repositories/sessions.rs`.
+    #[test]
+    fn activity_derivation_truth_table() {
+        use SessionActivity as A;
+        use SessionStatus as S;
+
+        let cases: &[(SessionStatus, Option<&str>, SessionActivity)] = &[
+            // Execution state wins: a running turn is running whatever the
+            // previous turn did.
+            (S::Active, None, A::Running),
+            (S::Active, Some("failed"), A::Running),
+            (S::WaitingForToolResults, Some("completed"), A::Running),
+            (S::Paused, Some("failed"), A::Paused),
+            // Otherwise the last terminal turn decides.
+            (S::Idle, Some("completed"), A::Completed),
+            (S::Idle, Some("failed"), A::Failed),
+            (S::Idle, Some("cancelled"), A::Failed),
+            (S::Started, Some("completed"), A::Completed),
+            // No completed turn yet, or an unrecognized outcome.
+            (S::Started, None, A::Idle),
+            (S::Idle, None, A::Idle),
+            (S::Idle, Some("weird"), A::Idle),
+        ];
+
+        for (status, last_turn, expected) in cases {
+            assert_eq!(
+                SessionActivity::derive(status, *last_turn),
+                *expected,
+                "status={status} last_turn={last_turn:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn session_source_round_trips_through_its_wire_string() {
+        for source in SessionSource::ALL {
+            assert_eq!(SessionSource::parse(source.as_str()), Some(*source));
+        }
+        // Unknown text degrades to the explicit unknown bucket rather than
+        // inventing a facet.
+        assert_eq!(SessionSource::from("not_a_source"), SessionSource::Unknown);
+    }
+
+    #[test]
+    fn only_chat_and_api_are_client_declarable() {
+        let declarable: Vec<_> = SessionSource::ALL
+            .iter()
+            .filter(|s| s.is_client_declarable())
+            .copied()
+            .collect();
+        assert_eq!(declarable, vec![SessionSource::Chat, SessionSource::Api]);
+    }
+
+    #[test]
+    fn session_activity_round_trips_through_its_wire_string() {
+        for activity in SessionActivity::ALL {
+            assert_eq!(SessionActivity::parse(activity.as_str()), Some(*activity));
+        }
+        assert_eq!(SessionActivity::parse("nope"), None);
+    }
+
+    #[test]
+    fn lifted_execution_view_round_trips_through_the_stored_record() {
+        let execution = ExecutionSession {
+            agent_id: Some(everruns_core::typed_id::AgentId::from_seed(7)),
+            title: Some("Lifted".to_string()),
+            tags: vec!["a".to_string()],
+            status: SessionExecutionState::Idle,
+            ..ExecutionSession::with_own_workspace(SessionId::new(), HarnessId::new())
+        };
+        let lifted = Session::from_execution_session(execution.clone(), PrincipalId::from_seed(1));
+        // Product fields get neutral defaults...
+        assert_eq!(lifted.source, SessionSource::Unknown);
+        assert_eq!(lifted.activity, SessionActivity::Idle);
+        assert_eq!(lifted.status, SessionStatus::Idle);
+        // ...and projecting back preserves every portable field.
+        let round_tripped = lifted.execution_session();
+        assert_eq!(
+            serde_json::to_value(&round_tripped).unwrap(),
+            serde_json::to_value(&execution).unwrap()
+        );
+    }
+
+    #[test]
+    fn stored_status_round_trips_through_the_neutral_execution_state() {
+        for status in [
+            SessionStatus::Started,
+            SessionStatus::Active,
+            SessionStatus::Idle,
+            SessionStatus::WaitingForToolResults,
+            SessionStatus::Paused,
+        ] {
+            let state = status.execution_state();
+            assert_eq!(SessionStatus::from(state), status);
+            // Wire strings agree, so string-based adapter paths (worker
+            // lifecycle, DB columns) map through either type identically.
+            assert_eq!(status.to_string(), state.to_string());
+        }
+    }
+}

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -707,7 +707,7 @@ fn forwarded_ag_ui_image_ids(forwarded_props: &Value) -> Result<Vec<ImageId>, Bo
 }
 
 struct SessionResolution {
-    session: everruns_core::Session,
+    session: everruns_platform::Session,
     is_new: bool,
 }
 
@@ -805,7 +805,7 @@ async fn find_or_create_session(
                     app.internal_id,
                     app.owner_principal_id,
                     app.resolved_owner_user_id,
-                    everruns_core::SessionSource::AgUi,
+                    everruns_platform::SessionSource::AgUi,
                     CreateSessionRequest {
                         source: None,
                         workspace_id: None,

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -1437,11 +1437,11 @@ impl ResourceUrlable for everruns_core::budget::Budget {
 /// API exposes them regardless of run state.
 pub fn session_allowed_actions(
     id: &str,
-    status: &everruns_core::session::SessionStatus,
+    status: &everruns_platform::SessionStatus,
     is_pinned: bool,
     api_base: &str,
 ) -> Vec<AllowedAction> {
-    use everruns_core::session::SessionStatus;
+    use everruns_platform::SessionStatus;
     let mut actions = Vec::new();
     actions.push(
         AllowedAction::new("self")
@@ -1503,7 +1503,7 @@ pub fn session_allowed_actions(
     actions
 }
 
-impl ResourceUrlable for everruns_core::Session {
+impl ResourceUrlable for everruns_platform::Session {
     fn api_path() -> &'static str {
         "v1/sessions"
     }
@@ -2215,7 +2215,7 @@ mod tests {
 
     #[test]
     fn session_actions_include_cancel_when_turn_is_active() {
-        use everruns_core::session::SessionStatus;
+        use everruns_platform::SessionStatus;
         let actions = session_allowed_actions(
             "session_01",
             &SessionStatus::Active,
@@ -2238,7 +2238,7 @@ mod tests {
 
     #[test]
     fn session_actions_omit_cancel_in_idle_or_paused_states() {
-        use everruns_core::session::SessionStatus;
+        use everruns_platform::SessionStatus;
         for status in [
             SessionStatus::Started,
             SessionStatus::Idle,
@@ -2256,7 +2256,7 @@ mod tests {
 
     #[test]
     fn session_actions_flip_pin_rel_on_is_pinned() {
-        use everruns_core::session::SessionStatus;
+        use everruns_platform::SessionStatus;
         let unpinned = session_allowed_actions(
             "session_01",
             &SessionStatus::Idle,
@@ -2287,7 +2287,7 @@ mod tests {
 
     #[test]
     fn session_actions_always_include_self_events_stream_update_delete() {
-        use everruns_core::session::SessionStatus;
+        use everruns_platform::SessionStatus;
         let actions = session_allowed_actions(
             "session_xyz",
             &SessionStatus::Idle,

--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -670,7 +670,7 @@ async fn resolve_session(
             app.internal_id,
             app.owner_principal_id,
             app.resolved_owner_user_id,
-            everruns_core::SessionSource::Fcp,
+            everruns_platform::SessionSource::Fcp,
             CreateSessionRequest {
                 source: None,
                 workspace_id: None,

--- a/crates/server/src/api/mcp_endpoint/tasks.rs
+++ b/crates/server/src/api/mcp_endpoint/tasks.rs
@@ -66,7 +66,7 @@ impl TaskStatus {
 
 /// Map an Everruns session status string to a Tasks lifecycle state.
 ///
-/// Session statuses (see `everruns_core::SessionStatus`):
+/// Session statuses (see `everruns_platform::SessionStatus`):
 /// - `started` / `active` → `working` (a turn is or will be running)
 /// - `waiting_for_tool_results` / `paused` → `input_required` (needs client
 ///   input: tool results, or a budget/limit action)

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -23,11 +23,13 @@ use everruns_core::typed_id::{
     AgentId, AgentIdentityId, HarnessId, ModelId, SessionId, WorkspaceId,
 };
 use everruns_core::{
-    Caller, PlatformDefinition, ResourceConfigResponse, ScopedMcpServers, Session,
-    SessionContextReport, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
+    Caller, PlatformDefinition, ResourceConfigResponse, ScopedMcpServers, SessionContextReport,
     SessionSeedMode, ToolDefinition, evaluate_policies_with, is_mcp_tool,
 };
 use everruns_platform::BuiltInHarnessRole;
+use everruns_platform::{
+    Session, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
+};
 use everruns_worker::AgentRunner;
 
 use super::common::{
@@ -47,7 +49,7 @@ pub struct CreateSessionRequest {
     /// server-owned so the sessions facet rail stays trustworthy.
     #[serde(default)]
     #[schema(value_type = Option<String>, example = "chat")]
-    pub source: Option<everruns_core::SessionSource>,
+    pub source: Option<everruns_platform::SessionSource>,
     /// ID of the harness for this session (format: harness_{32-hex}).
     /// If omitted, the harness is derived from the agent (when one is supplied),
     /// else the org default harness, else the built-in fallback. New orgs default

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -25,14 +25,15 @@ use axum::{
     routing::{get, post},
 };
 use chrono::Utc;
+use everruns_core::Caller;
 use everruns_core::channel::{
     InboundAttachment, InboundChannelEvent, SessionRoutingStrategy, ThreadContext,
     build_session_routing_tag,
 };
 use everruns_core::progress_reporting::sync_slack_reply_mode_tags;
 use everruns_core::validate_safe_url;
-use everruns_core::{Caller, SessionParticipantKind, SessionParticipantRole};
 use everruns_platform::{App, AppStatus, SessionStrategy, SlackChannelConfig, SlackReplyMode};
+use everruns_platform::{SessionParticipantKind, SessionParticipantRole};
 use everruns_worker::AgentRunner;
 use hmac::{Hmac, KeyInit, Mac};
 use moka::sync::Cache;
@@ -683,7 +684,7 @@ async fn process_slack_message(
                     app.internal_id,
                     app.owner_principal_id,
                     app.resolved_owner_user_id,
-                    everruns_core::SessionSource::Slack,
+                    everruns_platform::SessionSource::Slack,
                     req,
                 )
                 .await?;
@@ -2455,7 +2456,7 @@ mod tests {
         use crate::storage::models::CreateSessionRow;
 
         let row = CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: 1,
             app_id: None,

--- a/crates/server/src/api/tool_results.rs
+++ b/crates/server/src/api/tool_results.rs
@@ -18,10 +18,10 @@ use axum::{
     http::StatusCode,
     routing::post,
 };
-use everruns_core::SessionStatus;
 use everruns_core::events::{EventContext, EventRequest, ToolCompletedData};
 use everruns_core::message::ContentPart;
 use everruns_core::typed_id::{MessageId, SessionId, TurnId};
+use everruns_platform::SessionStatus;
 use everruns_worker::AgentRunner;
 
 use super::common::{ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, impl_auth_state};

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -317,7 +317,7 @@ pub struct VoiceEndResponse {
 pub struct VoiceSessionResponse<T> {
     /// The session this voice connection is attached to. Returned alongside
     /// the voice payload so a caller has a single round-trip view of both.
-    pub session: everruns_core::Session,
+    pub session: everruns_platform::Session,
     /// Voice connection details — concrete shape depends on the endpoint
     /// (e.g. `VoiceCallResponse` for `/voice/call`, `VoiceAttachResponse`
     /// for `/voice/attach`).

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -26,11 +26,12 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
     Caller, ContentPart, DriverId, DriverRegistry, EgressRequest, EgressRequestKind, EgressService,
-    EventData, Message, MessageRole, Session, SessionParticipant, SessionStatus, ToolDefinition,
-    ToolResultContentPart, UtilityLlmService, resolve_runtime_capabilities,
+    EventData, Message, MessageRole, ToolDefinition, ToolResultContentPart, UtilityLlmService,
+    resolve_runtime_capabilities,
 };
 use everruns_platform::{Agent, AgentStatus};
 use everruns_platform::{Harness, HarnessStatus, merge_harness};
+use everruns_platform::{Session, SessionParticipant, SessionStatus};
 use everruns_worker::mcp_executor::McpServerInfo;
 use everruns_worker::worker_adapters::{TurnContext, WorkerAdapters};
 use std::collections::HashMap;
@@ -338,6 +339,100 @@ impl DirectWorkerAdapters {
         }
     }
 
+    /// Load the stored platform Session record (server-internal; EVE-882).
+    ///
+    /// `WorkerAdapters::get_session` projects this into the portable
+    /// `ExecutionSession`; internal paths that need platform-only fields
+    /// (agent version pinning, scoped-MCP wiring) read the record here.
+    pub(crate) async fn get_stored_session(
+        &self,
+        org_id: i64,
+        session_id: Uuid,
+    ) -> Result<Option<Session>> {
+        let session_id_typed = SessionId::from_uuid(session_id);
+        let row = self
+            .db
+            .get_session(org_id, session_id_typed)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to get session: {}", e);
+                store_error("Failed to get session")
+            })?;
+
+        let Some(r) = row else {
+            return Ok(None);
+        };
+        let capabilities = serde_json::from_value(r.capabilities).unwrap_or_default();
+        let capabilities =
+            crate::domains::capabilities::queries::hydrate_declarative_capability_configs(
+                &self.db,
+                org_id,
+                capabilities,
+            )
+            .await
+            .unwrap_or_default();
+
+        Ok(Some({
+            // Parse capabilities from JSON
+            Session {
+                source: everruns_platform::SessionSource::from(r.source.as_str()),
+                activity: everruns_platform::SessionActivity::derive(
+                    &everruns_platform::SessionStatus::from(r.status.as_str()),
+                    r.last_turn_status.as_deref(),
+                ),
+                id: r.id,
+                organization_id: everruns_core::org_public_id_from_internal(org_id),
+                workspace_id: everruns_core::WorkspaceId::from_uuid(r.workspace_id),
+                harness_id: r.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
+                agent_id: r.agent_id,
+                agent_version_id: r.agent_version_id,
+                agent_identity_id: r.agent_identity_id,
+                owner_principal_id: r.owner_principal_id,
+                resolved_owner_user_id: r.resolved_owner_user_id,
+                owner: None,
+                effective_owner: None,
+                title: r.title,
+                goal: r.goal,
+                locale: r.locale,
+                preview: None,
+                output_preview: None,
+                tags: r.tags,
+                model_id: r.model_id,
+                capabilities,
+                tools: serde_json::from_value(r.tools).unwrap_or_default(),
+                mcp_servers: serde_json::from_value(r.mcp_servers).unwrap_or_default(),
+                system_prompt: r.system_prompt,
+                initial_files: serde_json::from_value(r.initial_files).unwrap_or_default(),
+                network_access: r
+                    .network_access
+                    .and_then(|v| serde_json::from_value(v).ok()),
+                hints: r.hints.and_then(|v| serde_json::from_value(v).ok()),
+                max_iterations: max_iterations::from_db(r.max_iterations),
+                parallel_tool_calls: r.parallel_tool_calls,
+                status: match r.status.as_str() {
+                    "started" => SessionStatus::Started,
+                    "active" => SessionStatus::Active,
+                    "idle" => SessionStatus::Idle,
+                    "running" => SessionStatus::Active,
+                    _ => SessionStatus::Started,
+                },
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+                started_at: r.started_at,
+                finished_at: r.finished_at,
+                usage: None,
+                is_pinned: None,
+                active_schedule_count: None,
+                features: vec![],
+                parent_session_id: r.parent_session_id,
+                forked_from_session_id: r.forked_from_session_id,
+                forked_from_sequence: r.forked_from_sequence,
+                blueprint_id: r.blueprint_id,
+                blueprint_config: r.blueprint_config,
+            }
+        }))
+    }
+
     async fn load_turn_messages(
         &self,
         session: &Session,
@@ -350,10 +445,12 @@ impl DirectWorkerAdapters {
         // the effective configuration.
         let harness_definition = harness.map(|h| h.definition()).unwrap_or_default();
         let agent_definition = agent.map(|a| a.definition());
+        // EVE-882: capability resolution consumes the portable execution view.
+        let execution_session = session.execution_session();
         let resolved = resolve_runtime_capabilities(
             &harness_definition,
             agent_definition.as_ref(),
-            session,
+            &execution_session,
             &self.capability_registry,
         );
         let message_filters = collect_message_filters_only(
@@ -571,97 +668,20 @@ impl WorkerAdapters for DirectWorkerAdapters {
     // Session Operations
     // =========================================================================
 
-    async fn get_session(&self, org_id: i64, session_id: Uuid) -> Result<Option<Session>> {
-        let session_id_typed = SessionId::from_uuid(session_id);
-        let row = self
-            .db
-            .get_session(org_id, session_id_typed)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to get session: {}", e);
-                store_error("Failed to get session")
-            })?;
-
-        let Some(r) = row else {
-            return Ok(None);
-        };
-        let capabilities = serde_json::from_value(r.capabilities).unwrap_or_default();
-        let capabilities =
-            crate::domains::capabilities::queries::hydrate_declarative_capability_configs(
-                &self.db,
-                org_id,
-                capabilities,
-            )
-            .await
-            .unwrap_or_default();
-
-        Ok(Some({
-            // Parse capabilities from JSON
-            Session {
-                source: everruns_core::SessionSource::from(r.source.as_str()),
-                activity: everruns_core::SessionActivity::derive(
-                    &everruns_core::SessionStatus::from(r.status.as_str()),
-                    r.last_turn_status.as_deref(),
-                ),
-                id: r.id,
-                organization_id: everruns_core::org_public_id_from_internal(org_id),
-                workspace_id: everruns_core::WorkspaceId::from_uuid(r.workspace_id),
-                harness_id: r.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
-                agent_id: r.agent_id,
-                agent_version_id: r.agent_version_id,
-                agent_identity_id: r.agent_identity_id,
-                owner_principal_id: r.owner_principal_id,
-                resolved_owner_user_id: r.resolved_owner_user_id,
-                owner: None,
-                effective_owner: None,
-                title: r.title,
-                goal: r.goal,
-                locale: r.locale,
-                preview: None,
-                output_preview: None,
-                tags: r.tags,
-                model_id: r.model_id,
-                capabilities,
-                tools: serde_json::from_value(r.tools).unwrap_or_default(),
-                mcp_servers: serde_json::from_value(r.mcp_servers).unwrap_or_default(),
-                system_prompt: r.system_prompt,
-                initial_files: serde_json::from_value(r.initial_files).unwrap_or_default(),
-                network_access: r
-                    .network_access
-                    .and_then(|v| serde_json::from_value(v).ok()),
-                hints: r.hints.and_then(|v| serde_json::from_value(v).ok()),
-                max_iterations: max_iterations::from_db(r.max_iterations),
-                parallel_tool_calls: r.parallel_tool_calls,
-                status: match r.status.as_str() {
-                    "started" => SessionStatus::Started,
-                    "active" => SessionStatus::Active,
-                    "idle" => SessionStatus::Idle,
-                    "running" => SessionStatus::Active,
-                    _ => SessionStatus::Started,
-                },
-                created_at: r.created_at,
-                updated_at: r.updated_at,
-                started_at: r.started_at,
-                finished_at: r.finished_at,
-                usage: None,
-                is_pinned: None,
-                active_schedule_count: None,
-                features: vec![],
-                parent_session_id: r.parent_session_id,
-                forked_from_session_id: r.forked_from_session_id,
-                forked_from_sequence: r.forked_from_sequence,
-                blueprint_id: r.blueprint_id,
-                blueprint_config: r.blueprint_config,
-            }
-        }))
-    }
-
-    async fn set_session_status(
+    async fn get_session(
         &self,
         org_id: i64,
         session_id: Uuid,
-        status: &str,
-    ) -> Result<Session> {
+    ) -> Result<Option<everruns_core::ExecutionSession>> {
+        // Loading seam (EVE-882): project the stored record into the portable
+        // execution view before it reaches host execution.
+        Ok(self
+            .get_stored_session(org_id, session_id)
+            .await?
+            .map(|session| session.execution_session()))
+    }
+
+    async fn set_session_status(&self, org_id: i64, session_id: Uuid, status: &str) -> Result<()> {
         let session_id_typed = SessionId::from_uuid(session_id);
         let update = UpdateSession {
             status: Some(status.to_string()),
@@ -676,10 +696,9 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 store_error("Failed to update session status")
             })?;
 
-        // Fetch and return updated session
-        self.get_session(org_id, session_id)
-            .await?
-            .ok_or_else(|| store_error("Session not found after update"))
+        // Acknowledgement only (EVE-882): status mutation exposes no session
+        // record to the worker path.
+        Ok(())
     }
 
     async fn set_session_title(
@@ -687,7 +706,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
         org_id: i64,
         session_id: Uuid,
         title: String,
-    ) -> Result<Session> {
+    ) -> Result<everruns_core::ExecutionSession> {
         let session_id_typed = SessionId::from_uuid(session_id);
         let update = UpdateSession {
             title: Some(title),
@@ -1372,7 +1391,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
     ) -> Result<McpServerInfo> {
         let mut runtime_agent_id = None;
         if let Some(session_id) = session_id
-            && let Some(session) = self.get_session(org_id, session_id).await?
+            && let Some(session) = self.get_stored_session(org_id, session_id).await?
             && let Some(harness) = self
                 .get_harness_impl(org_id, session.harness_id.uuid())
                 .await?
@@ -1460,9 +1479,11 @@ impl WorkerAdapters for DirectWorkerAdapters {
     // =========================================================================
 
     async fn load_turn_context(&self, org_id: i64, session_id: Uuid) -> Result<TurnContext> {
-        // Load session
+        // Load the stored record: the platform-only fields (agent version
+        // pinning, scoped-MCP wiring) are consumed here, at the loading seam,
+        // and only the projected execution view leaves in the TurnContext.
         let session = self
-            .get_session(org_id, session_id)
+            .get_stored_session(org_id, session_id)
             .await?
             .ok_or_else(|| store_error("Session not found"))?;
 
@@ -1599,7 +1620,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
         Ok(TurnContext {
             agent,
-            session,
+            session: session.execution_session(),
             messages,
             model,
             mcp_tool_definitions,
@@ -3981,7 +4002,7 @@ mod tests {
         use crate::storage::models::CreateSessionRow;
 
         db.create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id,
             app_id: None,
@@ -4935,7 +4956,7 @@ mod tests {
         let row = adapters
             .db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 workspace_id: None,
                 org_id: everruns_core::DEFAULT_ORG_ID,
                 app_id: None,

--- a/crates/server/src/domains/agent_triggers/commands.rs
+++ b/crates/server/src/domains/agent_triggers/commands.rs
@@ -1150,7 +1150,7 @@ async fn find_or_create_trigger_session(
                 app_id,
                 execution_context.owner_principal_id,
                 execution_context.resolved_owner_user_id,
-                everruns_core::SessionSource::Schedule,
+                everruns_platform::SessionSource::Schedule,
                 req,
             )
             .await

--- a/crates/server/src/domains/agent_triggers/tests.rs
+++ b/crates/server/src/domains/agent_triggers/tests.rs
@@ -231,7 +231,7 @@ async fn dispatch_trigger_message_uses_preserved_harness() {
         .unwrap();
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: Some(preserved_harness.id),

--- a/crates/server/src/domains/agents/health_check/runner.rs
+++ b/crates/server/src/domains/agents/health_check/runner.rs
@@ -171,7 +171,7 @@ async fn run_case(
             Some(agent_internal_id),
             Some(agent_public_id),
             // A health check is an internal API-shaped run, not a user session.
-            everruns_core::SessionSource::Api,
+            everruns_platform::SessionSource::Api,
             CreateSessionRequest {
                 source: None,
                 harness_id: None,
@@ -275,7 +275,7 @@ async fn run_case(
 async fn run_turn(
     ctx: &HealthCheckRunContext,
     org_id: i64,
-    session: &everruns_core::Session,
+    session: &everruns_platform::Session,
     harness_id: Uuid,
     agent_internal_id: Uuid,
     content: &str,

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -1452,11 +1452,11 @@ async fn find_or_create_invocation_session(
             // The invocation channel *is* the session's origin. `api_endpoint`
             // collapses into `webhook`: both are an inbound HTTP call into the app.
             match source {
-                AppInvocationSource::Schedule => everruns_core::SessionSource::Schedule,
+                AppInvocationSource::Schedule => everruns_platform::SessionSource::Schedule,
                 AppInvocationSource::Webhook | AppInvocationSource::ApiEndpoint => {
-                    everruns_core::SessionSource::Webhook
+                    everruns_platform::SessionSource::Webhook
                 }
-                AppInvocationSource::A2a => everruns_core::SessionSource::A2a,
+                AppInvocationSource::A2a => everruns_platform::SessionSource::A2a,
             },
             CreateSessionRequest {
                 source: None,

--- a/crates/server/src/domains/budgets/tests.rs
+++ b/crates/server/src/domains/budgets/tests.rs
@@ -40,7 +40,7 @@ async fn create_session_with_owner_and_tags(
     tags: Vec<String>,
 ) -> SessionRow {
     db.create_session(CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id,
         app_id: None,
@@ -79,7 +79,7 @@ async fn create_child_session(
     agent_id: Option<AgentId>,
 ) -> SessionRow {
     db.create_session(CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: parent.org_id,
         app_id: parent.app_id,
@@ -114,7 +114,7 @@ async fn create_child_session(
 
 async fn create_detached_session(db: &Arc<StorageBackend>, origin: &SessionRow) -> SessionRow {
     let input = CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: origin.org_id,
         app_id: origin.app_id,

--- a/crates/server/src/domains/evals/runner.rs
+++ b/crates/server/src/domains/evals/runner.rs
@@ -298,7 +298,7 @@ async fn execute_case_inner(
             harness_id,
             agent_id,
             agent_id.map(everruns_core::typed_id::AgentId::from_uuid),
-            everruns_core::SessionSource::Eval,
+            everruns_platform::SessionSource::Eval,
             CreateSessionRequest {
                 source: None,
                 workspace_id: None,

--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -10,12 +10,12 @@ use everruns_core::capabilities::{CapabilityRegistry, collect_capability_mcp_ser
 use everruns_core::mcp_server::sanitize_mcp_server_name;
 use everruns_core::traits::UserConnectionResolver;
 use everruns_core::{
-    Capability, EgressService, McpCapability, McpServerAuthMode, ScopedMcpServers, Session,
-    SessionId, ToolDefinition, merge_scoped_mcp_servers, resolve_runtime_capabilities,
-    validate_safe_url,
+    Capability, EgressService, McpCapability, McpServerAuthMode, ScopedMcpServers, SessionId,
+    ToolDefinition, merge_scoped_mcp_servers, resolve_runtime_capabilities, validate_safe_url,
 };
 use everruns_platform::Agent;
 use everruns_platform::Harness;
+use everruns_platform::Session;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -75,10 +75,12 @@ pub fn merge_effective_scoped_mcp_servers_with_capabilities(
     // stored records regardless of lifecycle status (EVE-877, EVE-881).
     let agent_definition = agent.map(|a| a.definition());
     let harness_definition = harness.definition();
+    // EVE-882: capability resolution consumes the portable execution view.
+    let execution_session = session.execution_session();
     let resolved = resolve_runtime_capabilities(
         &harness_definition,
         agent_definition.as_ref(),
-        session,
+        &execution_session,
         capability_registry,
     );
     let contributed =
@@ -316,7 +318,7 @@ fn scoped_mcp_server_uuid(session_id: Uuid, server_name: &str) -> Uuid {
 mod tests {
     use super::*;
     use chrono::Utc;
-    use everruns_core::{HarnessId, ScopedMcpServer, Session, SessionId, SessionStatus};
+    use everruns_core::{HarnessId, ScopedMcpServer, SessionId};
     use everruns_platform::{Agent, AgentStatus, generate_agent_public_id};
 
     struct MutableConnectionResolver {
@@ -485,7 +487,7 @@ mod tests {
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
-            status: SessionStatus::Started,
+            status: everruns_platform::SessionStatus::Started,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             started_at: None,

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -3,7 +3,8 @@ use crate::api::messages::{Message, MessageRole};
 use crate::domains::common::*;
 use crate::domains::messages::CreateMessageContext;
 use everruns_core::typed_id::{AgentId, SessionId, SessionParticipantId};
-use everruns_core::{SessionParticipantKind, SessionParticipantRole};
+use everruns_platform::{SessionParticipantKind, SessionParticipantRole};
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -100,7 +101,7 @@ inventory::submit! { CommandDescriptor::of::<CreateMessage>() }
 
 async fn require_platform_chat_owner(
     ctx: &Ctx,
-    session: &everruns_core::Session,
+    session: &everruns_platform::Session,
 ) -> Result<(), CommandError> {
     let harness = ctx
         .db
@@ -503,7 +504,7 @@ mod tests {
         let guest_agent = seed_agent(&db, harness.id, "routing-guest").await;
         let session = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(harness.id),
@@ -629,7 +630,7 @@ mod tests {
     async fn platform_chat_owner_fixture(
         caller_user_id: Uuid,
         owner_user_id: Uuid,
-    ) -> (Ctx, everruns_core::Session) {
+    ) -> (Ctx, everruns_platform::Session) {
         let db = Arc::new(StorageBackend::in_memory());
         let harness = db
             .create_harness(
@@ -653,7 +654,7 @@ mod tests {
             .expect("create Platform Chat harness");
         let row = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(harness.id),

--- a/crates/server/src/domains/messages/service.rs
+++ b/crates/server/src/domains/messages/service.rs
@@ -496,7 +496,7 @@ mod tests {
         org_id: i64,
     ) -> crate::storage::models::SessionRow {
         db.create_session(crate::storage::models::CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id,
             harness_id: None,

--- a/crates/server/src/domains/notifications/service.rs
+++ b/crates/server/src/domains/notifications/service.rs
@@ -267,7 +267,7 @@ mod tests {
 
         let session = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 workspace_id: None,
                 org_id: 1,
                 app_id: None,

--- a/crates/server/src/domains/observers/worker.rs
+++ b/crates/server/src/domains/observers/worker.rs
@@ -316,7 +316,7 @@ mod tests {
 
     fn session_row(agent: AgentId, harness: HarnessId, tags: Vec<String>) -> CreateSessionRow {
         CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: ORG,
             app_id: None,

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -17,7 +17,7 @@ use everruns_core::command::{
 };
 use everruns_core::command_host::StoreCommandHost;
 use everruns_core::runtime_context::resolve_runtime_capabilities;
-use everruns_core::traits::{AgentStore, SessionStore};
+use everruns_core::traits::AgentStore;
 use everruns_core::typed_id::SessionId;
 use everruns_core::{AgentDefinition, AgentLoopError, Caller, CapabilityRegistry, DriverRegistry};
 use everruns_platform::Harness;
@@ -81,10 +81,12 @@ impl SessionCommandService {
             .await?;
         authorize_platform_chat_owner(caller, &harness, &session)?;
         let harness_definition = harness.definition();
+        // EVE-882: capability resolution consumes the portable execution view.
+        let execution_session = session.execution_session();
         let resolved = resolve_runtime_capabilities(
             &harness_definition,
             agent.as_ref(),
-            &session,
+            &execution_session,
             &self.capability_registry,
         );
 
@@ -115,10 +117,12 @@ impl SessionCommandService {
             .await?;
         authorize_platform_chat_owner(caller, &harness, &session)?;
         let harness_definition = harness.definition();
+        // EVE-882: capability resolution consumes the portable execution view.
+        let execution_session = session.execution_session();
         let resolved = resolve_runtime_capabilities(
             &harness_definition,
             agent.as_ref(),
-            &session,
+            &execution_session,
             &self.capability_registry,
         );
 
@@ -198,13 +202,14 @@ impl SessionCommandService {
         &self,
         org_id: i64,
         session_id: SessionId,
-    ) -> Result<(Harness, Option<AgentDefinition>, everruns_core::Session)> {
+    ) -> Result<(Harness, Option<AgentDefinition>, everruns_platform::Session)> {
         let adapters = self.adapters();
-        let session_store = AdapterSessionStore::new(adapters.clone(), org_id);
         let agent_store = AdapterAgentStore::new(adapters.clone(), org_id);
 
-        let session = session_store
-            .get_session(session_id)
+        // Stored record (EVE-882): owner authorization is a platform surface,
+        // so it reads the persisted Session rather than the execution view.
+        let session = adapters
+            .get_stored_session(org_id, session_id.uuid())
             .await?
             .ok_or(ResourceNotFoundError::new("Session"))?;
         // Stored (pre-merged) record: command listing/authorization are
@@ -226,7 +231,7 @@ impl SessionCommandService {
 fn authorize_platform_chat_owner(
     caller: &Caller,
     harness: &Harness,
-    session: &everruns_core::Session,
+    session: &everruns_platform::Session,
 ) -> Result<()> {
     // The adapters return the pre-merged record whose identity/built-in flag
     // are leaf-owned, matching the historical single-element chain check.

--- a/crates/server/src/domains/session_files/commands.rs
+++ b/crates/server/src/domains/session_files/commands.rs
@@ -622,7 +622,7 @@ mod tests {
 
     fn session_row(workspace_id: Option<Uuid>) -> CreateSessionRow {
         CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,

--- a/crates/server/src/domains/session_sandbox/commands.rs
+++ b/crates/server/src/domains/session_sandbox/commands.rs
@@ -401,7 +401,7 @@ mod tests {
         .unwrap();
 
         db.create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,

--- a/crates/server/src/domains/session_sandbox/service.rs
+++ b/crates/server/src/domains/session_sandbox/service.rs
@@ -588,7 +588,7 @@ mod tests {
 
         let session = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
@@ -651,7 +651,7 @@ mod tests {
         .unwrap();
         let session = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
@@ -716,7 +716,7 @@ mod tests {
 
         let session = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -742,7 +742,7 @@ mod tests {
         ensure_base_harness(db, None).await;
 
         db.create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -782,7 +782,7 @@ mod tests {
         org_id: i64,
     ) -> everruns_core::SessionId {
         db.create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id,
             app_id: None,
             harness_id: None,
@@ -823,7 +823,7 @@ mod tests {
         parent: everruns_core::SessionId,
     ) -> everruns_core::SessionId {
         db.create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1742,7 +1742,7 @@ mod tests {
         let session_network_access = NetworkAccessList::allow_only(["b.example.com"]);
         let session_id = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(harness.id),
@@ -1835,7 +1835,7 @@ mod tests {
         let stale_harness_id = HarnessId::new();
         let session_id = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(stale_harness_id),

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -15,11 +15,12 @@ use everruns_core::events::{
 use everruns_core::model_profiles::get_model_profile;
 use everruns_core::provider::DriverId;
 use everruns_core::typed_id::{AgentId, MessageId, SessionParticipantId, TurnId};
-use everruns_core::{
-    Message, Session, SessionActivity, SessionContextReport, SessionParticipant,
-    SessionParticipantKind, SessionParticipantRole, SessionSource, session_title_updated_event,
-};
+use everruns_core::{Message, SessionContextReport, session_title_updated_event};
 use everruns_platform::ANONYMOUS_USER_ID;
+use everruns_platform::{
+    Session, SessionActivity, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
+    SessionSource,
+};
 use serde::Deserialize;
 use std::str::FromStr;
 use utoipa::ToSchema;
@@ -1260,7 +1261,7 @@ mod tests {
             .expect("reload session");
         assert_eq!(
             after.status,
-            everruns_core::SessionStatus::Idle,
+            everruns_platform::SessionStatus::Idle,
             "cancelled session must settle to idle"
         );
     }
@@ -1924,7 +1925,7 @@ impl Command for CancelSession {
         let session_id = q::parse_session_id(&self.session_id)?;
         let session = q::get_session(ctx, session_id, None).await?;
 
-        if session.status != everruns_core::SessionStatus::Active {
+        if session.status != everruns_platform::SessionStatus::Active {
             return Ok(CancelTurnResponse {
                 status: CancelStatus::NoOp,
                 message: "No turn currently running".to_string(),

--- a/crates/server/src/domains/sessions/list_filters_tests.rs
+++ b/crates/server/src/domains/sessions/list_filters_tests.rs
@@ -10,8 +10,8 @@ use crate::storage::{CreateEventRow, CreateSessionRow, StorageBackend};
 use everruns_core::typed_id::AgentId;
 use everruns_core::{
     Caller, DEFAULT_ORG_ID, DefaultPermissionResolver, OrgRole, PrincipalId, SessionId,
-    SessionSource,
 };
+use everruns_platform::SessionSource;
 use serde_json::json;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/server/src/domains/sessions/mod.rs
+++ b/crates/server/src/domains/sessions/mod.rs
@@ -13,7 +13,7 @@ pub use service::*;
 
 pub(crate) fn platform_chat_owner_matches(
     caller: &everruns_core::Caller,
-    session: &everruns_core::Session,
+    session: &everruns_platform::Session,
     is_platform_chat: bool,
 ) -> bool {
     // THREAT[TM-AGENT-017]: Platform Chat can act with its persisted owner's authority,

--- a/crates/server/src/domains/sessions/queries.rs
+++ b/crates/server/src/domains/sessions/queries.rs
@@ -1,8 +1,8 @@
 use crate::domains::common::{CommandError, Ctx, classify_anyhow};
 use crate::storage::StorageBackend;
 use anyhow::Context;
-use everruns_core::Session;
 use everruns_core::typed_id::HarnessId;
+use everruns_platform::Session;
 use everruns_worker::AgentRunner;
 use std::sync::Arc;
 

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -31,8 +31,7 @@ use everruns_core::{AgentCapabilityConfig, AgentId, Caller, CapabilityRegistry};
 use everruns_core::{
     DeclarativeCapabilityDefinition, FeatureFlags, HarnessId, InitialFile, ModelId, MountAccess,
     MountEntry, MountPoint, MountSource, OrgRole, Permission, Policy, PrincipalId,
-    PrincipalSummary, Rule, Session, SessionActivity, SessionFile, SessionId, SessionSeedMode,
-    SessionSource, SessionStatus, TokenUsage, WorkspaceId,
+    PrincipalSummary, Rule, SessionFile, SessionId, SessionSeedMode, TokenUsage, WorkspaceId,
     capabilities::{
         AttachSkillCapability, MEMORY_CAPABILITY_ID, RiskLevel, SystemPromptContext,
         collect_capabilities_with_configs, compute_features, resolve_capability_configs,
@@ -45,6 +44,7 @@ use everruns_core::{
 };
 use everruns_durable::UpdateField;
 use everruns_platform::AgentVersionPolicy;
+use everruns_platform::{Session, SessionActivity, SessionSource, SessionStatus};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -3303,7 +3303,7 @@ mod tests {
         let missing_owner_id = PrincipalId::new();
         let missing_reference_session = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
@@ -4406,7 +4406,7 @@ mod tests {
 
         let session_row = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 workspace_id: None,
                 org_id: caller.org_id,
                 app_id: None,
@@ -4746,7 +4746,7 @@ mod tests {
 
         let session_row = db
             .create_session(CreateSessionRow {
-                source: everruns_core::SessionSource::Api,
+                source: everruns_platform::SessionSource::Api,
                 workspace_id: None,
                 org_id: caller.org_id,
                 app_id: None,

--- a/crates/server/src/domains/tool_results/commands.rs
+++ b/crates/server/src/domains/tool_results/commands.rs
@@ -1,10 +1,10 @@
 use super::queries as q;
 use super::types::{ClientToolResult, SubmitToolResultsResponse};
 use crate::domains::common::*;
-use everruns_core::SessionStatus;
 use everruns_core::events::{EventContext, EventRequest, ToolCompletedData};
 use everruns_core::message::ContentPart;
 use everruns_core::typed_id::{MessageId, TurnId};
+use everruns_platform::SessionStatus;
 use serde::Deserialize;
 use utoipa::ToSchema;
 

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -426,7 +426,7 @@ async fn authorize_session_creation_is_owner_scoped_and_returns_budget_root() {
     let session = service
         .db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: everruns_core::DEFAULT_ORG_ID,
             app_id: None,
@@ -813,7 +813,7 @@ async fn platform_command_surface_uses_session_owner_and_org() {
     let session = service
         .db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: everruns_core::DEFAULT_ORG_ID,
             app_id: None,

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -168,8 +168,17 @@ impl WorkerService for WorkerServiceImpl {
         // are resolved, so attached MCP servers and A2A agents become usable on
         // the next turn with no change to the agent loop.
         if let Ok(store) = self.storage_store() {
-            everruns_core::ard_attachment::apply_session_attachments(store.as_ref(), &mut session)
-                .await;
+            // Attachments merge into the portable config layer (EVE-882);
+            // fold the merged fields back onto the stored record so proto
+            // conversion and scoped-MCP resolution below see them.
+            let mut execution_session = session.execution_session();
+            everruns_core::ard_attachment::apply_session_attachments(
+                store.as_ref(),
+                &mut execution_session,
+            )
+            .await;
+            session.mcp_servers = execution_session.mcp_servers;
+            session.capabilities = execution_session.capabilities;
         }
 
         // Get agent with capabilities via domain query (optional)
@@ -4213,7 +4222,7 @@ impl WorkerService for WorkerServiceImpl {
                     // Platform-initiated creation is a delegated child of a
                     // running session (subagent spawn / handoff), not an
                     // ordinary API call.
-                    everruns_core::SessionSource::Subagent,
+                    everruns_platform::SessionSource::Subagent,
                     create_req,
                 )
                 .await
@@ -4225,7 +4234,7 @@ impl WorkerService for WorkerServiceImpl {
                     harness_id,
                     agent_uuid,
                     create_req.agent_id,
-                    everruns_core::SessionSource::Subagent,
+                    everruns_platform::SessionSource::Subagent,
                     create_req,
                 )
                 .await

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -11,9 +11,9 @@ use everruns_core::provider::{Provider, ProviderTraceConfig};
 use everruns_core::{
     CapabilityInfo, ContextReportContribution, ContextReportSection, DriverId, Event, EventContext,
     EventData, FileInfo, FileStat, GrepMatch, GrepResult, LeasedResource, McpServer,
-    McpServerStatus, McpServerTransportType, Model, ModelWithProvider, ProviderStatus, Session,
-    SessionContextReport, SessionFile, SessionStatus, Skill, SkillContent, SkillFileEntry,
-    SkillSourceType, SkillStatus, SkillValidationResult, ToolCall,
+    McpServerStatus, McpServerTransportType, Model, ModelWithProvider, ProviderStatus,
+    SessionContextReport, SessionFile, Skill, SkillContent, SkillFileEntry, SkillSourceType,
+    SkillStatus, SkillValidationResult, ToolCall,
     events::{
         ActCompletedData, ActStartedData, InputMessageData, LlmGenerationData,
         LlmGenerationMetadata, LlmGenerationOutput, ModelMetadata, OutputMessageCompletedData,
@@ -23,6 +23,7 @@ use everruns_core::{
     },
 };
 use everruns_platform::{Agent, AgentStatus};
+use everruns_platform::{Session, SessionStatus};
 use serde_json::json;
 use utoipa::openapi::extensions::Extensions;
 use utoipa::openapi::{RefOr, Schema};

--- a/crates/server/src/services/event.rs
+++ b/crates/server/src/services/event.rs
@@ -27,7 +27,8 @@ use crate::storage::{
 use anyhow::{Result, bail};
 use everruns_core::events::{INPUT_MESSAGE, OUTPUT_MESSAGE_COMPLETED};
 use everruns_core::typed_id::{AgentId, AgentVersionId, EventId, PrincipalId, SessionId};
-use everruns_core::{Event, EventListener, EventRequest, FeatureFlags, SessionParticipantKind};
+use everruns_core::{Event, EventListener, EventRequest, FeatureFlags};
+use everruns_platform::SessionParticipantKind;
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;
@@ -563,8 +564,9 @@ mod tests {
     use crate::storage::StorageBackend;
     use crate::storage::models::{CreateSessionParticipantRow, CreateSessionRow};
     use everruns_core::events::{EventContext, InputMessageData, OutputMessageCompletedData};
-    use everruns_core::{DEFAULT_ORG_ID, HarnessId, Message, PrincipalId, SessionParticipantRole};
-    use everruns_core::{SessionParticipantKind, typed_id::AgentId};
+    use everruns_core::typed_id::AgentId;
+    use everruns_core::{DEFAULT_ORG_ID, HarnessId, Message, PrincipalId};
+    use everruns_platform::SessionParticipantRole;
     use std::sync::Arc;
 
     fn sample_metadata() -> AgentVersionEventMetadata {
@@ -609,7 +611,7 @@ mod tests {
 
     fn test_session_input(agent_id: AgentId) -> CreateSessionRow {
         CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,

--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -1393,7 +1393,7 @@ mod tests {
 
             let session = db
                 .create_session(CreateSessionRow {
-                    source: everruns_core::SessionSource::Api,
+                    source: everruns_platform::SessionSource::Api,
                     workspace_id: None,
                     org_id,
                     app_id,

--- a/crates/server/src/storage/connection_resolver.rs
+++ b/crates/server/src/storage/connection_resolver.rs
@@ -616,7 +616,7 @@ mod tests {
 
     fn session_input(owner_user_id: Option<Uuid>) -> CreateSessionRow {
         CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id: DEFAULT_ORG_ID,
             workspace_id: None,
             app_id: None,

--- a/crates/server/src/storage/leased_resource_store.rs
+++ b/crates/server/src/storage/leased_resource_store.rs
@@ -271,7 +271,7 @@ mod tests {
 
     async fn create_test_session(db: &StorageBackend) -> SessionId {
         db.create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,

--- a/crates/server/src/storage/memory/session_participants.rs
+++ b/crates/server/src/storage/memory/session_participants.rs
@@ -2,9 +2,8 @@ use super::super::models::*;
 use super::InMemoryDatabase;
 use crate::storage::backend::MAX_SESSION_PARTICIPANT_HISTORY;
 use anyhow::{Result, bail};
-use everruns_core::{
-    SessionId, SessionParticipantId, SessionParticipantKind, SessionParticipantRole,
-};
+use everruns_core::{SessionId, SessionParticipantId};
+use everruns_platform::{SessionParticipantKind, SessionParticipantRole};
 
 impl InMemoryDatabase {
     pub(crate) async fn insert_initial_session_participants(

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -6,7 +6,8 @@ use super::matches_search_tokens;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use everruns_core::{AgentId, EventId, HarnessId, PrincipalId, SessionId};
-use everruns_core::{SessionActivity, SessionStatus};
+use everruns_platform::{SessionActivity, SessionStatus};
+
 use uuid::Uuid;
 
 /// Facet dimension whose own selection is excluded when counting it.

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -3,10 +3,8 @@ use super::*;
 use crate::api::common::Pagination;
 use chrono::Utc;
 use everruns_core::message_filter::{MessageFilter, MessageQuery};
-use everruns_core::{
-    AgentId, AgentVersionId, DEFAULT_ORG_ID, HarnessId, PrincipalId, SessionId,
-    SessionParticipantKind, SessionParticipantRole,
-};
+use everruns_core::{AgentId, AgentVersionId, DEFAULT_ORG_ID, HarnessId, PrincipalId, SessionId};
+use everruns_platform::{SessionParticipantKind, SessionParticipantRole};
 
 /// Default pagination for tests (large enough to not truncate).
 fn default_pagination() -> Pagination {
@@ -19,7 +17,7 @@ fn test_harness_id() -> HarnessId {
 
 fn test_session_input(agent_id: Option<AgentId>) -> CreateSessionRow {
     CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
@@ -174,7 +172,7 @@ async fn test_create_and_list_sessions() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -228,7 +226,7 @@ async fn test_set_session_fork_lineage_roundtrip() {
     let db = InMemoryDatabase::new();
 
     let new_session = || CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
@@ -625,7 +623,7 @@ async fn test_session_aggregate_stats_by_agent_and_harness() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -731,7 +729,7 @@ async fn test_session_updated_at() {
     // Create session - updated_at should equal created_at
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -819,7 +817,7 @@ async fn test_events_sequence() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -908,7 +906,7 @@ async fn test_list_message_events_filtered_keep_head_loads_head_and_tail() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -992,7 +990,7 @@ async fn test_list_message_events_filtered_caps_unbounded_history() {
     let db = InMemoryDatabase::new();
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -1098,7 +1096,7 @@ async fn test_session_connection_resolution_uses_resolved_owner_user() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -1250,7 +1248,7 @@ async fn test_unpin_session_is_scoped_by_org() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -1333,7 +1331,7 @@ async fn create_session_with_events(db: &InMemoryDatabase) -> SessionId {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -2051,7 +2049,7 @@ async fn test_list_events_empty_session_with_limit() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -2122,7 +2120,7 @@ async fn test_sessions_pagination() {
     // Create 15 sessions
     for i in 0..15 {
         db.create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -2267,7 +2265,7 @@ async fn test_sessions_pagination_ordering() {
     // Create sessions with sequential titles
     for i in 1..=5 {
         db.create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -3013,7 +3011,7 @@ async fn test_search_sessions_by_title() {
     let agent = create_test_agent(&db, "Agent", None).await;
 
     db.create_session(CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
@@ -3046,7 +3044,7 @@ async fn test_search_sessions_by_title() {
     .unwrap();
 
     db.create_session(CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
@@ -3102,7 +3100,7 @@ async fn test_search_sessions_with_agent_filter() {
     let agent2 = create_test_agent(&db, "Agent2", None).await;
 
     db.create_session(CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
@@ -3135,7 +3133,7 @@ async fn test_search_sessions_with_agent_filter() {
     .unwrap();
 
     db.create_session(CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
@@ -3382,7 +3380,7 @@ async fn create_session_with_content_events(db: &InMemoryDatabase) -> SessionId 
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -3579,7 +3577,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
     // Create 3 sessions: one waiting+old, one waiting+recent, one active+old
     let s1 = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -3612,7 +3610,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
         .unwrap();
     let s2 = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -3645,7 +3643,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
         .unwrap();
     let s3 = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -3744,7 +3742,7 @@ async fn test_session_system_prompt_and_initial_files_round_trip() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
@@ -3801,7 +3799,7 @@ async fn test_session_system_prompt_defaults_to_none() {
 
     let session = db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -4,10 +4,10 @@ use chrono::{DateTime, Utc};
 use everruns_core::{
     AgentId, AgentIdentityId, EventId, HarnessId, ImageId, LeasedResourceId, McpServerId,
     MessageId, ModelId, NotificationId, PrincipalId, ProviderId, ScheduleId, ServiceKind,
-    SessionId, SessionParticipant, SessionParticipantId, SessionParticipantKind,
-    SessionParticipantRole, SkillId, TriggerId,
+    SessionId, SessionParticipantId, SkillId, TriggerId,
 };
 use everruns_durable::UpdateField;
+use everruns_platform::{SessionParticipant, SessionParticipantKind, SessionParticipantRole};
 use sqlx::FromRow;
 use uuid::Uuid;
 
@@ -804,7 +804,7 @@ pub struct SessionRow {
     pub parallel_tool_calls: Option<bool>,
     pub status: String,
     /// How the session was started (EVE-852). Stored as the closed-set string
-    /// backing `everruns_core::SessionSource`.
+    /// backing `everruns_platform::SessionSource`.
     #[sqlx(default)]
     pub source: String,
     /// Denormalized outcome of the most recent terminal turn: `completed`,
@@ -883,9 +883,9 @@ pub struct SessionListFilters {
     pub agent_id: Option<AgentId>,
     pub search: Option<String>,
     /// Empty means "any source".
-    pub sources: Vec<everruns_core::SessionSource>,
+    pub sources: Vec<everruns_platform::SessionSource>,
     /// Empty means "any activity".
-    pub activities: Vec<everruns_core::SessionActivity>,
+    pub activities: Vec<everruns_platform::SessionActivity>,
     /// Restrict to sessions whose resolved human owner is this user (`mine`).
     pub owner_user_id: Option<Uuid>,
     pub created_after: Option<DateTime<Utc>>,
@@ -949,7 +949,7 @@ pub struct CreateSessionRow {
     /// How this session was started. Set by the creating ingress path, never
     /// taken from untrusted client input except for the two client-declarable
     /// variants (see `SessionSource::is_client_declarable`).
-    pub source: everruns_core::SessionSource,
+    pub source: everruns_platform::SessionSource,
     pub app_id: Option<Uuid>,
     pub harness_id: Option<HarnessId>,
     pub agent_id: Option<AgentId>,

--- a/crates/server/src/storage/repositories/session_participants.rs
+++ b/crates/server/src/storage/repositories/session_participants.rs
@@ -2,9 +2,8 @@ use super::super::models::*;
 use super::Database;
 use crate::storage::backend::MAX_SESSION_PARTICIPANT_HISTORY;
 use anyhow::{Result, bail};
-use everruns_core::{
-    SessionId, SessionParticipantId, SessionParticipantKind, SessionParticipantRole,
-};
+use everruns_core::{SessionId, SessionParticipantId};
+use everruns_platform::{SessionParticipantKind, SessionParticipantRole};
 
 impl Database {
     pub async fn create_session_participant(

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -17,7 +17,7 @@ const SESSION_COLUMNS: &str = "id, org_id, workspace_id, app_id, harness_id, age
      forked_from_session_id, forked_from_sequence, \
      blueprint_id, blueprint_config";
 
-/// SQL mirror of `everruns_core::SessionActivity::derive` — the list filters in
+/// SQL mirror of `everruns_platform::SessionActivity::derive` — the list filters in
 /// the database while the in-memory backend filters in Rust. Both must change
 /// together; `activity_derivation_truth_table` in `everruns_core::session`
 /// spells out the shared contract.

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -9,10 +9,10 @@
 use crate::max_iterations;
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, Result, SessionId, StoreResultExt, TokenUsage,
-    session::{Session, SessionStatus},
+    AgentLoopError, ExecutionSession, Result, SessionId, StoreResultExt, TokenUsage,
     traits::SessionStore,
 };
+use everruns_platform::{Session, SessionActivity, SessionSource, SessionStatus};
 
 use super::repositories::Database;
 
@@ -41,9 +41,12 @@ impl DbSessionStore {
     }
 }
 
-#[async_trait]
-impl SessionStore for DbSessionStore {
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+impl DbSessionStore {
+    /// Load the stored platform Session record (server-internal; EVE-882).
+    ///
+    /// The core `SessionStore` seam below projects this into the portable
+    /// [`ExecutionSession`] — host execution never sees the stored record.
+    pub async fn get_stored_session(&self, session_id: SessionId) -> Result<Option<Session>> {
         let session_row = self
             .db
             .get_session(self.org_id, session_id)
@@ -110,9 +113,9 @@ impl SessionStore for DbSessionStore {
                 let capabilities = serde_json::from_value(row.capabilities).unwrap_or_default();
 
                 Ok(Some(Session {
-                    source: everruns_core::SessionSource::from(row.source.as_str()),
-                    activity: everruns_core::SessionActivity::derive(
-                        &everruns_core::SessionStatus::from(row.status.as_str()),
+                    source: SessionSource::from(row.source.as_str()),
+                    activity: SessionActivity::derive(
+                        &SessionStatus::from(row.status.as_str()),
                         row.last_turn_status.as_deref(),
                     ),
                     id: row.id,
@@ -162,6 +165,16 @@ impl SessionStore for DbSessionStore {
             }
             None => Ok(None),
         }
+    }
+}
+
+#[async_trait]
+impl SessionStore for DbSessionStore {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
+        Ok(self
+            .get_stored_session(session_id)
+            .await?
+            .map(|session| session.execution_session()))
     }
 }
 

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -20,12 +20,11 @@ use test_harness::TestServer;
 
 use everruns_core::provider::Provider;
 use everruns_core::typed_id::ScheduleId;
-use everruns_core::{
-    DEFAULT_ORG_ID, Model, PrincipalId, Session, SessionContextReport, SessionFile,
-};
+use everruns_core::{DEFAULT_ORG_ID, Model, PrincipalId, SessionContextReport, SessionFile};
 use everruns_durable::UpdateField;
 use everruns_platform::Agent;
 use everruns_platform::Harness;
+use everruns_platform::Session;
 use everruns_server::storage::models::{
     CreateAgentRow, CreatePrincipalRow, CreateSessionScheduleRow, UpdateOrganizationSettings,
     UpdateSession,
@@ -630,7 +629,7 @@ async fn test_list_agents_resolves_explicit_inherited_and_missing_harnesses() {
         .unwrap();
     assert_eq!(deleted_item["effective_harness"]["status"], "deleted");
 
-    let session: everruns_core::Session = server
+    let session: everruns_platform::Session = server
         .post(
             "/v1/sessions",
             json!({ "agent_id": inherited["id"], "title": "Inherited harness proof" }),

--- a/crates/server/tests/blob_offload_integration_test.rs
+++ b/crates/server/tests/blob_offload_integration_test.rs
@@ -144,7 +144,7 @@ async fn create_test_session(backend: &StorageBackend) -> everruns_core::Session
     let owner_principal_id = create_test_principal(backend, TEST_ORG_ID).await;
     backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,

--- a/crates/server/tests/evals_integration_test.rs
+++ b/crates/server/tests/evals_integration_test.rs
@@ -570,7 +570,7 @@ async fn seed_run_with_session_events(server: &TestServer) -> (String, String) {
     let session = server
         .db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -997,7 +997,7 @@ async fn seed_run_with_tool_iterations(
     let session = server
         .db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1354,7 +1354,7 @@ async fn seed_session_with_raw_events(
     let session = server
         .db
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -938,7 +938,7 @@ async fn create_second_org_backend(backend: &StorageBackend) -> i64 {
 async fn create_session_in_org(backend: &StorageBackend, org_id: i64) -> everruns_core::SessionId {
     let row = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id,
             app_id: None,

--- a/crates/server/tests/repository_conformance_test.rs
+++ b/crates/server/tests/repository_conformance_test.rs
@@ -44,7 +44,7 @@ async fn create_test_principal(repo: &dyn Repository, label: &str) -> PrincipalI
 
 fn session_input(owner_principal_id: PrincipalId, label: &str) -> CreateSessionRow {
     CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
         harness_id: None,

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -518,7 +518,7 @@ async fn test_session_connection_resolution_uses_resolved_owner_user() {
     let owner_principal_id = create_test_user_principal(&backend, TEST_ORG_ID, owner.id).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -685,7 +685,7 @@ async fn test_detached_budget_root_override_canonicalizes_postgres_chain() {
         .expect("add owner to org");
     let owner_principal_id = create_test_user_principal(&backend, TEST_ORG_ID, owner.id).await;
     let base = CreateSessionRow {
-        source: everruns_core::SessionSource::Api,
+        source: everruns_platform::SessionSource::Api,
         workspace_id: None,
         org_id: TEST_ORG_ID,
         app_id: None,
@@ -815,7 +815,7 @@ async fn test_session_crud() {
         .expect("Failed to create app");
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: Some(app.id),
@@ -1005,7 +1005,7 @@ async fn test_event_crud() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -1106,7 +1106,7 @@ async fn test_event_exclude_types() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -1215,7 +1215,7 @@ async fn test_message_events_filtered_offset_and_latest_limit() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -1318,7 +1318,7 @@ async fn test_message_events_filtered_keep_head_loads_head_and_tail() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -1437,7 +1437,7 @@ async fn test_long_message_history_reads_are_bounded_and_index_supported() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -1660,7 +1660,7 @@ async fn test_event_filter_types() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -1972,7 +1972,7 @@ async fn test_session_file_crud() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -2454,7 +2454,7 @@ async fn test_session_usage_tracking() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -2564,7 +2564,7 @@ async fn test_session_previews() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -3176,7 +3176,7 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
-            source: everruns_core::SessionSource::Api,
+            source: everruns_platform::SessionSource::Api,
             workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
@@ -3570,7 +3570,7 @@ async fn list_org_session_tasks_pg() {
         async move {
             backend
                 .create_session(CreateSessionRow {
-                    source: everruns_core::SessionSource::Api,
+                    source: everruns_platform::SessionSource::Api,
                     workspace_id: None,
                     org_id,
                     app_id: None,

--- a/crates/server/tests/session_git_integration_test.rs
+++ b/crates/server/tests/session_git_integration_test.rs
@@ -11,8 +11,8 @@ use axum::http::StatusCode;
 use serde_json::{Value, json};
 use test_harness::TestServer;
 
-use everruns_core::Session;
 use everruns_platform::Agent;
+use everruns_platform::Session;
 
 /// Helper: create an agent + session + populate files, return session ID
 async fn setup_session_with_files(server: &TestServer) -> String {

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -16,8 +16,9 @@
 //! - Uses LlmSim for workflow tests, no real API keys needed
 
 use everruns_core::provider::Provider;
-use everruns_core::{Model, Session, SessionFile};
+use everruns_core::{Model, SessionFile};
 use everruns_platform::Agent;
+use everruns_platform::Session;
 use serde_json::{Value, json};
 
 const SERVER_BASE_URL: &str = "http://localhost:9000";

--- a/crates/test-support/src/in_memory_loop.rs
+++ b/crates/test-support/src/in_memory_loop.rs
@@ -12,7 +12,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use chrono::Utc;
 
 use crate::llmsim_driver::{LlmSimConfig, LlmSimDriver};
 use everruns_core::agent_definition::AgentDefinition;
@@ -29,7 +28,7 @@ use everruns_core::in_memory::{
 };
 use everruns_core::message::Message;
 use everruns_core::message_retriever::{InputMessage, MessageRetriever};
-use everruns_core::session::{Session, SessionStatus};
+use everruns_core::session::ExecutionSession;
 use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolRegistry, ToolRegistryBuilder};
 use everruns_core::traits::{EventEmitter, ResolvedModel};
@@ -378,7 +377,6 @@ impl InMemoryAgenticLoopBuilder {
         // Create harness (portable execution configuration keyed by id; the
         // stored persistence record lives in everruns-platform, EVE-881).
         let harness_id = HarnessId::new();
-        let now = Utc::now();
         let harness =
             everruns_core::HarnessDefinition::new("in-memory", self.system_prompt.clone());
         harness_store.add_harness(harness_id, harness).await;
@@ -403,50 +401,10 @@ impl InMemoryAgenticLoopBuilder {
 
         // Create session
         let session_id = SessionId::new();
-        let session = Session {
-            source: Default::default(),
-            activity: Default::default(),
-            id: session_id,
-            workspace_id: everruns_core::WorkspaceId::from_uuid((session_id).uuid()),
-            organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
-            harness_id,
+        let session = ExecutionSession {
             agent_id: Some(agent_id),
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
             title: Some("In-Memory Session".to_string()),
-            goal: None,
-            locale: None,
-            preview: None,
-            output_preview: None,
-            tags: vec![],
-            model_id: None,
-            capabilities: vec![],
-            tools: vec![],
-            mcp_servers: Default::default(),
-            system_prompt: None,
-            initial_files: vec![],
-            hints: None,
-            network_access: None,
-            max_iterations: None,
-            parallel_tool_calls: None,
-            status: SessionStatus::Started,
-            created_at: now,
-            updated_at: now,
-            started_at: None,
-            finished_at: None,
-            usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
-            parent_session_id: None,
-            forked_from_session_id: None,
-            forked_from_sequence: None,
-            blueprint_id: None,
-            blueprint_config: None,
+            ..ExecutionSession::with_own_workspace(session_id, harness_id)
         };
         session_store.add_session(session).await;
 

--- a/crates/test-support/tests/command_host_test.rs
+++ b/crates/test-support/tests/command_host_test.rs
@@ -9,14 +9,15 @@ use everruns_core::{
     AgentLoopError, CapabilityRegistry, DisabledCommandHost, DriverRegistry, SessionId,
     StoreCommandHost,
 };
-use everruns_core::{CommandHost, Session, SessionCompletionError, SessionCompletionRequest};
+use everruns_core::{
+    CommandHost, ExecutionSession, SessionCompletionError, SessionCompletionRequest,
+};
 use everruns_test_support::TestMathCapability;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use everruns_core::AgentDefinition;
 
-use chrono::Utc;
 use everruns_core::driver_registry::LlmStreamEvent;
 use everruns_core::harness_definition::HarnessDefinition;
 use everruns_core::in_memory::{
@@ -25,7 +26,7 @@ use everruns_core::in_memory::{
 };
 use everruns_core::message_retriever::InputMessage;
 use everruns_core::provider::DriverId;
-use everruns_core::session::SessionStatus;
+use everruns_core::session::SessionExecutionState;
 use everruns_core::typed_id::{AgentId, HarnessId};
 use everruns_test_support::{LlmSimConfig, LlmSimDriver};
 use futures::StreamExt;
@@ -70,26 +71,20 @@ fn test_agent(agent_id: AgentId) -> AgentDefinition {
     }
 }
 
-fn test_session(session_id: SessionId, harness_id: HarnessId, agent_id: AgentId) -> Session {
-    Session {
-        source: Default::default(),
-        activity: Default::default(),
+fn test_session(
+    session_id: SessionId,
+    harness_id: HarnessId,
+    agent_id: AgentId,
+) -> ExecutionSession {
+    ExecutionSession {
         id: session_id,
         workspace_id: everruns_core::WorkspaceId::from_uuid((session_id).uuid()),
         organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
         harness_id,
         agent_id: Some(agent_id),
-        agent_version_id: None,
-        agent_identity_id: None,
-        owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-        resolved_owner_user_id: None,
-        owner: None,
-        effective_owner: None,
         title: None,
         goal: None,
         locale: None,
-        preview: None,
-        output_preview: None,
         tags: vec![],
         model_id: None,
         capabilities: vec![],
@@ -101,18 +96,10 @@ fn test_session(session_id: SessionId, harness_id: HarnessId, agent_id: AgentId)
         network_access: None,
         max_iterations: None,
         parallel_tool_calls: None,
-        status: SessionStatus::Started,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        started_at: None,
-        finished_at: None,
+        status: SessionExecutionState::Started,
         usage: None,
-        is_pinned: None,
-        active_schedule_count: None,
-        features: vec![],
         parent_session_id: None,
         forked_from_session_id: None,
-        forked_from_sequence: None,
         blueprint_id: None,
         blueprint_config: None,
     }

--- a/crates/test-support/tests/reason_atom_test.rs
+++ b/crates/test-support/tests/reason_atom_test.rs
@@ -18,9 +18,9 @@ use everruns_core::in_memory::{
     InMemorySessionStore,
 };
 use everruns_core::runtime_agent::RuntimeAgent;
-use everruns_core::session::{Session, SessionStatus};
+use everruns_core::session::{ExecutionSession, SessionExecutionState};
 use everruns_core::traits::{NoopEventEmitter, ResolvedModel};
-use everruns_core::typed_id::{HarnessId, MessageId, PrincipalId, SessionId, TurnId};
+use everruns_core::typed_id::{HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{CompactionCheckpointStore, Controls, Message, ToolCall};
 use everruns_test_support::llmsim_driver::{LlmSimConfig, LlmSimDriver, register_driver};
 use futures::stream;
@@ -49,7 +49,6 @@ async fn setup_test_environment() -> (
 
     // Create a test harness
     let harness_id = HarnessId::from_seed(1);
-    let now = chrono::Utc::now();
     let harness = HarnessDefinition::new("test-harness", "You are a helpful assistant.");
     harness_store.add_harness(harness_id, harness).await;
 
@@ -67,27 +66,17 @@ async fn setup_test_environment() -> (
 
     // Create a test session
     let session_id = Uuid::now_v7();
-    let session = Session {
-        source: Default::default(),
-        activity: Default::default(),
+    let session = ExecutionSession {
         id: session_id.into(),
         workspace_id: everruns_core::WorkspaceId::from_uuid(session_id),
         organization_id: "default".to_string(),
         harness_id,
         agent_id: Some(agent_id.into()),
-        agent_version_id: None,
-        agent_identity_id: None,
-        owner_principal_id: PrincipalId::from_seed(1),
-        resolved_owner_user_id: None,
-        owner: None,
-        effective_owner: None,
-        title: Some("Test Session".to_string()),
+        title: Some("Test ExecutionSession".to_string()),
         goal: None,
         locale: None,
-        preview: None,
-        output_preview: None,
         tags: vec![],
-        status: SessionStatus::Started,
+        status: SessionExecutionState::Started,
         model_id: None,
         capabilities: vec![],
         tools: vec![],
@@ -98,17 +87,9 @@ async fn setup_test_environment() -> (
         network_access: None,
         max_iterations: None,
         parallel_tool_calls: None,
-        created_at: now,
-        updated_at: now,
-        started_at: None,
-        finished_at: None,
         usage: None,
-        is_pinned: None,
-        active_schedule_count: None,
-        features: vec![],
         parent_session_id: None,
         forked_from_session_id: None,
-        forked_from_sequence: None,
         blueprint_id: None,
         blueprint_config: None,
     };
@@ -2017,28 +1998,17 @@ async fn test_reason_atom_with_different_configs() {
 
     // Second test with a different configuration
     let session_id2 = Uuid::now_v7();
-    let now2 = chrono::Utc::now();
-    let session2 = Session {
-        source: Default::default(),
-        activity: Default::default(),
+    let session2 = ExecutionSession {
         id: session_id2.into(),
         workspace_id: everruns_core::WorkspaceId::from_uuid(session_id2),
         organization_id: "default".to_string(),
         harness_id,
         agent_id: Some(agent_id.into()),
-        agent_version_id: None,
-        agent_identity_id: None,
-        owner_principal_id: PrincipalId::from_seed(1),
-        resolved_owner_user_id: None,
-        owner: None,
-        effective_owner: None,
-        title: Some("Test Session 2".to_string()),
+        title: Some("Test ExecutionSession 2".to_string()),
         goal: None,
         locale: None,
-        preview: None,
-        output_preview: None,
         tags: vec![],
-        status: SessionStatus::Started,
+        status: SessionExecutionState::Started,
         model_id: None,
         capabilities: vec![],
         tools: vec![],
@@ -2049,17 +2019,9 @@ async fn test_reason_atom_with_different_configs() {
         network_access: None,
         max_iterations: None,
         parallel_tool_calls: None,
-        created_at: now2,
-        updated_at: now2,
-        started_at: None,
-        finished_at: None,
         usage: None,
-        is_pinned: None,
-        active_schedule_count: None,
-        features: vec![],
         parent_session_id: None,
         forked_from_session_id: None,
-        forked_from_sequence: None,
         blueprint_id: None,
         blueprint_config: None,
     };
@@ -3818,29 +3780,18 @@ async fn test_session_system_prompt_is_prepended_to_agent_prompt() {
 
     // Re-add the session with a session-level system prompt override
     {
-        let now = chrono::Utc::now();
         session_store
-            .add_session(Session {
-                source: Default::default(),
-                activity: Default::default(),
+            .add_session(ExecutionSession {
                 id: session_id.into(),
                 workspace_id: everruns_core::WorkspaceId::from_uuid(session_id),
                 organization_id: "default".to_string(),
                 harness_id,
                 agent_id: Some(agent_id.into()),
-                agent_version_id: None,
-                agent_identity_id: None,
-                owner_principal_id: PrincipalId::from_seed(1),
-                resolved_owner_user_id: None,
-                owner: None,
-                effective_owner: None,
-                title: Some("Test Session".to_string()),
+                title: Some("Test ExecutionSession".to_string()),
                 goal: None,
                 locale: None,
-                preview: None,
-                output_preview: None,
                 tags: vec![],
-                status: SessionStatus::Started,
+                status: SessionExecutionState::Started,
                 model_id: None,
                 capabilities: vec![],
                 tools: vec![],
@@ -3853,17 +3804,9 @@ async fn test_session_system_prompt_is_prepended_to_agent_prompt() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
-                created_at: now,
-                updated_at: now,
-                started_at: None,
-                finished_at: None,
                 usage: None,
-                is_pinned: None,
-                active_schedule_count: None,
-                features: vec![],
                 parent_session_id: None,
                 forked_from_session_id: None,
-                forked_from_sequence: None,
                 blueprint_id: None,
                 blueprint_config: None,
             })
@@ -3920,7 +3863,7 @@ async fn test_session_system_prompt_is_prepended_to_agent_prompt() {
         .expect("System message should have been captured");
     assert!(
         system_msg.contains("SESSION PREFIX: You must always respond in French."),
-        "Session system_prompt should be prepended to the system message, got: '{}'",
+        "ExecutionSession system_prompt should be prepended to the system message, got: '{}'",
         system_msg
     );
     // Also verify the agent's system prompt is still present
@@ -3948,29 +3891,18 @@ async fn test_empty_session_system_prompt_is_ignored() {
 
     // Re-add session with empty system_prompt (should be ignored)
     {
-        let now = chrono::Utc::now();
         session_store
-            .add_session(Session {
-                source: Default::default(),
-                activity: Default::default(),
+            .add_session(ExecutionSession {
                 id: session_id.into(),
                 workspace_id: everruns_core::WorkspaceId::from_uuid(session_id),
                 organization_id: "default".to_string(),
                 harness_id,
                 agent_id: Some(agent_id.into()),
-                agent_version_id: None,
-                agent_identity_id: None,
-                owner_principal_id: PrincipalId::from_seed(1),
-                resolved_owner_user_id: None,
-                owner: None,
-                effective_owner: None,
-                title: Some("Test Session".to_string()),
+                title: Some("Test ExecutionSession".to_string()),
                 goal: None,
                 locale: None,
-                preview: None,
-                output_preview: None,
                 tags: vec![],
-                status: SessionStatus::Started,
+                status: SessionExecutionState::Started,
                 model_id: None,
                 capabilities: vec![],
                 tools: vec![],
@@ -3981,17 +3913,9 @@ async fn test_empty_session_system_prompt_is_ignored() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
-                created_at: now,
-                updated_at: now,
-                started_at: None,
-                finished_at: None,
                 usage: None,
-                is_pinned: None,
-                active_schedule_count: None,
-                features: vec![],
                 parent_session_id: None,
                 forked_from_session_id: None,
-                forked_from_sequence: None,
                 blueprint_id: None,
                 blueprint_config: None,
             })

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -25,9 +25,12 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, LeasedResourceId, MessageId, ModelId, SessionId};
 use everruns_core::{
-    AgentDefinition, HarnessDefinition, Message, MessageFilter, MessageRole, Session,
-    SessionParticipant, SessionStatus,
+    AgentDefinition, ExecutionSession, HarnessDefinition, Message, MessageFilter, MessageRole,
 };
+// EVE-882: the stored Session record and its lifecycle enums moved to
+// `everruns-platform`; the worker's PlatformStore surface still transports
+// them, while execution paths carry only the portable `ExecutionSession`.
+use everruns_platform::{Session, SessionParticipant, SessionStatus};
 // EVE-877: the stored Agent record moved to `everruns-platform`; the gRPC wire
 // still carries it between server and worker (proto shape unchanged).
 use everruns_internal_protocol::proto;
@@ -196,13 +199,17 @@ impl GrpcClient {
         }
     }
 
-    /// Set session status (started, active, idle)
+    /// Set session status (started, active, idle).
+    ///
+    /// Acknowledgement only (EVE-882): the wire response still carries the
+    /// stored record for older workers, but status mutation exposes no
+    /// session record to the caller.
     pub async fn set_session_status(
         &self,
         org_id: i64,
         session_id: SessionId,
         status: &str,
-    ) -> Result<Session> {
+    ) -> Result<()> {
         let request = proto::SetSessionStatusRequest {
             session_id: Some(uuid_to_proto(session_id.uuid())),
             status: status.to_string(),
@@ -210,26 +217,21 @@ impl GrpcClient {
         };
 
         let mut client = self.inner.lock().await;
-        let response = client
+        client
             .set_session_status(request)
             .await
             .map_err(grpc_status_to_error)?;
-
-        let proto_session = response
-            .into_inner()
-            .session
-            .ok_or_else(|| grpc_missing_field("No session in response"))?;
-
-        proto_session_to_session(proto_session)
+        Ok(())
     }
 
-    /// Set session title.
+    /// Set session title, acknowledging with the refreshed portable
+    /// execution view (EVE-882).
     pub async fn set_session_title(
         &self,
         org_id: i64,
         session_id: SessionId,
         title: &str,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         let request = proto::SetSessionTitleRequest {
             session_id: Some(uuid_to_proto(session_id.uuid())),
             title: title.to_string(),
@@ -1579,7 +1581,7 @@ fn proto_harness_to_harness(proto_harness: proto::Harness) -> Result<Harness> {
 
 #[async_trait]
 impl SessionStore for GrpcOrgAdapter {
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::GetSessionRequest {
@@ -1602,7 +1604,9 @@ impl SessionStore for GrpcOrgAdapter {
     }
 }
 
-fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
+/// Project the proto session payload straight into the portable execution
+/// view (EVE-882): the worker never materializes the stored Session record.
+fn proto_session_to_session(proto_session: proto::Session) -> Result<ExecutionSession> {
     let id = proto_uuid_to_uuid(proto_session.id.as_ref())?;
     let agent_id = proto_session
         .agent_id
@@ -1620,17 +1624,6 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         .as_ref()
         .map(|u| proto_uuid_to_uuid(Some(u)))
         .transpose()?;
-    let owner_principal_id = proto_session
-        .owner_principal_id
-        .as_ref()
-        .map(|u| proto_uuid_to_uuid(Some(u)))
-        .transpose()?
-        .ok_or_else(|| anyhow::anyhow!("Missing owner_principal_id in session proto"))?;
-    let resolved_owner_user_id = proto_session
-        .resolved_owner_user_id
-        .as_ref()
-        .map(|u| proto_uuid_to_uuid(Some(u)))
-        .transpose()?;
     let parent_session_id = proto_session
         .parent_session_id
         .as_ref()
@@ -1641,18 +1634,8 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         .as_deref()
         .and_then(|json| serde_json::from_str(json).ok());
 
-    let status = match proto_session.status.to_lowercase().as_str() {
-        "started" => everruns_core::SessionStatus::Started,
-        "active" => everruns_core::SessionStatus::Active,
-        "idle" => everruns_core::SessionStatus::Idle,
-        // Handle legacy values during migration
-        "running" => everruns_core::SessionStatus::Active,
-        "pending" | "completed" | "failed" => everruns_core::SessionStatus::Idle,
-        _ => everruns_core::SessionStatus::Started,
-    };
-
-    let created_at = proto_timestamp_or_now(proto_session.created_at.as_ref());
-    let updated_at = proto_timestamp_or_now(proto_session.updated_at.as_ref());
+    let status =
+        everruns_core::SessionExecutionState::from(proto_session.status.to_lowercase().as_str());
 
     // Parse capabilities from proto if present
     let capabilities = proto_session
@@ -1661,31 +1644,15 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         .filter_map(|c| serde_json::from_str::<everruns_core::AgentCapabilityConfig>(c).ok())
         .collect();
 
-    Ok(Session {
-        // The proto Session does not carry origin/activity: the worker has no
-        // use for either, and the control plane is their source of truth.
-        source: Default::default(),
-        activity: Default::default(),
+    Ok(ExecutionSession {
         id: id.into(),
         workspace_id: everruns_core::WorkspaceId::from_uuid(id),
         organization_id: proto_session.organization_id,
         agent_id: agent_id.map(|u| u.into()),
-        agent_version_id: proto_session
-            .agent_version_id
-            .as_ref()
-            .map(|id| proto_uuid_to_uuid(Some(id)).map(everruns_core::AgentVersionId::from_uuid))
-            .transpose()?,
-        agent_identity_id: None,
         harness_id: harness_id.into(),
-        owner_principal_id: owner_principal_id.into(),
-        resolved_owner_user_id,
-        owner: None,
-        effective_owner: None,
         title: non_empty_string(proto_session.title),
         goal: proto_session.goal.clone(),
         locale: non_empty_string(proto_session.locale),
-        preview: None,
-        output_preview: None,
         tags: proto_session.tags,
         model_id: model_id.map(|u| u.into()),
         capabilities,
@@ -1707,18 +1674,10 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         max_iterations: None,
         parallel_tool_calls: proto_session.parallel_tool_calls,
         status,
-        created_at,
-        updated_at,
-        started_at: None,
-        finished_at: None,
         usage: None, // Usage not tracked in worker context
-        is_pinned: None,
-        active_schedule_count: None,
-        features: vec![], // Computed at API read time, not in worker
         parent_session_id,
         // Fork lineage is API-read-time metadata, not carried over gRPC.
         forked_from_session_id: None,
-        forked_from_sequence: None,
         blueprint_id: proto_session.blueprint_id,
         blueprint_config,
     })
@@ -2287,7 +2246,7 @@ fn proto_event_to_core(proto_event: proto::Event) -> Result<Event> {
 /// Turn context loaded in one batched gRPC call
 pub struct TurnContext {
     pub agent: Option<Agent>,
-    pub session: Session,
+    pub session: ExecutionSession,
     pub messages: Vec<Message>,
     pub model: Option<ResolvedModel>,
     /// MCP tool definitions pre-resolved from agent's MCP capabilities
@@ -2689,7 +2648,7 @@ impl everruns_core::traits::SessionMutator for GrpcOrgAdapter {
         &self,
         session_id: everruns_core::SessionId,
         title: String,
-    ) -> Result<everruns_core::session::Session> {
+    ) -> Result<ExecutionSession> {
         self.client
             .set_session_title(self.org_id, session_id, &title)
             .await

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -18,8 +18,8 @@ use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
 use everruns_core::{
-    DriverRegistry, EgressService, Message, MessageHistory, MessageQuery, PlatformDefinition,
-    Session, UtilityLlmService,
+    DriverRegistry, EgressService, ExecutionSession, Message, MessageHistory, MessageQuery,
+    PlatformDefinition, UtilityLlmService,
 };
 use everruns_platform::{Agent, Harness};
 use std::collections::HashMap;
@@ -129,18 +129,13 @@ impl WorkerAdapters for GrpcWorkerAdapters {
     // Session Operations
     // =========================================================================
 
-    async fn get_session(&self, org_id: i64, session_id: Uuid) -> Result<Option<Session>> {
+    async fn get_session(&self, org_id: i64, session_id: Uuid) -> Result<Option<ExecutionSession>> {
         let store = GrpcSessionStore::new(self.client.clone(), org_id);
         everruns_core::traits::SessionStore::get_session(&store, SessionId::from_uuid(session_id))
             .await
     }
 
-    async fn set_session_status(
-        &self,
-        org_id: i64,
-        session_id: Uuid,
-        status: &str,
-    ) -> Result<Session> {
+    async fn set_session_status(&self, org_id: i64, session_id: Uuid, status: &str) -> Result<()> {
         self.client
             .set_session_status(org_id, SessionId::from_uuid(session_id), status)
             .await
@@ -151,7 +146,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         org_id: i64,
         session_id: Uuid,
         title: String,
-    ) -> Result<Session> {
+    ) -> Result<ExecutionSession> {
         self.client
             .set_session_title(org_id, SessionId::from_uuid(session_id), &title)
             .await

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -11,8 +11,8 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, SessionId};
 use everruns_core::{
-    CapabilityRegistry, DriverRegistry, EgressService, ResolvedExecutionSnapshot, SessionStatus,
-    UtilityLlmService,
+    CapabilityRegistry, DriverRegistry, EgressService, ResolvedExecutionSnapshot,
+    SessionExecutionState, UtilityLlmService,
 };
 use everruns_host::{ResolvedTurnInputs, RuntimeHostAdapter};
 use everruns_mcp::{
@@ -156,11 +156,10 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
         &self,
         org_id: i64,
         session_id: SessionId,
-        status: SessionStatus,
+        status: SessionExecutionState,
     ) -> Result<()> {
-        // WorkerAdapters still returns the stored record over the wire
-        // (compatibility adapter); the host contract keeps status mutation a
-        // record-free effect.
+        // Status mutation is an acknowledged effect end to end (EVE-882):
+        // neither the adapter nor the host contract exposes a session record.
         self.adapters
             .set_session_status(org_id, session_id.uuid(), &status.to_string())
             .await?;

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -1989,7 +1989,7 @@ mod tests {
                 &self,
                 _org_id: i64,
                 _session_id: Uuid,
-            ) -> CoreResult<Option<everruns_core::Session>> {
+            ) -> CoreResult<Option<everruns_core::ExecutionSession>> {
                 unimplemented!()
             }
             async fn set_session_status(
@@ -1997,7 +1997,7 @@ mod tests {
                 _org_id: i64,
                 _session_id: Uuid,
                 _status: &str,
-            ) -> CoreResult<everruns_core::Session> {
+            ) -> CoreResult<()> {
                 unimplemented!()
             }
             async fn set_session_title(
@@ -2005,7 +2005,7 @@ mod tests {
                 _org_id: i64,
                 _session_id: Uuid,
                 _title: String,
-            ) -> CoreResult<everruns_core::Session> {
+            ) -> CoreResult<everruns_core::ExecutionSession> {
                 unimplemented!()
             }
             async fn get_message(

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -24,8 +24,8 @@ use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
 use everruns_core::{
-    AgentDefinition, DriverRegistry, EgressService, HarnessDefinition, Message, MessageHistory,
-    MessageQuery, Session, ToolDefinition, UtilityLlmService,
+    AgentDefinition, DriverRegistry, EgressService, ExecutionSession, HarnessDefinition, Message,
+    MessageHistory, MessageQuery, ToolDefinition, UtilityLlmService,
 };
 // EVE-877: the stored Agent record moved to `everruns-platform`. WorkerAdapters
 // still transports it between control plane and worker; host/engine only ever
@@ -64,24 +64,22 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     // Session Operations
     // =========================================================================
 
-    /// Get session by ID
-    async fn get_session(&self, org_id: i64, session_id: Uuid) -> Result<Option<Session>>;
+    /// Get the portable execution view of a session by ID (EVE-882: the
+    /// stored Session record stays on the control plane).
+    async fn get_session(&self, org_id: i64, session_id: Uuid) -> Result<Option<ExecutionSession>>;
 
-    /// Set session status (started, active, idle)
-    async fn set_session_status(
-        &self,
-        org_id: i64,
-        session_id: Uuid,
-        status: &str,
-    ) -> Result<Session>;
+    /// Set session status (started, active, idle). Acknowledgement only —
+    /// status mutation exposes no session record (EVE-882).
+    async fn set_session_status(&self, org_id: i64, session_id: Uuid, status: &str) -> Result<()>;
 
-    /// Set a session title.
+    /// Set a session title, acknowledging with the refreshed portable
+    /// execution view.
     async fn set_session_title(
         &self,
         org_id: i64,
         session_id: Uuid,
         title: String,
-    ) -> Result<Session>;
+    ) -> Result<ExecutionSession>;
 
     // =========================================================================
     // Message Operations
@@ -503,7 +501,7 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 #[derive(Debug, Clone)]
 pub struct TurnContext {
     pub agent: Option<Agent>,
-    pub session: Session,
+    pub session: ExecutionSession,
     pub messages: Vec<Message>,
     pub model: Option<ResolvedModel>,
     /// MCP tool definitions pre-resolved from agent's MCP capabilities
@@ -635,7 +633,7 @@ impl<A: WorkerAdapters> everruns_core::traits::HarnessStore for OrgAdapter<A> {
 
 #[async_trait]
 impl<A: WorkerAdapters> everruns_core::traits::SessionStore for OrgAdapter<A> {
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         self.adapters
             .get_session(self.org_id, session_id.uuid())
             .await
@@ -644,7 +642,11 @@ impl<A: WorkerAdapters> everruns_core::traits::SessionStore for OrgAdapter<A> {
 
 #[async_trait]
 impl<A: WorkerAdapters> everruns_core::traits::SessionMutator for OrgAdapter<A> {
-    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> Result<ExecutionSession> {
         self.adapters
             .set_session_title(self.org_id, session_id.uuid(), title)
             .await

--- a/crates/worker/tests/resolved_turn_parity_test.rs
+++ b/crates/worker/tests/resolved_turn_parity_test.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use everruns_core::error::Result as CoreResult;
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
-use everruns_core::{DEFAULT_ORG_ID, ResolvedExecutionSnapshot, Session};
+use everruns_core::{DEFAULT_ORG_ID, ExecutionSession, ResolvedExecutionSnapshot};
 use everruns_host::{RuntimeHostAdapter, SessionBuilder};
 use everruns_platform::Harness;
 // EVE-877: the hosted adapters transport the stored platform record; the
@@ -18,7 +18,7 @@ use everruns_platform::{Agent, AgentStatus};
 use everruns_worker::{WorkerAdapters, WorkerRuntimeHost, WorkerTurnContext};
 use uuid::Uuid;
 
-fn fixture_records() -> (Harness, Agent, Session) {
+fn fixture_records() -> (Harness, Agent, ExecutionSession) {
     let harness_id = HarnessId::from_seed(872);
     let agent_id = AgentId::from_seed(872);
     let session_id = SessionId::from_seed(872);
@@ -88,7 +88,7 @@ fn fixture_records() -> (Harness, Agent, Session) {
 struct DirectMockAdapters {
     harness: Harness,
     agent: Agent,
-    session: Session,
+    session: ExecutionSession,
 }
 
 /// gRPC-style adapter: round-trips every record through serialization before
@@ -122,7 +122,7 @@ macro_rules! mock_worker_adapters {
                 &self,
                 _org_id: i64,
                 session_id: Uuid,
-            ) -> CoreResult<Option<Session>> {
+            ) -> CoreResult<Option<ExecutionSession>> {
                 let session = ($session)(self);
                 Ok((session.id.uuid() == session_id).then_some(session))
             }
@@ -131,15 +131,15 @@ macro_rules! mock_worker_adapters {
                 _org_id: i64,
                 _session_id: Uuid,
                 _status: &str,
-            ) -> CoreResult<Session> {
-                Ok(($session)(self))
+            ) -> CoreResult<()> {
+                Ok(())
             }
             async fn set_session_title(
                 &self,
                 _org_id: i64,
                 _session_id: Uuid,
                 _title: String,
-            ) -> CoreResult<Session> {
+            ) -> CoreResult<ExecutionSession> {
                 unimplemented!()
             }
             async fn get_message(
@@ -479,7 +479,7 @@ async fn worker_load_fails_for_archived_and_deleted_agents() {
 #[tokio::test]
 async fn worker_projection_fails_on_missing_records() {
     let (harness, agent, mut session) = fixture_records();
-    // Session referencing a harness outside the adapter's org scope resolves
+    // ExecutionSession referencing a harness outside the adapter's org scope resolves
     // to no records — the cross-tenant / missing shape.
     session.harness_id = HarnessId::from_seed(999);
     let host = WorkerRuntimeHost::new(DirectMockAdapters {

--- a/integrations/github/src/tools.rs
+++ b/integrations/github/src/tools.rs
@@ -478,13 +478,12 @@ impl Tool for SearchGitHubIssuesTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
     use everruns_core::error::Result;
     use everruns_core::traits::{
         KeyInfo, SecretInfo, SessionStorageStore, SessionStore, UserConnectionResolver,
     };
     use everruns_core::typed_id::SessionId;
-    use everruns_core::{HarnessId, PrincipalId, Session, SessionStatus};
+    use everruns_core::{ExecutionSession, HarnessId, SessionExecutionState};
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
@@ -598,12 +597,12 @@ mod tests {
     }
 
     struct MockSessionStore {
-        session: Session,
+        session: ExecutionSession,
     }
 
     #[async_trait]
     impl SessionStore for MockSessionStore {
-        async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+        async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
             if self.session.id == session_id {
                 return Ok(Some(self.session.clone()));
             }
@@ -611,26 +610,19 @@ mod tests {
         }
     }
 
-    fn child_session_with_parent(session_id: SessionId, parent_session_id: SessionId) -> Session {
-        Session {
-            source: Default::default(),
-            activity: Default::default(),
+    fn child_session_with_parent(
+        session_id: SessionId,
+        parent_session_id: SessionId,
+    ) -> ExecutionSession {
+        ExecutionSession {
             id: session_id,
             workspace_id: everruns_core::WorkspaceId::from_uuid((session_id).uuid()),
             organization_id: "org_00000000000000000000000000000001".to_string(),
             harness_id: HarnessId::new(),
             agent_id: None,
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
             title: Some("child".to_string()),
             goal: None,
             locale: None,
-            preview: None,
-            output_preview: None,
             tags: vec![],
             model_id: None,
             capabilities: vec![],
@@ -642,18 +634,10 @@ mod tests {
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
-            status: SessionStatus::Idle,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            started_at: None,
-            finished_at: None,
+            status: SessionExecutionState::Idle,
             usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
             parent_session_id: Some(parent_session_id),
             forked_from_session_id: None,
-            forked_from_sequence: None,
             blueprint_id: None,
             blueprint_config: None,
         }

--- a/knowledge/foundations/concepts.md
+++ b/knowledge/foundations/concepts.md
@@ -81,6 +81,11 @@ Working instance of an agentic loop. Configured by its harness and situationally
   lineage metadata (`forked_from_session_id`) and does not affect nesting guards.
 - Sessions may carry a `goal`, an objective shown in lists and injected into the
   runtime prompt as session metadata rather than as a user message.
+- Since EVE-882 the persisted Session aggregate (status/source/activity facets,
+  participants, ownership, previews, timestamps) lives in `everruns-platform`;
+  the execution kernel consumes only the portable
+  `everruns_core::ExecutionSession` projection plus the neutral
+  `SessionExecutionState`, produced at the platform loading seam.
 
 ### Capability
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,22 @@
 
 ## 2026-08-11
 
+* **Session aggregate extraction**: Moved the persisted `Session`
+  database/API aggregate — product status/source/activity facets,
+  participants, ownership references, previews, timestamps, catalog
+  relationships — out of `everruns-core` into `everruns-platform` (EVE-882,
+  breaking for direct core consumers in 0.18). Core keeps only the portable
+  `ExecutionSession` (correlation values plus the session configuration
+  overlay a turn consumes) and the neutral `SessionExecutionState`; the
+  stored `SessionStatus` maps to/from it at the adapter boundary, and host
+  status mutation acknowledges without returning a record. Server
+  repositories and worker adapters project the stored record via
+  `Session::execution_session()` at the loading seam; embedded/local hosts
+  lift the execution view back into a minimal record with
+  `Session::from_execution_session()` only where they implement platform
+  seams. REST/gRPC and stored schema are unchanged (OpenAPI byte-identical);
+  the agent-record isolation guard now also covers Session records.
+
 * **Harness record extraction**: Moved the stored `Harness` persistence
   record — lifecycle status, hierarchy identifiers, built-in flags, display
   metadata, timestamps, chain-merge helpers — and the built-in provisioning

--- a/scripts/lib/check-agent-record-isolation.sh
+++ b/scripts/lib/check-agent-record-isolation.sh
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
-# Architecture guard (EVE-877, EVE-881): stored platform persistence records —
-# Agent/AgentVersion (lifecycle status, versioning/publication metadata, fork
-# lineage) and Harness (lifecycle status, hierarchy identifiers, built-in
-# flags, display metadata, timestamps) plus the built-in harness provisioning
-# templates — live in crates/platform (`everruns-platform`). The execution
-# kernel consumes only the portable `everruns_core::AgentDefinition` /
-# `everruns_core::HarnessDefinition` and the resolved execution snapshot:
+# Architecture guard (EVE-877, EVE-881, EVE-882): stored platform persistence
+# records — Agent/AgentVersion (lifecycle status, versioning/publication
+# metadata, fork lineage), Harness (lifecycle status, hierarchy identifiers,
+# built-in flags, display metadata, timestamps) plus the built-in harness
+# provisioning templates, and Session (product status/source/activity facets,
+# participants, ownership references, previews, timestamps, catalog
+# relationships) — live in crates/platform (`everruns-platform`). The
+# execution kernel consumes only the portable `everruns_core::AgentDefinition`
+# / `everruns_core::HarnessDefinition` / `everruns_core::ExecutionSession` and
+# the resolved execution snapshot:
 #
 # 1. Kernel crate sources (core, engine, provider, capability) must not
-#    reference `everruns_platform` at all — the platform Agent/Harness records
-#    must never flow back into the kernel.
+#    reference `everruns_platform` at all — the platform Agent/Harness/Session
+#    records must never flow back into the kernel.
 # 2. Kernel crates must carry no everruns-platform edge of any kind (normal,
 #    build, or dev), so `cargo tree` stays clean.
 # 3. Provider-only crates must ship no everruns-platform subtree on their
 #    normal (shipped) dependency edges.
 # 4. Kernel crates must not re-declare the moved stored-record/provisioning
 #    types (Agent, AgentVersion, AgentStatus, Harness, HarnessStatus,
-#    BuiltInHarnessDefinition, BuiltInHarnessRole).
+#    BuiltInHarnessDefinition, BuiltInHarnessRole, Session, SessionStatus,
+#    SessionSource, SessionActivity, SessionParticipant and its enums).
 
 set -euo pipefail
 
@@ -35,17 +39,18 @@ KERNEL_TREES=(
   crates/capability
 )
 if matches=$(grep -rnE 'everruns_platform(::|;)' "${KERNEL_TREES[@]}" --include='*.rs' 2>/dev/null); then
-  echo "Kernel crates must not reference everruns_platform (EVE-877, EVE-881):"
+  echo "Kernel crates must not reference everruns_platform (EVE-877, EVE-881, EVE-882):"
   echo "$matches"
   FAILED=1
 fi
 
 # 1b. Kernel sources: the moved stored-record and provisioning types must not
-#     be re-declared inside the kernel (EVE-877 agents, EVE-881 harnesses).
-RECORD_TYPES='Agent|AgentVersion|AgentStatus|Harness|HarnessStatus|BuiltInHarnessDefinition|BuiltInHarnessRole'
+#     be re-declared inside the kernel (EVE-877 agents, EVE-881 harnesses,
+#     EVE-882 sessions).
+RECORD_TYPES='Agent|AgentVersion|AgentStatus|Harness|HarnessStatus|BuiltInHarnessDefinition|BuiltInHarnessRole|Session|SessionStatus|SessionSource|SessionActivity|SessionParticipant|SessionParticipantKind|SessionParticipantRole'
 if matches=$(grep -rnE "^[[:space:]]*pub (struct|enum) (${RECORD_TYPES})[[:space:]{<(]" \
   "${KERNEL_TREES[@]}" --include='*.rs' 2>/dev/null); then
-  echo "Kernel crates must not declare stored platform record types (EVE-877, EVE-881):"
+  echo "Kernel crates must not declare stored platform record types (EVE-877, EVE-881, EVE-882):"
   echo "$matches"
   FAILED=1
 fi
@@ -87,8 +92,8 @@ for crate in "${PROVIDER_CRATES[@]}"; do
 done
 
 if [ "$FAILED" -ne 0 ]; then
-  echo "Agent-record isolation guard failed. Stored Agent/AgentVersion and Harness records belong in crates/platform (EVE-877, EVE-881)."
+  echo "Agent-record isolation guard failed. Stored Agent/AgentVersion, Harness, and Session records belong in crates/platform (EVE-877, EVE-881, EVE-882)."
   exit 1
 fi
 
-echo "Agent-record isolation guard passed: kernel crates consume AgentDefinition/HarnessDefinition only; platform records stay in crates/platform."
+echo "Agent-record isolation guard passed: kernel crates consume AgentDefinition/HarnessDefinition/ExecutionSession only; platform records stay in crates/platform."

--- a/scripts/lib/pre-push.sh
+++ b/scripts/lib/pre-push.sh
@@ -159,7 +159,7 @@ else
   fail "observability isolation guard failed"
 fi
 
-# 15. Agent-record isolation guard (EVE-877, EVE-881: Agent and Harness records)
+# 15. Agent-record isolation guard (EVE-877, EVE-881, EVE-882: Agent, Harness, and Session records)
 echo "15/17 Agent-record isolation guard"
 if AGENT_RECORD_ISOLATION_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-agent-record-isolation.sh" 2>&1


### PR DESCRIPTION
## Summary

Separates the hosted Session database/API aggregate from neutral session identity and turn execution state, continuing the record-extraction series (EVE-877 Agent, EVE-881 Harness).

- The persisted `Session` record moves to `crates/platform/src/session.rs` together with the product-only enums — `SessionStatus`, `SessionSource`, `SessionActivity`, `SessionParticipant` and its kind/role enums — with projection seams `Session::execution_session()` and the inverse lift `Session::from_execution_session()` for embedded hosts.
- Core keeps only neutral execution values: `ExecutionSession` (correlation IDs + session config overlay + usage), `SessionExecutionState`, `SessionSeedMode`, `SubagentStatus`, and the ID types. Core's `SessionStore`/`SessionMutator` traits now speak `ExecutionSession`; the stored record lives behind the seam (server `DbSessionStore`, direct worker adapters, gRPC proto conversion targeting the platform record).
- Execution status stays a small neutral value (`SessionExecutionState`: started/active/idle/waiting_for_tool_results/paused) with an explicit 1:1 mapping to stored `SessionStatus` — wire strings identical, round-trip tested.
- Host status effects no longer expose stored records: `RuntimeHostAdapter::set_session_status` takes the neutral state and returns `()`; `set_session_title` returns the refreshed execution view. gRPC wire responses unchanged.
- Framework/embedded: host `SessionBuilder` builds `ExecutionSession`; `LocalSessionRunner` stays portable with the platform lift at the `LocalPlatformStore` seam.
- Isolation guard extended: `check-agent-record-isolation.sh` now also rejects kernel-crate use/re-declaration of the stored Session record types.

## Compatibility

- **OpenAPI export byte-identical** to `docs/api/openapi.json`; REST and gRPC serialized shapes preserved.
- No database migration; no Cargo.toml/lockfile changes.

## Testing

`just pre-push` green (17/17). Core 2345, platform 140 (new status/lift round-trip tests), full host suite (mid-turn wake, pause/auto-continue, tool scheduler, in-process runtime), worker resolved-turn parity (direct vs wire), server lib 2117, and against PostgreSQL: repository conformance, repository integration (34), api_integration (120/120). Rebased onto main after #3116 merged.

Fixes EVE-882

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_