### PR TITLE
refactor(context): resolve the session SQL store as a typed extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,6 +3413,7 @@ dependencies = [
  "base64 0.23.1",
  "chrono",
  "everruns-core",
+ "everruns-platform",
  "parking_lot",
  "rusqlite",
  "serde_json",

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -320,12 +320,6 @@ where
         vec![Arc::new(act_hooks::OutputHardLimitHook)]
     }
 
-    /// Set the SQL database store on this atom
-    pub fn with_sqldb_store(mut self, store: crate::traits::SessionSqlDbStoreRef) -> Self {
-        self.context_services.sqldb_store = Some(store);
-        self
-    }
-
     /// Set the session storage store on this atom
     pub fn with_storage_store(
         mut self,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -147,7 +147,6 @@ pub mod session_file;
 pub mod session_path;
 pub mod session_resource;
 pub mod session_schedule;
-pub mod session_sqldb;
 pub mod session_task;
 pub mod skill;
 pub mod system_allowlist;
@@ -275,10 +274,10 @@ pub use traits::{
     NoopPartialStreamStore, NoopStreamHeartbeater, NoopSubagentSpawnStore, OutboundToolRateLimiter,
     PartialStreamState, PartialStreamStore, ProviderStore, ReasoningEffortHandle, ResolvedImage,
     ResolvedModel, SecretInfo, SessionFileStore, SessionFileSystem, SessionFileSystemFactory,
-    SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef,
-    SessionStorageStore, SessionStore, SpawnClaimResult, StreamHeartbeater, StreamProgress,
-    SubagentNestingPolicy, SubagentSpawnStore, ToolCallClaimResult, ToolContext, ToolExecutor,
-    UserConnectionResolver, WorkspaceScopedFileSystem,
+    SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionStorageStore,
+    SessionStore, SpawnClaimResult, StreamHeartbeater, StreamProgress, SubagentNestingPolicy,
+    SubagentSpawnStore, ToolCallClaimResult, ToolContext, ToolExecutor, UserConnectionResolver,
+    WorkspaceScopedFileSystem,
 };
 pub use user_facing_error::{
     ErrorDisclosure, UserFacingError, UserFacingErrorContext, UserFacingErrorFields,
@@ -563,10 +562,10 @@ pub use session_file::{
 pub use session_resource::{
     RegisterSessionResource, SessionResourceEntry, SessionResourceFilter, SessionResourceStatus,
 };
-pub use session_sqldb::{
-    ColumnSchema, DatabaseInfo, SessionSqlDbError, SessionSqlDbStore, SqlExecuteResult,
-    SqlQueryResult, TableSchema,
-};
+// EVE-897: the session SQL database store and its value types moved to
+// `everruns-platform`. Records and trait travel together — the value types are
+// the trait's signature vocabulary — and nothing in the kernel names either:
+// the capability resolves the store as a typed context extension.
 pub use session_task::{
     CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
     SessionTaskState, SessionTaskUpdate, TASK_KIND_AGENT_HANDOFF, TASK_KIND_BACKGROUND_TOOL,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -1399,9 +1399,6 @@ impl SubagentNestingPolicy {
     }
 }
 
-/// Type alias for the session SQL DB store trait object.
-pub type SessionSqlDbStoreRef = Arc<dyn crate::session_sqldb::SessionSqlDbStore>;
-
 /// Resolves user connection tokens (e.g. GitHub) lazily at tool execution time.
 ///
 /// Instead of eagerly injecting tokens at session creation, tools call this
@@ -1738,7 +1735,6 @@ pub enum ToolContextService {
     UtilityLlmService,
     McpInvoker,
     EgressService,
-    SessionSqlDbStore,
     MessageRetriever,
     SessionStore,
     SessionMutator,
@@ -1770,7 +1766,6 @@ impl ToolContextService {
             Self::UtilityLlmService => "UtilityLlmService",
             Self::McpInvoker => "McpInvoker",
             Self::EgressService => "EgressService",
-            Self::SessionSqlDbStore => "SessionSqlDbStore",
             Self::MessageRetriever => "MessageRetriever",
             Self::SessionStore => "SessionStore",
             Self::SessionMutator => "SessionMutator",
@@ -1807,7 +1802,6 @@ pub struct ToolContextServices {
     pub utility_llm_service: Option<Arc<dyn crate::UtilityLlmService>>,
     pub mcp_invoker: Option<Arc<dyn crate::McpToolInvoker>>,
     pub egress_service: Option<Arc<dyn crate::EgressService>>,
-    pub sqldb_store: Option<SessionSqlDbStoreRef>,
     pub message_retriever: Option<Arc<dyn crate::message_retriever::MessageRetriever>>,
     pub session_store: Option<Arc<dyn SessionStore>>,
     pub session_mutator: Option<Arc<dyn SessionMutator>>,
@@ -1842,7 +1836,6 @@ impl ToolContextServices {
             ToolContextService::UtilityLlmService => self.utility_llm_service.is_some(),
             ToolContextService::McpInvoker => self.mcp_invoker.is_some(),
             ToolContextService::EgressService => self.egress_service.is_some(),
-            ToolContextService::SessionSqlDbStore => self.sqldb_store.is_some(),
             ToolContextService::MessageRetriever => self.message_retriever.is_some(),
             ToolContextService::SessionStore => self.session_store.is_some(),
             ToolContextService::SessionMutator => self.session_mutator.is_some(),
@@ -1947,9 +1940,6 @@ pub struct ToolContext {
 
     /// Optional outbound egress service for HTTP/API traffic.
     pub egress_service: Option<Arc<dyn crate::EgressService>>,
-
-    /// Optional session SQL database store
-    pub sqldb_store: Option<SessionSqlDbStoreRef>,
 
     /// Optional message retriever for tools that need conversation history access
     pub message_retriever: Option<Arc<dyn crate::message_retriever::MessageRetriever>>,
@@ -2083,7 +2073,6 @@ impl ToolContext {
             utility_llm_service: None,
             mcp_invoker: None,
             egress_service: None,
-            sqldb_store: None,
             message_retriever: None,
             session_store: None,
             session_mutator: None,
@@ -2126,7 +2115,6 @@ impl ToolContext {
             utility_llm_service: services.utility_llm_service.clone(),
             mcp_invoker: services.mcp_invoker.clone(),
             egress_service: services.egress_service.clone(),
-            sqldb_store: services.sqldb_store.clone(),
             message_retriever: services.message_retriever.clone(),
             session_store: services.session_store.clone(),
             session_mutator: services.session_mutator.clone(),
@@ -2169,7 +2157,6 @@ impl ToolContext {
             utility_llm_service: None,
             mcp_invoker: None,
             egress_service: None,
-            sqldb_store: None,
             message_retriever: None,
             session_store: None,
             session_mutator: None,
@@ -2215,7 +2202,6 @@ impl ToolContext {
             utility_llm_service: None,
             mcp_invoker: None,
             egress_service: None,
-            sqldb_store: None,
             message_retriever: None,
             session_store: None,
             session_mutator: None,
@@ -2257,7 +2243,6 @@ impl ToolContext {
             workspace_id: WorkspaceId::from_uuid(session_id.uuid()),
             file_store: Some(file_store),
             storage_store: Some(storage_store),
-            sqldb_store: None,
             image_store: None,
             provider_credential_store: None,
             utility_llm_service: None,
@@ -2291,12 +2276,6 @@ impl ToolContext {
             reasoning_effort_handle: None,
             cancellation: None,
         }
-    }
-
-    /// Add a SQL database store to this context
-    pub fn with_sqldb_store(mut self, sqldb_store: SessionSqlDbStoreRef) -> Self {
-        self.sqldb_store = Some(sqldb_store);
-        self
     }
 
     /// Add a message retriever to this context
@@ -2370,7 +2349,6 @@ impl ToolContext {
             utility_llm_service: None,
             mcp_invoker: None,
             egress_service: None,
-            sqldb_store: None,
             message_retriever: None,
             session_store: None,
             session_mutator: None,
@@ -2621,7 +2599,6 @@ impl std::fmt::Debug for ToolContext {
             )
             .field("utility_llm_service", &self.utility_llm_service.is_some())
             .field("egress_service", &self.egress_service.is_some())
-            .field("sqldb_store", &self.sqldb_store.is_some())
             .field("message_retriever", &self.message_retriever.is_some())
             .field("session_store", &self.session_store.is_some())
             .field("session_mutator", &self.session_mutator.is_some())

--- a/crates/host/src/host.rs
+++ b/crates/host/src/host.rs
@@ -21,8 +21,8 @@ use everruns_core::traits::{
     AgentStore, BudgetChecker, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver,
     LeasedResourceStore, PaymentAuthority, ProviderCredentialStore, ProviderStore,
     SessionCreationAuthority, SessionFileSystem, SessionMutator, SessionResourceRegistry,
-    SessionScheduleStore, SessionSqlDbStoreRef, SessionStorageStore, SessionStore,
-    ToolContextServices, UserConnectionResolver,
+    SessionScheduleStore, SessionStorageStore, SessionStore, ToolContextServices,
+    UserConnectionResolver,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
@@ -178,7 +178,9 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
         None
     }
 
-    fn sqldb_store(&self) -> Option<SessionSqlDbStoreRef> {
+    /// Session SQL database backend. Installed as a typed context extension
+    /// (EVE-897) — the kernel does not name this service.
+    fn sqldb_store(&self) -> Option<Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>> {
         None
     }
 
@@ -645,6 +647,11 @@ fn runtime_tool_context_services<A: RuntimeHostAdapter>(
         if let Some(search) = adapter.knowledge_index_search(org_id) {
             extensions.insert(Arc::new(KnowledgeIndexSearchExt(search)));
         }
+        if let Some(store) = adapter.sqldb_store() {
+            extensions.insert(Arc::new(
+                everruns_platform::session_sqldb::SessionSqlDbStoreExt(store),
+            ));
+        }
         extensions
     };
     ToolContextServices {
@@ -655,7 +662,6 @@ fn runtime_tool_context_services<A: RuntimeHostAdapter>(
         utility_llm_service: adapter.utility_llm_service(),
         mcp_invoker,
         egress_service: adapter.egress_service(),
-        sqldb_store: adapter.sqldb_store(),
         message_retriever: Some(adapter.message_store()),
         session_store: Some(adapter.session_store(org_id)),
         session_mutator: Some(adapter.session_mutator(org_id)),

--- a/crates/platform/src/capabilities/session_sql_database.rs
+++ b/crates/platform/src/capabilities/session_sql_database.rs
@@ -5,9 +5,9 @@
 // - sql_query: Read-only SELECT queries returning columns + rows as JSON.
 // - sql_schema: Introspect database schema (tables, columns, types).
 
+use crate::session_sqldb::{SessionSqlDbError, SessionSqlDbStoreExt};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
-use everruns_core::session_sqldb::SessionSqlDbError;
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -201,7 +201,7 @@ impl Tool for SqlExecuteTool {
             }
         };
 
-        let store = match &context.sqldb_store {
+        let store = match context.extensions.get::<SessionSqlDbStoreExt>() {
             Some(store) => store,
             None => {
                 return ToolExecutionResult::tool_error(
@@ -209,6 +209,7 @@ impl Tool for SqlExecuteTool {
                 );
             }
         };
+        let store = &store.0;
 
         match store.sql_execute(context.session_id, database, sql).await {
             Ok(result) => ToolExecutionResult::success(json!({
@@ -302,7 +303,7 @@ impl Tool for SqlQueryTool {
             }
         };
 
-        let store = match &context.sqldb_store {
+        let store = match context.extensions.get::<SessionSqlDbStoreExt>() {
             Some(store) => store,
             None => {
                 return ToolExecutionResult::tool_error(
@@ -310,6 +311,7 @@ impl Tool for SqlQueryTool {
                 );
             }
         };
+        let store = &store.0;
 
         match store.sql_query(context.session_id, database, sql).await {
             Ok(result) => {
@@ -405,7 +407,7 @@ impl Tool for SqlSchemaTool {
 
         let table = arguments.get("table").and_then(|v| v.as_str());
 
-        let store = match &context.sqldb_store {
+        let store = match context.extensions.get::<SessionSqlDbStoreExt>() {
             Some(store) => store,
             None => {
                 return ToolExecutionResult::tool_error(
@@ -413,6 +415,7 @@ impl Tool for SqlSchemaTool {
                 );
             }
         };
+        let store = &store.0;
 
         match store.sql_schema(context.session_id, database, table).await {
             Ok(tables) => {

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -69,6 +69,12 @@ pub mod session;
 // working-area row with its lifecycle status is control-plane state.
 pub mod workspace;
 
+// Session SQL database store carved out of `everruns-core` (EVE-897). The
+// value types are the signature vocabulary of `SessionSqlDbStore`, so records
+// and trait moved together once the kernel stopped naming the store on
+// `ToolContext`; the capability resolves it as a typed extension.
+pub mod session_sqldb;
+
 // Managed per-session sandbox carved out of `everruns-core` (EVE-880): the
 // persisted state record, the provider SPI integration crates register through
 // inventory, and the create/resume/pause/init lifecycle helpers. Execution
@@ -122,6 +128,12 @@ pub use principal::{Principal, PrincipalStatus};
 pub use session::{
     Session, SessionActivity, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
     SessionSource, SessionStatus,
+};
+
+// Session SQL database (EVE-897).
+pub use session_sqldb::{
+    ColumnSchema, DatabaseInfo, SessionSqlDbError, SessionSqlDbStore, SessionSqlDbStoreExt,
+    SqlExecuteResult, SqlQueryResult, TableSchema,
 };
 
 // Managed per-session sandbox (EVE-880).

--- a/crates/platform/src/session_sqldb.rs
+++ b/crates/platform/src/session_sqldb.rs
@@ -3,20 +3,17 @@
 // Types and async trait for session-scoped SQL databases.
 // Implementations live in the session-sqldb crate.
 //
-// EVE-880 kept this module in core, unlike the other session-service records.
-// The value types here are not persisted control-plane rows: they are the
-// signature vocabulary of `SessionSqlDbStore`, and that trait is pinned to
-// core by `ToolContext::sqldb_store`, which the platform capability reads at
-// execution time. Moving the records alone would leave core naming platform
-// types, which the dependency direction forbids. The whole module moves in
-// EVE-887, when the monolithic optional-field context is replaced by narrow
-// typed services owned beside each capability.
+// EVE-897: this module moved out of core with its trait. The value types are
+// the signature vocabulary of `SessionSqlDbStore`, so records and trait travel
+// together; what pinned them to the kernel was `ToolContext::sqldb_store`.
+// That field is gone — the capability now resolves the store as a typed
+// extension — so the whole family lives beside the capability that uses it.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::typed_id::SessionId;
+use everruns_core::typed_id::SessionId;
 
 /// Metadata about a session database (no content/pages).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -173,3 +170,11 @@ pub trait SessionSqlDbStore: Send + Sync {
         table: Option<&str>,
     ) -> Result<Vec<TableSchema>, SessionSqlDbError>;
 }
+
+/// Type-keyed wrapper installed on the tool context by hosted presets.
+///
+/// Core carries the generic extension bag but does not name this service: the
+/// session SQL database is a hosted capability's backend, so the capability and
+/// its store contract stay together in platform (EVE-897).
+#[derive(Clone)]
+pub struct SessionSqlDbStoreExt(pub std::sync::Arc<dyn SessionSqlDbStore>);

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -51,10 +51,10 @@ use axum::{
     routing::post,
 };
 use everruns_core::mcp_server::{McpErrorCode, McpExecuteError, classify_mcp_execute_error};
-use everruns_core::session_sqldb::SessionSqlDbStore;
 use everruns_core::{Caller, OrgRole};
 use everruns_durable::WorkflowEventStore;
 use everruns_host::HostComposition;
+use everruns_platform::session_sqldb::SessionSqlDbStore;
 use everruns_platform::validate_org_public_id;
 use everruns_worker::AgentRunner;
 use serde::{Deserialize, Serialize};

--- a/crates/server/src/api/session_databases.rs
+++ b/crates/server/src/api/session_databases.rs
@@ -16,8 +16,8 @@ use axum::{
     routing::get,
 };
 use everruns_core::Caller;
-use everruns_core::session_sqldb::{DatabaseInfo, SessionSqlDbStore};
 use everruns_core::typed_id::SessionId;
+use everruns_platform::session_sqldb::{DatabaseInfo, SessionSqlDbStore};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -670,7 +670,7 @@ impl ServerAppBuilder {
         );
 
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
-        let sqldb_store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore> = Arc::new(
+        let sqldb_store: Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore> = Arc::new(
             everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
         );
         tracing::info!("Session SQL database store initialized (in-memory)");

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -280,7 +280,7 @@ pub struct DirectWorkerAdapters {
     driver_registry: DriverRegistry,
     utility_llm_service: Option<Arc<dyn UtilityLlmService>>,
     egress_service: Option<Arc<dyn EgressService>>,
-    sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
+    sqldb_store: std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>,
     storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
     connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
     /// Platform vector store for Knowledge Index retrieval (`search_index`).
@@ -306,7 +306,7 @@ impl DirectWorkerAdapters {
         mcp_server_service: Arc<McpServerService>,
         capability_registry: CapabilityRegistry,
         driver_registry: DriverRegistry,
-        sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
+        sqldb_store: std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>,
     ) -> Self {
         Self {
             db,
@@ -1639,7 +1639,9 @@ impl WorkerAdapters for DirectWorkerAdapters {
         self.driver_registry.clone()
     }
 
-    fn sqldb_store(&self) -> everruns_core::traits::SessionSqlDbStoreRef {
+    fn sqldb_store(
+        &self,
+    ) -> std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore> {
         self.sqldb_store.clone()
     }
 
@@ -3738,9 +3740,10 @@ mod tests {
         let cap_registry = CapabilityRegistry::new();
         let driver_registry = everruns_worker::create_driver_registry();
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
-        let sqldb_store: everruns_core::traits::SessionSqlDbStoreRef = Arc::new(
-            everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
-        );
+        let sqldb_store: std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore> =
+            Arc::new(everruns_session_sqldb::InMemorySqlDbStore::new(
+                sqldb_backend,
+            ));
 
         DirectWorkerAdapters::new(
             db,
@@ -4497,9 +4500,10 @@ mod tests {
         let cap_registry = CapabilityRegistry::new();
         let driver_registry = everruns_worker::create_driver_registry();
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
-        let sqldb_store: everruns_core::traits::SessionSqlDbStoreRef = Arc::new(
-            everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
-        );
+        let sqldb_store: std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore> =
+            Arc::new(everruns_session_sqldb::InMemorySqlDbStore::new(
+                sqldb_backend,
+            ));
 
         DirectWorkerAdapters::new(
             db,

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -404,7 +404,7 @@ pub struct Ctx {
     pub model_sync_service: Option<Arc<crate::services::ModelSyncService>>,
     pub eval_service: Option<Arc<crate::domains::evals::EvalService>>,
     pub reporting_service: Option<Arc<crate::domains::reporting::ReportingService>>,
-    pub sqldb_store: Option<Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore>>,
+    pub sqldb_store: Option<Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>>,
     pub workflow_store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
     pub runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
     pub fallback_harness_name: Option<String>,
@@ -639,7 +639,7 @@ impl Ctx {
 
     pub fn with_sqldb_store(
         mut self,
-        store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore>,
+        store: Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>,
     ) -> Self {
         self.sqldb_store = Some(store);
         self

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -35,7 +35,7 @@ pub struct SessionCommandService {
     mcp_server_service: Arc<McpServerService>,
     capability_registry: CapabilityRegistry,
     driver_registry: DriverRegistry,
-    sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
+    sqldb_store: std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>,
     virtual_registry:
         Option<Arc<crate::domains::session_files::virtual_mount_registry::VirtualMountRegistry>>,
 }
@@ -49,7 +49,7 @@ impl SessionCommandService {
         mcp_server_service: Arc<McpServerService>,
         capability_registry: CapabilityRegistry,
         driver_registry: DriverRegistry,
-        sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
+        sqldb_store: std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>,
     ) -> Self {
         Self {
             db,

--- a/crates/server/src/domains/session_databases/commands.rs
+++ b/crates/server/src/domains/session_databases/commands.rs
@@ -1,13 +1,14 @@
 use super::queries as q;
 use super::types::{DatabaseInfoResponse, SchemaResponse};
 use crate::domains::common::*;
-use everruns_core::session_sqldb::SessionSqlDbError;
+use everruns_platform::session_sqldb::SessionSqlDbError;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 fn sqldb_store(
     ctx: &Ctx,
-) -> Result<&std::sync::Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore>, CommandError> {
+) -> Result<&std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>, CommandError>
+{
     ctx.sqldb_store.as_ref().ok_or_else(|| {
         CommandError::internal(anyhow::anyhow!("Session SQL DB store not configured"))
     })

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -513,7 +513,7 @@ pub struct WorkerServiceImpl {
     /// Session storage store for key/value and secret operations
     session_storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
     /// Session SQL database store for session-scoped databases
-    sqldb_store: Option<Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore>>,
+    sqldb_store: Option<Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>>,
     /// Agent runner for triggering turn workflows (platform management send_message)
     runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
     /// Lazy connection token resolver (decrypts stored tokens / mints GitHub App tokens)
@@ -638,7 +638,7 @@ impl WorkerServiceImpl {
 
         // Create session SQL database store (always available, in-memory backend)
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
-        let sqldb_store: Option<Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore>> =
+        let sqldb_store: Option<Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>> =
             Some(Arc::new(everruns_session_sqldb::InMemorySqlDbStore::new(
                 sqldb_backend,
             )));
@@ -851,7 +851,7 @@ impl WorkerServiceImpl {
     #[allow(clippy::result_large_err)]
     fn sqldb_store(
         &self,
-    ) -> Result<&Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore>, Status> {
+    ) -> Result<&Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>, Status> {
         self.sqldb_store
             .as_ref()
             .ok_or_else(|| Status::unavailable("Session SQL database not available"))
@@ -1094,8 +1094,8 @@ fn leased_resource_to_proto(s: &everruns_core::LeasedResource) -> proto::LeasedR
 }
 
 /// Convert a SessionSqlDbError to a gRPC Status with appropriate error codes.
-fn sqldb_error_to_status(e: everruns_core::session_sqldb::SessionSqlDbError) -> Status {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+fn sqldb_error_to_status(e: everruns_platform::session_sqldb::SessionSqlDbError) -> Status {
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     match &e {
         SessionSqlDbError::DatabaseNotFound(_) => Status::not_found(e.to_string()),
         SessionSqlDbError::DatabaseAlreadyExists(_) => Status::already_exists(e.to_string()),
@@ -1115,7 +1115,7 @@ fn sqldb_error_to_status(e: everruns_core::session_sqldb::SessionSqlDbError) -> 
 
 /// Convert a DatabaseInfo to its proto representation.
 fn db_info_to_proto(
-    db: everruns_core::session_sqldb::DatabaseInfo,
+    db: everruns_platform::session_sqldb::DatabaseInfo,
 ) -> proto::SessionSqlDbDatabaseInfo {
     use everruns_internal_protocol::datetime_to_proto_timestamp;
     proto::SessionSqlDbDatabaseInfo {

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -1096,7 +1096,7 @@ fn test_grpc_server_tls_panics_on_missing_cert_file() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_not_found() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::DatabaseNotFound("test_db".into());
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::NotFound);
@@ -1104,7 +1104,7 @@ fn test_sqldb_error_to_status_maps_not_found() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_already_exists() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::DatabaseAlreadyExists("test_db".into());
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::AlreadyExists);
@@ -1112,7 +1112,7 @@ fn test_sqldb_error_to_status_maps_already_exists() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_invalid_name() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::InvalidDatabaseName("bad!name".into());
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
@@ -1120,7 +1120,7 @@ fn test_sqldb_error_to_status_maps_invalid_name() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_limit_exceeded() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::LimitExceeded("max 10".into());
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::ResourceExhausted);
@@ -1128,7 +1128,7 @@ fn test_sqldb_error_to_status_maps_limit_exceeded() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_query_error() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::QueryError("syntax error".into());
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::FailedPrecondition);
@@ -1136,7 +1136,7 @@ fn test_sqldb_error_to_status_maps_query_error() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_timeout() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::QueryTimeout(30);
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
@@ -1144,7 +1144,7 @@ fn test_sqldb_error_to_status_maps_timeout() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_authorizer_blocked() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::AuthorizerBlocked("DROP TABLE".into());
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::PermissionDenied);
@@ -1152,7 +1152,7 @@ fn test_sqldb_error_to_status_maps_authorizer_blocked() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_result_too_large() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::ResultTooLarge("1MB limit".into());
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::FailedPrecondition);
@@ -1160,7 +1160,7 @@ fn test_sqldb_error_to_status_maps_result_too_large() {
 
 #[test]
 fn test_sqldb_error_to_status_maps_internal() {
-    use everruns_core::session_sqldb::SessionSqlDbError;
+    use everruns_platform::session_sqldb::SessionSqlDbError;
     let err = SessionSqlDbError::Internal("unexpected".into());
     let status = sqldb_error_to_status(err);
     assert_eq!(status.code(), tonic::Code::Internal);
@@ -1238,7 +1238,7 @@ fn test_json_value_to_proto_object() {
 fn test_db_info_to_proto_roundtrip() {
     use chrono::Utc;
     let now = Utc::now();
-    let info = everruns_core::session_sqldb::DatabaseInfo {
+    let info = everruns_platform::session_sqldb::DatabaseInfo {
         name: "test_db".into(),
         size_bytes: 4096,
         page_count: 1,

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -373,7 +373,7 @@ impl TestServer {
         );
         // Session SQL database store (in-memory for all test modes)
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
-        let sqldb_store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore> = Arc::new(
+        let sqldb_store: Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore> = Arc::new(
             everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
         );
         let provider_resolver = Arc::new(services::ProviderResolverService::new(

--- a/crates/session-sqldb/Cargo.toml
+++ b/crates/session-sqldb/Cargo.toml
@@ -14,6 +14,7 @@ rusqlite = { version = "0.39", features = ["bundled", "serialize", "column_declt
 
 # Core types
 everruns-core = { path = "../core" }
+everruns-platform = { path = "../platform" }  # SessionSqlDbStore contract (EVE-897)
 
 # Async
 tokio = { workspace = true, features = ["rt", "time", "sync"] }

--- a/crates/session-sqldb/src/error.rs
+++ b/crates/session-sqldb/src/error.rs
@@ -35,9 +35,9 @@ pub enum SqlDbError {
     Internal(String),
 }
 
-impl From<SqlDbError> for everruns_core::session_sqldb::SessionSqlDbError {
+impl From<SqlDbError> for everruns_platform::session_sqldb::SessionSqlDbError {
     fn from(e: SqlDbError) -> Self {
-        use everruns_core::session_sqldb::SessionSqlDbError;
+        use everruns_platform::session_sqldb::SessionSqlDbError;
         match e {
             SqlDbError::DatabaseNotFound(s) => SessionSqlDbError::DatabaseNotFound(s),
             SqlDbError::DatabaseAlreadyExists(s) => SessionSqlDbError::DatabaseAlreadyExists(s),

--- a/crates/session-sqldb/src/store.rs
+++ b/crates/session-sqldb/src/store.rs
@@ -4,11 +4,11 @@
 // since SQLite operations can take up to 30 seconds (query timeout).
 
 use async_trait::async_trait;
-use everruns_core::session_sqldb::{
+use everruns_core::typed_id::SessionId;
+use everruns_platform::session_sqldb::{
     DatabaseInfo, SessionSqlDbError, SessionSqlDbStore, SqlExecuteResult, SqlQueryResult,
     TableSchema,
 };
-use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
 
 use crate::memory::InMemorySqlDbBackend;

--- a/crates/session-sqldb/src/types.rs
+++ b/crates/session-sqldb/src/types.rs
@@ -3,6 +3,6 @@
 // Re-exports from core. The canonical type definitions live in
 // everruns_core::session_sqldb. This module keeps backward compatibility.
 
-pub use everruns_core::session_sqldb::{
+pub use everruns_platform::session_sqldb::{
     ColumnSchema, DatabaseInfo, SqlExecuteResult, SqlQueryResult, TableSchema,
 };

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -3862,7 +3862,7 @@ impl everruns_platform::PlatformStore for GrpcOrgAdapter {
 // GrpcSessionSqlDbStore - SessionSqlDbStore implementation over gRPC
 // ============================================================================
 
-use everruns_core::session_sqldb::{
+use everruns_platform::session_sqldb::{
     ColumnSchema, DatabaseInfo, SessionSqlDbError, SessionSqlDbStore, SqlExecuteResult,
     SqlQueryResult, TableSchema,
 };

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -410,7 +410,9 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         self.host_composition.driver_registry().clone()
     }
 
-    fn sqldb_store(&self) -> everruns_core::traits::SessionSqlDbStoreRef {
+    fn sqldb_store(
+        &self,
+    ) -> std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore> {
         Arc::new(GrpcSessionSqlDbStore::new(self.client.clone()))
     }
 

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -295,7 +295,9 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
         Some(self.adapters.connection_resolver())
     }
 
-    fn sqldb_store(&self) -> Option<everruns_core::traits::SessionSqlDbStoreRef> {
+    fn sqldb_store(
+        &self,
+    ) -> Option<std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>> {
         Some(self.adapters.sqldb_store())
     }
 

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -2189,7 +2189,10 @@ mod tests {
             fn driver_registry(&self) -> everruns_core::DriverRegistry {
                 unimplemented!()
             }
-            fn sqldb_store(&self) -> everruns_core::traits::SessionSqlDbStoreRef {
+            fn sqldb_store(
+                &self,
+            ) -> std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>
+            {
                 unimplemented!()
             }
             fn storage_store(&self) -> Arc<dyn everruns_core::traits::SessionStorageStore> {

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -253,7 +253,9 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     fn driver_registry(&self) -> DriverRegistry;
 
     /// Get the session SQL database store.
-    fn sqldb_store(&self) -> everruns_core::traits::SessionSqlDbStoreRef;
+    fn sqldb_store(
+        &self,
+    ) -> std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore>;
 
     fn compaction_checkpoint_store(
         &self,

--- a/crates/worker/tests/resolved_turn_parity_test.rs
+++ b/crates/worker/tests/resolved_turn_parity_test.rs
@@ -328,7 +328,9 @@ macro_rules! mock_worker_adapters {
             fn driver_registry(&self) -> everruns_core::DriverRegistry {
                 everruns_core::DriverRegistry::new()
             }
-            fn sqldb_store(&self) -> everruns_core::traits::SessionSqlDbStoreRef {
+            fn sqldb_store(
+                &self,
+            ) -> std::sync::Arc<dyn everruns_platform::session_sqldb::SessionSqlDbStore> {
                 unimplemented!()
             }
             fn storage_store(&self) -> Arc<dyn everruns_core::traits::SessionStorageStore> {

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,26 @@
 
 ## 2026-08-12
 
+* **Session SQL store becomes a typed context extension**: Removed
+  `ToolContext::sqldb_store` and moved the whole `session_sqldb` family —
+  store trait, value types and error — from `everruns-core` to
+  `everruns-platform` (EVE-897, first family). The field was the only thing
+  pinning the family to the kernel: core named the trait, the trait's
+  signatures named the value types, and no core execution path touched either.
+  The capability now resolves `SessionSqlDbStoreExt` from the type-keyed
+  extension bag core already carried, and the host installs it beside the
+  other typed services. `SessionSqlDbStoreRef` and the
+  `ToolContextService::SessionSqlDbStore` variant are gone. The capability
+  never declared this service in `required_context_services`, so a missing
+  store still surfaces as the same structured tool error.
+
+  The remaining ~18 optional service fields (~1250 call sites) follow one
+  family per change. This seam unblocks `session_sqldb` only: `session_task`
+  and `session_schedule` are pinned by `crates/core/src/tools.rs` creating
+  monitor and background-tool tasks during execution, and `session_resource`
+  by `resource_ownership.rs` and the portable skills capabilities — both
+  EVE-888 work.
+
 * **Composition root extraction**: Moved `PlatformDefinition` out of
   `everruns-core` into `everruns-host` as `HostComposition` (EVE-887).
   Selecting which capabilities, drivers and host services a deployment runs
@@ -29,12 +49,12 @@
   types and the provider SPI, and the `Workspace` row moved earlier in the
   same issue.
 
-  `session_sqldb` deliberately stayed in core. Its value types are the
-  signature vocabulary of `SessionSqlDbStore`, and that trait is pinned to
-  core by `ToolContext::sqldb_store`; splitting records from trait would make
-  core name platform types. The family moves with EVE-887, when the
-  monolithic optional-field context becomes narrow typed services. The same
-  reasoning holds for the session task, schedule and resource records, which
+  `session_sqldb` stayed in core in this change. Its value types are the
+  signature vocabulary of `SessionSqlDbStore`, and that trait was pinned to
+  core by `ToolContext::sqldb_store`; splitting records from trait would have
+  made core name platform types. (That family moved under EVE-897, not
+  EVE-887 as this entry first said — see the EVE-897 entry above.) The same
+  reasoning held for the session task, schedule and resource records, which
   still have execution-time consumers inside core.
 
 ## 2026-08-11

--- a/scripts/lib/check-agent-record-isolation.sh
+++ b/scripts/lib/check-agent-record-isolation.sh
@@ -38,7 +38,10 @@
 #    the moved session-service records (EVE-880): the org-scoped Workspace
 #    row and the managed per-session sandbox (config, persisted state,
 #    provider instance, exec/file payloads) together with the
-#    `SessionSandboxProvider` SPI and its inventory plugin.
+#    `SessionSandboxProvider` SPI and its inventory plugin, nor the session
+#    SQL database store and its value types (EVE-897) — records and trait
+#    travel together because the values are the trait's signature vocabulary,
+#    and the capability resolves the store as a typed context extension.
 
 set -euo pipefail
 
@@ -75,6 +78,7 @@ RECORD_TYPES="${RECORD_TYPES}|Connector|ConnectorPlugin|ConnectorRegistry|Connec
 RECORD_TYPES="${RECORD_TYPES}|EmailAddress|EmailMessage|EmailTag|EmailTemplate|MinimalEmailTemplate|BasicEmailTemplate|RenderedEmail|SentEmail|NoopEmailSender|DisabledEmailSender|ResendEmailSender|ResendEmailConfig|SystemEmailConfig"
 RECORD_TYPES="${RECORD_TYPES}|OAuthClient|OAuthError|TokenSet|PkcePair|ProtectedResourceMetadata|AuthorizationServerMetadata|RegisteredClient|ClientRegistration"
 RECORD_TYPES="${RECORD_TYPES}|Workspace|WorkspaceStatus"
+RECORD_TYPES="${RECORD_TYPES}|SessionSqlDbStore|SessionSqlDbStoreExt|SessionSqlDbError|DatabaseInfo|SqlQueryResult|SqlExecuteResult|TableSchema|ColumnSchema"
 RECORD_TYPES="${RECORD_TYPES}|SessionSandboxConfig|SessionSandboxInitConfig|SessionSandboxStatus|SessionSandboxStatusResponse|SessionSandboxInstance|SessionSandboxState|SessionSandboxExecRequest|SessionSandboxExecResponse|SessionSandboxReadFileResponse|SessionSandboxWriteFileResponse|SessionSandboxProvider|SessionSandboxProviderPlugin"
 # `trait` is included so the sandbox provider SPI cannot reappear in the
 # kernel: integration crates register providers against platform, and a turn


### PR DESCRIPTION
## What changed

`ToolContext::sqldb_store` is gone. The session SQL database capability now resolves its backend as `SessionSqlDbStoreExt` from the type-keyed extension bag `ToolContext` already carried, and the host installs it beside the other typed services.

With the kernel no longer naming the store, the whole `session_sqldb` family — trait, value types and error — moves from `everruns-core` to `everruns-platform`, next to the capability that uses it. Also removed: the `SessionSqlDbStoreRef` alias, the `ToolContextService::SessionSqlDbStore` variant, `ToolContext::with_sqldb_store` and `ActAtom::with_sqldb_store`.

## Why

First family of EVE-897, and the thing that finishes `session_sqldb` for EVE-880.

That field was the only reason the family sat in the kernel. Core named the trait; the trait's signatures named the value types; so records and trait both had to stay — even though no core execution path touches either. Splitting them was impossible in the other direction, since core cannot name platform types.

## Before / After

No behavior change.

The capability never declared this service in `required_context_services`, so a missing store surfaces as the same structured tool error it did before — `"SQL database not available in this context"`. Nothing regressed, and nothing gained validation it did not previously have. Worth stating plainly rather than implying this change tightened validation: it did not.

REST/gRPC surfaces, tool definitions, stored schema, `docs/api/openapi.json` and the generated UI types are all untouched.

```diff
- let store = match &context.sqldb_store {
+ let store = match context.extensions.get::<SessionSqlDbStoreExt>() {
```

`everruns-session-sqldb` gains an `everruns-platform` dependency, since the contract it implements moved there.

## Risk

- Low
- The compiler covers the move. The one behavioural seam is installation: the store now reaches the context through `ToolContextExtensions` rather than a struct field, so a host that builds services without going through `everruns_host::host` would silently lose it. Both production paths (server via `direct_worker_adapters`, worker via `runtime_host`) go through the `RuntimeHostAdapter::sqldb_store` seam that installs the extension, and the adapter method is retained precisely so those paths keep a typed hook.

## Security

- Threat categories reviewed: no security-relevant code changes. The store is the same object reaching the same capability, resolved by type instead of by field; session scoping stays inside the store implementation, which is unchanged. Moving a type between crates does not alter who can reach it.
- Findings and resolutions: none.

## Follow-ups

The remaining ~18 optional service fields on `ToolContext` (~1250 call sites: `file_store` 176, `session_store` 137, `event_emitter` 111, `egress_service` 107, `storage_store` 104, …) follow one family per change. One diff for all of them would be unreviewable.

**This seam unblocks `session_sqldb` only** — correcting the claim in EVE-897's original description, which I have also corrected on the issue. The other three EVE-880 families are pinned by genuine core *execution* consumers, not by the context seam:

- `session_task` / `session_schedule` — `crates/core/src/tools.rs` creates monitor and background-tool tasks through `SessionTaskRegistry` during background-tool execution, unfeatured. Making the registry an extension does not remove that call.
- `session_resource` — consumed by `resource_ownership.rs` and the skills capabilities, which are portable and stay in core by design.

Both are EVE-888 work (cut core down to the neutral execution kernel). EVE-888, not the rest of EVE-897, is what finishes EVE-880.

## Checklist

- [x] Tests added or updated — the agent-record isolation guard now covers the sqldb store, its extension wrapper and its value types, negative-tested (a probe `pub trait SessionSqlDbStore` in core fails it); the moved module keeps its existing tests
- [x] Backward compatibility considered — breaking for direct core consumers, in line with the 0.18 extraction epic
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Refs EVE-897, EVE-880

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_