### PR TITLE
refactor(capabilities): move session-service capabilities out of the kernel

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -94,10 +94,6 @@ mod infinity_context;
 mod openrouter_server_tools;
 #[cfg(feature = "ui-capabilities")]
 mod openui;
-mod session;
-mod session_sandbox;
-mod session_sql_database;
-mod session_storage;
 mod skills;
 mod skills_scoped;
 mod tool_approval;
@@ -141,23 +137,6 @@ pub use openrouter_server_tools::{
 };
 #[cfg(feature = "ui-capabilities")]
 pub use openui::{OPENUI_CAPABILITY_ID, OpenUiCapability};
-pub use session::{
-    GetSessionInfoTool, SESSION_CAPABILITY_ID, SessionCapability, SessionCapabilityConfig,
-    SessionTitleMutation, WriteSessionTitleTool, session_title_updated_event,
-    update_session_title_with_event,
-};
-pub use session_sandbox::{
-    SESSION_SANDBOX_CAPABILITY_ID, SandboxExecTool, SandboxManageTool, SandboxReadFileTool,
-    SandboxStatusTool, SandboxWriteFileTool, SessionSandboxCapability,
-};
-pub use session_sql_database::{
-    SESSION_SQL_DATABASE_CAPABILITY_ID, SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool,
-    SqlSchemaTool,
-};
-pub use session_storage::{
-    KvStoreTool, SESSION_STORAGE_CAPABILITY_ID, SecretStoreTool, SessionStorageCapability,
-    is_internal_session_kv_key, is_internal_session_secret_name,
-};
 pub use skills::{SKILLS_CAPABILITY_ID, SkillsCapability};
 pub use skills_scoped::{
     ScopedSkillsCapability, SkillDirResolver, SkillScope, SkillsConfig, VfsSkillDirResolver,
@@ -1240,8 +1219,6 @@ impl CapabilityRegistry {
         let mut registry = Self::new();
 
         registry.register(HumanIntentCapability);
-        registry.register(SessionStorageCapability);
-        registry.register(SessionCapability);
         registry.register(InfinityContextCapability);
         registry.register(SkillsCapability);
 
@@ -1258,9 +1235,6 @@ impl CapabilityRegistry {
         // Core capabilities (all environments)
         registry.register(HumanIntentCapability);
         registry.register(OpenRouterServerToolsCapability);
-        registry.register(SessionStorageCapability);
-        registry.register(SessionCapability);
-        registry.register(SessionSqlDatabaseCapability);
         registry.register(InfinityContextCapability);
 
         // Skills (filesystem-based discovery + activation, all environments)
@@ -1284,9 +1258,7 @@ impl CapabilityRegistry {
 
         // External integration plugins (registered via inventory::submit! in integration crates)
         let internal_flags = &feature_decisions.internal;
-        if internal_flags.session_sandbox {
-            registry.register(SessionSandboxCapability);
-        }
+        if internal_flags.session_sandbox {}
 
         for plugin in inventory::iter::<IntegrationPlugin>() {
             if (!plugin.experimental_only || grade.experimental_features_enabled())
@@ -2974,6 +2946,27 @@ mod tests {
         }
     }
 
+    /// Stands in for the product `session_storage` capability, which moved to
+    /// `everruns-platform` with the other service-backed families (EVE-886).
+    /// Feature computation is core's mechanism, so it is exercised here against
+    /// a fixture rather than a product implementation.
+    struct StorageFixture;
+
+    impl Capability for StorageFixture {
+        fn id(&self) -> &str {
+            "session_storage"
+        }
+        fn name(&self) -> &str {
+            "Fixture Storage"
+        }
+        fn description(&self) -> &str {
+            "Fixture session storage capability."
+        }
+        fn features(&self) -> Vec<&'static str> {
+            vec!["secrets", "key_value"]
+        }
+    }
+
     struct BashFixture;
 
     impl Capability for BashFixture {
@@ -3185,6 +3178,7 @@ mod tests {
         registry.register(WeatherFixture);
         registry.register(SampleDataFixture);
         registry.register(FileSystemFixture);
+        registry.register(StorageFixture);
         registry.register(BashFixture);
         registry.register(WebFetchFixture);
         registry.register(DynamicFactFixture);
@@ -3227,9 +3221,6 @@ mod tests {
     fn expected_core_builtin_ids() -> BTreeSet<&'static str> {
         let mut ids = [
             "human_intent",
-            "session_storage",
-            "session",
-            "session_sql_database",
             "infinity_context",
             "skills",
             "openrouter_server_tools",
@@ -3245,15 +3236,9 @@ mod tests {
 
     /// Capabilities present in the default in-process runtime registry.
     fn expected_runtime_builtin_ids() -> BTreeSet<&'static str> {
-        [
-            "human_intent",
-            "session_storage",
-            "session",
-            "infinity_context",
-            "skills",
-        ]
-        .into_iter()
-        .collect::<BTreeSet<_>>()
+        ["human_intent", "infinity_context", "skills"]
+            .into_iter()
+            .collect::<BTreeSet<_>>()
     }
 
     fn registry_ids(registry: &CapabilityRegistry) -> BTreeSet<&str> {
@@ -3315,7 +3300,13 @@ mod tests {
             "session_schedule",
             "subagents",
             "background_execution",
+            // Session-service capabilities moved to the product crate with the
+            // rest of the service-backed families (EVE-886); hosts that can
+            // serve them compose them back in.
+            "session",
+            "session_storage",
             "session_sql_database",
+            "session_sandbox",
             "knowledge_base",
             "knowledge_index",
             "data_knowledge",
@@ -3588,11 +3579,14 @@ mod tests {
 
     #[test]
     fn test_capability_icons_and_categories() {
+        // `session` used to stand in here; it moved to the product crate with
+        // the service-backed families (EVE-886). Icons and categories are a
+        // kernel-owned projection, so a kernel capability covers it.
         let registry = CapabilityRegistry::with_builtins();
 
-        let session = registry.get("session").unwrap();
-        assert_eq!(session.icon(), Some("panel-left"));
-        assert_eq!(session.category(), Some("Session"));
+        let skills = registry.get("skills").unwrap();
+        assert_eq!(skills.icon(), SkillsCapability.icon());
+        assert_eq!(skills.category(), SkillsCapability.category());
     }
 
     #[test]
@@ -5160,21 +5154,18 @@ mod tests {
     }
 
     #[test]
-    fn test_session_storage_capability_features() {
+    fn kernel_capability_features_are_declared_on_the_capability() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let storage = registry.get("session_storage").unwrap();
-        let features = storage.features();
-        assert!(features.contains(&"secrets"));
-        assert!(features.contains(&"key_value"));
-    }
-
-    #[test]
-    fn test_session_sql_database_capability_features() {
-        let registry = CapabilityRegistry::with_builtins();
-
-        let sql = registry.get("session_sql_database").unwrap();
-        assert_eq!(sql.features(), vec!["sql_database"]);
+        // `session_storage`/`session_sql_database` moved to the product crate
+        // (EVE-886); their feature declarations are covered there. What core
+        // owns is the mechanism: a registered capability's `features()` is what
+        // `compute_features` reports.
+        let skills = registry.get("skills").expect("skills is kernel-owned");
+        assert_eq!(
+            compute_features(&["skills".to_string()], &registry),
+            skills.features()
+        );
     }
 
     #[test]
@@ -5197,8 +5188,8 @@ mod tests {
     fn test_compute_features_single_capability() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let features = compute_features(&["session_storage".to_string()], &registry);
-        assert_eq!(features, vec!["secrets", "key_value"]);
+        let features = compute_features(&["skills".to_string()], &registry);
+        assert_eq!(features, registry.get("skills").expect("skills").features());
     }
 
     #[test]
@@ -5263,7 +5254,7 @@ mod tests {
 
     #[test]
     fn test_compute_features_unknown_capability_ignored() {
-        let registry = CapabilityRegistry::with_builtins();
+        let registry = fixture_registry();
 
         let features = compute_features(
             &["unknown_cap".to_string(), "session_storage".to_string()],

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1257,9 +1257,6 @@ impl CapabilityRegistry {
         // explicitly by tests and examples, never by product registries.
 
         // External integration plugins (registered via inventory::submit! in integration crates)
-        let internal_flags = &feature_decisions.internal;
-        if internal_flags.session_sandbox {}
-
         for plugin in inventory::iter::<IntegrationPlugin>() {
             if (!plugin.experimental_only || grade.experimental_features_enabled())
                 && plugin

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -445,10 +445,29 @@ mod tests {
 
     #[test]
     fn test_from_core_populates_features() {
+        /// Declares features the way the product capabilities do. The ones that
+        /// used to stand in here (`session_storage`) moved out of the kernel
+        /// (EVE-886); what this test covers is the projection.
+        struct FeatureCapability;
+
+        impl crate::capabilities::Capability for FeatureCapability {
+            fn id(&self) -> &str {
+                "feature_fixture"
+            }
+            fn name(&self) -> &str {
+                "Feature Fixture"
+            }
+            fn description(&self) -> &str {
+                "Fixture capability declaring features."
+            }
+            fn features(&self) -> Vec<&'static str> {
+                vec!["secrets", "key_value"]
+            }
+        }
+
         let registry = crate::capabilities::CapabilityRegistry::with_builtins();
 
-        let storage_cap = registry.get("session_storage").unwrap();
-        let info = CapabilityInfo::from_core(storage_cap.as_ref());
+        let info = CapabilityInfo::from_core(&FeatureCapability);
         assert!(info.features.contains(&"secrets".to_string()));
         assert!(info.features.contains(&"key_value".to_string()));
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -395,19 +395,16 @@ pub use capabilities::SystemPromptContext;
 pub use capabilities::{
     AgentBlueprint, AgentCapabilityConfig, AppliedCapabilities, BlueprintModel, Capability,
     CapabilityId, CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus,
-    CollectedCapabilities, DECLARATIVE_CAPABILITY_PREFIX, DependencyError, GetSessionInfoTool,
+    CollectedCapabilities, DECLARATIVE_CAPABILITY_PREFIX, DependencyError,
     HUMAN_INTENT_CAPABILITY_ID, HumanIntentCapability, INFINITY_CONTEXT_CAPABILITY_ID,
     InfinityContextCapability, IntegrationPlugin, MAX_RESOLVED_CAPABILITIES, MountAccess,
     MountDirectoryBuilder, MountEntry, MountPoint, MountSource, QueryHistoryTool,
-    ResolvedCapabilities, RiskLevel, SessionCapability, SessionCapabilityConfig,
-    SessionSandboxCapability, SessionSqlDatabaseCapability, SessionTitleMutation, SqlExecuteTool,
-    SqlQueryTool, SqlSchemaTool, ToolCallHook, ToolDefinitionHook, WriteSessionTitleTool,
-    apply_capabilities, collect_capabilities, collect_capabilities_with_configs, compute_features,
+    ResolvedCapabilities, RiskLevel, ToolCallHook, ToolDefinitionHook, apply_capabilities,
+    collect_capabilities, collect_capabilities_with_configs, compute_features,
     declarative_capability_id, declarative_capability_info, get_dependencies,
     hydrate_declarative_capability_config, hydrate_plugin_capability_config,
     is_declarative_capability, parse_declarative_capability_id, plugin_capability_info,
-    resolve_dependencies, session_title_updated_event, update_session_title_with_event,
-    validate_declarative_capability_definition,
+    resolve_dependencies, validate_declarative_capability_definition,
 };
 pub use capabilities::{
     AttachSkillCapability, SKILL_CAPABILITY_PREFIX, SKILLS_CAPABILITY_ID, SKILLS_DISCOVERY_PATH,

--- a/crates/host/src/capabilities.rs
+++ b/crates/host/src/capabilities.rs
@@ -29,8 +29,31 @@ pub fn runtime_capability_registry() -> CapabilityRegistry {
 /// environment composition as [`runtime_capability_registry`]. Existing
 /// registrations retain the registry's normal duplicate handling.
 pub fn compose_runtime_capability_registry(mut registry: CapabilityRegistry) -> CapabilityRegistry {
+    register_session_service_capabilities(&mut registry);
     register_selected_integrations(&mut registry);
     registry
+}
+
+/// Register the session-service capabilities an in-process host can serve.
+///
+/// `session` and `session_storage` moved to the product crate with the rest of
+/// the service-backed families (EVE-886), but the default in-process runtime
+/// supplies both services, so the Framework keeps advertising them. The SQL and
+/// sandbox capabilities need backends this host does not provide and stay with
+/// product composition.
+fn register_session_service_capabilities(registry: &mut CapabilityRegistry) {
+    if registry
+        .get(everruns_platform::capabilities::SESSION_CAPABILITY_ID)
+        .is_none()
+    {
+        registry.register(everruns_platform::capabilities::SessionCapability);
+    }
+    if registry
+        .get(everruns_platform::capabilities::SESSION_STORAGE_CAPABILITY_ID)
+        .is_none()
+    {
+        registry.register(everruns_platform::capabilities::SessionStorageCapability);
+    }
 }
 
 /// Return the egress service matching the selected host integrations.

--- a/crates/llm-tests/tests/tool_search_test.rs
+++ b/crates/llm-tests/tests/tool_search_test.rs
@@ -23,10 +23,10 @@ use everruns_builtins::{
     OpenAiToolSearchCapability, StatelessTodoListCapability, TOOL_SEARCH_TOOL_NAME,
     ToolSearchCapability,
 };
-use everruns_core::capabilities::SessionCapability;
 use everruns_core::events::{EventData, LLM_GENERATION};
 use everruns_integrations_bashkit::BashkitShellCapability;
 use everruns_integrations_filesystem::FileSystemCapability;
+use everruns_platform::capabilities::SessionCapability;
 use everruns_test_support::in_memory_loop::InMemoryAgenticLoop;
 
 async fn assert_hosted_tool_search_was_enabled(runner: &InMemoryAgenticLoop) {

--- a/crates/platform/src/capabilities/mod.rs
+++ b/crates/platform/src/capabilities/mod.rs
@@ -19,7 +19,11 @@ pub mod monitors;
 pub mod platform;
 pub mod platform_management;
 pub mod research;
+pub mod session;
+pub mod session_sandbox;
 pub mod session_schedule;
+pub mod session_sql_database;
+pub mod session_storage;
 pub mod session_tasks;
 pub mod subagents;
 pub mod user_hooks;
@@ -73,9 +77,26 @@ pub use platform_management::{
     ReadSessionsTool, SessionReadMessagesTool, SessionReadResponseTool, SessionSendMessageTool,
 };
 pub use research::{RESEARCH_CAPABILITY_ID, ResearchCapability};
+pub use session::{
+    GetSessionInfoTool, SESSION_CAPABILITY_ID, SessionCapability, SessionCapabilityConfig,
+    SessionTitleMutation, WriteSessionTitleTool, session_title_updated_event,
+    update_session_title_with_event,
+};
+pub use session_sandbox::{
+    SESSION_SANDBOX_CAPABILITY_ID, SandboxExecTool, SandboxManageTool, SandboxReadFileTool,
+    SandboxStatusTool, SandboxWriteFileTool, SessionSandboxCapability,
+};
 pub use session_schedule::{
     CancelScheduleTool, CreateScheduleTool, ListSchedulesTool, SESSION_SCHEDULE_CAPABILITY_ID,
     SessionScheduleCapability,
+};
+pub use session_sql_database::{
+    SESSION_SQL_DATABASE_CAPABILITY_ID, SessionSqlDatabaseCapability, SqlExecuteTool, SqlQueryTool,
+    SqlSchemaTool,
+};
+pub use session_storage::{
+    KvStoreTool, SESSION_STORAGE_CAPABILITY_ID, SecretStoreTool, SessionStorageCapability,
+    is_internal_session_kv_key, is_internal_session_secret_name,
 };
 pub use session_tasks::{SESSION_TASKS_CAPABILITY_ID, SessionTasksCapability};
 pub use subagents::{
@@ -121,6 +142,16 @@ pub fn register_hosted_capabilities(
     registry: &mut everruns_core::capabilities::CapabilityRegistry,
     grade: everruns_core::DeploymentGrade,
 ) {
+    // Session-service capabilities (EVE-886): every one needs a host service —
+    // a session store, session key/value + secret storage, a SQL database, or a
+    // sandbox provider — so they are composed here rather than shipped by the
+    // kernel.
+    registry.register(SessionCapability);
+    registry.register(SessionStorageCapability);
+    registry.register(SessionSqlDatabaseCapability);
+    if everruns_core::InternalFeatureFlags::from_env().session_sandbox {
+        registry.register(SessionSandboxCapability);
+    }
     registry.register(ResearchCapability);
     registry.register(MemoryCapability);
     registry.register(BackgroundExecutionCapability);

--- a/crates/platform/src/capabilities/session.rs
+++ b/crates/platform/src/capabilities/session.rs
@@ -4,15 +4,15 @@
 //! - `write_session_title`: update session title
 //! - `get_session_info`: return session id, title, agent name, and cumulative usage
 
-use super::{Capability, CapabilityLocalization, CapabilityStatus};
-use crate::error::{AgentLoopError, Result};
-use crate::events::{EventContext, EventRequest, SessionTitleUpdatedData, TokenUsage};
-use crate::session::ExecutionSession;
-use crate::tool_types::ToolHints;
-use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::{EventEmitter, SessionMutator, SessionStore, ToolContext};
-use crate::typed_id::SessionId;
 use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::events::{EventContext, EventRequest, SessionTitleUpdatedData, TokenUsage};
+use everruns_core::session::ExecutionSession;
+use everruns_core::tool_types::ToolHints;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::{EventEmitter, SessionMutator, SessionStore, ToolContext};
+use everruns_core::typed_id::SessionId;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -168,7 +168,7 @@ impl Capability for SessionCapability {
 
     async fn system_prompt_contribution_with_config(
         &self,
-        _ctx: &super::SystemPromptContext,
+        _ctx: &everruns_core::capabilities::SystemPromptContext,
         config: &Value,
     ) -> Option<String> {
         if !SessionCapabilityConfig::from_value(config).auto_title {
@@ -196,12 +196,12 @@ pub struct WriteSessionTitleTool;
 impl Tool for WriteSessionTitleTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        Some(crate::tool_narration::narrate_write_session_title(
+        Some(everruns_core::tool_narration::narrate_write_session_title(
             &tool_call.arguments,
             phase,
             locale,
@@ -293,12 +293,12 @@ pub struct GetSessionInfoTool;
 impl Tool for GetSessionInfoTool {
     fn narrate(
         &self,
-        _tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        _tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        Some(crate::tool_narration::narrate_get_session_info(
+        Some(everruns_core::tool_narration::narrate_get_session_info(
             phase, locale,
         ))
     }
@@ -385,12 +385,14 @@ fn usage_json(usage: &TokenUsage) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::AgentDefinition;
-    use crate::events::{Event, EventRequest};
-    use crate::session::{ExecutionSession, SessionExecutionState};
-    use crate::typed_id::{AgentId, EventId, HarnessId, MessageId, ModelId, SessionId, TurnId};
-    use crate::{AgentCapabilityConfig, Tool};
     use async_trait::async_trait;
+    use everruns_core::AgentDefinition;
+    use everruns_core::events::{Event, EventRequest};
+    use everruns_core::session::{ExecutionSession, SessionExecutionState};
+    use everruns_core::typed_id::{
+        AgentId, EventId, HarnessId, MessageId, ModelId, SessionId, TurnId,
+    };
+    use everruns_core::{AgentCapabilityConfig, Tool};
     use std::sync::{Arc, Mutex};
 
     #[derive(Clone)]
@@ -399,7 +401,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl crate::traits::SessionStore for MockSessionStore {
+    impl everruns_core::traits::SessionStore for MockSessionStore {
         async fn get_session(&self, _session_id: SessionId) -> Result<Option<ExecutionSession>> {
             Ok(self.session.lock().expect("poisoned").clone())
         }
@@ -411,7 +413,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl crate::traits::SessionMutator for MockSessionMutator {
+    impl everruns_core::traits::SessionMutator for MockSessionMutator {
         async fn update_session_title(
             &self,
             _session_id: SessionId,
@@ -433,7 +435,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl crate::traits::EventEmitter for RecordingEventEmitter {
+    impl everruns_core::traits::EventEmitter for RecordingEventEmitter {
         async fn emit(&self, request: EventRequest) -> Result<Event> {
             self.requests
                 .lock()
@@ -444,7 +446,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl crate::traits::AgentStore for MockAgentStore {
+    impl everruns_core::traits::AgentStore for MockAgentStore {
         async fn get_agent(&self, _agent_id: AgentId) -> Result<Option<AgentDefinition>> {
             Ok(self.agent.clone())
         }
@@ -462,8 +464,8 @@ mod tests {
 
     #[test]
     fn session_tools_narrate_all_phases() {
-        use crate::tool_narration::{ToolNarrationContext, ToolNarrationPhase};
-        use crate::tool_types::ToolCall;
+        use everruns_core::tool_narration::{ToolNarrationContext, ToolNarrationPhase};
+        use everruns_core::tool_types::ToolCall;
 
         let ctx = ToolNarrationContext::default();
         let title_call = ToolCall {
@@ -540,11 +542,14 @@ mod tests {
 
         let requests = emitter.requests.lock().expect("poisoned");
         assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].event_type, crate::events::SESSION_TITLE_UPDATED);
+        assert_eq!(
+            requests[0].event_type,
+            everruns_core::events::SESSION_TITLE_UPDATED
+        );
         assert_eq!(requests[0].context.turn_id, Some(turn_id));
         assert_eq!(requests[0].context.input_message_id, Some(input_message_id));
         match &requests[0].data {
-            crate::events::EventData::SessionTitleUpdated(data) => {
+            everruns_core::events::EventData::SessionTitleUpdated(data) => {
                 assert_eq!(data.previous_title.as_deref(), Some("Old title"));
                 assert_eq!(data.title, "New title");
             }
@@ -580,7 +585,8 @@ mod tests {
     #[tokio::test]
     async fn auto_title_policy_is_opt_in_and_mandatory_when_enabled() {
         let capability = SessionCapability;
-        let ctx = super::super::SystemPromptContext::without_file_store(SessionId::new());
+        let ctx =
+            everruns_core::capabilities::SystemPromptContext::without_file_store(SessionId::new());
 
         assert!(
             capability

--- a/crates/platform/src/capabilities/session_sandbox.rs
+++ b/crates/platform/src/capabilities/session_sandbox.rs
@@ -814,7 +814,7 @@ impl Tool for SandboxManageTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::capabilities::{Capability, CapabilityRegistry};
+    use everruns_core::capabilities::Capability;
     use everruns_core::deployment::DeploymentGrade;
     use everruns_core::traits::ToolContext;
 

--- a/crates/platform/src/capabilities/session_sandbox.rs
+++ b/crates/platform/src/capabilities/session_sandbox.rs
@@ -3,20 +3,20 @@
 //! One managed sandbox per session. The concrete provider is chosen by config
 //! (`provider: "daytona"` initially), while the tool surface stays stable.
 
-use super::{Capability, CapabilityLocalization, CapabilityStatus};
-pub use crate::session_sandbox::SESSION_SANDBOX_CAPABILITY_ID;
-use crate::session_sandbox::{
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
+pub use everruns_core::session_sandbox::SESSION_SANDBOX_CAPABILITY_ID;
+use everruns_core::session_sandbox::{
     DEFAULT_SESSION_SANDBOX_IDLE_TIMEOUT_SECS, SessionSandboxConfig, checkpoint_session_sandbox,
     create_session_sandbox_provider, delete_session_sandbox, ensure_session_sandbox_running,
     load_session_sandbox_state, pause_session_sandbox, session_sandbox_tool_hints,
 };
-use crate::tool_output_sanitizer::{
+use everruns_core::tool_output_sanitizer::{
     READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
 };
-use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::ToolContext;
-use crate::truncation_info::TruncationInfo;
-use async_trait::async_trait;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use everruns_core::truncation_info::TruncationInfo;
 use serde_json::{Value, json};
 
 pub struct SessionSandboxCapability;
@@ -195,7 +195,7 @@ fn parse_config(config: &Value) -> Result<SessionSandboxConfig, ToolExecutionRes
 
 fn provider_for_config(
     config: &SessionSandboxConfig,
-) -> Result<Box<dyn crate::SessionSandboxProvider>, ToolExecutionResult> {
+) -> Result<Box<dyn everruns_core::SessionSandboxProvider>, ToolExecutionResult> {
     create_session_sandbox_provider(&config.provider).ok_or_else(|| {
         ToolExecutionResult::tool_error(format!(
             "Session sandbox provider '{}' is not registered",
@@ -205,7 +205,7 @@ fn provider_for_config(
 }
 
 fn build_sandbox_exec_result(
-    response: crate::SessionSandboxExecResponse,
+    response: everruns_core::SessionSandboxExecResponse,
     cwd: Option<&str>,
 ) -> ToolExecutionResult {
     let mut result = json!({
@@ -229,7 +229,7 @@ fn build_sandbox_exec_result(
 }
 
 fn build_sandbox_read_file_result(
-    response: crate::SessionSandboxReadFileResponse,
+    response: everruns_core::SessionSandboxReadFileResponse,
     offset: usize,
     limit: usize,
 ) -> ToolExecutionResult {
@@ -270,13 +270,13 @@ impl SandboxExecTool {
 impl Tool for SandboxExecTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Sandbox");
-        Some(crate::tool_narration::narrate_shell_exec(
+        Some(everruns_core::tool_narration::narrate_shell_exec(
             &tool_call.arguments,
             fallback,
             phase,
@@ -299,14 +299,14 @@ impl Tool for SandboxExecTool {
                 "command": { "type": "string", "description": "Shell command to execute" },
                 "cwd": { "type": "string", "description": "Optional working directory inside the sandbox" },
                 "timeout_ms": { "type": "integer", "minimum": 1, "description": "Optional execution timeout in milliseconds" },
-                "output": crate::tool_output_sanitizer::output_verbosity_schema()
+                "output": everruns_core::tool_output_sanitizer::output_verbosity_schema()
             },
             "required": ["command"],
             "additionalProperties": false
         })
     }
 
-    fn hints(&self) -> crate::ToolHints {
+    fn hints(&self) -> everruns_core::ToolHints {
         session_sandbox_tool_hints()
     }
 
@@ -353,7 +353,7 @@ impl Tool for SandboxExecTool {
                 context,
                 &config,
                 &state.instance,
-                &crate::SessionSandboxExecRequest {
+                &everruns_core::SessionSandboxExecRequest {
                     command: command.to_string(),
                     cwd: arguments
                         .get("cwd")
@@ -404,12 +404,12 @@ impl SandboxReadFileTool {
 impl Tool for SandboxReadFileTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        Some(crate::tool_narration::narrate_read_file(
+        Some(everruns_core::tool_narration::narrate_read_file(
             &tool_call.arguments,
             phase,
             locale,
@@ -447,7 +447,7 @@ impl Tool for SandboxReadFileTool {
         })
     }
 
-    fn hints(&self) -> crate::ToolHints {
+    fn hints(&self) -> everruns_core::ToolHints {
         session_sandbox_tool_hints().with_readonly(true)
     }
 
@@ -511,12 +511,12 @@ impl SandboxWriteFileTool {
 impl Tool for SandboxWriteFileTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        Some(crate::tool_narration::narrate_write_file(
+        Some(everruns_core::tool_narration::narrate_write_file(
             &tool_call.arguments,
             phase,
             locale,
@@ -543,7 +543,7 @@ impl Tool for SandboxWriteFileTool {
         })
     }
 
-    fn hints(&self) -> crate::ToolHints {
+    fn hints(&self) -> everruns_core::ToolHints {
         session_sandbox_tool_hints()
     }
 
@@ -617,12 +617,14 @@ impl SandboxStatusTool {
 impl Tool for SandboxStatusTool {
     fn narrate(
         &self,
-        _tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        _tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        Some(crate::tool_narration::narrate_sandbox_status(phase, locale))
+        Some(everruns_core::tool_narration::narrate_sandbox_status(
+            phase, locale,
+        ))
     }
 
     fn name(&self) -> &str {
@@ -641,7 +643,7 @@ impl Tool for SandboxStatusTool {
         })
     }
 
-    fn hints(&self) -> crate::ToolHints {
+    fn hints(&self) -> everruns_core::ToolHints {
         session_sandbox_tool_hints()
             .with_readonly(true)
             .with_idempotent(true)
@@ -710,12 +712,12 @@ impl SandboxManageTool {
 impl Tool for SandboxManageTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        Some(crate::tool_narration::narrate_sandbox_manage(
+        Some(everruns_core::tool_narration::narrate_sandbox_manage(
             &tool_call.arguments,
             phase,
             locale,
@@ -745,7 +747,7 @@ impl Tool for SandboxManageTool {
         })
     }
 
-    fn hints(&self) -> crate::ToolHints {
+    fn hints(&self) -> everruns_core::ToolHints {
         session_sandbox_tool_hints().with_destructive(true)
     }
 
@@ -812,9 +814,9 @@ impl Tool for SandboxManageTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::capabilities::{Capability, CapabilityRegistry};
-    use crate::deployment::DeploymentGrade;
-    use crate::traits::ToolContext;
+    use everruns_core::capabilities::{Capability, CapabilityRegistry};
+    use everruns_core::deployment::DeploymentGrade;
+    use everruns_core::traits::ToolContext;
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -902,13 +904,17 @@ mod tests {
 
     #[test]
     fn session_sandbox_registry_is_flag_gated() {
+        // The gate moved with the capability (EVE-886): product composition
+        // decides, the kernel preset no longer carries it either way.
         let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_SESSION_SANDBOX") };
-        let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+        let registry =
+            crate::capabilities::hosted_capability_registry_for_grade(DeploymentGrade::Dev);
         assert!(!registry.has("session_sandbox"));
 
         unsafe { std::env::set_var("FEATURE_SESSION_SANDBOX", "true") };
-        let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+        let registry =
+            crate::capabilities::hosted_capability_registry_for_grade(DeploymentGrade::Dev);
         assert!(registry.has("session_sandbox"));
         unsafe { std::env::remove_var("FEATURE_SESSION_SANDBOX") };
     }
@@ -916,7 +922,7 @@ mod tests {
     #[tokio::test]
     async fn sandbox_exec_rejects_zero_timeout() {
         let tool = SandboxExecTool::new(json!({ "provider": "missing-provider" }));
-        let context = ToolContext::new(crate::typed_id::SessionId::new());
+        let context = ToolContext::new(everruns_core::typed_id::SessionId::new());
 
         let result = tool
             .execute_with_context(
@@ -939,7 +945,7 @@ mod tests {
     #[test]
     fn sandbox_exec_result_preserves_absent_raw_output() {
         let result = build_sandbox_exec_result(
-            crate::SessionSandboxExecResponse {
+            everruns_core::SessionSandboxExecResponse {
                 exit_code: 0,
                 stdout: "ok".to_string(),
                 stderr: String::new(),
@@ -960,7 +966,7 @@ mod tests {
     #[test]
     fn sandbox_exec_result_keeps_raw_output_sidecar_when_present() {
         let result = build_sandbox_exec_result(
-            crate::SessionSandboxExecResponse {
+            everruns_core::SessionSandboxExecResponse {
                 exit_code: 17,
                 stdout: "trimmed".to_string(),
                 stderr: "warn".to_string(),
@@ -984,7 +990,7 @@ mod tests {
     #[test]
     fn sandbox_read_file_result_applies_line_window() {
         let result = build_sandbox_read_file_result(
-            crate::SessionSandboxReadFileResponse {
+            everruns_core::SessionSandboxReadFileResponse {
                 path: "/workspace/src/lib.rs".to_string(),
                 content: "alpha\nbeta\ngamma\ndelta".to_string(),
                 encoding: "text".to_string(),
@@ -1013,7 +1019,7 @@ mod tests {
     #[test]
     fn sandbox_read_file_result_marks_untruncated_window() {
         let result = build_sandbox_read_file_result(
-            crate::SessionSandboxReadFileResponse {
+            everruns_core::SessionSandboxReadFileResponse {
                 path: "/workspace/src/lib.rs".to_string(),
                 content: "alpha\nbeta".to_string(),
                 encoding: "text".to_string(),

--- a/crates/platform/src/capabilities/session_sql_database.rs
+++ b/crates/platform/src/capabilities/session_sql_database.rs
@@ -5,13 +5,13 @@
 // - sql_query: Read-only SELECT queries returning columns + rows as JSON.
 // - sql_schema: Introspect database schema (tables, columns, types).
 
-use super::{Capability, CapabilityLocalization, CapabilityStatus};
-use crate::session_sqldb::SessionSqlDbError;
-use crate::tool_types::ToolHints;
-use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::ToolContext;
-use crate::truncation_info::{TruncationInfo, TruncationReason};
 use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
+use everruns_core::session_sqldb::SessionSqlDbError;
+use everruns_core::tool_types::ToolHints;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use everruns_core::truncation_info::{TruncationInfo, TruncationReason};
 use serde_json::{Value, json};
 
 pub const SESSION_SQL_DATABASE_CAPABILITY_ID: &str = "session_sql_database";
@@ -132,12 +132,12 @@ pub struct SqlExecuteTool;
 impl Tool for SqlExecuteTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        crate::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
+        everruns_core::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
     }
 
     fn name(&self) -> &str {
@@ -235,12 +235,12 @@ pub struct SqlQueryTool;
 impl Tool for SqlQueryTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        crate::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
+        everruns_core::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
     }
 
     fn name(&self) -> &str {
@@ -341,12 +341,12 @@ pub struct SqlSchemaTool;
 impl Tool for SqlSchemaTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        crate::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
+        everruns_core::tool_narration::narrate_sql(self.name(), &tool_call.arguments, phase, locale)
     }
 
     fn name(&self) -> &str {
@@ -450,7 +450,7 @@ impl Tool for SqlSchemaTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::typed_id::SessionId;
+    use everruns_core::typed_id::SessionId;
 
     // Metadata/tool-list constants covered by builtin_capabilities_satisfy_registry_invariants.
 
@@ -513,7 +513,7 @@ mod tests {
         let columns = vec!["id".to_string()];
         let rows = vec![vec![json!(1)], vec![json!(2)]];
         let response = shape_sql_query_response("db", &columns, &rows, 2, false);
-        crate::truncation_info::assert_conforms("sql_query", &response);
+        everruns_core::truncation_info::assert_conforms("sql_query", &response);
         assert_eq!(response["truncation"]["truncated"], false);
     }
 
@@ -522,7 +522,7 @@ mod tests {
         let columns = vec!["id".to_string()];
         let rows = vec![vec![json!(1)]; 1000];
         let response = shape_sql_query_response("db", &columns, &rows, 1000, true);
-        crate::truncation_info::assert_conforms("sql_query", &response);
+        everruns_core::truncation_info::assert_conforms("sql_query", &response);
         assert_eq!(response["truncation"]["truncated"], true);
         assert_eq!(response["truncation"]["reason"], "row_cap");
         assert!(

--- a/crates/platform/src/capabilities/session_storage.rs
+++ b/crates/platform/src/capabilities/session_storage.rs
@@ -7,11 +7,11 @@
 //! - `kv_store`: Key/value storage operations (set, get, delete, list)
 //! - `secret_store`: Encrypted secret storage operations (set, get, delete, list)
 
-use super::{Capability, CapabilityLocalization, CapabilityStatus};
-use crate::tool_types::ToolHints;
-use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::ToolContext;
 use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
+use everruns_core::tool_types::ToolHints;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
 use serde_json::{Value, json};
 
 // Reserve internal KV prefixes from the user-facing kv_store. Reference the
@@ -20,9 +20,9 @@ use serde_json::{Value, json};
 // attachments / discovery cache (`ard_attachment`). Reserving the ARD prefixes
 // stops a session/tool actor forging attachments via kv_store (TM-TOOL/TM-AGENT).
 const INTERNAL_KV_PREFIXES: &[&str] = &[
-    super::AGENT_RUN_KEY_PREFIX,
-    crate::ard_attachment::ARD_ATTACHMENT_KV_PREFIX,
-    crate::ard_attachment::ARD_DISCOVERY_KV_PREFIX,
+    everruns_core::capabilities::AGENT_RUN_KEY_PREFIX,
+    everruns_core::ard_attachment::ARD_ATTACHMENT_KV_PREFIX,
+    everruns_core::ard_attachment::ARD_DISCOVERY_KV_PREFIX,
 ];
 const INTERNAL_SECRET_PREFIXES: &[&str] = &["browserless_internal:", "mcp_oauth:"];
 
@@ -118,13 +118,13 @@ pub struct KvStoreTool;
 impl Tool for KvStoreTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Key-Value Store");
-        Some(crate::tool_narration::narrate_secret_store(
+        Some(everruns_core::tool_narration::narrate_secret_store(
             &tool_call.arguments,
             fallback,
             phase,
@@ -329,13 +329,13 @@ pub struct SecretStoreTool;
 impl Tool for SecretStoreTool {
     fn narrate(
         &self,
-        tool_call: &crate::tool_types::ToolCall,
-        phase: crate::tool_narration::ToolNarrationPhase,
+        tool_call: &everruns_core::tool_types::ToolCall,
+        phase: everruns_core::tool_narration::ToolNarrationPhase,
         locale: Option<&str>,
-        _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        _ctx: everruns_core::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
         let fallback = self.display_name().unwrap_or("Secret Store");
-        Some(crate::tool_narration::narrate_secret_store(
+        Some(everruns_core::tool_narration::narrate_secret_store(
             &tool_call.arguments,
             fallback,
             phase,
@@ -566,9 +566,9 @@ impl Tool for SecretStoreTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::SessionStorageStore;
-    use crate::typed_id::SessionId;
-    use crate::{KeyInfo, Result};
+    use everruns_core::traits::SessionStorageStore;
+    use everruns_core::typed_id::SessionId;
+    use everruns_core::{KeyInfo, Result};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
@@ -578,7 +578,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl crate::traits::SessionStorageStore for TestStorageStore {
+    impl everruns_core::traits::SessionStorageStore for TestStorageStore {
         async fn set_value(&self, _session_id: SessionId, key: &str, value: &str) -> Result<()> {
             self.values
                 .lock()
@@ -627,7 +627,10 @@ mod tests {
             Ok(false)
         }
 
-        async fn list_secrets(&self, _session_id: SessionId) -> Result<Vec<crate::SecretInfo>> {
+        async fn list_secrets(
+            &self,
+            _session_id: SessionId,
+        ) -> Result<Vec<everruns_core::SecretInfo>> {
             Ok(Vec::new())
         }
     }

--- a/crates/platform/tests/prompt_budget.rs
+++ b/crates/platform/tests/prompt_budget.rs
@@ -12,10 +12,10 @@
 // always fine.
 
 use everruns_core::capabilities::{
-    Capability, InfinityContextCapability, SessionSandboxCapability, SkillsCapability,
-    SystemPromptContext,
+    Capability, InfinityContextCapability, SkillsCapability, SystemPromptContext,
 };
 use everruns_core::typed_id::SessionId;
+use everruns_platform::capabilities::SessionSandboxCapability;
 use everruns_platform::capabilities::{
     DataKnowledgeCapability, MemoryCapability, SubagentCapability,
 };

--- a/crates/server/src/domains/session_storage/commands.rs
+++ b/crates/server/src/domains/session_storage/commands.rs
@@ -1,7 +1,9 @@
 use super::queries as q;
 use super::types::{BatchSetSecretsResponse, KeyValueInfo, SecretInfo};
 use crate::domains::common::*;
-use everruns_core::capabilities::{is_internal_session_kv_key, is_internal_session_secret_name};
+use everruns_platform::capabilities::{
+    is_internal_session_kv_key, is_internal_session_secret_name,
+};
 use serde::Deserialize;
 use utoipa::ToSchema;
 

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -15,8 +15,9 @@ use everruns_core::events::{
 use everruns_core::model_profiles::get_model_profile;
 use everruns_core::provider::DriverId;
 use everruns_core::typed_id::{AgentId, MessageId, SessionParticipantId, TurnId};
-use everruns_core::{Message, SessionContextReport, session_title_updated_event};
+use everruns_core::{Message, SessionContextReport};
 use everruns_platform::ANONYMOUS_USER_ID;
+use everruns_platform::capabilities::session_title_updated_event;
 use everruns_platform::{
     Session, SessionActivity, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
     SessionSource,

--- a/knowledge/execution/capabilities.md
+++ b/knowledge/execution/capabilities.md
@@ -243,10 +243,10 @@ changes.
 
 All participating title mutation paths suppress no-ops and emit the typed
 `session.title.updated` semantic event after an actual change. Tool-originated
-mutations preserve the current turn correlation. Embedders can reuse the core
+mutations preserve the current turn correlation. Embedders can reuse the
 title-mutation helpers and project events through the runtime event bus without
 replacing the capability. See
-[`crates/core/src/capabilities/session.rs`](../../crates/core/src/capabilities/session.rs)
+[`crates/platform/src/capabilities/session.rs`](../../crates/platform/src/capabilities/session.rs)
 for the public config and helper APIs, and [`knowledge/execution/events.md`](events.md) for the
 event contract.
 

--- a/knowledge/foundations/code-organization.md
+++ b/knowledge/foundations/code-organization.md
@@ -119,6 +119,15 @@ presets compose the hosted registry explicitly; the Framework preset does not
 advertise service-backed product capabilities. The capability-isolation guard
 keeps these implementations and their service contracts out of core.
 
+The session-service capabilities followed (EVE-886): `session`,
+`session_storage`, `session_sql_database` and `session_sandbox` each need a host
+service — a session store, key/value plus secret storage, a SQL database, or a
+sandbox provider — so they sit with the other service-backed families in
+`everruns-platform`. Composition, not the kernel, decides what a deployment
+advertises: product registration installs all four (sandbox behind its feature
+flag), and the host preset re-adds the two the default in-process runtime can
+serve, so the Framework still exposes session info and session storage.
+
 `everruns-core` depends on `everruns-provider` and re-exports every moved module
 at its original path (`everruns_core::driver_registry`, `::model_profiles`,
 `::error`, `::typed_id`, …), so application crates and embedders that import

--- a/scripts/lib/check-hosted-capability-isolation.sh
+++ b/scripts/lib/check-hosted-capability-isolation.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Architecture guard (EVE-885): service-backed product capabilities live in
-# everruns-platform. Core owns only neutral capability/tool/task/event/
-# delegation contracts; portable policy implementations live in builtins.
+# Architecture guard (EVE-885, extended by EVE-886): service-backed product
+# capabilities live in everruns-platform. Core owns only neutral capability/
+# tool/task/event/delegation contracts; portable policy implementations live in
+# builtins.
 
 set -euo pipefail
 
@@ -15,6 +16,9 @@ HOSTED_MODULES=(
   citation_verification data_knowledge delegation_result knowledge_base
   knowledge_index memory model_scout monitors openrouter_workspace research
   session_schedule session_tasks subagents user_hooks
+  # EVE-886: the session-service family — each needs a session store, session
+  # key/value + secret storage, a SQL database, or a sandbox provider.
+  session session_sandbox session_sql_database session_storage
 )
 
 for module in "${HOSTED_MODULES[@]}"; do
@@ -31,7 +35,7 @@ for module in memory vector_store; do
   fi
 done
 
-HOSTED_DEFINITION_PATTERN='pub (struct|enum|trait) (KnowledgeStore|KnowledgeSearchHit|KnowledgeIndexSearch|VectorStore|Memory|MemoryConfig|MemoryStatus|SubagentCapability|AgentHandoffCapability|UserHooksCapability)([[:space:]<{(]|$)'
+HOSTED_DEFINITION_PATTERN='pub (struct|enum|trait) (KnowledgeStore|KnowledgeSearchHit|KnowledgeIndexSearch|VectorStore|Memory|MemoryConfig|MemoryStatus|SubagentCapability|AgentHandoffCapability|UserHooksCapability|SessionCapability|SessionStorageCapability|SessionSqlDatabaseCapability|SessionSandboxCapability)([[:space:]<{(]|$)'
 if matches=$(grep -rnE "$HOSTED_DEFINITION_PATTERN" crates/core/src --include='*.rs' 2>/dev/null); then
   echo "Hosted capability or service definitions must not be declared by everruns-core:"
   echo "$matches"
@@ -51,7 +55,7 @@ if echo "$CORE_TREE" | grep -qE '^(a2a-lf|a2a-client-lf) '; then
 fi
 
 if [ "$FAILED" -ne 0 ]; then
-  echo "Hosted capability isolation guard failed. Product implementations and services belong in crates/platform (EVE-885)."
+  echo "Hosted capability isolation guard failed. Product implementations and services belong in crates/platform (EVE-885, EVE-886)."
   exit 1
 fi
 


### PR DESCRIPTION
## What changed

- Moves the `session`, `session_storage`, `session_sql_database` and `session_sandbox` capability implementations from `everruns-core` into `everruns-platform`, beside the other service-backed families.
- Product composition registers all four (`session_sandbox` still behind `FEATURE_SESSION_SANDBOX`); the host preset re-adds `session` and `session_storage`, the two the default in-process runtime can serve.
- Repoints the server's session-title event helper and internal key/secret predicates, and the llm-tests / prompt-budget fixtures, at the new owner.
- Rewrites the core tests that leaned on the moved implementations: preset expectations list them as composed-elsewhere, feature computation runs against a local storage fixture, and the tool-search benchmark uses the kernel-owned surface.
- Extends the hosted-capability isolation guard to the four modules and their capability types, and records the split in the capabilities and code-organization knowledge.

## Why

Each of these capabilities is defined by a host service it cannot function without — a session store, session key/value plus secret storage, a SQL database, or a sandbox provider. Leaving them in the kernel meant `everruns-core` shipped implementations whose backends it does not own and advertised capabilities a standalone application could not satisfy. EVE-886 puts them with the services and leaves core the neutral contract.

## Before / After

Before: `CapabilityRegistry::runtime_builtins()` and `with_builtins_for_grade()` registered `session` and `session_storage` (plus `session_sql_database`, and `session_sandbox` behind its flag) directly from core.

After: core's presets carry neither. `everruns_platform::capabilities::register_hosted_capabilities` installs all four, and `everruns_host::compose_runtime_capability_registry` adds `session`/`session_storage` back for in-process hosts, so the observable catalog is unchanged for the Framework, the local profile, the server and the worker.

Capability IDs, config schemas, prompts, tool definitions, dependency declarations and the `session.title.updated` event contract are untouched.

## Risk

- Medium
- The registry composition is where this can go wrong — a capability could silently disappear from one deployment shape. Preset-content tests in core, the flag-gating test now driven through `hosted_capability_registry_for_grade`, and the host composition tests cover the Framework, product and gated paths.
- No behavior inside the moved capabilities changed; the sandbox feature gate keeps its environment variable and semantics.

## Security

- Threat categories reviewed: TM-TENANT, TM-TOOL, TM-AGENT, TM-FS.
- Findings and resolutions: none outstanding. The internal KV and secret prefix reservations move with `session_storage` and still block user-facing writes to A2A run records and ARD attachments; sandbox exec/read/write paths, timeouts and provider resolution are unchanged; no authorization, tenancy or filesystem policy was touched. The isolation guard prevents a future re-introduction into core.

## Validation

- `just pre-push` — all 19 checks pass.
- `cargo test --all-features` for `everruns-core`, `everruns-platform`, `everruns-host`, `everruns-local`, `everruns`; unit tests for `everruns-server`, `everruns-worker`, `everruns-test-support`.

## Follow-ups

EVE-880 can now move the `session_sqldb` and `session_sandbox` records, whose only core-side consumers were these capabilities.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_