### PR TITLE
chore(knowledge): close EVE-897 and record why the context bag stays

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,59 @@
 # Everruns Knowledge Update Log
 
+## 2026-08-13
+
+* **EVE-897 closed at two families: the `ToolContext` service bag mostly cannot
+  be dismantled.** `session_sqldb` and `session_mutator` now resolve as typed
+  extensions; the other 17 families stay. The reason is structural rather than
+  effortful, and is the durable finding here.
+
+  A capability reads `context.storage_store` today — a field on core's
+  `ToolContext`. Moving `SessionStorageStore` to platform turns that into
+  `context.extensions.get::<SessionStorageStoreExt>()`, and naming that wrapper
+  requires depending on `everruns-platform`. But platform already depends on
+  those crates: `environment-capabilities` pulls in filesystem, bashkit, lua,
+  web-fetch and openrouter-workspace, and `portable-builtins` pulls in
+  `everruns-builtins`. So `consumer -> platform -> consumer` is a dependency
+  cycle, which Cargo rejects outright.
+
+  Of the 17 remaining families, 16 have a consumer below platform. Four are
+  reached from `everruns-builtins`, four from core itself (where the direction
+  is the epic's foundation), and the rest through integration crates — five of
+  which platform depends on, making those cycles too. Only the nine
+  non-cycle integrations could take a new edge, and that means every
+  integration crate pulling all of platform to name a wrapper type.
+
+  The issue assumed these optional fields were hosted services leaking into the
+  kernel. Most are neutral contracts that portable code legitimately needs
+  during a turn — independently the same conclusion EVE-880 reached about
+  `session_schedule`. `ToolContext`'s width is a symptom of many hosted
+  services existing, not of them living in the wrong crate.
+
+  The structural fix, not taken: a neutral contracts crate below builtins,
+  integrations and platform. Worth revisiting only if the bag becomes a
+  concrete maintenance problem rather than an aesthetic one.
+
+  Practical test for the next person asking "should this leave core?" — check
+  the crates *below* platform, not just core's own consumers. Core-side
+  cleanliness is not evidence a move is possible.
+
+  `session_task_registry` is the one clean family left unmoved.
+
+* **Kernel dependency hygiene (EVE-888).** Removed two vestigial features from
+  `everruns-core`: `sqlx` (zero usage in the crate; it only forwarded to
+  `everruns-provider/sqlx`, where the typed-ID Postgres impls live — the server
+  now depends on provider directly) and `embedded-platform-docs` (gated nothing;
+  `include_dir` was unused and the real embedding moved to platform with
+  EVE-839). Core is down to 15 direct dependencies. A manifest-wide sweep
+  matching each declared dependency against source identifiers found no others,
+  so this vein is exhausted.
+
+  `utoipa` stays, and needs no work: it is already `optional = true` behind an
+  `openapi` feature absent from core's defaults. Core's default build resolves
+  zero utoipa crates; the 183 `ToSchema` derives are all
+  `#[cfg_attr(feature = "openapi", ...)]` and compile away unless a consumer
+  opts in. EVE-888's "remove OpenAPI derives" bullet is satisfied as written.
+
 ## 2026-08-12
 
 * **EVE-880 closed: three session families stay in the kernel by design.**


### PR DESCRIPTION
## What changed

Knowledge-only. Records the EVE-897 closeout and today's EVE-888 dependency hygiene. No code.

## Why

EVE-897 assumed `ToolContext`'s optional service fields were hosted services leaking into the kernel, each movable to platform behind a typed extension. Two were. Sixteen are not — and mostly not for want of effort.

**The mechanism.** A capability reads `context.storage_store`, a field on core's `ToolContext`. Moving `SessionStorageStore` to platform turns that into `context.extensions.get::<SessionStorageStoreExt>()`, and naming that wrapper requires depending on `everruns-platform`. But platform already depends on those crates — `environment-capabilities` pulls in filesystem, bashkit, lua, web-fetch and openrouter-workspace; `portable-builtins` pulls in `everruns-builtins`. So `consumer → platform → consumer` is a dependency cycle, which Cargo rejects outright.

I scanned all 17 remaining families:

| class | count | fixable |
|---|---|---|
| Cycle — platform depends on the consumer (builtins ×4, plus families reached via the five integration crates platform pulls in) | most | No |
| Cycle — consumer is core (`session_resource_registry`, `message_retriever`, `agent_store`, `subagent_delegate`) | 4 | No — that direction is the epic's foundation |
| New edge, would compile (brave-search, browserless, cursor, daytona, deno, e2b, github, openai-image, sprites) | 9 | Yes, but every integration crate pulls all of platform to name a wrapper |
| Clean (`session_task_registry`) | 1 | Yes — left unmoved |

**The conceptual error:** most of these are neutral contracts that portable code legitimately needs during a turn, not hosted services in the wrong crate. `ToolContext`'s width is a symptom of many hosted services existing. This is independently the same conclusion EVE-880 reached about `session_schedule`.

**Structural fix not taken:** a neutral contracts crate below builtins, integrations and platform. It would work, and it means a new dependency edge for ~15 integration crates to relocate contracts that are already neutral. Worth revisiting only if the bag becomes a concrete maintenance problem rather than an aesthetic one.

The entry also records the practical test this produced: **check the crates below platform, not just core's own consumers.** Core-side cleanliness is not evidence a move is possible — `session_schedule` and `session_mutator` look identical from core and differ entirely one crate down.

## Before / After

Documentation only.

Second entry records today's EVE-888 hygiene — the `sqlx` and `embedded-platform-docs` removals (#3145, #3146) — and one correction worth having in writing: **`utoipa` needs no work.** It is already `optional = true` behind an `openapi` feature absent from core's defaults. Verified: core's default build resolves 0 utoipa crates, `--features openapi` resolves 3. The 183 `ToSchema` derives are all `#[cfg_attr(feature = "openapi", ...)]` and compile away unless a consumer opts in. EVE-888's "remove OpenAPI derives" bullet is satisfied as written, so nobody should spend a week building mirror DTOs for it.

## Risk

- None. Docs-only; `just check-okf` passes.

## Security

- Threat categories reviewed: no security-relevant content — knowledge prose.
- Findings and resolutions: none.

## Follow-ups

`session_task_registry` remains the one clean, unmoved family. Not worth reopening EVE-897 for on its own; a good pickup for whoever next touches that area.

## Checklist

- [x] Tests added or updated — not applicable, knowledge-only
- [x] Backward compatibility considered — no code change
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-897

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHMMkzZ6bCUCadX8NSTLs5)_