### PR TITLE
chore(knowledge): close EVE-880 — three session families stay in the kernel

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,34 @@
 
 ## 2026-08-12
 
+* **EVE-880 closed: three session families stay in the kernel by design.**
+  `Workspace`, the managed sandbox and `session_sqldb` moved to
+  `everruns-platform`. `session_task`, `session_schedule` and
+  `session_resource` stay in `everruns-core`, and the reason is the same in
+  each case: a portable, kernel-resident consumer needs the contract during a
+  turn.
+
+  - `session_task` — `wake_queue` decides mid-turn wakes from the task's wake
+    policy, `task_observer` is the lifecycle SPI, and the record is serialized
+    whole into the canonical `task.created` / `task.updated` /
+    `task.message.*` payloads.
+  - `session_schedule` — `crates/builtins/src/usage_limit_auto_continue.rs`
+    reads `ctx.services.schedule_store` to schedule an auto-resume after a
+    provider usage limit. `everruns-builtins` depends only on
+    `everruns-capability` and `everruns-core`; platform depends on *it*, so
+    moving the contract to platform would put it out of a portable built-in's
+    reach. A typed extension does not help — the wrapper would live in
+    platform, equally invisible.
+  - `session_resource` — `resource_ownership.rs` and the skills capabilities
+    in `crates/core/src/capabilities/`, which are portable and stay.
+
+  Core already owns neutral store contracts of this kind (`SessionFileSystem`,
+  `SessionStorageStore`); these belong with them. The generalisable rule, worth
+  carrying into EVE-888: whether something is a platform record is answered by
+  *who consumes it during a turn*, not by whether it is persisted. All three
+  families that stay are persisted, and all three are load-bearing for
+  portable execution.
+
 * **Background tool runs leave the kernel**: Moved `spawn_background` — the
   tool, its session-task mirroring, the scheduled-monitor path, the background
   event sink, admission-control permits and the reattach entry point — out of
@@ -39,11 +67,10 @@
   store still surfaces as the same structured tool error.
 
   The remaining ~18 optional service fields (~1250 call sites) follow one
-  family per change. This seam unblocks `session_sqldb` only: `session_task`
-  and `session_schedule` are pinned by `crates/core/src/tools.rs` creating
-  monitor and background-tool tasks during execution, and `session_resource`
-  by `resource_ownership.rs` and the portable skills capabilities — both
-  EVE-888 work.
+  family per change. This seam frees `session_sqldb` only. (An earlier version
+  of this entry expected `session_task`, `session_schedule` and
+  `session_resource` to follow under EVE-888; they do not — see the EVE-880
+  closeout below.)
 
 * **Composition root extraction**: Moved `PlatformDefinition` out of
   `everruns-core` into `everruns-host` as `HostComposition` (EVE-887).


### PR DESCRIPTION
## What changed

Knowledge-only. Records the closeout decision for EVE-880 and corrects an earlier entry that pointed the wrong way.

No code changes.

## Why

EVE-880 assumed six session-adjacent families were platform records that had drifted into `everruns-core`. Three were, and moved. Three are not, and stay — each because a portable, kernel-resident consumer needs the contract during a turn:

| family | outcome |
|---|---|
| `Workspace` | moved to platform (`834a3a923`) |
| session sandbox | moved to platform (`834a3a923`) |
| `session_sqldb` | moved to platform (`5d58810b4`, via EVE-897) |
| `session_task` | stays — `wake_queue` decides mid-turn wakes from it, `task_observer` is its SPI, and it is serialized whole into canonical `task.*` event payloads |
| `session_schedule` | stays — see below |
| `session_resource` | stays — `resource_ownership.rs` and the portable skills capabilities in `crates/core/src/capabilities/` consume it |

`session_schedule` is the interesting one and the reason this is a note rather than a move. After EVE-888 took `spawn_background` out, core's only internal consumer is the `SessionScheduleStore` trait itself — which looks exactly like the `session_sqldb` shape that moved cleanly. But `crates/builtins/src/usage_limit_auto_continue.rs` reads `ctx.services.schedule_store` to schedule an auto-resume after a provider usage limit, and `everruns-builtins` depends only on `everruns-capability` and `everruns-core`; **platform depends on builtins, not the reverse**. Moving the contract to platform would put it out of reach of a portable built-in, and the typed-extension pattern does not rescue it — the `Ext` wrapper would live in platform, equally invisible.

Alternatives weighed and rejected: relocating the contract to `everruns-capability` (tidy in principle, but platform and host do not depend on that crate today, and it has never owned a store contract), or moving `usage_limit_auto_continue` into platform to free the family (re-litigates EVE-884's deliberate placement).

Core already owns neutral store contracts of exactly this kind — `SessionFileSystem`, `SessionStorageStore`. These belong with them.

## Before / After

Documentation only. The corrected entry is the EVE-897 one, which expected these three families to follow under EVE-888; they do not, and leaving that standing would have sent the next person looking for a move that should not happen.

## Risk

- None. No code, no configuration. `just check-okf` passes.

## Security

- Threat categories reviewed: no security-relevant changes — knowledge prose only.
- Findings and resolutions: none.

## Follow-ups

The generalisable rule this produced, worth carrying into EVE-888: whether something is a platform record is answered by **who consumes it during a turn**, not by whether it is persisted. All three families that stay are persisted, and all three are load-bearing for portable execution. EVE-888's remaining record-removal bullets should be read through that lens rather than assuming persistence implies platform.

## Checklist

- [x] Tests added or updated — not applicable, knowledge-only
- [x] Backward compatibility considered — no code change
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-880

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_