### PR TITLE
refactor(core): drop the dead embedded-platform-docs feature from the kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,7 +2578,6 @@ dependencies = [
  "globset",
  "hex",
  "http 1.5.0",
- "include_dir",
  "insta",
  "inventory",
  "jsonschema",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -107,7 +107,6 @@ everruns-openui = { path = "../openui", version = "0.17.26", optional = true }
 everruns-a2ui = { path = "../a2ui", version = "0.17.26", optional = true }
 
 # Compile-time directory embedding for virtual mounts (platform docs)
-include_dir = { version = "0.7", optional = true }
 
 [features]
 # Portable optional subtrees stay ON by default for existing core consumers.
@@ -116,7 +115,6 @@ include_dir = { version = "0.7", optional = true }
 # Note: OTLP telemetry moved to `everruns-observability` (EVE-876); no core
 # build — default or otherwise — carries exporter dependencies.
 default = ["llm-tests"]
-embedded-platform-docs = ["dep:include_dir"]
 openapi = ["utoipa", "everruns-provider/openapi"]
 tree-sitter-outlines = ["dep:tree-sitter", "dep:tree-sitter-rust", "dep:tree-sitter-typescript", "dep:tree-sitter-python"]
 ui-capabilities = ["dep:everruns-openui", "dep:everruns-a2ui"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -106,8 +106,6 @@ everruns-openui = { path = "../openui", version = "0.17.26", optional = true }
 # A2UI component catalog and prompt generator
 everruns-a2ui = { path = "../a2ui", version = "0.17.26", optional = true }
 
-# Compile-time directory embedding for virtual mounts (platform docs)
-
 [features]
 # Portable optional subtrees stay ON by default for existing core consumers.
 # Hosted A2A/delegation implementations are owned by everruns-platform and no

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -39,7 +39,7 @@ openapi = ["dep:utoipa", "everruns-core/openapi"]
 # Embed the workspace `docs/` tree into the platform-management docs tools,
 # mirroring core's former build. Off by default; the build script gates the
 # actual embedding on the docs directory existing (EVE-839).
-embedded-platform-docs = ["dep:include_dir", "everruns-core/embedded-platform-docs"]
+embedded-platform-docs = ["dep:include_dir"]
 # EVE-888: the `sqlx` passthrough is gone. The kernel never used sqlx, and the
 # Postgres encode/decode impls for typed IDs live on `everruns-provider`, which
 # the server now depends on directly. No crate enabled this passthrough.

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -86,7 +86,7 @@ tar.workspace = true
 bashkit = { version = "0.16.0", features = ["scripted_tool", "jq"] }
 
 everruns-capability = { workspace = true }
-everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "tree-sitter-outlines", "ui-capabilities"] }
+everruns-core = { path = "../core", features = ["openapi", "tree-sitter-outlines", "ui-capabilities"] }
 # sqlx Postgres encode/decode for TypedId lives on everruns-provider (EVE-888).
 # The kernel never used sqlx, so the server asks the crate that owns the impls.
 everruns-provider = { path = "../provider", features = ["sqlx"] }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -22,7 +22,7 @@ anyhow.workspace = true
 tracing.workspace = true
 
 everruns-capability = { workspace = true }
-everruns-core = { path = "../core", features = ["embedded-platform-docs", "tree-sitter-outlines", "ui-capabilities"] }
+everruns-core = { path = "../core", features = ["tree-sitter-outlines", "ui-capabilities"] }
 # Telemetry init (OTLP exporter + tracing-subscriber layers) — installed
 # explicitly by the worker binary; core no longer ships it (EVE-876).
 everruns-observability = { workspace = true }


### PR DESCRIPTION
**Stacked on #3145** — review that one first; this targets its branch and will retarget to `main` when it merges.

## What changed

`everruns-core` no longer has an optional `include_dir` dependency or an `embedded-platform-docs` feature.

- **core** — dependency and feature removed.
- **platform** — its feature of the same name stops forwarding to core's; it keeps its own `dep:include_dir`, which is the one doing the work.
- **server, worker** — stop enabling the feature on core.

## Why

Same shape as the `sqlx` removal in #3145, found by the same sweep. Core declared `include_dir` behind `embedded-platform-docs`, but nothing in the crate used either:

- no `include_dir!` invocation in `crates/core/src` or `crates/core/build.rs`
- no `#[cfg(feature = "embedded-platform-docs")]` anywhere in core

The embedding moved to platform with the platform-management capability in EVE-839. Platform declares its own `include_dir` and gates the real code on `#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]` in `capabilities/platform_management.rs`. What stayed behind in core was a feature that did nothing, which server, worker and platform all dutifully enabled.

## Before / After

No behaviour change. The capability that actually embeds the docs is untouched — verified directly:

```
cargo check -p everruns-platform --features embedded-platform-docs   → clean
```

Core is down to **15 direct dependencies** (17 before #3145).

## Risk

- Low. Feature-graph change only, no source edits.
- The failure mode to rule out is a `#[cfg]` in core silently losing its gate and compiling code out. There is no such `#[cfg]` — grep confirms zero occurrences in the crate — so there is nothing for the removal to disable.

## Security

- Threat categories reviewed: no security-relevant changes. Removes an unused optional dependency from one crate's feature graph; no code, credentials or data paths touched. Slightly reduces kernel supply-chain surface.
- Findings and resolutions: none.

## Follow-ups

I swept the rest of core's manifest the same way — parsing declared dependencies and matching each against identifiers in the source. `sqlx` and `include_dir` were the only two with no reference, so this vein is exhausted.

The remaining EVE-888 dependency bullet is the OpenAPI derives, and it is a different animal: 183 `ToSchema` occurrences across 25 core files feeding a 215-endpoint spec. Those are genuinely used, so removing them needs mirror DTOs in platform, and any drift shows up in `docs/api/openapi.json`. That deserves its own PR with the spec diff inspected deliberately, not a slice folded into a dependency sweep.

## Checklist

- [x] Tests added or updated — none needed; verification is the standalone platform build above, and all 20 pre-push checks pass
- [x] Backward compatibility considered — `everruns-core/embedded-platform-docs` was a public feature that did nothing; removed in the 0.18 breaking window. Consumers wanting embedded docs enable `everruns-platform/embedded-platform-docs`, which is where the code lives
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Refs EVE-888

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_