### PR TITLE
ci: stop third-party apt repo failures from reddening main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,7 +687,12 @@ jobs:
 
       - name: Install shell test dependencies
         run: |
-          sudo apt-get update
+          # `apt-get update` exits non-zero when *any* configured repo fails, and
+          # the runner image ships third-party lists we never install from
+          # (packages.microsoft.com has 403'd and reddened main). Tolerate a
+          # partial refresh; `apt-get install` still fails loudly if a package is
+          # genuinely unavailable.
+          sudo apt-get update || true
           sudo apt-get install -y lsof netcat-openbsd ripgrep
 
           CADDY_VERSION="2.9.1"
@@ -1342,8 +1347,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Ensure jq is available
+        run: |
+          # jq ships with the GitHub-hosted runner image, so the apt path is only
+          # a fallback. See the shell-test job for why the refresh is tolerated.
+          if command -v jq >/dev/null 2>&1; then
+            jq --version
+            exit 0
+          fi
+          sudo apt-get update || true
+          sudo apt-get install -y jq
 
       - name: Download server binary
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## What changed

Two CI jobs that install packages with apt no longer fail when an apt repo
unrelated to what they install is unavailable.

- `CLI E2E Tests` now uses jq straight from the runner image and only falls
  back to apt when jq is genuinely absent.
- `Shell Tests` tolerates a partial `apt-get update` before installing
  `lsof`, `netcat-openbsd` and `ripgrep`.

`apt-get install` is unchanged, so a package that is really unavailable
still fails the job loudly.

## Why

`apt-get update` exits non-zero when *any* configured repo fails, not just
the ones a job installs from. The GitHub-hosted runner image ships
`packages.microsoft.com` lists that nothing here installs from, and those
started returning 403:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
E: The repository 'https://packages.microsoft.com/repos/azure-cli noble InRelease' is no longer signed.
##[error]Process completed with exit code 100.
```

That took the `Install jq` step down, then `CLI E2E Tests`, then the
`Build Check` gate — leaving main red on f250ad6 while nothing in the
repository was actually broken.

## Before / After

Before — run [31553093453](https://github.com/everruns/everruns/actions/runs/31553093453) on main:
`CLI E2E Tests` fails at `Install jq` with exit code 100 before downloading
any binary; `Build Check` fails its `Verify all jobs passed` step.

After — the job resolves jq from the image (`jq --version` prints and the
step exits 0) and proceeds to the e2e run. A 403 from an unrelated apt repo
can no longer fail either job.

## Risk

- Low
- Workflow-only change, no product code. Worst case is a package genuinely
  missing from the archive, which `apt-get install -y` still reports as a
  failure — the tolerated command is only the index refresh.

## Security

- Threat categories reviewed: no security-relevant code changes. The diff
  touches only CI package installation; it adds no new package source,
  changes no pinned version, and grants no additional workflow permission.
  Tolerating a failed index refresh does not weaken package verification —
  apt still verifies signatures on whatever it installs.
- Findings and resolutions: none.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated — n/a, CI configuration change; the workflow run itself is the test
- [x] Backward compatibility considered — no external interface affected
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYURe1rB1qFTXY2dvvvFMV)_