### PR TITLE
refactor(platform): move the Workspace and managed session sandbox records out of the kernel

### DIFF
--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -14644,7 +14644,7 @@ export interface components {
     SessionSandboxAction: "pause" | "resume" | "delete";
     /**
      * @description Wire-facing status of a session sandbox. Mirrors
-     *     `everruns_core::SessionSandboxStatus` for the public API.
+     *     `everruns_platform::session_sandbox::SessionSandboxStatus` for the public API.
      * @enum {string}
      */
     SessionSandboxStatusValue: "running" | "paused" | "lost";

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -139,7 +139,6 @@ pub mod session;
 pub mod session_file;
 pub mod session_path;
 pub mod session_resource;
-pub mod session_sandbox;
 pub mod session_schedule;
 pub mod session_sqldb;
 pub mod session_task;
@@ -378,17 +377,10 @@ pub use credential_provider::{CredentialProvider, EnvCredentialProvider, Provide
 // product provisioning templates are platform/server composition, not
 // Framework execution configuration.
 pub use platform_definition::{PlatformDefinition, PlatformDefinitionBuilder};
-pub use session_sandbox::{
-    DEFAULT_SESSION_SANDBOX_IDLE_TIMEOUT_SECS, SESSION_SANDBOX_CAPABILITY_ID,
-    SESSION_SANDBOX_SECRET_NAME, SessionSandboxConfig, SessionSandboxExecRequest,
-    SessionSandboxExecResponse, SessionSandboxInitConfig, SessionSandboxInstance,
-    SessionSandboxProvider, SessionSandboxProviderPlugin, SessionSandboxReadFileResponse,
-    SessionSandboxState, SessionSandboxStatus, SessionSandboxStatusResponse,
-    SessionSandboxWriteFileResponse, create_session_sandbox_provider, delete_session_sandbox,
-    delete_session_sandbox_state, ensure_session_sandbox_running, load_session_sandbox_state,
-    pause_session_sandbox, run_session_sandbox_init_if_needed, save_session_sandbox_state,
-    session_sandbox_config_from_capabilities, session_sandbox_tool_hints,
-};
+// EVE-880: the managed session sandbox record, its provider SPI and lifecycle
+// helpers moved to the `everruns-platform` crate. One provider-backed sandbox
+// per session is control-plane state — a turn reaches it through the sandbox
+// capability, never through the kernel.
 
 pub use capabilities::SystemPromptContext;
 pub use capabilities::{

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -147,7 +147,6 @@ pub mod skill;
 pub mod system_allowlist;
 pub mod task_observer;
 pub mod wake_queue;
-pub mod workspace;
 pub mod workspace_policy;
 pub mod workspace_roots;
 

--- a/crates/core/src/session_sqldb.rs
+++ b/crates/core/src/session_sqldb.rs
@@ -1,8 +1,16 @@
 // Session SQL Database types and trait
 //
 // Types and async trait for session-scoped SQL databases.
-// Defined in core so capability tools can depend on them.
 // Implementations live in the session-sqldb crate.
+//
+// EVE-880 kept this module in core, unlike the other session-service records.
+// The value types here are not persisted control-plane rows: they are the
+// signature vocabulary of `SessionSqlDbStore`, and that trait is pinned to
+// core by `ToolContext::sqldb_store`, which the platform capability reads at
+// execution time. Moving the records alone would leave core naming platform
+// types, which the dependency direction forbids. The whole module moves in
+// EVE-887, when the monolithic optional-field context is replaced by narrow
+// typed services owned beside each capability.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -762,7 +762,8 @@ pub trait TaskExecutor: Send + Sync {
 }
 
 /// Inventory plugin so capabilities register executors without core knowing
-/// about them (same pattern as `SessionSandboxProviderPlugin`).
+/// about them (same pattern as `everruns-platform`'s
+/// `SessionSandboxProviderPlugin`).
 pub struct TaskExecutorPlugin {
     pub executor: fn() -> Arc<dyn TaskExecutor>,
 }

--- a/crates/platform/src/capabilities/session_sandbox.rs
+++ b/crates/platform/src/capabilities/session_sandbox.rs
@@ -3,14 +3,14 @@
 //! One managed sandbox per session. The concrete provider is chosen by config
 //! (`provider: "daytona"` initially), while the tool surface stays stable.
 
-use async_trait::async_trait;
-use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
-pub use everruns_core::session_sandbox::SESSION_SANDBOX_CAPABILITY_ID;
-use everruns_core::session_sandbox::{
+pub use crate::session_sandbox::SESSION_SANDBOX_CAPABILITY_ID;
+use crate::session_sandbox::{
     DEFAULT_SESSION_SANDBOX_IDLE_TIMEOUT_SECS, SessionSandboxConfig, checkpoint_session_sandbox,
     create_session_sandbox_provider, delete_session_sandbox, ensure_session_sandbox_running,
     load_session_sandbox_state, pause_session_sandbox, session_sandbox_tool_hints,
 };
+use async_trait::async_trait;
+use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
 use everruns_core::tool_output_sanitizer::{
     READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
 };
@@ -195,7 +195,7 @@ fn parse_config(config: &Value) -> Result<SessionSandboxConfig, ToolExecutionRes
 
 fn provider_for_config(
     config: &SessionSandboxConfig,
-) -> Result<Box<dyn everruns_core::SessionSandboxProvider>, ToolExecutionResult> {
+) -> Result<Box<dyn crate::session_sandbox::SessionSandboxProvider>, ToolExecutionResult> {
     create_session_sandbox_provider(&config.provider).ok_or_else(|| {
         ToolExecutionResult::tool_error(format!(
             "Session sandbox provider '{}' is not registered",
@@ -205,7 +205,7 @@ fn provider_for_config(
 }
 
 fn build_sandbox_exec_result(
-    response: everruns_core::SessionSandboxExecResponse,
+    response: crate::session_sandbox::SessionSandboxExecResponse,
     cwd: Option<&str>,
 ) -> ToolExecutionResult {
     let mut result = json!({
@@ -229,7 +229,7 @@ fn build_sandbox_exec_result(
 }
 
 fn build_sandbox_read_file_result(
-    response: everruns_core::SessionSandboxReadFileResponse,
+    response: crate::session_sandbox::SessionSandboxReadFileResponse,
     offset: usize,
     limit: usize,
 ) -> ToolExecutionResult {
@@ -353,7 +353,7 @@ impl Tool for SandboxExecTool {
                 context,
                 &config,
                 &state.instance,
-                &everruns_core::SessionSandboxExecRequest {
+                &crate::session_sandbox::SessionSandboxExecRequest {
                     command: command.to_string(),
                     cwd: arguments
                         .get("cwd")
@@ -945,7 +945,7 @@ mod tests {
     #[test]
     fn sandbox_exec_result_preserves_absent_raw_output() {
         let result = build_sandbox_exec_result(
-            everruns_core::SessionSandboxExecResponse {
+            crate::session_sandbox::SessionSandboxExecResponse {
                 exit_code: 0,
                 stdout: "ok".to_string(),
                 stderr: String::new(),
@@ -966,7 +966,7 @@ mod tests {
     #[test]
     fn sandbox_exec_result_keeps_raw_output_sidecar_when_present() {
         let result = build_sandbox_exec_result(
-            everruns_core::SessionSandboxExecResponse {
+            crate::session_sandbox::SessionSandboxExecResponse {
                 exit_code: 17,
                 stdout: "trimmed".to_string(),
                 stderr: "warn".to_string(),
@@ -990,7 +990,7 @@ mod tests {
     #[test]
     fn sandbox_read_file_result_applies_line_window() {
         let result = build_sandbox_read_file_result(
-            everruns_core::SessionSandboxReadFileResponse {
+            crate::session_sandbox::SessionSandboxReadFileResponse {
                 path: "/workspace/src/lib.rs".to_string(),
                 content: "alpha\nbeta\ngamma\ndelta".to_string(),
                 encoding: "text".to_string(),
@@ -1019,7 +1019,7 @@ mod tests {
     #[test]
     fn sandbox_read_file_result_marks_untruncated_window() {
         let result = build_sandbox_read_file_result(
-            everruns_core::SessionSandboxReadFileResponse {
+            crate::session_sandbox::SessionSandboxReadFileResponse {
                 path: "/workspace/src/lib.rs".to_string(),
                 content: "alpha\nbeta".to_string(),
                 encoding: "text".to_string(),

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -69,6 +69,13 @@ pub mod session;
 // working-area row with its lifecycle status is control-plane state.
 pub mod workspace;
 
+// Managed per-session sandbox carved out of `everruns-core` (EVE-880): the
+// persisted state record, the provider SPI integration crates register through
+// inventory, and the create/resume/pause/init lifecycle helpers. Execution
+// reaches a sandbox only through the `session_sandbox` capability, which lives
+// beside this module.
+pub mod session_sandbox;
+
 // Management/reporting aggregates carved out of `everruns-core` (EVE-878):
 // persisted eval definitions/runs/results/datasets, observer records with
 // judge configuration and trace-score lifecycle, and the org/product
@@ -115,6 +122,19 @@ pub use principal::{Principal, PrincipalStatus};
 pub use session::{
     Session, SessionActivity, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
     SessionSource, SessionStatus,
+};
+
+// Managed per-session sandbox (EVE-880).
+pub use session_sandbox::{
+    DEFAULT_SESSION_SANDBOX_IDLE_TIMEOUT_SECS, SESSION_SANDBOX_CAPABILITY_ID,
+    SESSION_SANDBOX_SECRET_NAME, SessionSandboxConfig, SessionSandboxExecRequest,
+    SessionSandboxExecResponse, SessionSandboxInitConfig, SessionSandboxInstance,
+    SessionSandboxProvider, SessionSandboxProviderPlugin, SessionSandboxReadFileResponse,
+    SessionSandboxState, SessionSandboxStatus, SessionSandboxStatusResponse,
+    SessionSandboxWriteFileResponse, create_session_sandbox_provider, delete_session_sandbox,
+    delete_session_sandbox_state, ensure_session_sandbox_running, load_session_sandbox_state,
+    pause_session_sandbox, run_session_sandbox_init_if_needed, save_session_sandbox_state,
+    session_sandbox_config_from_capabilities, session_sandbox_tool_hints,
 };
 
 // Management/reporting aggregates (EVE-878).

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -64,6 +64,11 @@ pub mod harness;
 // to/from the stored `SessionStatus` at the adapter boundary.
 pub mod session;
 
+// Org-scoped Workspace record carved out of `everruns-core` (EVE-880). A turn
+// resolves workspace *paths* through core's roots/policy types; the stored
+// working-area row with its lifecycle status is control-plane state.
+pub mod workspace;
+
 // Management/reporting aggregates carved out of `everruns-core` (EVE-878):
 // persisted eval definitions/runs/results/datasets, observer records with
 // judge configuration and trace-score lifecycle, and the org/product

--- a/crates/platform/src/session_sandbox.rs
+++ b/crates/platform/src/session_sandbox.rs
@@ -9,10 +9,10 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::capability_types::AgentCapabilityConfig;
-use crate::tool_types::ToolHints;
-use crate::tools::ToolExecutionResult;
-use crate::traits::ToolContext;
+use everruns_core::capability_types::AgentCapabilityConfig;
+use everruns_core::tool_types::ToolHints;
+use everruns_core::tools::ToolExecutionResult;
+use everruns_core::traits::ToolContext;
 
 /// Capability id for the managed session sandbox capability.
 pub const SESSION_SANDBOX_CAPABILITY_ID: &str = "session_sandbox";
@@ -566,9 +566,9 @@ fn now_rfc3339() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::{SecretInfo, SessionStorageStore};
     use async_trait::async_trait;
     use chrono::Utc;
+    use everruns_core::traits::{SecretInfo, SessionStorageStore};
     use std::collections::HashMap;
     use std::sync::{Arc, LazyLock, Mutex};
 
@@ -581,42 +581,42 @@ mod tests {
     impl SessionStorageStore for MemorySecrets {
         async fn set_value(
             &self,
-            _session_id: crate::SessionId,
+            _session_id: everruns_core::SessionId,
             _key: &str,
             _value: &str,
-        ) -> crate::Result<()> {
+        ) -> everruns_core::Result<()> {
             unreachable!()
         }
 
         async fn get_value(
             &self,
-            _session_id: crate::SessionId,
+            _session_id: everruns_core::SessionId,
             _key: &str,
-        ) -> crate::Result<Option<String>> {
+        ) -> everruns_core::Result<Option<String>> {
             unreachable!()
         }
 
         async fn delete_value(
             &self,
-            _session_id: crate::SessionId,
+            _session_id: everruns_core::SessionId,
             _key: &str,
-        ) -> crate::Result<bool> {
+        ) -> everruns_core::Result<bool> {
             unreachable!()
         }
 
         async fn list_keys(
             &self,
-            _session_id: crate::SessionId,
-        ) -> crate::Result<Vec<crate::KeyInfo>> {
+            _session_id: everruns_core::SessionId,
+        ) -> everruns_core::Result<Vec<everruns_core::KeyInfo>> {
             unreachable!()
         }
 
         async fn set_secret(
             &self,
-            _session_id: crate::SessionId,
+            _session_id: everruns_core::SessionId,
             name: &str,
             value: &str,
-        ) -> crate::Result<()> {
+        ) -> everruns_core::Result<()> {
             self.secrets
                 .lock()
                 .unwrap()
@@ -626,24 +626,24 @@ mod tests {
 
         async fn get_secret(
             &self,
-            _session_id: crate::SessionId,
+            _session_id: everruns_core::SessionId,
             name: &str,
-        ) -> crate::Result<Option<String>> {
+        ) -> everruns_core::Result<Option<String>> {
             Ok(self.secrets.lock().unwrap().get(name).cloned())
         }
 
         async fn delete_secret(
             &self,
-            _session_id: crate::SessionId,
+            _session_id: everruns_core::SessionId,
             name: &str,
-        ) -> crate::Result<bool> {
+        ) -> everruns_core::Result<bool> {
             Ok(self.secrets.lock().unwrap().remove(name).is_some())
         }
 
         async fn list_secrets(
             &self,
-            _session_id: crate::SessionId,
-        ) -> crate::Result<Vec<SecretInfo>> {
+            _session_id: everruns_core::SessionId,
+        ) -> everruns_core::Result<Vec<SecretInfo>> {
             Ok(self
                 .secrets
                 .lock()
@@ -694,7 +694,7 @@ mod tests {
     #[tokio::test]
     async fn session_sandbox_state_round_trip() {
         let storage = Arc::new(MemorySecrets::default());
-        let context = ToolContext::with_storage_store(crate::SessionId::new(), storage);
+        let context = ToolContext::with_storage_store(everruns_core::SessionId::new(), storage);
 
         let state = SessionSandboxState {
             provider: "daytona".to_string(),
@@ -941,7 +941,7 @@ mod tests {
         reset_test_provider_state(external_id, SessionSandboxStatus::Paused);
 
         let storage = Arc::new(MemorySecrets::default());
-        let context = ToolContext::with_storage_store(crate::SessionId::new(), storage);
+        let context = ToolContext::with_storage_store(everruns_core::SessionId::new(), storage);
         let state = SessionSandboxState {
             provider: "core-test-session-sandbox".to_string(),
             status: SessionSandboxStatus::Running,
@@ -969,7 +969,7 @@ mod tests {
         reset_test_provider_state(external_id, SessionSandboxStatus::Lost);
 
         let storage = Arc::new(MemorySecrets::default());
-        let context = ToolContext::with_storage_store(crate::SessionId::new(), storage);
+        let context = ToolContext::with_storage_store(everruns_core::SessionId::new(), storage);
         let state = SessionSandboxState {
             provider: "core-test-session-sandbox".to_string(),
             status: SessionSandboxStatus::Running,
@@ -997,7 +997,7 @@ mod tests {
         reset_test_provider_state(external_id, SessionSandboxStatus::Running);
 
         let storage = Arc::new(MemorySecrets::default());
-        let context = ToolContext::with_storage_store(crate::SessionId::new(), storage);
+        let context = ToolContext::with_storage_store(everruns_core::SessionId::new(), storage);
         let state = SessionSandboxState {
             provider: "core-test-session-sandbox".to_string(),
             status: SessionSandboxStatus::Running,

--- a/crates/platform/src/workspace.rs
+++ b/crates/platform/src/workspace.rs
@@ -1,4 +1,9 @@
-// Workspace domain types
+// Workspace persistence record (EVE-880).
+//
+// The stored, org-scoped working area. Execution never loads this row: a turn
+// consumes only `WorkspaceId` plus the resolved roots/policy that stay in
+// `everruns-core`, so the record and its lifecycle live with the other
+// control-plane aggregates.
 //
 // Design intent lives in `knowledge/runtime-resources/workspace.md`.
 //
@@ -11,7 +16,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::typed_id::WorkspaceId;
+use everruns_core::typed_id::WorkspaceId;
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;

--- a/crates/server/src/api/session_sandbox.rs
+++ b/crates/server/src/api/session_sandbox.rs
@@ -22,7 +22,7 @@ use utoipa::ToSchema;
 use super::common::{ApiResult, impl_auth_state};
 
 /// Wire-facing status of a session sandbox. Mirrors
-/// `everruns_core::SessionSandboxStatus` for the public API.
+/// `everruns_platform::session_sandbox::SessionSandboxStatus` for the public API.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionSandboxStatusValue {
@@ -31,12 +31,12 @@ pub enum SessionSandboxStatusValue {
     Lost,
 }
 
-impl From<everruns_core::SessionSandboxStatus> for SessionSandboxStatusValue {
-    fn from(status: everruns_core::SessionSandboxStatus) -> Self {
+impl From<everruns_platform::session_sandbox::SessionSandboxStatus> for SessionSandboxStatusValue {
+    fn from(status: everruns_platform::session_sandbox::SessionSandboxStatus) -> Self {
         match status {
-            everruns_core::SessionSandboxStatus::Running => Self::Running,
-            everruns_core::SessionSandboxStatus::Paused => Self::Paused,
-            everruns_core::SessionSandboxStatus::Lost => Self::Lost,
+            everruns_platform::session_sandbox::SessionSandboxStatus::Running => Self::Running,
+            everruns_platform::session_sandbox::SessionSandboxStatus::Paused => Self::Paused,
+            everruns_platform::session_sandbox::SessionSandboxStatus::Lost => Self::Lost,
         }
     }
 }

--- a/crates/server/src/domains/session_sandbox/commands.rs
+++ b/crates/server/src/domains/session_sandbox/commands.rs
@@ -4,7 +4,7 @@ use super::types::{
     SessionSandboxStatusValue,
 };
 use crate::domains::common::*;
-use everruns_core::{
+use everruns_platform::session_sandbox::{
     create_session_sandbox_provider, delete_session_sandbox, ensure_session_sandbox_running,
     load_session_sandbox_state, pause_session_sandbox,
 };
@@ -15,8 +15,8 @@ fn status_response(
     configured: bool,
     exists: bool,
     provider: Option<String>,
-    state: Option<&everruns_core::SessionSandboxState>,
-    status: Option<everruns_core::SessionSandboxStatusResponse>,
+    state: Option<&everruns_platform::session_sandbox::SessionSandboxState>,
+    status: Option<everruns_platform::session_sandbox::SessionSandboxStatusResponse>,
 ) -> GetSessionSandboxResponse {
     let session_status = status
         .as_ref()
@@ -43,7 +43,7 @@ fn status_response(
 
 fn manage_response_from_state(
     action: SessionSandboxAction,
-    state: &everruns_core::SessionSandboxState,
+    state: &everruns_platform::session_sandbox::SessionSandboxState,
 ) -> ManageSessionSandboxResponse {
     ManageSessionSandboxResponse {
         action,
@@ -225,19 +225,19 @@ mod tests {
     use crate::domains::session_sandbox::SessionSandboxService;
     use crate::domains::sessions::SessionService;
     use crate::storage::{CreateHarnessRow, CreateSessionRow, StorageBackend};
-    use everruns_core::session_sandbox::{
+    use everruns_core::{Caller, DEFAULT_ORG_ID, InitialFile, SessionStorageStore};
+    use everruns_platform::session_sandbox::{
         SessionSandboxConfig, SessionSandboxExecRequest, SessionSandboxExecResponse,
         SessionSandboxInstance, SessionSandboxProvider, SessionSandboxReadFileResponse,
         SessionSandboxStatusResponse, SessionSandboxWriteFileResponse,
     };
-    use everruns_core::{Caller, DEFAULT_ORG_ID, InitialFile, SessionStorageStore};
     use serde_json::json;
     use std::sync::Arc;
 
     struct TestSessionSandboxProvider;
 
     inventory::submit! {
-        everruns_core::SessionSandboxProviderPlugin {
+        everruns_platform::session_sandbox::SessionSandboxProviderPlugin {
             factory: || Box::new(TestSessionSandboxProvider),
         }
     }
@@ -340,7 +340,7 @@ mod tests {
             &self,
             _context: &everruns_core::ToolContext,
             _config: &SessionSandboxConfig,
-            state: &everruns_core::SessionSandboxState,
+            state: &everruns_platform::session_sandbox::SessionSandboxState,
         ) -> Result<SessionSandboxStatusResponse, everruns_core::ToolExecutionResult> {
             Ok(SessionSandboxStatusResponse {
                 provider: state.provider.clone(),

--- a/crates/server/src/domains/session_sandbox/service.rs
+++ b/crates/server/src/domains/session_sandbox/service.rs
@@ -12,15 +12,15 @@ use crate::org_init;
 use crate::storage::{DbLeasedResourceStore, DbSessionResourceRegistry, StorageBackend};
 use anyhow::Context;
 use async_trait::async_trait;
-use everruns_core::session_sandbox::{
-    SessionSandboxConfig, ensure_session_sandbox_running, pause_session_sandbox,
-    session_sandbox_config_from_capabilities,
-};
 use everruns_core::typed_id::{AgentId, SessionId};
 use everruns_core::{
     AgentCapabilityConfig, Event, EventData, EventListener, LeasedResourceStore,
     SessionResourceRegistry, SessionStorageStore, ToolContext, UserConnectionResolver,
     merge_capabilities,
+};
+use everruns_platform::session_sandbox::{
+    SessionSandboxConfig, ensure_session_sandbox_running, pause_session_sandbox,
+    session_sandbox_config_from_capabilities,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -258,19 +258,19 @@ impl EventListener for SessionSandboxEventListener {
 mod tests {
     use super::*;
     use crate::storage::{CreateHarnessRow, CreateSessionRow, StorageBackend};
-    use everruns_core::session_sandbox::{
+    use everruns_core::{DEFAULT_ORG_ID, InitialFile, SessionStorageStore, UserConnectionResolver};
+    use everruns_platform::session_sandbox::{
         SessionSandboxExecRequest, SessionSandboxExecResponse, SessionSandboxInstance,
         SessionSandboxProvider, SessionSandboxReadFileResponse, SessionSandboxState,
         SessionSandboxStatus, SessionSandboxStatusResponse, SessionSandboxWriteFileResponse,
         load_session_sandbox_state,
     };
-    use everruns_core::{DEFAULT_ORG_ID, InitialFile, SessionStorageStore, UserConnectionResolver};
     use serde_json::json;
 
     struct TestSessionSandboxProvider;
 
     inventory::submit! {
-        everruns_core::SessionSandboxProviderPlugin {
+        everruns_platform::session_sandbox::SessionSandboxProviderPlugin {
             factory: || Box::new(TestSessionSandboxProvider),
         }
     }
@@ -389,7 +389,7 @@ mod tests {
     struct ResolverRequiredSessionSandboxProvider;
 
     inventory::submit! {
-        everruns_core::SessionSandboxProviderPlugin {
+        everruns_platform::session_sandbox::SessionSandboxProviderPlugin {
             factory: || Box::new(ResolverRequiredSessionSandboxProvider),
         }
     }

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -26,7 +26,6 @@ use crate::storage::{
     },
 };
 use anyhow::Result;
-use everruns_core::session_sandbox::SESSION_SANDBOX_CAPABILITY_ID;
 use everruns_core::{AgentCapabilityConfig, AgentId, Caller, CapabilityRegistry};
 use everruns_core::{
     DeclarativeCapabilityDefinition, HarnessId, InitialFile, ModelId, MountAccess, MountEntry,
@@ -44,6 +43,7 @@ use everruns_core::{
 use everruns_durable::UpdateField;
 use everruns_mcp::is_mcp_capability;
 use everruns_platform::FeatureFlags;
+use everruns_platform::session_sandbox::SESSION_SANDBOX_CAPABILITY_ID;
 use everruns_platform::{
     AgentVersionPolicy, MemoryConfig, MemoryMountAccess, capabilities::MEMORY_CAPABILITY_ID,
 };

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -34345,7 +34345,7 @@
       },
       "SessionSandboxStatusValue": {
         "type": "string",
-        "description": "Wire-facing status of a session sandbox. Mirrors\n`everruns_core::SessionSandboxStatus` for the public API.",
+        "description": "Wire-facing status of a session sandbox. Mirrors\n`everruns_platform::session_sandbox::SessionSandboxStatus` for the public API.",
         "enum": [
           "running",
           "paused",

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -75,7 +75,7 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    everruns_core::SessionSandboxProviderPlugin {
+    everruns_platform::session_sandbox::SessionSandboxProviderPlugin {
         factory: || Box::new(DaytonaSessionSandboxProvider),
     }
 }

--- a/integrations/daytona/src/session_sandbox_provider.rs
+++ b/integrations/daytona/src/session_sandbox_provider.rs
@@ -1,14 +1,14 @@
 //! Daytona implementation of the provider-neutral session_sandbox contract.
 
 use everruns_core::exec_tool_result::ExecToolResultPayload;
-use everruns_core::session_sandbox::{
+use everruns_core::tools::ToolExecutionResult;
+use everruns_core::traits::ToolContext;
+use everruns_platform::session_sandbox::{
     SessionSandboxConfig, SessionSandboxExecRequest, SessionSandboxExecResponse,
     SessionSandboxInstance, SessionSandboxProvider, SessionSandboxReadFileResponse,
     SessionSandboxState, SessionSandboxStatus, SessionSandboxStatusResponse,
     SessionSandboxWriteFileResponse,
 };
-use everruns_core::tools::ToolExecutionResult;
-use everruns_core::traits::ToolContext;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -19,13 +19,13 @@
 
 use async_trait::async_trait;
 use everruns_core::error::Result;
-use everruns_core::session_sandbox::{SessionSandboxConfig, create_session_sandbox_provider};
 use everruns_core::traits::{KeyInfo, SecretInfo, ToolContext, UserConnectionResolver};
-use everruns_core::{
-    SessionSandboxExecRequest, SessionSandboxState, SessionSandboxStatus, SessionStorageStore,
-    typed_id::SessionId,
-};
+use everruns_core::{SessionStorageStore, typed_id::SessionId};
 use everruns_integrations_daytona::client::DaytonaClient;
+use everruns_platform::session_sandbox::{
+    SessionSandboxConfig, SessionSandboxExecRequest, SessionSandboxState, SessionSandboxStatus,
+    create_session_sandbox_provider,
+};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/integrations/daytona/tests/session_sandbox_provider.rs
+++ b/integrations/daytona/tests/session_sandbox_provider.rs
@@ -2,10 +2,11 @@
 
 use async_trait::async_trait;
 use everruns_core::error::Result;
-use everruns_core::session_sandbox::{SessionSandboxConfig, create_session_sandbox_provider};
 use everruns_core::traits::{KeyInfo, SecretInfo, ToolContext, UserConnectionResolver};
-use everruns_core::{
-    SessionSandboxExecRequest, SessionSandboxInstance, SessionStorageStore, typed_id::SessionId,
+use everruns_core::{SessionStorageStore, typed_id::SessionId};
+use everruns_platform::session_sandbox::{
+    SessionSandboxConfig, SessionSandboxExecRequest, SessionSandboxInstance,
+    create_session_sandbox_provider,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -300,9 +301,9 @@ async fn daytona_provider_replaces_lost_instance_and_restores_workspace() {
         .status(
             &context,
             &config,
-            &everruns_core::SessionSandboxState {
+            &everruns_platform::session_sandbox::SessionSandboxState {
                 provider: "daytona".to_string(),
-                status: everruns_core::SessionSandboxStatus::Running,
+                status: everruns_platform::session_sandbox::SessionSandboxStatus::Running,
                 instance: instance.clone(),
                 init_completed_at: Some(chrono::Utc::now().to_rfc3339()),
                 last_init_error: None,
@@ -314,7 +315,7 @@ async fn daytona_provider_replaces_lost_instance_and_restores_workspace() {
         .unwrap();
     assert_eq!(
         lost_status.session_status,
-        everruns_core::SessionSandboxStatus::Lost
+        everruns_platform::session_sandbox::SessionSandboxStatus::Lost
     );
 
     let replacement = provider.resume(&context, &config, &instance).await.unwrap();
@@ -555,7 +556,7 @@ async fn daytona_provider_manages_managed_sandbox_flow() {
             &context,
             &config,
             &instance,
-            &everruns_core::SessionSandboxExecRequest {
+            &everruns_platform::session_sandbox::SessionSandboxExecRequest {
                 command: "echo ready".to_string(),
                 cwd: Some("/home/daytona".to_string()),
                 timeout_ms: Some(10_000),
@@ -595,9 +596,9 @@ async fn daytona_provider_manages_managed_sandbox_flow() {
         .status(
             &context,
             &config,
-            &everruns_core::SessionSandboxState {
+            &everruns_platform::session_sandbox::SessionSandboxState {
                 provider: "daytona".to_string(),
-                status: everruns_core::SessionSandboxStatus::Running,
+                status: everruns_platform::session_sandbox::SessionSandboxStatus::Running,
                 instance: resumed.clone(),
                 init_completed_at: None,
                 last_init_error: None,

--- a/knowledge/foundations/code-organization.md
+++ b/knowledge/foundations/code-organization.md
@@ -128,6 +128,17 @@ advertises: product registration installs all four (sandbox behind its feature
 flag), and the host preset re-adds the two the default in-process runtime can
 serve, so the Framework still exposes session info and session storage.
 
+The records those capabilities read follow them (EVE-880). The org-scoped
+`Workspace` row and the managed per-session sandbox — state record, provider
+SPI, inventory plugin and lifecycle helpers — live in `everruns-platform`; a
+turn resolves workspace *paths* through core's roots and policy types, and
+reaches a sandbox only through the capability. `session_sqldb` is the
+deliberate exception: its value types are the signature vocabulary of
+`SessionSqlDbStore`, which `ToolContext` still holds as an optional field, so
+records and trait move together under EVE-887 rather than leaving core naming
+platform types. Session task, schedule and resource records likewise stay
+while core execution still consumes them.
+
 `everruns-core` depends on `everruns-provider` and re-exports every moved module
 at its original path (`everruns_core::driver_registry`, `::model_profiles`,
 `::error`, `::typed_id`, …), so application crates and embedders that import

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,27 @@
 # Everruns Knowledge Update Log
 
+## 2026-08-12
+
+* **Session sandbox record extraction**: Moved the managed per-session sandbox
+  — config, persisted state, provider instance and exec/file payloads, the
+  `SessionSandboxProvider` SPI with its inventory plugin, and the
+  create/resume/pause/delete/init/checkpoint lifecycle helpers — out of
+  `everruns-core` into `everruns-platform` (EVE-880), where the sandbox
+  capability already lives after EVE-886. One provider-backed sandbox per
+  session is control-plane state: a turn reaches it through the capability,
+  never through the kernel. Integration providers (Daytona) register against
+  platform. The agent-record isolation guard now covers the sandbox record
+  types and the provider SPI, and the `Workspace` row moved earlier in the
+  same issue.
+
+  `session_sqldb` deliberately stayed in core. Its value types are the
+  signature vocabulary of `SessionSqlDbStore`, and that trait is pinned to
+  core by `ToolContext::sqldb_store`; splitting records from trait would make
+  core name platform types. The family moves with EVE-887, when the
+  monolithic optional-field context becomes narrow typed services. The same
+  reasoning holds for the session task, schedule and resource records, which
+  still have execution-time consumers inside core.
+
 ## 2026-08-11
 
 * **Hosted capability extraction**: Moved hosted knowledge, Memory,

--- a/knowledge/runtime-resources/session-sandbox.md
+++ b/knowledge/runtime-resources/session-sandbox.md
@@ -56,7 +56,7 @@ Configured through normal capability config on harness, agent, or session:
 
 ### Config contract
 
-See `crates/core/src/session_sandbox.rs` for the full type definitions.
+See `crates/platform/src/session_sandbox.rs` for the full type definitions.
 
 - `provider`: required provider id
 - `auto_start`: best-effort sandbox start on session creation
@@ -84,9 +84,9 @@ The session owns exactly one sandbox, and provider selection comes from config.
 
 ## Architecture
 
-### Core
+### Platform
 
-`crates/core/src/session_sandbox.rs` defines:
+`crates/platform/src/session_sandbox.rs` defines:
 
 - config, state, and response types
 - `SessionSandboxProvider` trait
@@ -94,7 +94,7 @@ The session owns exactly one sandbox, and provider selection comes from config.
 - state persistence helpers using session secret storage
 - generic create/resume/pause/delete/init/checkpoint helpers
 
-`crates/core/src/capabilities/session_sandbox.rs` exposes the capability and
+`crates/platform/src/capabilities/session_sandbox.rs` exposes the capability and
 generic tools. Tool execution resolves the configured provider and delegates
 through the trait. After a completed shell or file mutation, the provider
 checkpoint is persisted before the tool result is returned to the runtime.
@@ -103,7 +103,7 @@ checkpoint is persisted before the tool result is returned to the runtime.
 
 Provider implementations live in integration crates and register with:
 
-`everruns_core::SessionSandboxProviderPlugin`
+`everruns_platform::SessionSandboxProviderPlugin`
 
 Daytona is the first implementation and lives in:
 

--- a/scripts/lib/check-agent-record-isolation.sh
+++ b/scripts/lib/check-agent-record-isolation.sh
@@ -34,7 +34,11 @@
 #    ObserverMatch, LlmJudgeConfig, TraceScore, FeatureFlags, FeatureFlagMap,
 #    FeatureFlagDefinition), nor the moved connector/email/OAuth
 #    infrastructure types (ConnectorRegistry, ConnectorPlugin, EmailMessage,
-#    SystemEmailConfig, ResendEmailSender, OAuthClient, TokenSet, ...).
+#    SystemEmailConfig, ResendEmailSender, OAuthClient, TokenSet, ...), nor
+#    the moved session-service records (EVE-880): the org-scoped Workspace
+#    row and the managed per-session sandbox (config, persisted state,
+#    provider instance, exec/file payloads) together with the
+#    `SessionSandboxProvider` SPI and its inventory plugin.
 
 set -euo pipefail
 
@@ -70,9 +74,14 @@ RECORD_TYPES="${RECORD_TYPES}|FeatureFlags|FeatureFlagMap|FeatureFlagDefinition"
 RECORD_TYPES="${RECORD_TYPES}|Connector|ConnectorPlugin|ConnectorRegistry|ConnectorRegistryBuilder|ConnectorType|ConnectorValidation"
 RECORD_TYPES="${RECORD_TYPES}|EmailAddress|EmailMessage|EmailTag|EmailTemplate|MinimalEmailTemplate|BasicEmailTemplate|RenderedEmail|SentEmail|NoopEmailSender|DisabledEmailSender|ResendEmailSender|ResendEmailConfig|SystemEmailConfig"
 RECORD_TYPES="${RECORD_TYPES}|OAuthClient|OAuthError|TokenSet|PkcePair|ProtectedResourceMetadata|AuthorizationServerMetadata|RegisteredClient|ClientRegistration"
-if matches=$(grep -rnE "^[[:space:]]*pub (struct|enum) (${RECORD_TYPES})[[:space:]{<(]" \
+RECORD_TYPES="${RECORD_TYPES}|Workspace|WorkspaceStatus"
+RECORD_TYPES="${RECORD_TYPES}|SessionSandboxConfig|SessionSandboxInitConfig|SessionSandboxStatus|SessionSandboxStatusResponse|SessionSandboxInstance|SessionSandboxState|SessionSandboxExecRequest|SessionSandboxExecResponse|SessionSandboxReadFileResponse|SessionSandboxWriteFileResponse|SessionSandboxProvider|SessionSandboxProviderPlugin"
+# `trait` is included so the sandbox provider SPI cannot reappear in the
+# kernel: integration crates register providers against platform, and a turn
+# reaches a sandbox only through the capability.
+if matches=$(grep -rnE "^[[:space:]]*pub (struct|enum|trait) (${RECORD_TYPES})[[:space:]{<(]" \
   "${KERNEL_TREES[@]}" --include='*.rs' 2>/dev/null); then
-  echo "Kernel crates must not declare stored platform record types or moved connector/OAuth/email infrastructure (EVE-877, EVE-881, EVE-882, EVE-878, EVE-879):"
+  echo "Kernel crates must not declare stored platform record types or moved connector/OAuth/email infrastructure (EVE-877, EVE-881, EVE-882, EVE-878, EVE-879, EVE-880):"
   echo "$matches"
   FAILED=1
 fi
@@ -114,8 +123,8 @@ for crate in "${PROVIDER_CRATES[@]}"; do
 done
 
 if [ "$FAILED" -ne 0 ]; then
-  echo "Agent-record isolation guard failed. Stored Agent/AgentVersion, Harness, and Session records plus eval/observer/feature-management aggregates — and the connector/email infrastructure — belong in crates/platform; the OAuth protocol client belongs in crates/mcp (EVE-877, EVE-881, EVE-882, EVE-878, EVE-879)."
+  echo "Agent-record isolation guard failed. Stored Agent/AgentVersion, Harness, and Session records, eval/observer/feature-management aggregates, the connector/email infrastructure, and the Workspace/session-sandbox records belong in crates/platform; the OAuth protocol client belongs in crates/mcp (EVE-877, EVE-881, EVE-882, EVE-878, EVE-879, EVE-880)."
   exit 1
 fi
 
-echo "Agent-record isolation guard passed: kernel crates consume AgentDefinition/HarnessDefinition/ExecutionSession and resolved execution features only; platform records and connector/OAuth/email infrastructure stay out of the kernel."
+echo "Agent-record isolation guard passed: kernel crates consume AgentDefinition/HarnessDefinition/ExecutionSession and resolved execution features only; platform records, connector/OAuth/email infrastructure, and the Workspace/session-sandbox records stay out of the kernel."


### PR DESCRIPTION
## What changed

Two session-service record families leave `everruns-core` for `everruns-platform`:

- **Workspace** — the org-scoped stored working area and its lifecycle status. A turn resolves workspace *paths* through the roots and policy types that stay in core, and never loads the row.
- **Managed session sandbox** — config, persisted state, provider instance, exec/file payloads, the `SessionSandboxProvider` SPI with its inventory plugin, and the create/resume/pause/delete/init/checkpoint lifecycle helpers. These land beside the `session_sandbox` capability, which moved to platform in EVE-886. Daytona already depended on platform and now registers its provider there.

No behavior or stored-schema change: this is a module relocation plus import updates in the server domains, the OpenAPI status mapping, and the daytona test suites.

The agent-record isolation guard now covers the sandbox record types and the provider SPI. Its match pattern widened from `struct|enum` to include `trait`, so the SPI cannot reappear in the kernel, and it picked up the `Workspace` row that the earlier commit moved without guarding.

## Why

EVE-880 in the core-extraction epic. Once EVE-886 moved the session-service *capabilities* to platform, the records those capabilities read were the only reason the kernel still carried a sandbox provider registry and an org-scoped working-area row. Execution reaches a sandbox through the capability; the kernel has no business knowing a provider catalog exists.

## Before / After

No observable behavior change — pure refactor. Endpoints, tool definitions, capability IDs, and stored schema are untouched.

Two textual differences are worth naming rather than glossing:

- `docs/api/openapi.json` changes by one line. `SessionSandboxStatusValue`'s doc comment cites the type it mirrors, and that comment is the source of a `description` field in the generated spec, so the citation moved with the type:

  ```diff
  - "description": "Wire-facing status of a session sandbox. Mirrors\n`everruns_core::SessionSandboxStatus` for the public API.",
  + "description": "Wire-facing status of a session sandbox. Mirrors\n`everruns_platform::session_sandbox::SessionSandboxStatus` for the public API.",
  ```

  No schema, path, or field changes.
- Embedders who referenced `everruns_core::SessionSandbox*` directly now import `everruns_platform::session_sandbox::*`.

## Risk

- Low
- The realistic failure mode is a missed import in a feature-gated tree. Verified with `cargo clippy --all-targets --all-features -- -D warnings`, which caught one such case in a `daytona-live-tests` gated file. Provider registration goes through `inventory`, so a mis-wired plugin would surface as a sandbox provider that fails to resolve at runtime rather than a compile error — covered by the daytona provider tests, which exercise registration and lookup.

## Security

- Threat categories reviewed: no security-relevant code changes. The sandbox state record is persisted through the same session-secret storage path, under the same `session_sandbox` secret name, with no change to encryption, tenancy scoping, or the ownership checks in `resource_ownership`. Moving a type between crates does not alter who can reach it.
- Findings and resolutions: none.

## Follow-ups

Four of EVE-880's six record families stay in core for now, each blocked on the same seam rather than deferred by preference:

- `session_sqldb` — the value types are the signature vocabulary of `SessionSqlDbStore`, and that trait is pinned to core by `ToolContext::sqldb_store`, which the platform capability reads at execution time. Moving the records alone would leave core naming platform types, which the dependency direction forbids.
- `session_task` and `session_schedule` — `crates/core/src/tools.rs` creates monitor and background-tool tasks during execution.
- `session_resource` — consumed by `resource_ownership.rs` and the skills capabilities, which are portable and stay in core.

All four clear once EVE-887 replaces the monolithic optional-field `ToolContext` with narrow typed services owned beside each capability. EVE-880 stays open to absorb them.

## Checklist

- [x] Tests added or updated — the isolation guard was extended and negative-tested (a probe `pub struct SessionSandboxState` in core fails it); the moved module carries its existing unit tests
- [x] Backward compatibility considered — internal crate boundary; import paths change for direct core consumers, consistent with the rest of the 0.18 extraction epic
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Refs EVE-880