### PR TITLE
refactor(context): resolve the session mutator as a typed extension

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -54,8 +54,8 @@ use crate::tool_narration::{
 };
 use crate::tool_types::{SideEffectClass, ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{
-    AgentStore, DurableToolResultStore, EventEmitter, SessionFileSystem, SessionMutator,
-    SessionStore, ToolCallClaimResult, ToolContext, ToolExecutor,
+    AgentStore, DurableToolResultStore, EventEmitter, SessionFileSystem, SessionStore,
+    ToolCallClaimResult, ToolContext, ToolExecutor,
 };
 use crate::typed_id::{AgentId, HarnessId};
 use uuid::Uuid;
@@ -374,12 +374,6 @@ where
     /// Set session store for context-aware tools.
     pub fn with_session_store(mut self, store: Arc<dyn SessionStore>) -> Self {
         self.context_services.session_store = Some(store);
-        self
-    }
-
-    /// Set session mutator for context-aware tools.
-    pub fn with_session_mutator(mut self, mutator: Arc<dyn SessionMutator>) -> Self {
-        self.context_services.session_mutator = Some(mutator);
         self
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -274,9 +274,9 @@ pub use traits::{
     NoopPartialStreamStore, NoopStreamHeartbeater, NoopSubagentSpawnStore, OutboundToolRateLimiter,
     PartialStreamState, PartialStreamStore, ProviderStore, ReasoningEffortHandle, ResolvedImage,
     ResolvedModel, SecretInfo, SessionFileStore, SessionFileSystem, SessionFileSystemFactory,
-    SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionStorageStore,
-    SessionStore, SpawnClaimResult, StreamHeartbeater, StreamProgress, SubagentNestingPolicy,
-    SubagentSpawnStore, ToolCallClaimResult, ToolContext, ToolExecutor, UserConnectionResolver,
+    SessionFileSystemFactoryContext, SessionResourceRegistry, SessionStorageStore, SessionStore,
+    SpawnClaimResult, StreamHeartbeater, StreamProgress, SubagentNestingPolicy, SubagentSpawnStore,
+    ToolCallClaimResult, ToolContext, ToolExecutor, UserConnectionResolver,
     WorkspaceScopedFileSystem,
 };
 pub use user_facing_error::{

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -197,7 +197,6 @@ impl<T: HarnessStore + ?Sized> HarnessStore for std::sync::Arc<T> {
 // SessionStore - For retrieving session information
 // ============================================================================
 
-use crate::capability_types::AgentCapabilityConfig;
 use crate::leased_resource::{LeasedResource, UpsertLeasedResource};
 use crate::session::ExecutionSession;
 
@@ -222,76 +221,9 @@ impl<T: SessionStore + ?Sized> SessionStore for std::sync::Arc<T> {
     }
 }
 
-/// Trait for updating mutable session metadata.
-///
-/// Mutations acknowledge with the refreshed portable execution view, never a
-/// stored platform record (EVE-882).
-#[async_trait]
-pub trait SessionMutator: Send + Sync {
-    /// Update a session's human-readable title.
-    async fn update_session_title(
-        &self,
-        session_id: SessionId,
-        title: String,
-    ) -> Result<ExecutionSession>;
-
-    /// Add or replace a session-scoped capability atomically.
-    ///
-    /// Session backends that support live capability reconfiguration override
-    /// this method. The default keeps existing backends source-compatible and
-    /// fails closed instead of pretending the capability was applied.
-    async fn upsert_session_capability(
-        &self,
-        _session_id: SessionId,
-        _capability: AgentCapabilityConfig,
-    ) -> Result<ExecutionSession> {
-        Err(crate::error::AgentLoopError::store(
-            "session backend does not support live capability reconfiguration",
-        ))
-    }
-
-    /// Remove a session-scoped capability atomically.
-    async fn remove_session_capability(
-        &self,
-        _session_id: SessionId,
-        _capability_id: &str,
-    ) -> Result<ExecutionSession> {
-        Err(crate::error::AgentLoopError::store(
-            "session backend does not support live capability reconfiguration",
-        ))
-    }
-}
-
-#[async_trait]
-impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
-    async fn update_session_title(
-        &self,
-        session_id: SessionId,
-        title: String,
-    ) -> Result<ExecutionSession> {
-        (**self).update_session_title(session_id, title).await
-    }
-
-    async fn upsert_session_capability(
-        &self,
-        session_id: SessionId,
-        capability: AgentCapabilityConfig,
-    ) -> Result<ExecutionSession> {
-        (**self)
-            .upsert_session_capability(session_id, capability)
-            .await
-    }
-
-    async fn remove_session_capability(
-        &self,
-        session_id: SessionId,
-        capability_id: &str,
-    ) -> Result<ExecutionSession> {
-        (**self)
-            .remove_session_capability(session_id, capability_id)
-            .await
-    }
-}
+// EVE-897: `SessionMutator` moved to `everruns-platform`. Mutating stored
+// session metadata is a hosted control-plane service; the capability that
+// uses it resolves `SessionMutatorExt` from the typed extension bag.
 
 // ============================================================================
 // ProviderStore - For retrieving LLM provider configurations
@@ -1737,7 +1669,6 @@ pub enum ToolContextService {
     EgressService,
     MessageRetriever,
     SessionStore,
-    SessionMutator,
     AgentStore,
     ConnectionResolver,
     ScheduleStore,
@@ -1768,7 +1699,6 @@ impl ToolContextService {
             Self::EgressService => "EgressService",
             Self::MessageRetriever => "MessageRetriever",
             Self::SessionStore => "SessionStore",
-            Self::SessionMutator => "SessionMutator",
             Self::AgentStore => "AgentStore",
             Self::ConnectionResolver => "ConnectionResolver",
             Self::ScheduleStore => "SessionScheduleStore",
@@ -1804,7 +1734,6 @@ pub struct ToolContextServices {
     pub egress_service: Option<Arc<dyn crate::EgressService>>,
     pub message_retriever: Option<Arc<dyn crate::message_retriever::MessageRetriever>>,
     pub session_store: Option<Arc<dyn SessionStore>>,
-    pub session_mutator: Option<Arc<dyn SessionMutator>>,
     pub agent_store: Option<Arc<dyn AgentStore>>,
     pub connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
     pub schedule_store: Option<Arc<dyn SessionScheduleStore>>,
@@ -1838,7 +1767,6 @@ impl ToolContextServices {
             ToolContextService::EgressService => self.egress_service.is_some(),
             ToolContextService::MessageRetriever => self.message_retriever.is_some(),
             ToolContextService::SessionStore => self.session_store.is_some(),
-            ToolContextService::SessionMutator => self.session_mutator.is_some(),
             ToolContextService::AgentStore => self.agent_store.is_some(),
             ToolContextService::ConnectionResolver => self.connection_resolver.is_some(),
             ToolContextService::ScheduleStore => self.schedule_store.is_some(),
@@ -1946,9 +1874,6 @@ pub struct ToolContext {
 
     /// Optional session store for tools that need session metadata access.
     pub session_store: Option<Arc<dyn SessionStore>>,
-
-    /// Optional session mutator for tools that need to update session metadata.
-    pub session_mutator: Option<Arc<dyn SessionMutator>>,
 
     /// Optional agent store for tools that need agent metadata access.
     pub agent_store: Option<Arc<dyn AgentStore>>,
@@ -2075,7 +2000,6 @@ impl ToolContext {
             egress_service: None,
             message_retriever: None,
             session_store: None,
-            session_mutator: None,
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
@@ -2117,7 +2041,6 @@ impl ToolContext {
             egress_service: services.egress_service.clone(),
             message_retriever: services.message_retriever.clone(),
             session_store: services.session_store.clone(),
-            session_mutator: services.session_mutator.clone(),
             agent_store: services.agent_store.clone(),
             connection_resolver: services.connection_resolver.clone(),
             schedule_store: services.schedule_store.clone(),
@@ -2159,7 +2082,6 @@ impl ToolContext {
             egress_service: None,
             message_retriever: None,
             session_store: None,
-            session_mutator: None,
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
@@ -2204,7 +2126,6 @@ impl ToolContext {
             egress_service: None,
             message_retriever: None,
             session_store: None,
-            session_mutator: None,
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
@@ -2250,7 +2171,6 @@ impl ToolContext {
             egress_service: None,
             message_retriever: None,
             session_store: None,
-            session_mutator: None,
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
@@ -2290,12 +2210,6 @@ impl ToolContext {
     /// Add a session store to this context.
     pub fn with_session_store(mut self, store: Arc<dyn SessionStore>) -> Self {
         self.session_store = Some(store);
-        self
-    }
-
-    /// Add a session mutator to this context.
-    pub fn with_session_mutator(mut self, mutator: Arc<dyn SessionMutator>) -> Self {
-        self.session_mutator = Some(mutator);
         self
     }
 
@@ -2351,7 +2265,6 @@ impl ToolContext {
             egress_service: None,
             message_retriever: None,
             session_store: None,
-            session_mutator: None,
             agent_store: None,
             connection_resolver: None,
             schedule_store: None,
@@ -2601,7 +2514,6 @@ impl std::fmt::Debug for ToolContext {
             .field("egress_service", &self.egress_service.is_some())
             .field("message_retriever", &self.message_retriever.is_some())
             .field("session_store", &self.session_store.is_some())
-            .field("session_mutator", &self.session_mutator.is_some())
             .field("agent_store", &self.agent_store.is_some())
             .field("connection_resolver", &self.connection_resolver.is_some())
             .field("schedule_store", &self.schedule_store.is_some())

--- a/crates/host/src/backends.rs
+++ b/crates/host/src/backends.rs
@@ -13,11 +13,12 @@ use everruns_core::in_memory::{InMemoryAgentStore, InMemoryHarnessStore, InMemor
 use everruns_core::session::ExecutionSession;
 use everruns_core::session_task::SessionTaskRegistry;
 use everruns_core::traits::{
-    AgentStore, HarnessStore, ProviderStore, ResolvedModel, SessionMutator, SessionScheduleStore,
+    AgentStore, HarnessStore, ProviderStore, ResolvedModel, SessionScheduleStore,
     SessionStorageStore, SessionStore, UserConnectionResolver,
 };
 use everruns_core::typed_id::{HarnessId, SessionId};
 use everruns_platform::PlatformStore;
+use everruns_platform::SessionMutator;
 use std::sync::Arc;
 
 /// Factory producing a per-org [`SessionScheduleStore`]. Embedders that have a

--- a/crates/host/src/host.rs
+++ b/crates/host/src/host.rs
@@ -20,9 +20,8 @@ use everruns_core::tools::Tool;
 use everruns_core::traits::{
     AgentStore, BudgetChecker, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver,
     LeasedResourceStore, PaymentAuthority, ProviderCredentialStore, ProviderStore,
-    SessionCreationAuthority, SessionFileSystem, SessionMutator, SessionResourceRegistry,
-    SessionScheduleStore, SessionStorageStore, SessionStore, ToolContextServices,
-    UserConnectionResolver,
+    SessionCreationAuthority, SessionFileSystem, SessionResourceRegistry, SessionScheduleStore,
+    SessionStorageStore, SessionStore, ToolContextServices, UserConnectionResolver,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
@@ -31,6 +30,7 @@ use everruns_core::{
     UserFacingError, UtilityLlmService, assemble_turn_context, org_public_id_from_internal,
     resolve_runtime_capabilities,
 };
+use everruns_platform::SessionMutator;
 use everruns_platform::capabilities::{
     report_result_tool_for_child_session, report_task_progress_tool_for_child_session,
 };
@@ -647,6 +647,9 @@ fn runtime_tool_context_services<A: RuntimeHostAdapter>(
         if let Some(search) = adapter.knowledge_index_search(org_id) {
             extensions.insert(Arc::new(KnowledgeIndexSearchExt(search)));
         }
+        extensions.insert(Arc::new(
+            everruns_platform::session_mutator::SessionMutatorExt(adapter.session_mutator(org_id)),
+        ));
         if let Some(store) = adapter.sqldb_store() {
             extensions.insert(Arc::new(
                 everruns_platform::session_sqldb::SessionSqlDbStoreExt(store),
@@ -664,7 +667,6 @@ fn runtime_tool_context_services<A: RuntimeHostAdapter>(
         egress_service: adapter.egress_service(),
         message_retriever: Some(adapter.message_store()),
         session_store: Some(adapter.session_store(org_id)),
-        session_mutator: Some(adapter.session_mutator(org_id)),
         agent_store: Some(adapter.agent_store(org_id)),
         connection_resolver: adapter.connection_resolver(),
         schedule_store: adapter.schedule_store(org_id),

--- a/crates/host/src/in_memory.rs
+++ b/crates/host/src/in_memory.rs
@@ -13,9 +13,10 @@ use everruns_core::session_file::{
 };
 use everruns_core::traits::{
     KeyInfo, SecretInfo, SessionFileSystem, SessionFileSystemFactory,
-    SessionFileSystemFactoryContext, SessionMutator, SessionStorageStore, SessionStore,
+    SessionFileSystemFactoryContext, SessionStorageStore, SessionStore,
 };
 use everruns_core::typed_id::SessionId;
+use everruns_platform::SessionMutator;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use tokio::sync::RwLock;

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -38,8 +38,8 @@ use everruns_core::runtime_context::{AssembledTurnContext, inspect_turn_context}
 use everruns_core::session::{ExecutionSession, SessionExecutionState};
 use everruns_core::session_file::{InitialFile, SessionFile};
 use everruns_core::traits::{
-    AgentStore, EventEmitter, HarnessStore, ProviderStore, ResolvedModel, SessionMutator,
-    SessionStorageStore, SessionStore, UserConnectionResolver,
+    AgentStore, EventEmitter, HarnessStore, ProviderStore, ResolvedModel, SessionStorageStore,
+    SessionStore, UserConnectionResolver,
 };
 use everruns_core::turn::TurnStopReason;
 use everruns_core::typed_id::{AgentId, MessageId, OrgId, SessionId, TurnId};
@@ -51,6 +51,7 @@ use everruns_core::{
 use everruns_engine::{
     ActOutcome, plan_after_act, plan_after_process_input, plan_after_reason, reason_schedules_act,
 };
+use everruns_platform::SessionMutator;
 use sha2::{Digest, Sha256};
 use std::collections::VecDeque;
 use std::path::Path;

--- a/crates/host/tests/filesystem_narration_paths_test.rs
+++ b/crates/host/tests/filesystem_narration_paths_test.rs
@@ -18,8 +18,7 @@ use everruns_core::tool_narration::{
     ToolNarrationContext, ToolNarrationPhase, narrate_list_directory,
 };
 use everruns_core::traits::{
-    AgentStore, EventEmitter, HarnessStore, ProviderStore, SessionFileSystem, SessionMutator,
-    SessionStore,
+    AgentStore, EventEmitter, HarnessStore, ProviderStore, SessionFileSystem, SessionStore,
 };
 use everruns_core::typed_id::{HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
@@ -31,6 +30,7 @@ use everruns_host::{
     execute_act_activity, multi_root_file_system,
 };
 use everruns_integrations_filesystem::FileSystemCapability;
+use everruns_platform::SessionMutator;
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/host/tests/runtime_host_test.rs
+++ b/crates/host/tests/runtime_host_test.rs
@@ -17,8 +17,7 @@ use everruns_core::session_task::{
     SessionTaskUpdate, TaskMessage, apply_task_update, new_session_task,
 };
 use everruns_core::traits::{
-    AgentStore, EventEmitter, HarnessStore, ProviderStore, SessionFileSystem, SessionMutator,
-    SessionStore,
+    AgentStore, EventEmitter, HarnessStore, ProviderStore, SessionFileSystem, SessionStore,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
@@ -32,6 +31,7 @@ use everruns_host::{
     RuntimeTurnPlan, RuntimeTurnState, TurnStopReason, execute_act_activity,
     execute_input_activity, plan_next_host_turn,
 };
+use everruns_platform::SessionMutator;
 use everruns_test_support::TestMathCapability;
 use serde_json::json;
 use std::collections::HashMap;
@@ -405,7 +405,7 @@ impl Tool for ContextParityTool {
             "file_store": context.file_store.is_some(),
             "message_retriever": context.message_retriever.is_some(),
             "session_store": context.session_store.is_some(),
-            "session_mutator": context.session_mutator.is_some(),
+            "session_mutator": context.extensions.get::<everruns_platform::SessionMutatorExt>().is_some(),
             "agent_store": context.agent_store.is_some(),
             "session_task_registry": context.session_task_registry.is_some(),
             "capability_registry": context.capability_registry.is_some(),

--- a/crates/local/src/session_store.rs
+++ b/crates/local/src/session_store.rs
@@ -7,9 +7,10 @@ use async_trait::async_trait;
 use everruns_core::AgentCapabilityConfig;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::session::ExecutionSession;
-use everruns_core::traits::{SessionMutator, SessionStore};
+use everruns_core::traits::SessionStore;
 use everruns_core::typed_id::{HarnessId, SessionId};
 use everruns_host::{RuntimeSessionStore, SessionBuilder};
+use everruns_platform::SessionMutator;
 use rusqlite::{OptionalExtension, params};
 
 use crate::SqliteDb;
@@ -163,7 +164,7 @@ fn store_error(error: impl std::fmt::Display) -> AgentLoopError {
 
 #[cfg(test)]
 mod tests {
-    use everruns_core::traits::{SessionMutator, SessionStore};
+    use everruns_core::traits::SessionStore;
     use everruns_host::RuntimeSessionStore;
 
     use super::*;

--- a/crates/platform/src/capabilities/session.rs
+++ b/crates/platform/src/capabilities/session.rs
@@ -4,6 +4,7 @@
 //! - `write_session_title`: update session title
 //! - `get_session_info`: return session id, title, agent name, and cumulative usage
 
+use crate::session_mutator::{SessionMutator, SessionMutatorExt};
 use async_trait::async_trait;
 use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
 use everruns_core::error::{AgentLoopError, Result};
@@ -11,7 +12,7 @@ use everruns_core::events::{EventContext, EventRequest, SessionTitleUpdatedData,
 use everruns_core::session::ExecutionSession;
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
-use everruns_core::traits::{EventEmitter, SessionMutator, SessionStore, ToolContext};
+use everruns_core::traits::{EventEmitter, SessionStore, ToolContext};
 use everruns_core::typed_id::SessionId;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -257,11 +258,12 @@ impl Tool for WriteSessionTitleTool {
         let Some(session_store) = &context.session_store else {
             return ToolExecutionResult::tool_error("Session store not available in this context");
         };
-        let Some(mutator) = &context.session_mutator else {
+        let Some(mutator) = context.extensions.get::<SessionMutatorExt>() else {
             return ToolExecutionResult::tool_error(
                 "Session mutator not available in this context",
             );
         };
+        let mutator = &mutator.0;
         let Some(event_emitter) = &context.event_emitter else {
             return ToolExecutionResult::tool_error("Event emitter not available in this context");
         };
@@ -413,7 +415,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl everruns_core::traits::SessionMutator for MockSessionMutator {
+    impl SessionMutator for MockSessionMutator {
         async fn update_session_title(
             &self,
             _session_id: SessionId,
@@ -521,9 +523,11 @@ mod tests {
         let input_message_id = MessageId::new();
         let mut context = ToolContext::new(session_id);
         context.session_store = Some(Arc::new(MockSessionStore { session: stored }));
-        context.session_mutator = Some(Arc::new(MockSessionMutator {
-            session: Arc::new(Mutex::new(session)),
-        }));
+        context
+            .extensions
+            .insert(Arc::new(SessionMutatorExt(Arc::new(MockSessionMutator {
+                session: Arc::new(Mutex::new(session)),
+            }))));
         context.event_emitter = Some(Arc::new(emitter.clone()));
         context.event_context = Some(EventContext::turn(turn_id, input_message_id));
 
@@ -566,9 +570,11 @@ mod tests {
         context.session_store = Some(Arc::new(MockSessionStore {
             session: Arc::new(Mutex::new(Some(session.clone()))),
         }));
-        context.session_mutator = Some(Arc::new(MockSessionMutator {
-            session: Arc::new(Mutex::new(session)),
-        }));
+        context
+            .extensions
+            .insert(Arc::new(SessionMutatorExt(Arc::new(MockSessionMutator {
+                session: Arc::new(Mutex::new(session)),
+            }))));
         context.event_emitter = Some(Arc::new(emitter.clone()));
 
         let result = WriteSessionTitleTool

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -76,6 +76,12 @@ pub mod workspace;
 // contracts; creating session tasks and schedules is hosted behaviour.
 pub mod background_run;
 
+// Session metadata mutation carved out of `everruns-core` (EVE-897). The
+// kernel never mutated a session; it only carried the trait so a hosted
+// capability could reach it. That capability resolves the store as a typed
+// extension now.
+pub mod session_mutator;
+
 // Session SQL database store carved out of `everruns-core` (EVE-897). The
 // value types are the signature vocabulary of `SessionSqlDbStore`, so records
 // and trait moved together once the kernel stopped naming the store on
@@ -136,6 +142,9 @@ pub use session::{
     Session, SessionActivity, SessionParticipant, SessionParticipantKind, SessionParticipantRole,
     SessionSource, SessionStatus,
 };
+
+// Session metadata mutation (EVE-897).
+pub use session_mutator::{SessionMutator, SessionMutatorExt};
 
 // Session SQL database (EVE-897).
 pub use session_sqldb::{

--- a/crates/platform/src/session_mutator.rs
+++ b/crates/platform/src/session_mutator.rs
@@ -1,0 +1,94 @@
+//! Mutating stored session metadata.
+//!
+//! `SessionMutator` is the hosted control-plane service behind the `session`
+//! capability's title and live-capability-reconfigure tools. It moved out of
+//! `everruns-core` with EVE-897: the kernel never mutated a session itself, it
+//! only carried the trait on `ToolContext` so a hosted capability could reach
+//! it. That capability now resolves [`SessionMutatorExt`] from the type-keyed
+//! extension bag instead.
+//!
+//! Mutations acknowledge with the refreshed portable
+//! `everruns_core::ExecutionSession`, never a stored platform record (EVE-882).
+
+use async_trait::async_trait;
+use everruns_core::ExecutionSession;
+use everruns_core::capability_types::AgentCapabilityConfig;
+use everruns_core::error::Result;
+use everruns_core::typed_id::SessionId;
+
+/// Trait for updating mutable session metadata.
+///
+/// Mutations acknowledge with the refreshed portable execution view, never a
+/// stored platform record (EVE-882).
+#[async_trait]
+pub trait SessionMutator: Send + Sync {
+    /// Update a session's human-readable title.
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> Result<ExecutionSession>;
+
+    /// Add or replace a session-scoped capability atomically.
+    ///
+    /// Session backends that support live capability reconfiguration override
+    /// this method. The default keeps existing backends source-compatible and
+    /// fails closed instead of pretending the capability was applied.
+    async fn upsert_session_capability(
+        &self,
+        _session_id: SessionId,
+        _capability: AgentCapabilityConfig,
+    ) -> Result<ExecutionSession> {
+        Err(everruns_core::error::AgentLoopError::store(
+            "session backend does not support live capability reconfiguration",
+        ))
+    }
+
+    /// Remove a session-scoped capability atomically.
+    async fn remove_session_capability(
+        &self,
+        _session_id: SessionId,
+        _capability_id: &str,
+    ) -> Result<ExecutionSession> {
+        Err(everruns_core::error::AgentLoopError::store(
+            "session backend does not support live capability reconfiguration",
+        ))
+    }
+}
+
+#[async_trait]
+impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> Result<ExecutionSession> {
+        (**self).update_session_title(session_id, title).await
+    }
+
+    async fn upsert_session_capability(
+        &self,
+        session_id: SessionId,
+        capability: AgentCapabilityConfig,
+    ) -> Result<ExecutionSession> {
+        (**self)
+            .upsert_session_capability(session_id, capability)
+            .await
+    }
+
+    async fn remove_session_capability(
+        &self,
+        session_id: SessionId,
+        capability_id: &str,
+    ) -> Result<ExecutionSession> {
+        (**self)
+            .remove_session_capability(session_id, capability_id)
+            .await
+    }
+}
+
+/// Type-keyed wrapper installed on the tool context by hosted presets.
+///
+/// Core carries the generic extension bag but does not name this service.
+#[derive(Clone)]
+pub struct SessionMutatorExt(pub std::sync::Arc<dyn SessionMutator>);

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -2643,7 +2643,7 @@ impl everruns_core::traits::UserConnectionResolver for GrpcAdapter {
 // ============================================================================
 
 #[async_trait]
-impl everruns_core::traits::SessionMutator for GrpcOrgAdapter {
+impl everruns_platform::SessionMutator for GrpcOrgAdapter {
     async fn update_session_title(
         &self,
         session_id: everruns_core::SessionId,

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -7,7 +7,7 @@ use everruns_core::error::Result;
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver, PaymentAuthority,
     ProviderCredentialStore, ProviderStore, SessionCreationAuthority, SessionFileSystem,
-    SessionMutator, SessionStore,
+    SessionStore,
 };
 use everruns_core::typed_id::{AgentId, SessionId};
 use everruns_core::{
@@ -18,6 +18,7 @@ use everruns_host::{ResolvedTurnInputs, RuntimeHostAdapter};
 use everruns_mcp::{
     McpClient, McpConnection, McpConnectionResolver, McpEndpoint, McpExecutor, NoAuthProvider,
 };
+use everruns_platform::SessionMutator;
 use std::sync::Arc;
 use uuid::Uuid;
 

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -643,7 +643,7 @@ impl<A: WorkerAdapters> everruns_core::traits::SessionStore for OrgAdapter<A> {
 }
 
 #[async_trait]
-impl<A: WorkerAdapters> everruns_core::traits::SessionMutator for OrgAdapter<A> {
+impl<A: WorkerAdapters> everruns_platform::SessionMutator for OrgAdapter<A> {
     async fn update_session_title(
         &self,
         session_id: SessionId,


### PR DESCRIPTION
## What changed

`ToolContext::session_mutator` is gone. The `session` capability resolves `SessionMutatorExt` from the type-keyed extension bag the context already carried, and the host installs it beside the other typed services.

With the kernel no longer naming the trait, `SessionMutator` moves from `everruns-core` to `everruns-platform`. Also removed: the `ToolContextService::SessionMutator` variant and both `with_session_mutator` builders (`ToolContext` and `ActAtom`).

## Why

Second family of EVE-897. Mutating stored session metadata — a title, a live capability reconfigure — is a hosted control-plane service. Core never called it; it only carried the trait so a hosted capability could reach it, which is exactly the coupling this issue exists to remove.

Mutations still acknowledge with the portable `everruns_core::ExecutionSession` rather than a stored record, so EVE-882's boundary is untouched.

## Before / After

No behaviour change. Same trait, same signatures, same structured tool error when the service is absent — only the resolution path differs:

```diff
- let Some(mutator) = &context.session_mutator else {
+ let Some(mutator) = context.extensions.get::<SessionMutatorExt>() else {
```

## Risk

- Low, with one seam worth naming: the mutator now reaches the context through `ToolContextExtensions` rather than a struct field, so a host assembling services without going through `everruns_host::host` would silently lose it. Both production paths (server via `direct_worker_adapters`, worker via `runtime_host`) go through the `RuntimeHostAdapter::session_mutator` seam that installs the extension, and that adapter method is retained precisely so those paths keep a typed hook.
- The two capability tests that exercise the mutator install it as an extension and pass unchanged, so the resolution path is covered rather than assumed.

## Security

- Threat categories reviewed: no security-relevant changes. Same object reaching the same capability, resolved by type instead of by field; org/session scoping lives inside the implementations, which are unchanged.
- Findings and resolutions: none.

## Follow-ups

I checked the crates *below* platform before starting this one, after `session_schedule` proved that matters — a family can look clean from core's side and still be pinned by a consumer that cannot see platform.

Of the four small families remaining, **this was the only clean one**:

| family | sites | status |
|---|---|---|
| `session_mutator` | 18 | **this PR** — consumers are platform, host, worker, local; all above platform |
| `mcp_invoker` | 15 | blocked — `crates/builtins/src/guardrails.rs` consumes it, and builtins sits below platform |
| `image_store` | 15 | blocked — consumed by `integrations/openai-image` |
| `provider_credential_store` | 21 | blocked — consumed by `integrations/openai-image` and `integrations/openrouter-workspace` |

The three blocked ones need the same kind of decision `session_schedule` got, not more effort. The remaining large families (`file_store` 176 sites, `session_store` 137, `event_emitter` 111, `egress_service` 107, `storage_store` 104) are unexamined for sub-platform consumers.

## Checklist

- [x] Tests added or updated — the two `session` capability tests covering title writes install the mutator as an extension and pass unchanged; 50 platform session tests green
- [x] Backward compatibility considered — breaking for direct core consumers of `SessionMutator` / `with_session_mutator`, in line with the 0.18 extraction epic; all in-tree consumers updated
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Refs EVE-897

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_