### PR TITLE
fix(core): fail closed on unknown capability registration gates

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -64,7 +64,9 @@ pub struct IntegrationPlugin {
     /// If true, only registered when `DeploymentGrade::experimental_features_enabled()` is true.
     pub experimental_only: bool,
     /// If set, only registered when the named deployment feature flag is enabled.
-    /// Both API-visible and internal flag catalogs are checked at registry build time.
+    /// Resolved at registry build time via `ExecutionFeatureDecisions`: internal
+    /// infrastructure flags first, otherwise the explicit `FEATURE_<NAME>` env
+    /// var (fail-closed — no grade-based default for registration gates).
     pub feature_flag: Option<&'static str>,
     /// Factory function that creates the capability instance.
     pub factory: fn() -> Box<dyn Capability>,

--- a/crates/core/src/execution_features.rs
+++ b/crates/core/src/execution_features.rs
@@ -76,7 +76,6 @@ impl InternalFeatureFlags {
 /// filtering the capability list handed to the worker.
 #[derive(Debug, Clone)]
 pub struct ExecutionFeatureDecisions {
-    grade: DeploymentGrade,
     /// Outbound agent delegation capabilities (`a2a_agent_delegation`,
     /// `agent_handoff`). Experimental: auto-enabled in dev, off in prod by
     /// default. When off, the capabilities are not registered at all.
@@ -91,16 +90,18 @@ impl ExecutionFeatureDecisions {
         Self {
             agent_delegation: experimental_flag("FEATURE_AGENT_DELEGATION", &grade),
             internal: InternalFeatureFlags::from_env(),
-            grade,
         }
     }
 
     /// Whether a registration-time feature gate is enabled.
     ///
     /// Internal infrastructure flags win; any other name resolves via the
-    /// experimental `FEATURE_<NAME>` env rule (explicit env var beats the
-    /// grade's experimental default), matching the platform's system-level
-    /// resolution for experimental product flags. Used by
+    /// standard `FEATURE_<NAME>` env rule: enabled only by an explicit env
+    /// var, never by the grade's experimental default. Registration gates
+    /// control real side effects (e.g. the `machine_payments` gate on the
+    /// payments capability, where spend is irreversible), so an unknown gate
+    /// must fail closed even in dev — the pre-EVE-878 flag catalog classified
+    /// `machine_payments` as standard/off, and this preserves that. Used by
     /// `IntegrationPlugin::feature_flag` gating.
     pub fn is_enabled(&self, flag: &str) -> bool {
         match flag {
@@ -110,7 +111,7 @@ impl ExecutionFeatureDecisions {
             "agent_delegation" => self.agent_delegation,
             _ => {
                 let env_var = format!("FEATURE_{}", flag.to_ascii_uppercase());
-                experimental_flag(&env_var, &self.grade)
+                standard_flag(&env_var, false)
             }
         }
     }
@@ -274,17 +275,21 @@ mod tests {
     }
 
     #[test]
-    fn test_decisions_resolve_product_flags_via_experimental_env_rule() {
+    fn test_decisions_resolve_unknown_gates_via_standard_env_rule() {
         let _lock = lock_env();
-        unsafe { std::env::remove_var("FEATURE_VOICE") };
+        // Registration gates fail closed without an explicit env var, in every
+        // grade — a payments-style gate must not auto-enable in dev.
+        unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
         let dev = ExecutionFeatureDecisions::from_env(DeploymentGrade::Dev);
-        assert!(dev.is_enabled("voice"));
+        assert!(!dev.is_enabled("machine_payments"));
         let prod = ExecutionFeatureDecisions::from_env(DeploymentGrade::Prod);
-        assert!(!prod.is_enabled("voice"));
+        assert!(!prod.is_enabled("machine_payments"));
 
-        unsafe { std::env::set_var("FEATURE_VOICE", "true") };
+        unsafe { std::env::set_var("FEATURE_MACHINE_PAYMENTS", "true") };
+        let dev = ExecutionFeatureDecisions::from_env(DeploymentGrade::Dev);
+        assert!(dev.is_enabled("machine_payments"));
         let prod = ExecutionFeatureDecisions::from_env(DeploymentGrade::Prod);
-        assert!(prod.is_enabled("voice"));
-        unsafe { std::env::remove_var("FEATURE_VOICE") };
+        assert!(prod.is_enabled("machine_payments"));
+        unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
     }
 }

--- a/crates/core/tests/no_platform_dependency.rs
+++ b/crates/core/tests/no_platform_dependency.rs
@@ -15,8 +15,33 @@ fn core_manifest_has_no_edge_to_platform() {
         .unwrap_or_else(|e| panic!("read {}: {e}", manifest_path.display()));
 
     assert!(
-        !manifest.contains("everruns-platform"),
+        !declares_platform_edge(&manifest),
         "everruns-core must not depend on everruns-platform \
          (allowed direction is platform -> core)"
     );
+}
+
+/// Whether the manifest *declares* a dependency on `everruns-platform`.
+///
+/// Comments are stripped first: prose that merely names the crate — such as a
+/// note recording where a module moved — documents the boundary rather than
+/// crossing it, and must not fail the build.
+fn declares_platform_edge(manifest: &str) -> bool {
+    manifest
+        .lines()
+        .map(|line| line.split_once('#').map_or(line, |(code, _)| code))
+        .any(|code| code.contains("everruns-platform"))
+}
+
+#[test]
+fn comments_naming_the_crate_are_not_edges() {
+    assert!(!declares_platform_edge(
+        "# email senders moved out of core (everruns-mcp, everruns-platform)\nserde = \"1\"\n"
+    ));
+    assert!(declares_platform_edge(
+        "everruns-platform = { path = \"../platform\" }"
+    ));
+    assert!(declares_platform_edge(
+        "everruns-platform = { path = \"../platform\" } # still an edge"
+    ));
 }


### PR DESCRIPTION
Two independent CI blockers, both surfaced by #3120 but neither caused by it.

## 1. Registration gates stopped failing closed

When feature management moved to platform (#3118), core's `ExecutionFeatureDecisions::is_enabled` resolved unknown gate names through the **experimental** rule, which auto-enables in dev when no env var is set. `IntegrationPlugin::feature_flag` gating runs through that path, so the payments capability — gated on `machine_payments`, deliberately classified standard/off precisely because spend is irreversible — began registering by default in dev. `payments_capability_disabled_by_default` caught it.

Unknown registration gates now resolve via the standard rule: enabled only by an explicit `FEATURE_<NAME>` env var, never by deployment grade. Registration gates control real side effects, so the default must be off.

**Why main didn't catch it:** the job running that assertion is path-filtered to `integrations/parallel/**`, and #3118 only touched core, so it never ran. The regression sat latent on main until #3120 touched those crates. The replacement test lives in core's always-on unit suite (`test_decisions_resolve_unknown_gates_via_standard_env_rule`), asserting a payments-style gate stays off in both dev and prod without an env var — so path filters can't hide a recurrence.

Also drops the now-unread `grade` field from `ExecutionFeatureDecisions` (dead-code lint) and corrects the `feature_flag` doc comment, which still described the old both-catalogs behavior.

## 2. Dependency guard matched comments

`core_manifest_has_no_edge_to_platform` substring-matched the entire manifest text, so a comment naming `everruns-platform` failed the build with no dependency edge present — which is exactly what EVE-879's note recording where the email senders moved does. Documenting a boundary is not crossing it. The guard now strips comments before matching, with a unit test pinning the distinction (comment → allowed; declaration, with or without a trailing comment → rejected).

## Testing

`just pre-push` green (17/17), including all five isolation guards. `everruns-core` unit tests and `everruns-integrations-parallel --test plugin_registration` (9/9, previously 8/9) pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_