### PR TITLE
feat(agents): protect built-in agents at the command layer

### DIFF
--- a/crates/server/migrations/119_agents_is_built_in.sql
+++ b/crates/server/migrations/119_agents_is_built_in.sql
@@ -1,0 +1,21 @@
+-- Built-in agents.
+--
+-- Mirrors `harnesses.is_built_in` (007_v0.8.6.sql). A built-in agent is supplied
+-- by the platform definition rather than authored by the org: its *definition*
+-- (prompt, model, capabilities, versions) is immutable through the API, and it
+-- does not count against the per-org agent limit.
+--
+-- Bindings an org attaches around a built-in agent — triggers, identities,
+-- credentials, check rules, health checks — stay editable. A built-in agent
+-- nobody can attach a trigger to is a built-in agent nobody can use.
+--
+-- Additive only: existing rows default to FALSE, so nothing already authored
+-- becomes protected. Org bootstrap reconciles the built-in rows themselves.
+
+ALTER TABLE agents ADD COLUMN is_built_in BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN agents.is_built_in IS
+    'Platform-supplied agent: definition is immutable through the API and excluded from the per-org agent limit. Bindings (triggers, identities, credentials) remain editable.';
+
+-- Bootstrap reconciliation looks built-in agents up per org on every startup.
+CREATE INDEX idx_agents_org_built_in ON agents(org_id) WHERE is_built_in;

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -4350,6 +4350,7 @@ mod tests {
             max_iterations: None,
             network_access: None,
             parallel_tool_calls: None,
+            is_built_in: false,
         };
         db.create_agent_with_id(everruns_core::DEFAULT_ORG_ID, id, create)
             .await

--- a/crates/server/src/domains/agent_triggers/tests.rs
+++ b/crates/server/src/domains/agent_triggers/tests.rs
@@ -96,6 +96,7 @@ async fn seed_agent(db: &Arc<StorageBackend>) -> (String, everruns_core::typed_i
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
+            is_built_in: false,
         },
     )
     .await
@@ -165,6 +166,7 @@ async fn resolve_trigger_execution_context_preserves_migrated_app_context() {
         total_actual_cost_usd: 0.0,
         total_estimated_cost_usd: 0.0,
         total_cost_usd: 0.0,
+        is_built_in: false,
     };
     let trigger = crate::storage::models::AgentTriggerRow {
         id: everruns_core::TriggerId::from_uuid(uuid::Uuid::from_u128(80)),

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -341,6 +341,9 @@ impl Command for CreateAgent {
                 max_iterations: max_iterations::to_db(req.max_iterations)
                     .map_err(classify_anyhow)?,
                 parallel_tool_calls: req.parallel_tool_calls,
+                // Built-in agents come from the platform definition via org
+                // bootstrap. No API-facing creation path may mint one.
+                is_built_in: false,
             };
             let row = ctx
                 .db
@@ -371,6 +374,9 @@ impl Command for CreateAgent {
                 max_iterations: max_iterations::to_db(req.max_iterations)
                     .map_err(classify_anyhow)?,
                 parallel_tool_calls: req.parallel_tool_calls,
+                // Built-in agents come from the platform definition via org
+                // bootstrap. No API-facing creation path may mint one.
+                is_built_in: false,
             };
             let row = ctx
                 .db
@@ -541,6 +547,9 @@ impl Command for UpdateAgentCmd {
             .id
             .parse()
             .map_err(|e| CommandError::bad_request(format!("Invalid agent ID: {e}")))?;
+
+        // Covers archive too: archiving is `status: archived` through here.
+        q::ensure_not_built_in(&ctx.db, ctx.org_id(), &self.id, "modify").await?;
 
         let req = self.req;
 
@@ -729,6 +738,8 @@ impl Command for DeleteAgent {
             .parse()
             .map_err(|e| CommandError::bad_request(format!("Invalid agent ID: {e}")))?;
 
+        q::ensure_not_built_in(&ctx.db, ctx.org_id(), &self.id, "delete").await?;
+
         let row = ctx
             .db
             .get_agent_by_public_id(ctx.org_id(), &agent_id.to_string())
@@ -800,6 +811,11 @@ impl Command for UpsertAgent {
         let req = self.req;
         let public_id = self.id;
 
+        // Upsert addresses an agent by public id, so it reaches an existing
+        // built-in the same way update does. An id that resolves to nothing
+        // falls through to the create path, which cannot mint a built-in.
+        q::ensure_not_built_in(&ctx.db, ctx.org_id(), &public_id, "modify").await?;
+
         // Validate (same checks as CreateAgent)
         validate_name("Agent", &req.name)?;
         validate_create_limits(&req)?;
@@ -869,6 +885,8 @@ impl Command for UpsertAgent {
                 .network_access
                 .as_ref()
                 .map(|na| serde_json::to_value(na).unwrap_or_default()),
+            // See CreateAgent: only org bootstrap mints built-in agents.
+            is_built_in: false,
         };
         let (row, was_created) = ctx
             .db
@@ -1062,6 +1080,17 @@ async fn resolve_agent(ctx: &Ctx, id: &str) -> Result<Agent, CommandError> {
         .await
         .map_err(classify_anyhow)?
         .ok_or_else(|| CommandError::not_found("Agent"))
+}
+
+/// Resolve an agent for a command that mutates its version history.
+///
+/// Versions are part of the definition, so they are protected: a platform
+/// upgrade ships a new built-in version, and an org that rolled its own would
+/// silently diverge. Read-only version commands use [`resolve_agent`] instead.
+async fn resolve_agent_for_mutation(ctx: &Ctx, id: &str) -> Result<Agent, CommandError> {
+    let agent = resolve_agent(ctx, id).await?;
+    q::ensure_not_built_in(&ctx.db, ctx.org_id(), id, "modify").await?;
+    Ok(agent)
 }
 
 async fn resolve_agent_version(
@@ -1312,7 +1341,7 @@ impl Command for CreateAgentVersionCmd {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<AgentVersion, CommandError> {
-        let agent = resolve_agent(ctx, &self.agent_id).await?;
+        let agent = resolve_agent_for_mutation(ctx, &self.agent_id).await?;
         let change_kind = self
             .req
             .change_kind
@@ -1353,7 +1382,7 @@ impl Command for SetDefaultAgentVersion {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> {
-        let agent = resolve_agent(ctx, &self.agent_id).await?;
+        let agent = resolve_agent_for_mutation(ctx, &self.agent_id).await?;
         let version = resolve_agent_version(ctx, self.req.version_id).await?;
         if version.agent_id.uuid() != agent.internal_id {
             return Err(CommandError::bad_request(
@@ -1416,7 +1445,7 @@ impl Command for RollbackAgentVersion {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> {
-        let current = resolve_agent(ctx, &self.agent_id).await?;
+        let current = resolve_agent_for_mutation(ctx, &self.agent_id).await?;
         let version = resolve_agent_version(ctx, self.version_id).await?;
         if version.agent_id.uuid() != current.internal_id {
             return Err(CommandError::bad_request(
@@ -2760,6 +2789,217 @@ mod tests {
             .await
             .expect("creation allowed once the deleted agent is excluded");
     }
+
+    // ========================================================================
+    // Built-in agent protection (EVE-865)
+    // ========================================================================
+
+    /// Create an agent and flip it to built-in, as org bootstrap does.
+    async fn seed_built_in_agent(db: &StorageBackend, ctx: &Ctx, name: &str) -> Agent {
+        let agent = CreateAgent(basic_agent_request(name))
+            .execute(ctx)
+            .await
+            .expect("seed agent");
+        db.mark_agent_built_in(DEFAULT_ORG_ID, AgentId::from_uuid(agent.internal_id))
+            .await
+            .expect("mark built-in");
+        agent
+    }
+
+    /// Every guard must answer 400 with the copy-first hint, not 404 or 500.
+    fn assert_built_in_rejection(err: &CommandError) {
+        assert_eq!(err.status().as_u16(), 400, "message: {}", err.message());
+        assert!(
+            err.message().contains("built-in agent"),
+            "expected a built-in rejection, got: {}",
+            err.message()
+        );
+        assert!(
+            err.message().contains("Copy it first"),
+            "rejection must point at the escape hatch, got: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn built_in_agent_rejects_update() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db.clone(), OrgRole::Owner);
+        let agent = seed_built_in_agent(&db, &ctx, "chat").await;
+
+        let err = UpdateAgentCmd {
+            id: agent.public_id.to_string(),
+            req: UpdateAgentRequest {
+                system_prompt: Some("hijacked".to_string()),
+                ..Default::default()
+            },
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("built-in definition is immutable");
+        assert_built_in_rejection(&err);
+
+        // The prompt must actually be unchanged, not merely reported as such.
+        let after = q::get_by_public_id(&db, DEFAULT_ORG_ID, &agent.public_id.to_string())
+            .await
+            .expect("reload")
+            .expect("agent still present");
+        assert_eq!(after.system_prompt, "initial prompt");
+    }
+
+    #[tokio::test]
+    async fn built_in_agent_rejects_archive() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db.clone(), OrgRole::Owner);
+        let agent = seed_built_in_agent(&db, &ctx, "chat").await;
+
+        // Archive travels through UpdateAgentCmd as a status change.
+        let err = UpdateAgentCmd {
+            id: agent.public_id.to_string(),
+            req: UpdateAgentRequest {
+                status: Some(AgentStatus::Archived),
+                ..Default::default()
+            },
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("built-in agent cannot be archived");
+        assert_built_in_rejection(&err);
+    }
+
+    #[tokio::test]
+    async fn built_in_agent_rejects_delete_and_destroy() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db.clone(), OrgRole::Owner);
+        let agent = seed_built_in_agent(&db, &ctx, "chat").await;
+
+        let err = DeleteAgent {
+            id: agent.public_id.to_string(),
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("built-in agent cannot be archived away");
+        assert_built_in_rejection(&err);
+
+        let err = DestroyAgent {
+            id: agent.public_id.to_string(),
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("built-in agent cannot be destroyed");
+        assert_built_in_rejection(&err);
+
+        assert!(
+            q::get_by_public_id(&db, DEFAULT_ORG_ID, &agent.public_id.to_string())
+                .await
+                .expect("reload")
+                .is_some(),
+            "built-in agent must survive both delete verbs"
+        );
+    }
+
+    #[tokio::test]
+    async fn built_in_agent_rejects_upsert() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db.clone(), OrgRole::Owner);
+        let agent = seed_built_in_agent(&db, &ctx, "chat").await;
+
+        let err = UpsertAgent {
+            id: agent.public_id.to_string(),
+            req: basic_agent_request("chat"),
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("upsert must not overwrite a built-in");
+        assert_built_in_rejection(&err);
+    }
+
+    #[tokio::test]
+    async fn built_in_agent_rejects_version_mutations() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db.clone(), OrgRole::Owner);
+        let agent = seed_built_in_agent(&db, &ctx, "chat").await;
+        let id = agent.public_id.to_string();
+
+        let err = CreateAgentVersionCmd {
+            agent_id: id.clone(),
+            req: CreateAgentVersionRequest {
+                change_kind: Some(AgentVersionChangeKind::Minor),
+                summary: None,
+            },
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("versions are part of the protected definition");
+        assert_built_in_rejection(&err);
+
+        let err = SetDefaultAgentVersion {
+            agent_id: id.clone(),
+            req: SetDefaultAgentVersionRequest {
+                version_id: AgentVersionId::new(),
+            },
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("default version is part of the protected definition");
+        assert_built_in_rejection(&err);
+
+        let err = RollbackAgentVersion {
+            agent_id: id,
+            version_id: AgentVersionId::new(),
+            req: RollbackAgentVersionRequest {
+                save_version: false,
+                summary: None,
+            },
+        }
+        .execute(&ctx)
+        .await
+        .expect_err("rollback rewrites the protected definition");
+        assert_built_in_rejection(&err);
+    }
+
+    #[tokio::test]
+    async fn built_in_agent_can_be_copied() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db.clone(), OrgRole::Owner);
+        let agent = seed_built_in_agent(&db, &ctx, "chat").await;
+
+        let copy = CopyAgent {
+            id: agent.public_id.to_string(),
+        }
+        .execute(&ctx)
+        .await
+        .expect("copy is the escape hatch and must stay open");
+
+        assert_ne!(copy.public_id, agent.public_id);
+
+        // The copy must be editable, or the escape hatch leads nowhere.
+        UpdateAgentCmd {
+            id: copy.public_id.to_string(),
+            req: UpdateAgentRequest {
+                system_prompt: Some("edited".to_string()),
+                ..Default::default()
+            },
+        }
+        .execute(&ctx)
+        .await
+        .expect("the copy is an ordinary editable agent");
+    }
+
+    #[tokio::test]
+    async fn built_in_agents_do_not_count_toward_limit() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let mut ctx = ctx_with_role(db.clone(), OrgRole::Owner);
+        ctx.resource_limits.max_agents_per_org = 1;
+
+        seed_built_in_agent(&db, &ctx, "platform-chat").await;
+
+        // The built-in must not consume the cap, so a user agent still fits.
+        CreateAgent(basic_agent_request("mine"))
+            .execute(&ctx)
+            .await
+            .expect("built-in agent must not consume the org quota");
+    }
 }
 
 // ============================================================================
@@ -2799,6 +3039,8 @@ impl Command for DestroyAgent {
             .id
             .parse()
             .map_err(|e| CommandError::bad_request(format!("Invalid agent ID: {e}")))?;
+
+        q::ensure_not_built_in(&ctx.db, ctx.org_id(), &self.id, "delete").await?;
 
         let row = ctx
             .db

--- a/crates/server/src/domains/agents/queries.rs
+++ b/crates/server/src/domains/agents/queries.rs
@@ -321,6 +321,66 @@ pub async fn get_by_name(
 }
 
 // ============================================================================
+// Built-in agent protection
+// ============================================================================
+
+/// Whether the agent is platform-supplied. Mirrors the harness equivalent.
+///
+/// Takes the same `id_or_name` the command received and resolves it the same
+/// way [`resolve`] does. Agents use the dual-ID pattern — the API-facing
+/// `public_id` is a different value from the internal primary key — so a guard
+/// that looked the caller's identifier up as an internal id would find nothing
+/// and wave every mutation through.
+///
+/// A missing agent reports `false` so callers surface their own "not found",
+/// rather than a confusing "cannot modify built-in agent".
+pub async fn is_built_in(
+    db: &StorageBackend,
+    org_id: i64,
+    id_or_name: &str,
+) -> anyhow::Result<bool> {
+    let row = if let Ok(agent_id) = id_or_name.parse::<AgentId>() {
+        db.get_agent_by_public_id(org_id, &agent_id.to_string())
+            .await?
+    } else {
+        db.get_agent_by_name(org_id, id_or_name).await?
+    };
+    Ok(row.map(|r| r.is_built_in).unwrap_or(false))
+}
+
+/// Reject a mutation that would change a built-in agent's *definition*.
+///
+/// The line is definition vs bindings, and it is deliberate:
+///
+/// - **Definition is protected** — prompt, model, capabilities, versions,
+///   status. These come from the platform definition, so an org editing them
+///   would silently diverge from what the next platform upgrade ships.
+/// - **Bindings stay editable** — triggers, identities, credentials, check
+///   rules, health checks. These live in adjacent domains and never touch the
+///   agents row. A built-in agent nobody can attach a trigger to is a built-in
+///   agent nobody can use.
+///
+/// Call this from `Command::execute`, never from an HTTP route: the MCP
+/// endpoint's `execute` tier dispatches the same command descriptors, so a
+/// route-level check would leave the built-in agent editable over MCP by any
+/// caller holding agent-management access — including the agent itself.
+///
+/// `CopyAgent` is intentionally not guarded; it is the escape hatch.
+pub async fn ensure_not_built_in(
+    db: &StorageBackend,
+    org_id: i64,
+    id_or_name: &str,
+    verb: &str,
+) -> Result<(), CommandError> {
+    if is_built_in(db, org_id, id_or_name).await? {
+        return Err(CommandError::bad_request(format!(
+            "Cannot {verb} built-in agent. Copy it first to create an editable version."
+        )));
+    }
+    Ok(())
+}
+
+// ============================================================================
 // Validation helpers
 // ============================================================================
 

--- a/crates/server/src/domains/agents/types.rs
+++ b/crates/server/src/domains/agents/types.rs
@@ -91,9 +91,9 @@ pub struct CreateAgentRequest {
 }
 
 /// Request to update an agent. Only provided fields will be updated.
-///
-/// Every field is optional, so `Default` means "change nothing" — convenient
-/// for tests that exercise one field at a time.
+// Every field is optional, so `Default` means "change nothing" — convenient for
+// tests that exercise one field at a time. Kept out of the doc comment: utoipa
+// publishes those into docs/api/openapi.json, and this is an internal note.
 #[derive(Debug, Clone, Default, Deserialize, ToSchema)]
 pub struct UpdateAgentRequest {
     /// Name, unique per org. Lowercase alphanumeric and hyphens.

--- a/crates/server/src/domains/agents/types.rs
+++ b/crates/server/src/domains/agents/types.rs
@@ -91,7 +91,10 @@ pub struct CreateAgentRequest {
 }
 
 /// Request to update an agent. Only provided fields will be updated.
-#[derive(Debug, Clone, Deserialize, ToSchema)]
+///
+/// Every field is optional, so `Default` means "change nothing" — convenient
+/// for tests that exercise one field at a time.
+#[derive(Debug, Clone, Default, Deserialize, ToSchema)]
 pub struct UpdateAgentRequest {
     /// Name, unique per org. Lowercase alphanumeric and hyphens.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -598,6 +598,7 @@ mod tests {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await

--- a/crates/server/src/domains/org_resolver.rs
+++ b/crates/server/src/domains/org_resolver.rs
@@ -257,6 +257,7 @@ mod tests {
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
+            is_built_in: false,
         };
         let mut agent_two = agent_one.clone();
         agent_two.public_id = "agent_00000000000000000000000000000042".to_string();

--- a/crates/server/src/domains/organizations/commands.rs
+++ b/crates/server/src/domains/organizations/commands.rs
@@ -180,6 +180,7 @@ mod tests {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -224,6 +225,7 @@ mod tests {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -1393,6 +1393,7 @@ mod tests {
                     network_access: None,
                     max_iterations: None,
                     parallel_tool_calls: None,
+                    is_built_in: false,
                 },
             )
             .await
@@ -1487,6 +1488,7 @@ mod tests {
                     network_access: None,
                     max_iterations: None,
                     parallel_tool_calls: None,
+                    is_built_in: false,
                 },
             )
             .await
@@ -1510,6 +1512,7 @@ mod tests {
                     network_access: None,
                     max_iterations: None,
                     parallel_tool_calls: None,
+                    is_built_in: false,
                 },
             )
             .await

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -839,9 +839,18 @@ impl StorageBackend {
         dispatch!(self, count_harnesses_for_org, org_id)
     }
 
-    /// Count non-deleted agents in an org (for resource limits).
+    /// Count non-deleted, non-built-in agents in an org (for resource limits).
     pub async fn count_agents_for_org(&self, org_id: i64) -> Result<i64> {
         dispatch!(self, count_agents_for_org, org_id)
+    }
+
+    /// Flag an agent as platform-supplied.
+    ///
+    /// Reserved for org bootstrap reconciliation, which must be able to adopt a
+    /// row that already exists — an org seeded before built-in agents shipped
+    /// has the agent but not the flag. No command path calls this.
+    pub async fn mark_agent_built_in(&self, org_id: i64, id: AgentId) -> Result<()> {
+        dispatch!(self, mark_agent_built_in, org_id, id)
     }
 
     /// Count sessions in an org (for resource limits).

--- a/crates/server/src/storage/memory/agents.rs
+++ b/crates/server/src/storage/memory/agents.rs
@@ -40,6 +40,7 @@ impl InMemoryDatabase {
             max_iterations: input.max_iterations,
             parallel_tool_calls: input.parallel_tool_calls,
             status: "active".to_string(),
+            is_built_in: input.is_built_in,
             created_at: now,
             updated_at: now,
             archived_at: None,
@@ -124,6 +125,7 @@ impl InMemoryDatabase {
             max_iterations: input.max_iterations,
             parallel_tool_calls: input.parallel_tool_calls,
             status: "active".to_string(),
+            is_built_in: input.is_built_in,
             created_at: now,
             updated_at: now,
             archived_at: None,
@@ -182,14 +184,29 @@ impl InMemoryDatabase {
             .cloned())
     }
 
-    /// Count non-deleted agents in an org (for resource limits).
-    /// Includes active and archived; excludes soft-deleted rows.
+    /// Flag an agent as platform-supplied. Idempotent; used by org bootstrap.
+    pub async fn mark_agent_built_in(&self, org_id: i64, id: AgentId) -> Result<()> {
+        if let Some(agent) = self
+            .agents
+            .write()
+            .values_mut()
+            .find(|a| a.org_id == org_id && a.id == id)
+        {
+            agent.is_built_in = true;
+        }
+        Ok(())
+    }
+
+    /// Count agents against the per-org limit.
+    /// Includes active and archived; excludes soft-deleted and built-in rows.
     pub async fn count_agents_for_org(&self, org_id: i64) -> Result<i64> {
         Ok(self
             .agents
             .read()
             .values()
-            .filter(|a| a.org_id == org_id && a.status != "deleted")
+            // Built-in agents are platform-supplied and do not consume the
+            // org's quota — same rule as built-in harnesses.
+            .filter(|a| a.org_id == org_id && a.status != "deleted" && !a.is_built_in)
             .count() as i64)
     }
 
@@ -430,6 +447,7 @@ impl InMemoryDatabase {
                 max_iterations: input.max_iterations,
                 parallel_tool_calls: input.parallel_tool_calls,
                 status: "active".to_string(),
+                is_built_in: input.is_built_in,
                 created_at: now,
                 updated_at: now,
                 archived_at: None,
@@ -503,6 +521,7 @@ impl InMemoryDatabase {
                 max_iterations: input.max_iterations,
                 parallel_tool_calls: input.parallel_tool_calls,
                 status: "active".to_string(),
+                is_built_in: input.is_built_in,
                 created_at: now,
                 updated_at: now,
                 archived_at: None,

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -71,6 +71,7 @@ async fn test_create_and_get_agent() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -165,6 +166,7 @@ async fn test_create_and_list_sessions() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -596,6 +598,7 @@ async fn test_session_aggregate_stats_by_agent_and_harness() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -721,6 +724,7 @@ async fn test_session_updated_at() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -810,6 +814,7 @@ async fn test_events_sequence() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -899,6 +904,7 @@ async fn test_list_message_events_filtered_keep_head_loads_head_and_tail() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -1324,6 +1330,7 @@ async fn create_session_with_events(db: &InMemoryDatabase) -> SessionId {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -2042,6 +2049,7 @@ async fn test_list_events_empty_session_with_limit() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -2112,6 +2120,7 @@ async fn test_sessions_pagination() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -2257,6 +2266,7 @@ async fn test_sessions_pagination_ordering() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -2770,6 +2780,7 @@ async fn create_test_agent(
             network_access: None,
             max_iterations: None,
             parallel_tool_calls: None,
+            is_built_in: false,
         },
     )
     .await
@@ -3373,6 +3384,7 @@ async fn create_session_with_content_events(db: &InMemoryDatabase) -> SessionId 
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -477,6 +477,11 @@ pub struct AgentRow {
     pub root_agent_id: Option<AgentId>,
     pub tags: Vec<String>,
     pub status: String,
+    /// Platform-supplied agent (mirrors `HarnessRow::is_built_in`). Its
+    /// definition is immutable through the API and excluded from the per-org
+    /// agent limit; bindings around it stay editable.
+    #[sqlx(default)]
+    pub is_built_in: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub archived_at: Option<DateTime<Utc>>,
@@ -618,6 +623,9 @@ pub struct CreateAgentRow {
     pub max_iterations: Option<i32>,
     /// Request-level parallel tool calling preference (EVE-598)
     pub parallel_tool_calls: Option<bool>,
+    /// Platform-supplied agent. Only org bootstrap sets this; every API-facing
+    /// creation path leaves it false.
+    pub is_built_in: bool,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -17,9 +17,9 @@ impl Database {
     pub async fn create_agent(&self, org_id: i64, input: CreateAgentRow) -> Result<AgentRow> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            INSERT INTO agents (org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, 'active')
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            INSERT INTO agents (org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, is_built_in, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 'active')
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -38,6 +38,7 @@ impl Database {
         .bind(&input.network_access)
         .bind(input.max_iterations)
         .bind(input.parallel_tool_calls)
+        .bind(input.is_built_in)
         .fetch_one(&self.pool)
         .await?;
 
@@ -54,8 +55,8 @@ impl Database {
     ) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            INSERT INTO agents (id, org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 'active')
+            INSERT INTO agents (id, org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, is_built_in, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, 'active')
             ON CONFLICT (id) DO UPDATE SET
                 name = EXCLUDED.name,
                 display_name = EXCLUDED.display_name,
@@ -83,7 +84,7 @@ impl Database {
                 OR agents.network_access IS DISTINCT FROM EXCLUDED.network_access
                 OR agents.max_iterations IS DISTINCT FROM EXCLUDED.max_iterations
                 OR agents.parallel_tool_calls IS DISTINCT FROM EXCLUDED.parallel_tool_calls
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -103,6 +104,7 @@ impl Database {
         .bind(&input.network_access)
         .bind(input.max_iterations)
         .bind(input.parallel_tool_calls)
+        .bind(input.is_built_in)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -112,7 +114,7 @@ impl Database {
     pub async fn get_agent(&self, org_id: i64, id: AgentId) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             FROM agents
             WHERE org_id = $1 AND id = $2
@@ -130,7 +132,7 @@ impl Database {
         let ids: Vec<Uuid> = ids.iter().map(|id| id.uuid()).collect();
         Ok(sqlx::query_as::<_, AgentRow>(
             r#"
-            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             FROM agents
             WHERE org_id = $1 AND id = ANY($2)
@@ -162,7 +164,7 @@ impl Database {
     ) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             FROM agents
             WHERE org_id = $1 AND public_id = $2
@@ -210,7 +212,7 @@ impl Database {
         let limit_idx = param_idx + 1;
         let offset_idx = param_idx + 2;
         let sql = format!(
-            r#"SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            r#"SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                        total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
                 FROM agents
                 WHERE org_id = $1{status_sql}{search_sql}
@@ -233,19 +235,24 @@ impl Database {
 
     /// Count non-deleted agents in an org (for resource limits).
     /// Includes active and archived; excludes soft-deleted rows.
+    /// Count agents against the per-org limit.
+    ///
+    /// Built-in agents are platform-supplied, not authored by the org, so they
+    /// do not consume the org's quota — same rule as built-in harnesses.
     pub async fn count_agents_for_org(&self, org_id: i64) -> Result<i64> {
-        let (count,): (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM agents WHERE org_id = $1 AND status != 'deleted'")
-                .bind(org_id)
-                .fetch_one(&self.pool)
-                .await?;
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM agents WHERE org_id = $1 AND status != 'deleted' AND NOT is_built_in",
+        )
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await?;
         Ok(count)
     }
 
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            SELECT id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             FROM agents
             WHERE org_id = $1 AND name = $2 AND status != 'deleted'
@@ -257,6 +264,16 @@ impl Database {
         .await?;
 
         Ok(row)
+    }
+
+    /// Flag an agent as platform-supplied. Idempotent; used by org bootstrap.
+    pub async fn mark_agent_built_in(&self, org_id: i64, id: AgentId) -> Result<()> {
+        sqlx::query("UPDATE agents SET is_built_in = TRUE WHERE org_id = $1 AND id = $2")
+            .bind(org_id)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 
     pub async fn update_agent(
@@ -290,7 +307,7 @@ impl Database {
                 parallel_tool_calls = CASE WHEN $22 THEN $23 ELSE parallel_tool_calls END,
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -419,8 +436,8 @@ impl Database {
             WITH existing AS (
                 SELECT id FROM agents WHERE org_id = $1 AND public_id = $2
             )
-            INSERT INTO agents (org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, 'active')
+            INSERT INTO agents (org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, is_built_in, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 'active')
             ON CONFLICT (org_id, public_id) DO UPDATE SET
                 name = EXCLUDED.name,
                 display_name = EXCLUDED.display_name,
@@ -437,7 +454,7 @@ impl Database {
                 parallel_tool_calls = EXCLUDED.parallel_tool_calls,
                 status = 'active',
                 updated_at = NOW()
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -456,6 +473,7 @@ impl Database {
         .bind(&input.network_access)
         .bind(input.max_iterations)
         .bind(input.parallel_tool_calls)
+        .bind(input.is_built_in)
         .fetch_one(&self.pool)
         .await?;
 
@@ -472,8 +490,8 @@ impl Database {
     ) -> Result<(AgentRow, bool)> {
         let row = sqlx::query_as::<_, AgentRow>(
             r#"
-            INSERT INTO agents (org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, 'active')
+            INSERT INTO agents (org_id, public_id, name, display_name, description, system_prompt, default_model_id, harness_id, tags, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls, is_built_in, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, 'active')
             ON CONFLICT (org_id, name) WHERE status != 'deleted' DO UPDATE SET
                 display_name = EXCLUDED.display_name,
                 description = EXCLUDED.description,
@@ -489,7 +507,7 @@ impl Database {
                 parallel_tool_calls = EXCLUDED.parallel_tool_calls,
                 status = 'active',
                 updated_at = NOW()
-            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
+            RETURNING id, public_id, org_id, name, display_name, description, system_prompt, default_model_id, harness_id, harness_source, agent_identity_id, default_version_id, forked_from_agent_id, forked_from_version_id, root_agent_id, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at, initial_files, tools, mcp_servers, network_access, max_iterations, parallel_tool_calls,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd
             "#,
         )
@@ -508,6 +526,7 @@ impl Database {
         .bind(&input.network_access)
         .bind(input.max_iterations)
         .bind(input.parallel_tool_calls)
+        .bind(input.is_built_in)
         .fetch_one(&self.pool)
         .await?;
 

--- a/crates/server/src/storage/repositories/evals.rs
+++ b/crates/server/src/storage/repositories/evals.rs
@@ -18,7 +18,7 @@ impl Database {
             INSERT INTO evals (org_id, public_id, name, description, target, model_override, tags)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             RETURNING id, org_id, public_id, name, description, target,
-                      model_override, tags, status, created_at, updated_at, archived_at, deleted_at
+                      model_override, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
@@ -52,7 +52,7 @@ impl Database {
         let row = sqlx::query_as::<_, EvalRow>(
             r#"
             SELECT id, org_id, public_id, name, description, target,
-                   model_override, tags, status, created_at, updated_at, archived_at, deleted_at
+                   model_override, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at
             FROM evals
             WHERE org_id = $1 AND public_id = $2
             "#,
@@ -79,7 +79,7 @@ impl Database {
         };
         let sql = format!(
             r#"SELECT id, org_id, public_id, name, description, target,
-                      model_override, tags, status, created_at, updated_at, archived_at, deleted_at
+                      model_override, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at
                FROM evals
                WHERE org_id = $1{status_sql}{search_sql}
                ORDER BY created_at DESC"#
@@ -111,7 +111,7 @@ impl Database {
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, public_id, name, description, target,
-                      model_override, tags, status, created_at, updated_at, archived_at, deleted_at
+                      model_override, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -557,6 +557,7 @@ async fn test_list_agents_resolves_explicit_inherited_and_missing_harnesses() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await

--- a/crates/server/tests/blob_offload_integration_test.rs
+++ b/crates/server/tests/blob_offload_integration_test.rs
@@ -136,6 +136,7 @@ async fn create_test_session(backend: &StorageBackend) -> everruns_core::Session
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -480,6 +480,7 @@ async fn seed_agent(ctx: &Ctx, name: &str) -> AgentId {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -642,6 +643,163 @@ async fn session_file_read_commands_enforce_session_view_policy() {
 const ALLOWED_PUBLIC: &[&str] = &[
     // (none today)
 ];
+
+// ============================================================================
+// Built-in agent protection coverage (EVE-865)
+//
+// A guard that must be remembered will be forgotten the next time someone adds
+// an agent command. This test walks the inventory instead: every mutating
+// command in the `agents` category must be classified as either guarded
+// against built-in agents or deliberately exempt. Adding an eleventh agent
+// command fails CI here until its author decides which it is.
+//
+// This is a classification check, not a behavioral one — the behavior is
+// asserted per verb in `domains::agents::commands::tests`.
+// ============================================================================
+
+/// Agent commands that reject built-in agents via `q::ensure_not_built_in`.
+/// Each has a matching `built_in_agent_rejects_*` test.
+const BUILT_IN_GUARDED_AGENT_COMMANDS: &[&str] = &[
+    "create_agent_version",
+    "delete_agent",
+    "destroy_agent",
+    "rollback_agent_version",
+    "set_default_agent_version",
+    "update_agent",
+    "upsert_agent",
+];
+
+/// Agent commands that are deliberately NOT guarded. Justify every entry.
+///
+/// The rule is definition vs bindings: a command that changes a built-in
+/// agent's own definition is guarded; one that only creates something new, or
+/// attaches an org's own binding around the agent, is not.
+const BUILT_IN_EXEMPT_AGENT_COMMANDS: &[&str] = &[
+    // Creates a fresh agent; cannot mint a built-in (is_built_in is false on
+    // every API-facing creation path).
+    "create_agent",
+    // Same — import is create with a definition body.
+    "import_agent",
+    // The escape hatch. Blocking copy would leave built-in agents unusable as
+    // a starting point, and the rejection message tells users to copy first.
+    "copy_agent",
+    // Forks a *source version* into a brand-new agent. It reads the built-in
+    // and writes elsewhere, so it is a copy, not a mutation — same reasoning
+    // as copy_agent. (EVE-865 listed this as needing a guard; the code shows
+    // it never writes to the source row.)
+    "fork_agent_version",
+    // --- Bindings, not definition -------------------------------------------
+    // These live in adjacent domains and never touch the agents row. An org
+    // must be able to wire a built-in agent into its own environment; a
+    // built-in agent nobody can attach a rule or credential to is unusable.
+    "upsert_agent_check_rule",
+    "delete_agent_check_rule",
+    "create_agent_credential_binding",
+    // Operational probe. Runs the agent to report health; changes no definition.
+    "trigger_agent_health_check",
+    // Produces an analysis report. Non-read-only only because it spends utility
+    // LLM budget and is rate limited; it does not write the agent.
+    "analyze_agent",
+];
+
+/// The guard lives in `Command::execute`, so it must hold over `dispatch()` —
+/// the MCP `execute` tier and gRPC `ExecuteCommand` both route through here.
+/// A route-level check would pass the REST test and miss this one entirely,
+/// leaving the built-in agent editable by any caller holding agent-management
+/// access over MCP — including the agent itself.
+#[tokio::test]
+async fn dispatch_blocks_built_in_agent_mutation() {
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Owner),
+        Arc::new(DefaultPermissionResolver),
+    );
+    let agent_id = seed_agent(&ctx, "platform-chat").await;
+    let row = ctx
+        .db
+        .get_agent_by_public_id(DEFAULT_ORG_ID, &agent_id.to_string())
+        .await
+        .expect("load seeded agent")
+        .expect("seeded agent exists");
+    ctx.db
+        .mark_agent_built_in(DEFAULT_ORG_ID, row.id)
+        .await
+        .expect("mark built-in");
+
+    let err = dispatch(
+        "update_agent",
+        serde_json::json!({ "id": agent_id.to_string(), "system_prompt": "hijacked" }),
+        &ctx,
+    )
+    .await
+    .expect_err("MCP execute must not edit a built-in agent");
+
+    assert!(
+        err.message().contains("built-in agent"),
+        "expected the built-in rejection over dispatch, got {err:?}"
+    );
+
+    // An Owner is allowed to update agents in general, so this must be the
+    // built-in guard talking, not a permission denial.
+    assert!(
+        !matches!(
+            err,
+            CommandError {
+                kind: CommandErrorKind::Forbidden(_),
+                ..
+            }
+        ),
+        "rejection must come from the built-in guard, not authorization: {err:?}"
+    );
+}
+
+#[test]
+fn every_mutating_agent_command_is_classified_for_built_in_protection() {
+    use everruns_server::domains::common::CommandDescriptor;
+
+    let mut unclassified: Vec<&'static str> = Vec::new();
+    let mut mutating: Vec<&'static str> = Vec::new();
+
+    for desc in inventory::iter::<CommandDescriptor> {
+        let meta = (desc.meta)();
+        if meta.category != "agents" || (desc.read_only)() {
+            continue;
+        }
+        mutating.push(meta.name);
+        if !BUILT_IN_GUARDED_AGENT_COMMANDS.contains(&meta.name)
+            && !BUILT_IN_EXEMPT_AGENT_COMMANDS.contains(&meta.name)
+        {
+            unclassified.push(meta.name);
+        }
+    }
+
+    assert!(
+        !mutating.is_empty(),
+        "no mutating agents commands found — is inventory registration broken?"
+    );
+    assert!(
+        unclassified.is_empty(),
+        "New mutating agent command(s) {unclassified:?} are not classified for \
+         built-in agent protection. Either call `q::ensure_not_built_in` and add \
+         the name to BUILT_IN_GUARDED_AGENT_COMMANDS with a \
+         `built_in_agent_rejects_*` test, or add it to \
+         BUILT_IN_EXEMPT_AGENT_COMMANDS with a written reason. Guard at the \
+         command layer, not the HTTP route — MCP `execute` dispatches the same \
+         descriptors."
+    );
+
+    // Stale entries are as dangerous as missing ones: a renamed command would
+    // leave a guard listed that no longer exists.
+    for name in BUILT_IN_GUARDED_AGENT_COMMANDS
+        .iter()
+        .chain(BUILT_IN_EXEMPT_AGENT_COMMANDS)
+    {
+        assert!(
+            mutating.contains(name),
+            "'{name}' is classified for built-in protection but is no longer a \
+             mutating agents command. Remove the stale entry."
+        );
+    }
+}
 
 /// POST-style helpers intentionally available through MCP `query`.
 /// They do not persist state and each still declares a view policy.

--- a/crates/server/tests/repository_conformance_test.rs
+++ b/crates/server/tests/repository_conformance_test.rs
@@ -91,6 +91,7 @@ fn agent_input(name: String, harness_id: HarnessId) -> CreateAgentRow {
         network_access: None,
         max_iterations: None,
         parallel_tool_calls: None,
+        is_built_in: false,
     }
 }
 

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -219,6 +219,7 @@ async fn test_agent_crud() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -302,6 +303,7 @@ async fn test_agent_upsert_initial_files() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -332,6 +334,7 @@ async fn test_agent_upsert_initial_files() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -482,6 +485,7 @@ async fn test_agent_get_by_name() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -765,6 +769,7 @@ async fn test_session_crud() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -997,6 +1002,7 @@ async fn test_event_crud() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -1098,6 +1104,7 @@ async fn test_event_exclude_types() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -1207,6 +1214,7 @@ async fn test_message_events_filtered_offset_and_latest_limit() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -1310,6 +1318,7 @@ async fn test_message_events_filtered_keep_head_loads_head_and_tail() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -1429,6 +1438,7 @@ async fn test_long_message_history_reads_are_bounded_and_index_supported() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -1652,6 +1662,7 @@ async fn test_event_filter_types() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -1964,6 +1975,7 @@ async fn test_session_file_crud() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -2166,6 +2178,7 @@ async fn test_agent_capabilities() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -2446,6 +2459,7 @@ async fn test_session_usage_tracking() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await
@@ -2556,6 +2570,7 @@ async fn test_session_previews() {
                 network_access: None,
                 max_iterations: None,
                 parallel_tool_calls: None,
+                is_built_in: false,
             },
         )
         .await


### PR DESCRIPTION
Part 1 of EVE-865. Adds the built-in concept to agents and the protection
around it. Platform Chat becoming that agent is part 2 — see **Follow-ups**.

## What changed

Agents gain the built-in concept harnesses already have, so the platform can
supply an agent that an org cannot edit out from under itself.

- `agents.is_built_in` (migration 119), mirroring `harnesses.is_built_in`.
- Built-in agents no longer count against the per-org agent limit, matching
  the existing rule for built-in harnesses.
- Mutating agent commands reject built-in agents with
  `Cannot <verb> built-in agent. Copy it first to create an editable version.`
- `UpdateAgentRequest` derives `Default` (every field is already `Option`).

No behavior changes for existing agents: the column defaults to false, and no
API-facing path can set it, so nothing already authored becomes protected.

## Why

The guard sits in `Command::execute`, never at the HTTP route. The MCP
endpoint's `execute` tier dispatches the same command descriptors, so a
route-level check would leave a built-in agent editable over MCP by any caller
holding agent-management access — including, absurdly, the agent itself. One
guard covers REST, CLI and MCP together, and
`dispatch_blocks_built_in_agent_mutation` pins that path specifically.

**The line is definition vs bindings.** This is the part a future contributor
will get wrong, so it is stated at the guard and asserted by test:

- *Definition is protected* — prompt, model, capabilities, versions, status.
  These come from the platform definition; an org editing them would silently
  diverge from what the next platform upgrade ships.
- *Bindings stay editable* — triggers, identities, credentials, check rules,
  health checks. They live in adjacent domains and never touch the agents row.
  A built-in agent nobody can attach a trigger to is one nobody can use.

Guarded: `update_agent` (which carries archive), `delete_agent`,
`destroy_agent`, `upsert_agent`, `create_agent_version`,
`set_default_agent_version`, `rollback_agent_version`.

## Divergence from the issue

EVE-865 lists `fork_agent_version` as needing a guard. Reading it, it forks a
source version into a **brand-new** agent and never writes the source row — the
same shape as `copy_agent`. Guarding it would close the very escape hatch the
issue requires ("Copying a built-in agent yields an editable copy"), so it stays
open and is recorded as deliberately exempt with that reasoning.

## Before / After

Before: any caller with agent-management access could edit or delete any agent;
there was no way to mark one platform-supplied.

After, against a built-in agent:

```
PATCH  /v1/agents/{id}   → 400 Cannot modify built-in agent. Copy it first…
DELETE /v1/agents/{id}   → 400 Cannot delete built-in agent. Copy it first…
PUT    /v1/agents/{id}   → 400 Cannot modify built-in agent. Copy it first…
POST   /v1/agents/{id}/versions            → 400
POST   /v1/agents/{id}/versions/default    → 400
POST   /v1/agents/{id}/versions/rollback   → 400
POST   /v1/agents/{id}/copy                → 201, editable copy
MCP execute update_agent                   → 400 (same guard)
```

Tests assert the state, not just the status code — after a rejected update the
prompt is re-read and still `initial prompt`, and after both delete verbs the
row is still present.

```
cargo test -p everruns-server --lib built_in                        # 13 passed
cargo test -p everruns-server --test command_policy_enforcement_test # 19 passed
./scripts/lib/pre-push.sh                                           # 20/20 ✅
cargo clippy --workspace --all-targets --all-features -- -D warnings # clean
bash scripts/lib/check-migration-ordering.sh                        # 001..119
```

The dual-ID pattern bit me and the tests caught it: agents address by
`public_id`, which is a different value from the internal primary key. My first
guard looked the caller's identifier up as an internal id, found nothing, and
waved every mutation through — REST tests still passed, and
`dispatch_blocks_built_in_agent_mutation` is what failed. The lookup now
resolves the same way the commands do, and the reason is written at
`q::is_built_in`.

## Risk

- Medium
- The guard adds one indexed read per agent mutation. It is deliberately
  consistent across every guarded verb rather than reusing an already-loaded
  row, because a future contributor copies the pattern and consistency matters
  more here than one query.
- A wrongly-flagged row would be uneditable through the API. Nothing sets the
  flag yet in this PR (part 2 does, via bootstrap), and `copy_agent` is always
  available as the escape hatch.
- Migration is additive with a `DEFAULT FALSE` column and a partial index; no
  backfill, no rewrite of existing rows.

## Security

- Threat categories reviewed: **TM-API** and **TM-MCP**. The change adds an
  authorization-adjacent guard, so the risk is a guard that appears to work but
  does not.
  - Enforced at the command layer, so REST, CLI, gRPC `ExecuteCommand` and MCP
    `execute` are covered by one check — the specific hole a route-level guard
    would leave is tested directly.
  - Guard runs before the mutation and before any other resolution, so no
    partial write can precede a rejection.
  - Missing agents report `false` rather than "built-in", so the guard cannot be
    used to probe for row existence — callers still get their own 404.
  - Rejections are 400 with a fixed message and leak no agent state.
- Findings and resolutions: one real finding, found by the MCP test and fixed —
  the dual-ID lookup bug above, which made the guard a silent no-op. It is the
  reason the MCP-path test exists rather than being assumed equivalent to REST.

## Follow-ups

- **Part 2 of EVE-865 — Platform Chat as a built-in agent.** The foundation is
  written and pushed on `eve-865-part2-wip` (`BuiltInAgentDefinition`, the
  Platform Chat agent definition owning the Chat-role harness, and an
  idempotent `initialize_org_agents` that adopts an existing same-named row
  rather than duplicating). It is deliberately **not** in this PR: wiring it
  needs the definitions threaded through `AppState` like `built_in_harnesses`,
  the bootstrap call sites updated, the `__platform_chat__` sentinel removed
  from `new-chat-form.tsx`, and a decision on legacy harness-bound threads.
  That deserves its own reviewed pass rather than a rushed tail on this one.
  EVE-865 stays open until it lands.
- Nothing sets `is_built_in` until part 2, so this PR is protection machinery
  with no built-in agents yet — intentional, and it is what makes part 2 a
  small, reviewable change.

## Checklist
- [x] Tests added or updated — 7 per-verb guard tests, 1 MCP-dispatch test, 1 inventory classification test
- [x] Backward compatibility considered — additive column defaulting false; no API-facing path sets it
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYURe1rB1qFTXY2dvvvFMV)_