### PR TITLE
ci: take the live LLM matrix off the main gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -981,24 +981,13 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --preserve-env="DATABASE_URL" -- cargo test -p everruns-server --test slack_integration_test -- --test-threads=1
 
-      # Gated to push events so PR-controlled cargo test cannot exfiltrate the
-      # Doppler vault via env (build.rs, proc-macros, test bodies). PR coverage
-      # of the LLM matrix is still mocked in `unit-test`.
-      - name: Run LLM integration tests (skips providers without API keys or out of quota)
-        if: github.event_name == 'push'
-        timeout-minutes: 15
-        # Provider API keys come from Doppler (the repo has no per-provider
-        # GitHub secrets), matching the Slack live step above. `doppler run`
-        # injects ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY /
-        # OPENROUTER_API_KEY; the matrix runs every provider and skips only
-        # those whose key is absent from the vault, or whose account is out of
-        # quota/credits (a live billing condition, not a code regression — see
-        # `skip_if_quota!` / `is_quota_exhausted` in
-        # crates/llm-tests/tests/llm_test_matrix/mod.rs). Genuine API/contract
-        # breaks still fail the step.
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-        run: doppler run --preserve-env="DATABASE_URL" -- cargo test -p everruns-llm-tests --test agent_run_basic --test agent_run_with_thinking --test subagent_live_test --all-features
+      # The live LLM matrix moved to .github/workflows/llm-live-matrix.yml
+      # (daily + on demand). Those tests assert on model behaviour — that a
+      # model chose to call a tool, that it emitted thinking blocks — so they
+      # fail for provider-side reasons that are not code regressions. Gating
+      # main on them meant a green PR did not predict a green main, because
+      # they only ran on push. PR coverage of the LLM matrix is still mocked in
+      # `unit-test`; the live suites need no database, so nothing else moved.
 
   # S3 blob-backend integration tests.
   # The PostgreSQL `integration-test` job above only exercises the inline

--- a/.github/workflows/llm-live-matrix.yml
+++ b/.github/workflows/llm-live-matrix.yml
@@ -1,0 +1,74 @@
+# Live LLM provider matrix.
+#
+# Split out of the `Integration Tests (PostgreSQL)` job in ci.yml, which runs on
+# pushes to main. These tests call real providers and assert on model behaviour
+# — "the model called the tool", "the model produced thinking blocks" — so they
+# fail for reasons that are not code regressions: a provider changing sampling,
+# a model declining to emit a tool call, transient provider errors. When they
+# gated main, a green PR did not predict a green main, and main went red three
+# times in a row for reasons no PR could have caught.
+#
+# Provider drift is still worth catching, so the matrix runs daily here and can
+# be dispatched on demand. A failure means "investigate provider behaviour",
+# not "main is broken".
+#
+# Secrets: provider API keys come from Doppler. This workflow only ever runs
+# against a repository ref (schedule/dispatch on the default branch), never
+# against PR-authored code, preserving the property the original push gate
+# existed for — PR-controlled `cargo test` (build.rs, proc-macros, test bodies)
+# must never see the Doppler vault.
+name: LLM Live Matrix
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 05:00 UTC daily — after the weekday nightly window, before EU morning.
+    - cron: '0 5 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  llm-live-matrix:
+    name: LLM Live Matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      # The matrix runs every provider and skips those whose key is absent from
+      # the vault, or whose account is out of quota/credits (a live billing
+      # condition, not a code regression — see `skip_if_quota!` /
+      # `is_quota_exhausted` in crates/llm-tests/tests/llm_test_matrix/mod.rs).
+      # Genuine API/contract breaks still fail the step.
+      #
+      # These suites need no database; they were only colocated with the
+      # PostgreSQL job because that job already had Doppler wired up.
+      - name: Run LLM integration tests (skips providers without API keys or out of quota)
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          doppler run -- cargo test -p everruns-llm-tests \
+            --test agent_run_basic \
+            --test agent_run_with_thinking \
+            --test subagent_live_test \
+            --all-features


### PR DESCRIPTION
## What changed

The three live LLM suites (`agent_run_basic`, `agent_run_with_thinking`, `subagent_live_test`) move out of the push-gated step in `Integration Tests (PostgreSQL)` into a new `.github/workflows/llm-live-matrix.yml`, running daily at 05:00 UTC plus `workflow_dispatch`.

Nothing else moves.

## Why

Those tests assert on **model behaviour** — that a model chose to call a tool, that it emitted thinking blocks. They fail for provider-side reasons that are not code regressions. And because the step ran only on `push`, no PR could catch or predict such a failure.

`main` went red on three consecutive merges this way. One is confirmed from the logs:

```
OPENROUTER_API_KEY:openai/gpt-4o-mini: attempt 1/3 not acceptable (success=true, tool_calls=0, error=None); retrying
OPENROUTER_API_KEY:openai/gpt-4o-mini: attempt 2/3 not acceptable (success=true, tool_calls=0, error=None); retrying
OPENROUTER_API_KEY:openai/gpt-4o-mini: attempt 3/3 not acceptable (success=true, tool_calls=0, error=None); giving up
panicked: Should have called get_current_time (tool_calls_count=0, iterations=1)
```

The model simply declined to call the tool, three times, with no error. The in-test retry already exists and did not help, because this is not a transient fault.

After this change, everything gating `main` also runs on PRs, so a green PR predicts a green main. Provider drift is still caught within a day, in a place where a failure reads as "investigate the provider" rather than "main is broken".

## Before / After

| | Before | After |
|---|---|---|
| Live LLM suites | push to main only | daily + on demand |
| Runs on PRs | no | no (unchanged — see security note) |
| Blocks main | yes | no |
| Provider drift caught | per merge | within 24h |
| Database | inherited the Postgres service | none needed |

The suites have no `DATABASE_URL` or Postgres dependency — verified by grep across `crates/llm-tests`. They were colocated with the Postgres job only because Doppler was already wired up there, so the new workflow starts no services.

## Risk

- Low. This removes a gate rather than adding behaviour, and the removed gate was firing on non-regressions.
- The real tradeoff: a genuine provider API/contract break now surfaces within a day instead of at merge time. That is the intended trade — the alternative is continuing to redden main for model sampling.
- Both workflow files parse (`yaml.safe_load`), and `everruns-llm-tests` is now referenced only by the new workflow.

## Security

- Threat categories reviewed: **TM-CI / secret exposure**. The original push gate existed so PR-controlled `cargo test` (build.rs, proc-macros, test bodies) could never see the Doppler vault via env. That property is preserved exactly: `schedule` and `workflow_dispatch` run repository refs, never PR-authored code. The new workflow declares `permissions: contents: read` and takes `DOPPLER_TOKEN` only on the single step that needs it. The rationale is restated in the workflow header so a future edit does not silently reintroduce the exposure by adding `pull_request`.
- Findings and resolutions: none.

## Follow-ups

Push-only surface that remains, deliberately — all either deterministic or genuinely external, so a failure on main is signal rather than noise:

- `Workflow Tests (Server + Worker)` and `CLI E2E Tests` — deterministic, push-only for cost/time. If you want PR parity here, that is a runner-cost decision rather than a correctness one.
- The Slack live step in the Postgres job — a real external API, but not model sampling.
- `Daytona` / `Browserless` / `E2B` / `Deno` live API jobs — external providers, already backstopped by the weekly `Integration Live Sweep`.

Worth a separate ticket if you want the deterministic two running on PRs.

## Checklist

- [x] Tests added or updated — CI configuration change; both workflow files validated as YAML, and the moved command is byte-identical apart from dropping the unnecessary `--preserve-env="DATABASE_URL"`
- [x] Backward compatibility considered — no code change; the only behavioural difference is when the live matrix runs
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_