### PR TITLE
fix(scripts): stop export-openapi truncating the committed spec

### DIFF
--- a/scripts/export-openapi.sh
+++ b/scripts/export-openapi.sh
@@ -8,14 +8,33 @@
 #
 # Output defaults to docs/api/openapi.json
 
-set -e
+set -euo pipefail
 
 OUTPUT_FILE="${1:-docs/api/openapi.json}"
 
 echo "Generating OpenAPI spec..."
 
-# Build and run the export-openapi binary
-cargo run --bin export-openapi --release 2>/dev/null > "$OUTPUT_FILE"
+# Generate to a temporary file and move it into place only on success.
+#
+# The release build takes minutes, so an interrupted run is routine. Redirecting
+# the binary's stdout straight at $OUTPUT_FILE truncates the committed spec the
+# moment the shell opens it, which leaves an empty docs/api/openapi.json behind
+# on Ctrl-C, a timeout, or a build failure.
+TEMP_FILE="$(mktemp "${TMPDIR:-/tmp}/openapi-export.XXXXXX.json")"
+trap 'rm -f "$TEMP_FILE"' EXIT
+
+cargo run --bin export-openapi --release 2>/dev/null > "$TEMP_FILE"
+
+# A half-written spec is worse than none: it would be committed and could pass
+# a freshness diff against another half-written copy. Require valid JSON that
+# actually carries paths before replacing the checked-in file.
+if ! jq -e '.paths | length > 0' "$TEMP_FILE" > /dev/null 2>&1; then
+  echo "Generated spec is empty or invalid — leaving $OUTPUT_FILE untouched." >&2
+  exit 1
+fi
+
+mv "$TEMP_FILE" "$OUTPUT_FILE"
+trap - EXIT
 
 echo "OpenAPI spec saved to $OUTPUT_FILE"
 echo "Spec version: $(jq -r '.info.version' "$OUTPUT_FILE")"


### PR DESCRIPTION
## What changed

`scripts/export-openapi.sh` now generates to a `mktemp` file and moves it into place only after the run succeeds, with a trap cleaning up the temporary on any exit path. It also refuses to install a spec that is not valid JSON carrying at least one path.

## Why

The script redirected the generator's stdout straight into `docs/api/openapi.json`:

```bash
cargo run --bin export-openapi --release 2>/dev/null > "$OUTPUT_FILE"
```

The shell truncates the target the instant it opens it, before the build even starts. The release build takes minutes, so an interrupted run is routine — Ctrl-C, a timeout, or a build failure all leave an empty committed spec behind. This is exactly how `docs/api/openapi.json` hit zero bytes while regenerating it during EVE-880; it was recoverable only because the file was still in git.

The validity check covers the second failure mode: a generator that exits 0 having written half a document. That would otherwise be committed, and could pass a freshness diff against another half-written copy.

## Before / After

Behaviour on success is unchanged — same output path, same summary lines.

| Scenario | Before | After |
|---|---|---|
| Interrupted build (Ctrl-C, timeout) | committed spec truncated to 0 bytes | untouched, exit 130 |
| Generator exits 0 with partial output | partial spec written and committable | untouched, exit 1 with a message |
| Success | spec written | spec written (byte-identical) |

Verified against all three with a stub generator on `PATH`, checking `git status` on the spec after each.

## Risk

- Low
- Also switched `set -e` to `set -euo pipefail`. The script has one optional positional parameter, already defaulted via `${1:-...}`, so `-u` has nothing to trip on.
- `mktemp` honours `TMPDIR` and falls back to `/tmp`; the `mv` is a rename within a filesystem in the normal case, and `mv` handles the cross-filesystem case by copying.

## Security

- Threat categories reviewed: no security-relevant code changes. This is a developer script that writes a public API document; no credentials, network calls, or user input are involved. `mktemp` replaces a fixed path, which is marginally safer than the previous direct write.
- Findings and resolutions: none.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated — no test harness exists for `scripts/`; verified manually against all three failure/success paths as described above
- [x] Backward compatibility considered — same invocation, same output path, same success behaviour
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_