### PR TITLE
refactor(storage): move in-memory backends to owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **Moved concrete in-memory backends out of `everruns-core`.** Embedded-host
+  agent, harness, session, and provider stores now live in `everruns-host`.
+  Writable deterministic `InMemoryMessageRetriever` and
+  `InMemoryEventEmitter` fixtures now live in `everruns-test-support`.
+  Hosted conversation history has no writable message-store replacement:
+  append through `EventLog` / `HostEventEmitter` and read through
+  `EventHistory`, preserving canonical-events-only writes.
+
 - **Moved connector, OAuth, and system-email infrastructure out of
   `everruns-core`.** The hosted connector catalog — `Connector`,
   `ConnectorRegistry`, `ConnectorRegistryBuilder`, `ConnectorPlugin`,

--- a/crates/builtins/src/infinity_context.rs
+++ b/crates/builtins/src/infinity_context.rs
@@ -812,7 +812,7 @@ fn format_recent_result(messages: &[&Message], total: usize) -> ToolExecutionRes
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::in_memory::InMemoryMessageRetriever;
+    use crate::test_fixtures::TestMessageRetriever;
     use crate::typed_id::SessionId;
 
     // Metadata/tool-list constants covered by builtin_capabilities_satisfy_registry_invariants.
@@ -1285,7 +1285,7 @@ mod tests {
         }
 
         let session_id = SessionId::new();
-        let retriever = InMemoryMessageRetriever::new();
+        let retriever = TestMessageRetriever::new();
         let result = QueryHistoryTool
             .execute_with_context(
                 json!({"message_range": {"from": "bad", "to": 1}}),
@@ -1304,7 +1304,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_history_tool_empty_history() {
         let session_id = SessionId::new();
-        let retriever = InMemoryMessageRetriever::new();
+        let retriever = TestMessageRetriever::new();
 
         let result = QueryHistoryTool
             .execute_with_context(
@@ -1325,7 +1325,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_history_tool_searches_history() {
         let session_id = SessionId::new();
-        let retriever = InMemoryMessageRetriever::new();
+        let retriever = TestMessageRetriever::new();
         retriever
             .seed(
                 session_id,
@@ -1356,7 +1356,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_history_tool_search_no_match() {
         let session_id = SessionId::new();
-        let retriever = InMemoryMessageRetriever::new();
+        let retriever = TestMessageRetriever::new();
         retriever
             .seed(
                 session_id,
@@ -1383,7 +1383,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_history_tool_reads_range() {
         let session_id = SessionId::new();
-        let retriever = InMemoryMessageRetriever::new();
+        let retriever = TestMessageRetriever::new();
         retriever
             .seed(
                 session_id,
@@ -1415,7 +1415,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_history_tool_clamps_out_of_bounds_range() {
         let session_id = SessionId::new();
-        let retriever = InMemoryMessageRetriever::new();
+        let retriever = TestMessageRetriever::new();
         retriever
             .seed(
                 session_id,

--- a/crates/builtins/src/lib.rs
+++ b/crates/builtins/src/lib.rs
@@ -81,11 +81,14 @@ pub(crate) use everruns_core::{
 // Collocated unit tests use a wider compatibility subset than the library.
 pub(crate) use everruns_core::{
     atoms, budget, capability_dto, capability_types, command, command_host, driver_registry, error,
-    events, guardrail_checks, in_memory, llm_conversions, llm_error_hook, mcp_server, message,
-    message_filter, model_profiles, output_guardrail, provider, runtime_agent, session,
-    session_file, session_resource, session_schedule, skill, tool_fingerprint, tool_narration,
+    events, guardrail_checks, llm_conversions, llm_error_hook, mcp_server, message, message_filter,
+    model_profiles, output_guardrail, provider, runtime_agent, session, session_file,
+    session_resource, session_schedule, skill, tool_fingerprint, tool_narration,
     tool_output_sanitizer, tool_types, tools, traits, typed_id, user_facing_error, utility_llm,
 };
+
+#[cfg(test)]
+mod test_fixtures;
 
 #[cfg(feature = "ui-capabilities")]
 pub use a2ui::{A2UI_CAPABILITY_ID, A2UiCapability};

--- a/crates/builtins/src/test_fixtures.rs
+++ b/crates/builtins/src/test_fixtures.rs
@@ -1,0 +1,106 @@
+use async_trait::async_trait;
+use everruns_core::error::Result;
+use everruns_core::message::Message;
+use everruns_core::message_filter::{MessageFilter, MessageQuery};
+use everruns_core::message_retriever::{MessageHistory, MessageRetriever};
+use everruns_core::typed_id::{MessageId, SessionId};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Private fixture for collocated built-in capability tests.
+#[derive(Clone, Default)]
+pub(crate) struct TestMessageRetriever {
+    messages: Arc<RwLock<HashMap<SessionId, Vec<Message>>>>,
+}
+
+impl TestMessageRetriever {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) async fn seed(&self, session_id: SessionId, messages: Vec<Message>) {
+        self.messages.write().await.insert(session_id, messages);
+    }
+}
+
+#[async_trait]
+impl MessageRetriever for TestMessageRetriever {
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
+        Ok(self
+            .messages
+            .read()
+            .await
+            .get(&session_id)
+            .and_then(|messages| {
+                messages
+                    .iter()
+                    .find(|message| message.id == message_id)
+                    .cloned()
+            }))
+    }
+
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
+        Ok(self
+            .messages
+            .read()
+            .await
+            .get(&session_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn load_filtered(&self, query: MessageQuery) -> Result<Vec<Message>> {
+        let mut messages = self.load(query.session_id).await?;
+        if let Some(after) = query.after_sequence {
+            messages = messages.into_iter().skip(after.max(0) as usize).collect();
+        }
+        for filter in &query.filters {
+            match filter {
+                MessageFilter::TimeRange { from, to } => messages.retain(|message| {
+                    from.is_none_or(|time| message.created_at >= time)
+                        && to.is_none_or(|time| message.created_at <= time)
+                }),
+                MessageFilter::Search(query) => {
+                    let query = query.to_lowercase();
+                    messages.retain(|message| {
+                        message
+                            .text()
+                            .is_some_and(|text| text.to_lowercase().contains(&query))
+                    });
+                }
+                MessageFilter::Custom(predicate) => messages.retain(|message| predicate(message)),
+                _ => {}
+            }
+        }
+        query.apply_windowing(&mut messages);
+        if query.has_injections() {
+            query.apply_injections(&mut messages);
+        }
+        Ok(messages)
+    }
+
+    async fn load_filtered_history(&self, query: MessageQuery) -> Result<MessageHistory> {
+        let source_sequence = self
+            .messages
+            .read()
+            .await
+            .get(&query.session_id)
+            .map(|messages| messages.len() as i64)
+            .unwrap_or(0);
+        Ok(MessageHistory {
+            messages: self.load_filtered(query).await?,
+            source_sequence: Some(source_sequence),
+        })
+    }
+
+    async fn count(&self, session_id: SessionId) -> Result<usize> {
+        Ok(self
+            .messages
+            .read()
+            .await
+            .get(&session_id)
+            .map(Vec::len)
+            .unwrap_or(0))
+    }
+}

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -49,11 +49,13 @@ hosted capabilities come from their owning integration or product crates.
 - An LLM driver registry and provider-neutral message, tool, and reasoning types
 - Context assembly shared by embedded, worker, and server execution paths
 - Neutral capability collection hooks and type-keyed host-service extensions
-- Minimal portable in-memory stores for embedding and prototyping
+- Read-only storage traits and canonical event/message contracts
 
 Environment implementations live in `everruns-integrations-filesystem`,
 `everruns-integrations-bashkit`, `everruns-integrations-web-fetch`,
 `everruns-integrations-lua`, `everruns-mcp`, and `everruns-http`.
+Application-grade in-memory backends live in `everruns-host`; deterministic
+writable fixtures live in `everruns-test-support`.
 
 ## Documentation
 

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -2609,7 +2609,7 @@ mod tests {
         let mut executor = ToolRegistry::new();
         executor.register(ArgumentEchoTool);
         let tool_def = executor.get("argument_echo").unwrap().to_definition();
-        let emitter = crate::in_memory::InMemoryEventEmitter::new();
+        let emitter = crate::test_fixtures::TestEventEmitter::new();
         let atom = ActAtom::new(executor, emitter.clone())
             .with_tool_call_hooks(vec![std::sync::Arc::new(HumanIntentFixtureHook)]);
 
@@ -2687,7 +2687,7 @@ mod tests {
     #[tokio::test]
     async fn test_act_atom_strips_human_intent_from_client_tool_calls() {
         let executor = ToolRegistry::new();
-        let emitter = crate::in_memory::InMemoryEventEmitter::new();
+        let emitter = crate::test_fixtures::TestEventEmitter::new();
         let atom = ActAtom::new(executor, emitter)
             .with_tool_call_hooks(vec![std::sync::Arc::new(HumanIntentFixtureHook)]);
 

--- a/crates/core/src/atoms/input.rs
+++ b/crates/core/src/atoms/input.rs
@@ -115,13 +115,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::in_memory::InMemoryMessageRetriever;
     use crate::message_retriever::InputMessage;
+    use crate::test_fixtures::TestMessageRetriever;
     use crate::typed_id::{MessageId, SessionId, TurnId};
 
     #[tokio::test]
     async fn test_input_atom_retrieves_message() {
-        let retriever = InMemoryMessageRetriever::new();
+        let retriever = TestMessageRetriever::new();
         let session_id = SessionId::new();
         let turn_id = TurnId::new();
 
@@ -142,7 +142,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_input_atom_not_found() {
-        let retriever = InMemoryMessageRetriever::new();
+        let retriever = TestMessageRetriever::new();
         let session_id = SessionId::new();
         let turn_id = TurnId::new();
         let missing_id = MessageId::new();

--- a/crates/core/src/execution_snapshot.rs
+++ b/crates/core/src/execution_snapshot.rs
@@ -243,8 +243,8 @@ pub async fn load_execution_snapshot_for_session(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::in_memory::{InMemoryAgentStore, InMemoryHarnessStore};
     use crate::network_access::NetworkAccessList;
+    use crate::test_fixtures::{TestAgentStore, TestHarnessStore};
     use std::collections::HashMap;
 
     fn harness() -> HarnessDefinition {
@@ -536,9 +536,9 @@ mod tests {
     #[tokio::test]
     async fn loader_fails_on_missing_records_before_execution() {
         let (harness_id, agent_id, session_id) = ids();
-        let harness_store = InMemoryHarnessStore::new();
-        let agent_store = InMemoryAgentStore::new();
-        let session_store = crate::in_memory::InMemorySessionStore::new();
+        let harness_store = TestHarnessStore::new();
+        let agent_store = TestAgentStore::new();
+        let session_store = crate::test_fixtures::TestSessionStore::new();
 
         // Missing session (also the cross-tenant shape: org-scoped stores
         // return None for records outside the caller's org).

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -217,12 +217,10 @@ pub mod traits;
 pub mod truncation_info;
 pub use everruns_provider::user_facing_error;
 
-// Minimal in-memory implementations of the core store traits. These back the
-// default `everruns-host` backend bundle and core's own unit tests. The
-// deterministic simulator (`llmsim`), the in-memory agentic loop, and the
-// mock/echo/failing test doubles live in the `everruns-test-support` crate
-// (EVE-875) so production builds carry no test implementations.
-pub mod in_memory;
+// Private doubles for collocated unit tests. Public application backends live
+// in everruns-host; reusable deterministic fixtures live in test-support.
+#[cfg(test)]
+mod test_fixtures;
 
 // Turn orchestration (state machine, context, outcomes)
 pub mod turn;

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -397,13 +397,13 @@ mod tests {
 
     use crate::capabilities::{AgentBlueprint, BlueprintModel, Capability, CapabilityRegistry};
     use crate::harness_definition::HarnessDefinition;
-    use crate::in_memory::{
-        InMemoryAgentStore, InMemoryHarnessStore, InMemoryMessageRetriever, InMemoryProviderStore,
-    };
     use crate::message::Controls;
     use crate::message_retriever::InputMessage;
     use crate::network_access::NetworkAccessList;
     use crate::session::ExecutionSession;
+    use crate::test_fixtures::{
+        TestAgentStore, TestHarnessStore, TestMessageRetriever, TestProviderStore,
+    };
     use crate::tools::{Tool, ToolExecutionResult};
     use crate::typed_id::{AgentId, HarnessId};
 
@@ -518,15 +518,15 @@ mod tests {
         let agent_id = "agent_00000000000000000000000000000081".parse().unwrap();
         let session_id = "session_00000000000000000000000000000081".parse().unwrap();
 
-        let harness_store = InMemoryHarnessStore::new();
+        let harness_store = TestHarnessStore::new();
         harness_store.add_harness(harness_id, harness()).await;
-        let agent_store = InMemoryAgentStore::new();
+        let agent_store = TestAgentStore::new();
         agent_store.add_agent(agent(agent_id)).await;
-        let session_store = crate::in_memory::InMemorySessionStore::new();
+        let session_store = crate::test_fixtures::TestSessionStore::new();
         session_store
             .add_session(session(session_id, harness_id, agent_id))
             .await;
-        let message_store = InMemoryMessageRetriever::new();
+        let message_store = TestMessageRetriever::new();
         let mut input = InputMessage::user("What is 2 * 3?");
         input.controls = Some(Controls {
             speed: None,
@@ -539,7 +539,7 @@ mod tests {
         });
         message_store.add(session_id, input).await.unwrap();
 
-        let provider_store = InMemoryProviderStore::new();
+        let provider_store = TestProviderStore::new();
         provider_store
             .set_default_model(ResolvedModel {
                 model: "llmsim-model".into(),
@@ -587,16 +587,16 @@ mod tests {
         let agent_id = "agent_00000000000000000000000000000084".parse().unwrap();
         let session_id = "session_00000000000000000000000000000084".parse().unwrap();
 
-        let harness_store = InMemoryHarnessStore::new();
+        let harness_store = TestHarnessStore::new();
         harness_store.add_harness(harness_id, harness()).await;
-        let agent_store = InMemoryAgentStore::new();
+        let agent_store = TestAgentStore::new();
         agent_store.add_agent(agent(agent_id)).await;
         let mut session_record = session(session_id, harness_id, agent_id);
         session_record.locale = Some("en-US".into());
-        let session_store = crate::in_memory::InMemorySessionStore::new();
+        let session_store = crate::test_fixtures::TestSessionStore::new();
         session_store.add_session(session_record).await;
 
-        let message_store = InMemoryMessageRetriever::new();
+        let message_store = TestMessageRetriever::new();
         let mut input = InputMessage::user("Use locale from metadata");
         input.metadata = Some(
             [(
@@ -608,7 +608,7 @@ mod tests {
         );
         message_store.add(session_id, input).await.unwrap();
 
-        let provider_store = InMemoryProviderStore::new();
+        let provider_store = TestProviderStore::new();
         provider_store
             .set_default_model(ResolvedModel {
                 model: "llmsim-model".into(),
@@ -653,17 +653,17 @@ mod tests {
         let agent_id = "agent_00000000000000000000000000000082".parse().unwrap();
         let session_id = "session_00000000000000000000000000000082".parse().unwrap();
 
-        let harness_store = InMemoryHarnessStore::new();
+        let harness_store = TestHarnessStore::new();
         harness_store.add_harness(harness_id, harness()).await;
-        let agent_store = InMemoryAgentStore::new();
+        let agent_store = TestAgentStore::new();
         agent_store.add_agent(agent(agent_id)).await;
-        let session_store = crate::in_memory::InMemorySessionStore::new();
+        let session_store = crate::test_fixtures::TestSessionStore::new();
         session_store
             .add_session(session(session_id, harness_id, agent_id))
             .await;
-        let message_store = InMemoryMessageRetriever::new();
+        let message_store = TestMessageRetriever::new();
 
-        let provider_store = InMemoryProviderStore::new();
+        let provider_store = TestProviderStore::new();
         provider_store
             .set_default_model(ResolvedModel {
                 model: "llmsim-model".into(),
@@ -706,24 +706,24 @@ mod tests {
 
         let mut harness_record = harness();
         harness_record.network_access = Some(NetworkAccessList::allow_only(["example.com"]));
-        let harness_store = InMemoryHarnessStore::new();
+        let harness_store = TestHarnessStore::new();
         harness_store.add_harness(harness_id, harness_record).await;
 
-        let agent_store = InMemoryAgentStore::new();
+        let agent_store = TestAgentStore::new();
         agent_store.add_agent(agent(agent_id)).await;
 
         let mut session_record = session(session_id, harness_id, agent_id);
         session_record.blueprint_id = Some("net_test_blueprint".to_string());
-        let session_store = crate::in_memory::InMemorySessionStore::new();
+        let session_store = crate::test_fixtures::TestSessionStore::new();
         session_store.add_session(session_record).await;
 
-        let message_store = InMemoryMessageRetriever::new();
+        let message_store = TestMessageRetriever::new();
         message_store
             .add(session_id, InputMessage::user("run blueprint"))
             .await
             .unwrap();
 
-        let provider_store = InMemoryProviderStore::new();
+        let provider_store = TestProviderStore::new();
         provider_store
             .set_default_model(ResolvedModel {
                 model: "llmsim-model".into(),

--- a/crates/core/src/test_fixtures.rs
+++ b/crates/core/src/test_fixtures.rs
@@ -1,12 +1,8 @@
-// Minimal in-memory implementations of the core store traits.
-//
-// These implementations keep all data in memory. They back the default
-// `everruns-host` backend bundle (`HostBackends::in_memory`) and are useful
-// for standalone examples, unit tests, and quick prototyping.
-//
-// Test doubles (mock/echo/failing tool executors, the mock chat driver) and
-// the deterministic simulator live in the `everruns-test-support` crate
-// (EVE-875), not here.
+#![allow(dead_code)]
+
+// Private, cfg(test)-only doubles for collocated core unit tests. These are not
+// public backends; host owns application stores and test-support owns reusable
+// deterministic fixtures.
 
 use crate::agent_definition::AgentDefinition;
 use crate::credential_provider::CredentialProvider;
@@ -30,7 +26,7 @@ use crate::traits::{AgentStore, HarnessStore, ProviderStore, SessionStore};
 use chrono::Utc;
 
 // ============================================================================
-// InMemoryMessageRetriever - In-memory message storage for testing
+// TestMessageRetriever - In-memory message storage for testing
 // ============================================================================
 
 /// In-memory message retriever
@@ -41,35 +37,35 @@ use chrono::Utc;
 /// Note: Write operations (add, store) are provided as inherent methods
 /// for testing purposes. In production, messages are stored via EventEmitter.
 #[derive(Debug, Default, Clone)]
-pub struct InMemoryMessageRetriever {
+pub(crate) struct TestMessageRetriever {
     messages: Arc<RwLock<HashMap<SessionId, Vec<Message>>>>,
 }
 
-impl InMemoryMessageRetriever {
+impl TestMessageRetriever {
     /// Create a new in-memory message retriever
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             messages: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
     /// Get all sessions
-    pub async fn sessions(&self) -> Vec<SessionId> {
+    pub(crate) async fn sessions(&self) -> Vec<SessionId> {
         self.messages.read().await.keys().copied().collect()
     }
 
     /// Clear all messages
-    pub async fn clear(&self) {
+    pub(crate) async fn clear(&self) {
         self.messages.write().await.clear();
     }
 
     /// Clear messages for a specific session
-    pub async fn clear_session(&self, session_id: SessionId) {
+    pub(crate) async fn clear_session(&self, session_id: SessionId) {
         self.messages.write().await.remove(&session_id);
     }
 
     /// Pre-populate with messages (useful for testing)
-    pub async fn seed(&self, session_id: SessionId, messages: Vec<Message>) {
+    pub(crate) async fn seed(&self, session_id: SessionId, messages: Vec<Message>) {
         self.messages.write().await.insert(session_id, messages);
     }
 
@@ -77,7 +73,7 @@ impl InMemoryMessageRetriever {
     ///
     /// Note: In production, messages are stored via EventService.
     /// This method is provided for test setup and in-memory usage.
-    pub async fn add(&self, session_id: SessionId, input: InputMessage) -> Result<Message> {
+    pub(crate) async fn add(&self, session_id: SessionId, input: InputMessage) -> Result<Message> {
         let message = Message {
             id: MessageId::new(),
             role: input.role,
@@ -105,7 +101,7 @@ impl InMemoryMessageRetriever {
     ///
     /// Note: In production, messages are stored via EventEmitter.
     /// This method is provided for test setup and in-memory usage.
-    pub async fn store(&self, session_id: SessionId, message: Message) -> Result<()> {
+    pub(crate) async fn store(&self, session_id: SessionId, message: Message) -> Result<()> {
         self.messages
             .write()
             .await
@@ -117,7 +113,7 @@ impl InMemoryMessageRetriever {
 }
 
 #[async_trait]
-impl MessageRetriever for InMemoryMessageRetriever {
+impl MessageRetriever for TestMessageRetriever {
     async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
         Ok(self
             .messages
@@ -206,7 +202,7 @@ impl MessageRetriever for InMemoryMessageRetriever {
 }
 
 // ============================================================================
-// InMemoryAgentStore - Stores agents in memory
+// TestAgentStore - Stores agents in memory
 // ============================================================================
 
 /// In-memory agent store
@@ -214,43 +210,43 @@ impl MessageRetriever for InMemoryMessageRetriever {
 /// Stores agents in a HashMap keyed by agent ID.
 /// Useful for testing and examples where you want to configure agents without a database.
 #[derive(Debug, Default, Clone)]
-pub struct InMemoryAgentStore {
+pub(crate) struct TestAgentStore {
     agents: Arc<RwLock<HashMap<AgentId, AgentDefinition>>>,
 }
 
-impl InMemoryAgentStore {
+impl TestAgentStore {
     /// Create a new in-memory agent store
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             agents: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
     /// Add an agent to the store
-    pub async fn add_agent(&self, agent: AgentDefinition) {
+    pub(crate) async fn add_agent(&self, agent: AgentDefinition) {
         self.agents.write().await.insert(agent.id, agent);
     }
 
     /// Get all agent IDs
-    pub async fn agent_ids(&self) -> Vec<AgentId> {
+    pub(crate) async fn agent_ids(&self) -> Vec<AgentId> {
         self.agents.read().await.keys().copied().collect()
     }
 
     /// Clear all agents
-    pub async fn clear(&self) {
+    pub(crate) async fn clear(&self) {
         self.agents.write().await.clear();
     }
 }
 
 #[async_trait]
-impl AgentStore for InMemoryAgentStore {
+impl AgentStore for TestAgentStore {
     async fn get_agent(&self, agent_id: AgentId) -> Result<Option<AgentDefinition>> {
         Ok(self.agents.read().await.get(&agent_id).cloned())
     }
 }
 
 // ============================================================================
-// InMemoryHarnessStore - Stores harnesses in memory
+// TestHarnessStore - Stores harnesses in memory
 // ============================================================================
 
 /// In-memory harness store
@@ -260,33 +256,33 @@ impl AgentStore for InMemoryAgentStore {
 /// itself is the portable, id-free configuration). Useful for testing and
 /// examples where you want to configure harnesses without a database.
 #[derive(Debug, Default, Clone)]
-pub struct InMemoryHarnessStore {
+pub(crate) struct TestHarnessStore {
     harnesses: Arc<RwLock<HashMap<HarnessId, HarnessDefinition>>>,
 }
 
-impl InMemoryHarnessStore {
+impl TestHarnessStore {
     /// Create a new in-memory harness store
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             harnesses: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
     /// Add a harness definition to the store under the given id.
-    pub async fn add_harness(&self, harness_id: HarnessId, harness: HarnessDefinition) {
+    pub(crate) async fn add_harness(&self, harness_id: HarnessId, harness: HarnessDefinition) {
         self.harnesses.write().await.insert(harness_id, harness);
     }
 }
 
 #[async_trait]
-impl HarnessStore for InMemoryHarnessStore {
+impl HarnessStore for TestHarnessStore {
     async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<HarnessDefinition>> {
         Ok(self.harnesses.read().await.get(&harness_id).cloned())
     }
 }
 
 // ============================================================================
-// InMemorySessionStore - Stores sessions in memory
+// TestSessionStore - Stores sessions in memory
 // ============================================================================
 
 /// In-memory session store
@@ -294,43 +290,43 @@ impl HarnessStore for InMemoryHarnessStore {
 /// Stores sessions in a HashMap keyed by session ID.
 /// Useful for testing and examples where you want to configure sessions without a database.
 #[derive(Debug, Default, Clone)]
-pub struct InMemorySessionStore {
+pub(crate) struct TestSessionStore {
     sessions: Arc<RwLock<HashMap<SessionId, ExecutionSession>>>,
 }
 
-impl InMemorySessionStore {
+impl TestSessionStore {
     /// Create a new in-memory session store
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             sessions: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
     /// Add a session to the store
-    pub async fn add_session(&self, session: ExecutionSession) {
+    pub(crate) async fn add_session(&self, session: ExecutionSession) {
         self.sessions.write().await.insert(session.id, session);
     }
 
     /// Get all session IDs
-    pub async fn session_ids(&self) -> Vec<SessionId> {
+    pub(crate) async fn session_ids(&self) -> Vec<SessionId> {
         self.sessions.read().await.keys().copied().collect()
     }
 
     /// Clear all sessions
-    pub async fn clear(&self) {
+    pub(crate) async fn clear(&self) {
         self.sessions.write().await.clear();
     }
 }
 
 #[async_trait]
-impl SessionStore for InMemorySessionStore {
+impl SessionStore for TestSessionStore {
     async fn get_session(&self, session_id: SessionId) -> Result<Option<ExecutionSession>> {
         Ok(self.sessions.read().await.get(&session_id).cloned())
     }
 }
 
 // ============================================================================
-// InMemoryProviderStore - Stores LLM provider configurations in memory
+// TestProviderStore - Stores LLM provider configurations in memory
 // ============================================================================
 
 /// In-memory LLM provider store
@@ -341,21 +337,21 @@ impl SessionStore for InMemorySessionStore {
 /// # Example
 ///
 /// ```ignore
-/// use everruns_core::in_memory::InMemoryProviderStore;
+/// use everruns_core::test_fixtures::TestProviderStore;
 /// use everruns_core::EnvCredentialProvider;
 ///
-/// let store = InMemoryProviderStore::from_credential_provider(&EnvCredentialProvider).await;
+/// let store = TestProviderStore::from_credential_provider(&EnvCredentialProvider).await;
 /// // Uses OPENAI_API_KEY or ANTHROPIC_API_KEY via the injected provider
 /// ```
 #[derive(Debug, Default, Clone)]
-pub struct InMemoryProviderStore {
+pub(crate) struct TestProviderStore {
     models: Arc<RwLock<HashMap<ModelId, ResolvedModel>>>,
     default_model: Arc<RwLock<Option<ResolvedModel>>>,
 }
 
-impl InMemoryProviderStore {
+impl TestProviderStore {
     /// Create a new empty in-memory provider store
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             models: Arc::new(RwLock::new(HashMap::new())),
             default_model: Arc::new(RwLock::new(None)),
@@ -369,7 +365,7 @@ impl InMemoryProviderStore {
     /// the process environment itself; standalone/dev callers pass
     /// [`EnvCredentialProvider`](crate::credential_provider::EnvCredentialProvider)
     /// to opt into env-based credentials.
-    pub async fn from_credential_provider(provider: &dyn CredentialProvider) -> Self {
+    pub(crate) async fn from_credential_provider(provider: &dyn CredentialProvider) -> Self {
         let store = Self::new();
 
         // Check for OpenAI first, then Anthropic.
@@ -405,31 +401,31 @@ impl InMemoryProviderStore {
     }
 
     /// Create a provider store with a specific default model
-    pub async fn with_default(model: ResolvedModel) -> Self {
+    pub(crate) async fn with_default(model: ResolvedModel) -> Self {
         let store = Self::new();
         store.set_default_model(model).await;
         store
     }
 
     /// Add a model to the store
-    pub async fn add_model(&self, model_id: ModelId, model: ResolvedModel) {
+    pub(crate) async fn add_model(&self, model_id: ModelId, model: ResolvedModel) {
         self.models.write().await.insert(model_id, model);
     }
 
     /// Set the default model
-    pub async fn set_default_model(&self, model: ResolvedModel) {
+    pub(crate) async fn set_default_model(&self, model: ResolvedModel) {
         *self.default_model.write().await = Some(model);
     }
 
     /// Clear all models
-    pub async fn clear(&self) {
+    pub(crate) async fn clear(&self) {
         self.models.write().await.clear();
         *self.default_model.write().await = None;
     }
 }
 
 #[async_trait]
-impl ProviderStore for InMemoryProviderStore {
+impl ProviderStore for TestProviderStore {
     async fn get_resolved_model(&self, model_id: ModelId) -> Result<Option<ResolvedModel>> {
         Ok(self.models.read().await.get(&model_id).cloned())
     }
@@ -440,7 +436,7 @@ impl ProviderStore for InMemoryProviderStore {
 }
 
 // ============================================================================
-// InMemoryEventEmitter - Stores events in memory for testing
+// TestEventEmitter - Stores events in memory for testing
 // ============================================================================
 
 use crate::events::{Event, EventRequest};
@@ -454,9 +450,9 @@ use crate::traits::EventEmitter;
 /// # Example
 ///
 /// ```ignore
-/// use everruns_core::in_memory::InMemoryEventEmitter;
+/// use everruns_core::test_fixtures::TestEventEmitter;
 ///
-/// let emitter = InMemoryEventEmitter::new();
+/// let emitter = TestEventEmitter::new();
 ///
 /// // Emit events...
 ///
@@ -465,14 +461,14 @@ use crate::traits::EventEmitter;
 /// assert_eq!(events.len(), 2);
 /// ```
 #[derive(Debug, Default, Clone)]
-pub struct InMemoryEventEmitter {
+pub(crate) struct TestEventEmitter {
     events: Arc<RwLock<Vec<Event>>>,
     sequence: Arc<RwLock<i32>>,
 }
 
-impl InMemoryEventEmitter {
+impl TestEventEmitter {
     /// Create a new in-memory event emitter
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             events: Arc::new(RwLock::new(Vec::new())),
             sequence: Arc::new(RwLock::new(0)),
@@ -480,23 +476,23 @@ impl InMemoryEventEmitter {
     }
 
     /// Get all emitted events
-    pub async fn events(&self) -> Vec<Event> {
+    pub(crate) async fn events(&self) -> Vec<Event> {
         self.events.read().await.clone()
     }
 
     /// Get the count of emitted events
-    pub async fn event_count(&self) -> usize {
+    pub(crate) async fn event_count(&self) -> usize {
         self.events.read().await.len()
     }
 
     /// Clear all events
-    pub async fn clear(&self) {
+    pub(crate) async fn clear(&self) {
         self.events.write().await.clear();
         *self.sequence.write().await = 0;
     }
 
     /// Get events by type
-    pub async fn events_by_type(&self, event_type: &str) -> Vec<Event> {
+    pub(crate) async fn events_by_type(&self, event_type: &str) -> Vec<Event> {
         self.events
             .read()
             .await
@@ -507,7 +503,7 @@ impl InMemoryEventEmitter {
     }
 
     /// Get events for a specific session
-    pub async fn events_for_session(&self, session_id: Uuid) -> Vec<Event> {
+    pub(crate) async fn events_for_session(&self, session_id: Uuid) -> Vec<Event> {
         self.events
             .read()
             .await
@@ -519,7 +515,7 @@ impl InMemoryEventEmitter {
 }
 
 #[async_trait]
-impl EventEmitter for InMemoryEventEmitter {
+impl EventEmitter for TestEventEmitter {
     async fn emit(&self, request: EventRequest) -> Result<Event> {
         let mut sequence = self.sequence.write().await;
         *sequence += 1;
@@ -540,7 +536,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_in_memory_message_retriever() {
-        let store = InMemoryMessageRetriever::new();
+        let store = TestMessageRetriever::new();
         let session_id: SessionId = Uuid::now_v7().into();
 
         store
@@ -555,7 +551,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_in_memory_message_retriever_add_and_get() {
-        let store = InMemoryMessageRetriever::new();
+        let store = TestMessageRetriever::new();
         let session_id: SessionId = Uuid::now_v7().into();
 
         // Add a message using the add method
@@ -580,7 +576,7 @@ mod tests {
     /// add() must match the ID stored internally, so that get(returned_id) succeeds.
     #[tokio::test]
     async fn test_message_retriever_add_returns_consistent_id() {
-        let store = InMemoryMessageRetriever::new();
+        let store = TestMessageRetriever::new();
         let session_id: SessionId = Uuid::now_v7().into();
 
         // Add a message
@@ -616,7 +612,7 @@ mod tests {
     async fn test_in_memory_event_emitter() {
         use crate::events::{EventContext, EventRequest, InputMessageData};
 
-        let emitter = InMemoryEventEmitter::new();
+        let emitter = TestEventEmitter::new();
         let session_id: SessionId = Uuid::now_v7().into();
         let event_context = EventContext::empty();
 
@@ -655,7 +651,7 @@ mod tests {
             ReasonStartedData,
         };
 
-        let emitter = InMemoryEventEmitter::new();
+        let emitter = TestEventEmitter::new();
         let session_id: SessionId = Uuid::now_v7().into();
         let event_context = EventContext::empty();
 
@@ -694,7 +690,7 @@ mod tests {
     async fn test_in_memory_event_emitter_filter_by_session() {
         use crate::events::{EventContext, EventRequest, InputMessageData};
 
-        let emitter = InMemoryEventEmitter::new();
+        let emitter = TestEventEmitter::new();
         let session1: SessionId = Uuid::now_v7().into();
         let session2: SessionId = Uuid::now_v7().into();
 
@@ -730,7 +726,7 @@ mod tests {
     async fn test_in_memory_event_emitter_clear() {
         use crate::events::{EventContext, EventRequest, InputMessageData};
 
-        let emitter = InMemoryEventEmitter::new();
+        let emitter = TestEventEmitter::new();
         let session_id: SessionId = Uuid::now_v7().into();
         let event_context = EventContext::empty();
 

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -8,15 +8,13 @@ use everruns_core::{
     BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy, ToolResultImage,
 };
 use everruns_core::{
-    Message, MessageRetriever, MessageRole, SessionId,
-    in_memory::InMemoryMessageRetriever,
+    Message, MessageRole,
     tools::{EchoTool, FailingTool, Tool, ToolExecutionResult, ToolRegistry},
     traits::ToolExecutor,
 };
 use serde_json::json;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use uuid::Uuid;
 
 // =============================================================================
 // Tests for ToolRegistry as ToolExecutor
@@ -263,183 +261,6 @@ async fn test_registered_tool_executes() {
 }
 
 // =============================================================================
-// Message Store Tool Calls Tests
-// =============================================================================
-// These tests verify that messages with tool_calls survive the store/load cycle.
-// This specifically tests the bug fix where tool_calls were not being persisted.
-
-#[tokio::test]
-async fn test_message_retriever_preserves_tool_calls() {
-    let store = InMemoryMessageRetriever::new();
-    let session_id: SessionId = Uuid::now_v7().into();
-
-    // Create an assistant message with tool calls (the critical case)
-    let tool_calls = vec![
-        ToolCall {
-            id: "call_weather".to_string(),
-            name: "get_weather".to_string(),
-            arguments: json!({"city": "Tokyo"}),
-        },
-        ToolCall {
-            id: "call_time".to_string(),
-            name: "get_time".to_string(),
-            arguments: json!({"format": "unix"}),
-        },
-    ];
-
-    let assistant_msg = Message::assistant_with_tools("Let me check that for you.", tool_calls);
-    store.store(session_id, assistant_msg).await.unwrap();
-
-    // Load messages back
-    let loaded = store.load(session_id).await.unwrap();
-    assert_eq!(loaded.len(), 1);
-
-    let loaded_msg = &loaded[0];
-    assert_eq!(loaded_msg.role, MessageRole::Agent);
-    assert_eq!(loaded_msg.text(), Some("Let me check that for you."));
-
-    // Verify tool_calls are preserved - this is the key assertion
-    let loaded_tool_calls = loaded_msg.tool_calls();
-    assert_eq!(loaded_tool_calls.len(), 2);
-    assert_eq!(loaded_tool_calls[0].id, "call_weather");
-    assert_eq!(loaded_tool_calls[0].name, "get_weather");
-    assert_eq!(loaded_tool_calls[1].id, "call_time");
-    assert_eq!(loaded_tool_calls[1].name, "get_time");
-}
-
-#[tokio::test]
-async fn test_message_retriever_full_tool_conversation() {
-    let store = InMemoryMessageRetriever::new();
-    let session_id: SessionId = Uuid::now_v7().into();
-
-    // Simulate a full tool-calling conversation:
-    // 1. User message
-    // 2. Assistant message with tool calls
-    // 3. Tool result messages
-    // 4. Final assistant message
-
-    // 1. User asks a question
-    store
-        .store(session_id, Message::user("What's the weather in Tokyo?"))
-        .await
-        .unwrap();
-
-    // 2. Assistant responds with a tool call
-    let tool_call = ToolCall {
-        id: "call_123".to_string(),
-        name: "get_weather".to_string(),
-        arguments: json!({"city": "Tokyo"}),
-    };
-    let assistant_with_tool = Message::assistant_with_tools("", vec![tool_call.clone()]);
-    store.store(session_id, assistant_with_tool).await.unwrap();
-
-    // 3. Tool result
-    let tool_result = Message::tool_result(
-        "call_123",
-        Some(json!({"temperature": 22, "conditions": "sunny"})),
-        None,
-    );
-    store.store(session_id, tool_result).await.unwrap();
-
-    // 4. Final assistant response
-    store
-        .store(
-            session_id,
-            Message::assistant("The weather in Tokyo is 22°C and sunny!"),
-        )
-        .await
-        .unwrap();
-
-    // Load all messages
-    let messages = store.load(session_id).await.unwrap();
-    assert_eq!(messages.len(), 4);
-
-    // Verify message order and content
-    assert_eq!(messages[0].role, MessageRole::User);
-    assert_eq!(messages[1].role, MessageRole::Agent);
-    assert_eq!(messages[2].role, MessageRole::ToolResult);
-    assert_eq!(messages[3].role, MessageRole::Agent);
-
-    // Verify the assistant message with tool calls has them preserved
-    let assistant_msg = &messages[1];
-    let tool_calls = assistant_msg.tool_calls();
-    assert!(
-        !tool_calls.is_empty(),
-        "Assistant message should have tool_calls"
-    );
-    assert_eq!(tool_calls.len(), 1);
-    assert_eq!(tool_calls[0].name, "get_weather");
-
-    // Verify the tool result has correct content
-    assert_eq!(messages[2].tool_call_id(), Some("call_123"));
-
-    // Verify final response doesn't have tool_calls
-    assert!(messages[3].tool_calls().is_empty());
-}
-
-#[tokio::test]
-async fn test_message_retriever_parallel_tool_calls() {
-    let store = InMemoryMessageRetriever::new();
-    let session_id: SessionId = Uuid::now_v7().into();
-
-    // Create an assistant message with multiple parallel tool calls
-    let tool_calls = vec![
-        ToolCall {
-            id: "call_1".to_string(),
-            name: "get_weather".to_string(),
-            arguments: json!({"city": "Tokyo"}),
-        },
-        ToolCall {
-            id: "call_2".to_string(),
-            name: "get_weather".to_string(),
-            arguments: json!({"city": "London"}),
-        },
-        ToolCall {
-            id: "call_3".to_string(),
-            name: "get_weather".to_string(),
-            arguments: json!({"city": "New York"}),
-        },
-    ];
-
-    store
-        .store(
-            session_id,
-            Message::assistant_with_tools("Let me check all three cities.", tool_calls),
-        )
-        .await
-        .unwrap();
-
-    // Store tool results
-    for (id, city, temp) in [
-        ("call_1", "Tokyo", 22),
-        ("call_2", "London", 15),
-        ("call_3", "New York", 18),
-    ] {
-        store
-            .store(
-                session_id,
-                Message::tool_result(id, Some(json!({"city": city, "temp": temp})), None),
-            )
-            .await
-            .unwrap();
-    }
-
-    // Load and verify
-    let messages = store.load(session_id).await.unwrap();
-    assert_eq!(messages.len(), 4); // 1 assistant + 3 tool results
-
-    // Verify all 3 tool calls are preserved in assistant message
-    let assistant_msg = &messages[0];
-    let loaded_calls = assistant_msg.tool_calls();
-    assert_eq!(loaded_calls.len(), 3);
-
-    // Verify each tool call
-    for (i, expected_city) in ["Tokyo", "London", "New York"].iter().enumerate() {
-        assert_eq!(loaded_calls[i].arguments["city"], *expected_city);
-    }
-}
-
-// =============================================================================
 // Image Tool Result Tests
 // =============================================================================
 
@@ -627,30 +448,6 @@ async fn test_tool_result_with_images_llm_conversion() {
         }
         _ => panic!("Expected Parts content"),
     }
-}
-
-#[tokio::test]
-async fn test_tool_result_with_images_store_roundtrip() {
-    let store = InMemoryMessageRetriever::new();
-    let session_id: SessionId = Uuid::now_v7().into();
-
-    let images = vec![ToolResultImage {
-        base64: "AAAA".to_string(),
-        media_type: "image/png".to_string(),
-    }];
-
-    let msg = Message::tool_result_with_images("call_rt", Some(json!({"ok": true})), images);
-
-    store.store(session_id, msg).await.unwrap();
-
-    let loaded = store.load(session_id).await.unwrap();
-    assert_eq!(loaded.len(), 1);
-
-    let loaded_msg = &loaded[0];
-    assert_eq!(loaded_msg.role, MessageRole::ToolResult);
-    assert_eq!(loaded_msg.tool_call_id(), Some("call_rt"));
-    // Should preserve both ToolResult and Image content parts
-    assert_eq!(loaded_msg.content.len(), 2);
 }
 
 #[test]

--- a/crates/host/README.md
+++ b/crates/host/README.md
@@ -32,6 +32,8 @@ fn accepts_inputs(_: ResolvedTurnInputs) {}
 
 - Canonical event append, bounded replay, and read-only history projection
 - Backend/store composition and low-level in-process execution
+- Reference `InMemoryAgentStore`, `InMemoryHarnessStore`,
+  `InMemorySessionStore`, and `InMemoryProviderStore` implementations
 - Shared input, reason, act, lifecycle, MCP, filesystem, and scheduling host work
 - Host adapter contracts for worker, local, and advanced integrations
 

--- a/crates/host/src/backends.rs
+++ b/crates/host/src/backends.rs
@@ -4,12 +4,14 @@
 // rebuildable read projection.
 
 use crate::events::{EventLog, EventSink, InMemoryEventLog, NoopEventSink};
-use crate::in_memory::{InMemorySessionStorageStore, InMemorySessionStore};
+use crate::in_memory::{
+    InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore, InMemorySessionStorageStore,
+    InMemorySessionStore,
+};
 use async_trait::async_trait;
 use everruns_core::agent_definition::AgentDefinition;
 use everruns_core::error::Result;
 use everruns_core::harness_definition::HarnessDefinition;
-use everruns_core::in_memory::{InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore};
 use everruns_core::session::ExecutionSession;
 use everruns_core::session_task::SessionTaskRegistry;
 use everruns_core::traits::{

--- a/crates/host/src/in_memory.rs
+++ b/crates/host/src/in_memory.rs
@@ -5,22 +5,167 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use everruns_core::AgentCapabilityConfig;
+use everruns_core::agent_definition::AgentDefinition;
+use everruns_core::credential_provider::CredentialProvider;
 use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::harness_definition::HarnessDefinition;
+use everruns_core::provider::DriverId;
 use everruns_core::session::ExecutionSession;
 use everruns_core::session_file::{
     FileInfo, FileStat, GrepMatch, GrepOptions, GrepSearchResult, InitialFile, SessionFile,
     build_grep_search_result,
 };
 use everruns_core::traits::{
-    KeyInfo, SecretInfo, SessionFileSystem, SessionFileSystemFactory,
-    SessionFileSystemFactoryContext, SessionStorageStore, SessionStore,
+    AgentStore, HarnessStore, KeyInfo, ProviderStore, ResolvedModel, SecretInfo, SessionFileSystem,
+    SessionFileSystemFactory, SessionFileSystemFactoryContext, SessionStorageStore, SessionStore,
 };
-use everruns_core::typed_id::SessionId;
+use everruns_core::typed_id::{AgentId, HarnessId, ModelId, SessionId};
 use everruns_platform::SessionMutator;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use uuid::Uuid;
+
+/// Application-grade in-memory agent store for embedded hosts.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryAgentStore {
+    agents: Arc<RwLock<HashMap<AgentId, AgentDefinition>>>,
+}
+
+impl InMemoryAgentStore {
+    /// Create an empty agent store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace an agent definition.
+    pub async fn add_agent(&self, agent: AgentDefinition) {
+        self.agents.write().await.insert(agent.id, agent);
+    }
+
+    /// Return every configured agent id.
+    pub async fn agent_ids(&self) -> Vec<AgentId> {
+        self.agents.read().await.keys().copied().collect()
+    }
+
+    /// Remove every configured agent.
+    pub async fn clear(&self) {
+        self.agents.write().await.clear();
+    }
+}
+
+#[async_trait]
+impl AgentStore for InMemoryAgentStore {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<AgentDefinition>> {
+        Ok(self.agents.read().await.get(&agent_id).cloned())
+    }
+}
+
+/// Application-grade in-memory harness store for embedded hosts.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryHarnessStore {
+    harnesses: Arc<RwLock<HashMap<HarnessId, HarnessDefinition>>>,
+}
+
+impl InMemoryHarnessStore {
+    /// Create an empty harness store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace a harness definition.
+    pub async fn add_harness(&self, harness_id: HarnessId, harness: HarnessDefinition) {
+        self.harnesses.write().await.insert(harness_id, harness);
+    }
+}
+
+#[async_trait]
+impl HarnessStore for InMemoryHarnessStore {
+    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<HarnessDefinition>> {
+        Ok(self.harnesses.read().await.get(&harness_id).cloned())
+    }
+}
+
+/// Application-grade in-memory provider store for embedded hosts.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryProviderStore {
+    models: Arc<RwLock<HashMap<ModelId, ResolvedModel>>>,
+    default_model: Arc<RwLock<Option<ResolvedModel>>>,
+}
+
+impl InMemoryProviderStore {
+    /// Create an empty provider store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configure a default model from explicitly injected credentials.
+    pub async fn from_credential_provider(provider: &dyn CredentialProvider) -> Self {
+        let store = Self::new();
+        if let Some(credentials) = provider
+            .resolve(&DriverId::OpenAI)
+            .filter(|credentials| credentials.api_key.is_some())
+        {
+            store
+                .set_default_model(ResolvedModel {
+                    model: "gpt-5.4".to_string(),
+                    provider_type: DriverId::OpenAI,
+                    api_key: credentials.api_key,
+                    base_url: credentials.base_url,
+                    provider_metadata: None,
+                })
+                .await;
+        } else if let Some(credentials) = provider
+            .resolve(&DriverId::Anthropic)
+            .filter(|credentials| credentials.api_key.is_some())
+        {
+            store
+                .set_default_model(ResolvedModel {
+                    model: "claude-sonnet-4-20250514".to_string(),
+                    provider_type: DriverId::Anthropic,
+                    api_key: credentials.api_key,
+                    base_url: credentials.base_url,
+                    provider_metadata: None,
+                })
+                .await;
+        }
+        store
+    }
+
+    /// Create a provider store with one default model.
+    pub async fn with_default(model: ResolvedModel) -> Self {
+        let store = Self::new();
+        store.set_default_model(model).await;
+        store
+    }
+
+    /// Insert or replace a model by id.
+    pub async fn add_model(&self, model_id: ModelId, model: ResolvedModel) {
+        self.models.write().await.insert(model_id, model);
+    }
+
+    /// Set the default model used when a session has no explicit model id.
+    pub async fn set_default_model(&self, model: ResolvedModel) {
+        *self.default_model.write().await = Some(model);
+    }
+
+    /// Remove all configured models and the default.
+    pub async fn clear(&self) {
+        self.models.write().await.clear();
+        *self.default_model.write().await = None;
+    }
+}
+
+#[async_trait]
+impl ProviderStore for InMemoryProviderStore {
+    async fn get_resolved_model(&self, model_id: ModelId) -> Result<Option<ResolvedModel>> {
+        Ok(self.models.read().await.get(&model_id).cloned())
+    }
+
+    async fn get_default_model(&self) -> Result<Option<ResolvedModel>> {
+        Ok(self.default_model.read().await.clone())
+    }
+}
 
 /// In-memory `SessionStore` + `SessionMutator` for embedded runtimes.
 ///
@@ -43,6 +188,16 @@ impl InMemorySessionStore {
     /// Insert or replace a session in the store.
     pub async fn add_session(&self, session: ExecutionSession) {
         self.sessions.write().await.insert(session.id, session);
+    }
+
+    /// Return every configured session id.
+    pub async fn session_ids(&self) -> Vec<SessionId> {
+        self.sessions.read().await.keys().copied().collect()
+    }
+
+    /// Remove every configured session.
+    pub async fn clear(&self) {
+        self.sessions.write().await.clear();
     }
 }
 

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -83,8 +83,8 @@ pub use host::{
     execute_reason_activity_with_prompt_messages,
 };
 pub use in_memory::{
-    InMemorySessionFileStore, InMemorySessionFileSystemFactory, InMemorySessionStorageStore,
-    InMemorySessionStore,
+    InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore, InMemorySessionFileStore,
+    InMemorySessionFileSystemFactory, InMemorySessionStorageStore, InMemorySessionStore,
 };
 #[cfg(feature = "process")]
 pub use process_command::ProcessCommandExecutor;

--- a/crates/host/tests/filesystem_narration_paths_test.rs
+++ b/crates/host/tests/filesystem_narration_paths_test.rs
@@ -10,10 +10,6 @@ use everruns_core::capabilities::{
     CapabilityRegistry, SystemPromptContext, collect_capabilities_with_configs,
 };
 use everruns_core::driver_registry::DriverRegistry;
-use everruns_core::in_memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryMessageRetriever,
-    InMemoryProviderStore,
-};
 use everruns_core::tool_narration::{
     ToolNarrationContext, ToolNarrationPhase, narrate_list_directory,
 };
@@ -26,11 +22,13 @@ use everruns_core::{
     SessionExecutionState, ToolCall, WorkspaceRootSet,
 };
 use everruns_host::{
-    InMemorySessionFileStore, RealDiskFileStore, ResolvedTurnInputs, RuntimeHostAdapter,
-    execute_act_activity, multi_root_file_system,
+    InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore, InMemorySessionFileStore,
+    RealDiskFileStore, ResolvedTurnInputs, RuntimeHostAdapter, execute_act_activity,
+    multi_root_file_system,
 };
 use everruns_integrations_filesystem::FileSystemCapability;
 use everruns_platform::SessionMutator;
+use everruns_test_support::{InMemoryEventEmitter, InMemoryMessageRetriever};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/host/tests/runtime_host_test.rs
+++ b/crates/host/tests/runtime_host_test.rs
@@ -8,10 +8,6 @@ use everruns_core::capabilities::{
     Capability, CapabilityStatus, SystemPromptContext, collect_capabilities_with_configs,
 };
 use everruns_core::driver_registry::DriverRegistry;
-use everruns_core::in_memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryMessageRetriever,
-    InMemoryProviderStore,
-};
 use everruns_core::session_task::{
     CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
     SessionTaskUpdate, TaskMessage, apply_task_update, new_session_task,
@@ -27,12 +23,13 @@ use everruns_core::{
     inspect_turn_context, user_facing_error_codes,
 };
 use everruns_host::{
-    InMemorySessionFileStore, ResolvedTurnInputs, RuntimeHostAdapter, RuntimeSessionLifecycle,
-    RuntimeTurnPlan, RuntimeTurnState, TurnStopReason, execute_act_activity,
-    execute_input_activity, plan_next_host_turn,
+    InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore, InMemorySessionFileStore,
+    ResolvedTurnInputs, RuntimeHostAdapter, RuntimeSessionLifecycle, RuntimeTurnPlan,
+    RuntimeTurnState, TurnStopReason, execute_act_activity, execute_input_activity,
+    plan_next_host_turn,
 };
 use everruns_platform::SessionMutator;
-use everruns_test_support::TestMathCapability;
+use everruns_test_support::{InMemoryEventEmitter, InMemoryMessageRetriever, TestMathCapability};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/llm-tests/examples/turn_based_execution.rs
+++ b/crates/llm-tests/examples/turn_based_execution.rs
@@ -29,14 +29,14 @@ use everruns_core::{
     },
     capabilities::CapabilityRegistry,
     driver_registry::DriverRegistry,
-    in_memory::{
-        InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryMessageRetriever,
-        InMemoryProviderStore, InMemorySessionStore,
-    },
     session::{ExecutionSession, SessionExecutionState},
     tools::{Tool, ToolExecutionResult, ToolRegistry, ToolRegistryBuilder},
     typed_id::{AgentId, HarnessId, TurnId},
 };
+use everruns_host::{
+    InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore, InMemorySessionStore,
+};
+use everruns_test_support::{InMemoryEventEmitter, InMemoryMessageRetriever};
 use serde_json::{Value, json};
 use uuid::Uuid;
 

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -30,8 +30,8 @@ categories = ["development-tools", "asynchronous"]
 # (the `everruns` facade, the worker's llmsim provider) select only `sim` so
 # their dependency trees never carry the demo capability fixtures.
 default = ["sim", "fixtures", "host"]
-# The in-process `llmsim` chat driver plus the in-memory agentic loop built
-# on it.
+# The in-process `llmsim` chat driver. The agentic loop additionally requires
+# the `host` feature so conversation history is projected from canonical events.
 sim = ["dep:llmsim"]
 # Fake demo capabilities: fake AWS/CRM/financial/warehouse, test math and
 # weather, the sample-data mount demo, and the noop fixture. The fake AWS
@@ -57,6 +57,7 @@ inventory.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["sync", "time", "rt"] }
+uuid.workspace = true
 
 # LLM simulation. default-features = false sheds the server/cli/tui/tokens
 # subtrees (axum, tower-http, tiktoken-rs, clap, tracing-subscriber,
@@ -67,4 +68,3 @@ llmsim = { version = "0.5.1", default-features = false, optional = true }
 [dev-dependencies]
 everruns-builtins.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
-uuid.workspace = true

--- a/crates/test-support/README.md
+++ b/crates/test-support/README.md
@@ -46,8 +46,11 @@ assert!(result.contains("4"));
   scripting, latency/TTFT simulation, error injection, and effort/message
   capture sinks (`sim` feature)
 - `InMemoryAgenticLoop` — a complete `input → reason → act` loop over
-  in-memory stores, for tests and prototypes with no database or network
-  (`sim` feature)
+  host-owned in-memory stores and a canonical in-memory event log, for tests
+  and prototypes with no database or network (`sim` + `host` features)
+- `InMemoryMessageRetriever` / `InMemoryEventEmitter` — writable deterministic
+  fixtures for isolated atom and trait tests; hosted loops instead append once
+  to an event log and read through `EventHistory`
 - `MockProvider`, `MockToolExecutor`, `EchoToolExecutor`,
   `FailingToolExecutor` — test doubles for the core execution traits
 - Fake demo capabilities — `FakeAwsCapability`, `FakeCrmCapability`,

--- a/crates/test-support/src/in_memory.rs
+++ b/crates/test-support/src/in_memory.rs
@@ -1,0 +1,219 @@
+//! Deterministic in-memory fixtures for isolated tests.
+//!
+//! These fixtures deliberately expose setup writes. Application runtimes use
+//! `everruns-host` stores and append conversation state to an `EventLog`.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use everruns_core::error::Result;
+use everruns_core::events::{Event, EventRequest};
+use everruns_core::message::Message;
+use everruns_core::message_filter::{MessageFilter, MessageQuery};
+use everruns_core::message_retriever::{InputMessage, MessageHistory, MessageRetriever};
+use everruns_core::traits::EventEmitter;
+use everruns_core::typed_id::{EventId, MessageId, SessionId};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+/// Writable message fixture for isolated tests that do not exercise a host.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryMessageRetriever {
+    messages: Arc<RwLock<HashMap<SessionId, Vec<Message>>>>,
+}
+
+impl InMemoryMessageRetriever {
+    /// Create an empty message fixture.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return session ids currently represented in the fixture.
+    pub async fn sessions(&self) -> Vec<SessionId> {
+        self.messages.read().await.keys().copied().collect()
+    }
+
+    /// Remove every seeded message.
+    pub async fn clear(&self) {
+        self.messages.write().await.clear();
+    }
+
+    /// Remove messages for one session.
+    pub async fn clear_session(&self, session_id: SessionId) {
+        self.messages.write().await.remove(&session_id);
+    }
+
+    /// Replace one session's deterministic message history.
+    pub async fn seed(&self, session_id: SessionId, messages: Vec<Message>) {
+        self.messages.write().await.insert(session_id, messages);
+    }
+
+    /// Construct and append a message from test input.
+    pub async fn add(&self, session_id: SessionId, input: InputMessage) -> Result<Message> {
+        let message = Message {
+            id: MessageId::new(),
+            role: input.role,
+            content: input.content,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+            controls: input.controls,
+            metadata: input.metadata,
+            external_actor: None,
+            created_at: Utc::now(),
+        };
+        self.store(session_id, message.clone()).await?;
+        Ok(message)
+    }
+
+    /// Append an already-constructed message.
+    pub async fn store(&self, session_id: SessionId, message: Message) -> Result<()> {
+        self.messages
+            .write()
+            .await
+            .entry(session_id)
+            .or_default()
+            .push(message);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl MessageRetriever for InMemoryMessageRetriever {
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
+        Ok(self
+            .messages
+            .read()
+            .await
+            .get(&session_id)
+            .and_then(|messages| messages.iter().find(|m| m.id == message_id).cloned()))
+    }
+
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
+        Ok(self
+            .messages
+            .read()
+            .await
+            .get(&session_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn load_filtered(&self, query: MessageQuery) -> Result<Vec<Message>> {
+        let mut messages = self.load(query.session_id).await?;
+        if let Some(after) = query.after_sequence {
+            messages = messages.into_iter().skip(after.max(0) as usize).collect();
+        }
+        for filter in &query.filters {
+            match filter {
+                MessageFilter::TimeRange { from, to } => messages.retain(|message| {
+                    from.is_none_or(|time| message.created_at >= time)
+                        && to.is_none_or(|time| message.created_at <= time)
+                }),
+                MessageFilter::Search(query) => {
+                    let query = query.to_lowercase();
+                    messages.retain(|message| {
+                        message
+                            .text()
+                            .is_some_and(|text| text.to_lowercase().contains(&query))
+                    });
+                }
+                MessageFilter::Custom(predicate) => messages.retain(|message| predicate(message)),
+                _ => {}
+            }
+        }
+        query.apply_windowing(&mut messages);
+        if query.has_injections() {
+            query.apply_injections(&mut messages);
+        }
+        Ok(messages)
+    }
+
+    async fn load_filtered_history(&self, query: MessageQuery) -> Result<MessageHistory> {
+        let source_sequence = self
+            .messages
+            .read()
+            .await
+            .get(&query.session_id)
+            .map(|messages| messages.len() as i64)
+            .unwrap_or(0);
+        Ok(MessageHistory {
+            messages: self.load_filtered(query).await?,
+            source_sequence: Some(source_sequence),
+        })
+    }
+
+    async fn count(&self, session_id: SessionId) -> Result<usize> {
+        Ok(self
+            .messages
+            .read()
+            .await
+            .get(&session_id)
+            .map(Vec::len)
+            .unwrap_or(0))
+    }
+}
+
+/// Event emitter fixture with deterministic, process-local sequencing.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryEventEmitter {
+    events: Arc<RwLock<Vec<Event>>>,
+    sequence: Arc<RwLock<i32>>,
+}
+
+impl InMemoryEventEmitter {
+    /// Create an empty event fixture.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return all emitted events in order.
+    pub async fn events(&self) -> Vec<Event> {
+        self.events.read().await.clone()
+    }
+
+    /// Return the number of emitted events.
+    pub async fn event_count(&self) -> usize {
+        self.events.read().await.len()
+    }
+
+    /// Remove all events and reset deterministic sequencing.
+    pub async fn clear(&self) {
+        self.events.write().await.clear();
+        *self.sequence.write().await = 0;
+    }
+
+    /// Return events with the requested protocol type.
+    pub async fn events_by_type(&self, event_type: &str) -> Vec<Event> {
+        self.events
+            .read()
+            .await
+            .iter()
+            .filter(|event| event.event_type == event_type)
+            .cloned()
+            .collect()
+    }
+
+    /// Return events emitted for one session UUID.
+    pub async fn events_for_session(&self, session_id: Uuid) -> Vec<Event> {
+        self.events
+            .read()
+            .await
+            .iter()
+            .filter(|event| event.session_uuid() == session_id)
+            .cloned()
+            .collect()
+    }
+}
+
+#[async_trait]
+impl EventEmitter for InMemoryEventEmitter {
+    async fn emit(&self, request: EventRequest) -> Result<Event> {
+        let mut sequence = self.sequence.write().await;
+        *sequence += 1;
+        let event = request.into_event(EventId::new(), *sequence);
+        self.events.write().await.push(event.clone());
+        Ok(event)
+    }
+}

--- a/crates/test-support/src/in_memory_loop.rs
+++ b/crates/test-support/src/in_memory_loop.rs
@@ -11,9 +11,8 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
-
 use crate::llmsim_driver::{LlmSimConfig, LlmSimDriver};
+use chrono::Utc;
 use everruns_core::agent_definition::AgentDefinition;
 use everruns_core::atoms::{
     ActAtom, ActInput, Atom, AtomContext, InputAtom, InputAtomInput, ReasonAtom, ReasonInput,
@@ -21,11 +20,7 @@ use everruns_core::atoms::{
 use everruns_core::capabilities::{AgentCapabilityConfig, Capability, CapabilityRegistry};
 use everruns_core::driver_registry::{DriverId, DriverRegistry};
 use everruns_core::error::Result;
-use everruns_core::events::{Event, EventData, EventRequest, OUTPUT_MESSAGE_COMPLETED};
-use everruns_core::in_memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryMessageRetriever,
-    InMemoryProviderStore, InMemorySessionStore,
-};
+use everruns_core::events::{Event, EventContext, EventData, EventRequest, InputMessageData};
 use everruns_core::message::Message;
 use everruns_core::message_retriever::{InputMessage, MessageRetriever};
 use everruns_core::session::ExecutionSession;
@@ -33,66 +28,12 @@ use everruns_core::tool_types::ToolCall;
 use everruns_core::tools::{Tool, ToolRegistry, ToolRegistryBuilder};
 use everruns_core::traits::{EventEmitter, ResolvedModel};
 use everruns_core::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine, TurnStopReason};
-use everruns_core::typed_id::{AgentId, HarnessId, SessionId, TurnId};
-
-// ============================================================================
-// Bridging Event Emitter
-// ============================================================================
-
-/// Event emitter that bridges events to message storage
-///
-/// When a `output.message.completed` event is emitted, it also stores the message
-/// in the provided message retriever. This enables full agentic loops
-/// in memory without the database layer.
-#[derive(Clone)]
-struct BridgingEventEmitter {
-    inner: InMemoryEventEmitter,
-    message_retriever: InMemoryMessageRetriever,
-}
-
-impl BridgingEventEmitter {
-    fn new(message_retriever: InMemoryMessageRetriever) -> Self {
-        Self {
-            inner: InMemoryEventEmitter::new(),
-            message_retriever,
-        }
-    }
-
-    async fn events(&self) -> Vec<Event> {
-        self.inner.events().await
-    }
-
-    async fn events_by_type(&self, event_type: &str) -> Vec<Event> {
-        self.inner.events_by_type(event_type).await
-    }
-
-    async fn event_count(&self) -> usize {
-        self.inner.event_count().await
-    }
-
-    async fn clear(&self) {
-        self.inner.clear().await;
-    }
-}
-
-#[async_trait]
-impl EventEmitter for BridgingEventEmitter {
-    async fn emit(&self, request: EventRequest) -> Result<Event> {
-        // If this is an output.message.completed event, also store the message
-        if request.data.event_type() == OUTPUT_MESSAGE_COMPLETED
-            && let EventData::OutputMessageCompleted(data) = &request.data
-        {
-            // Store the message in the retriever
-            let _ = self
-                .message_retriever
-                .store(request.session_id, data.message.clone())
-                .await;
-        }
-
-        // Delegate to the inner emitter
-        self.inner.emit(request).await
-    }
-}
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
+use everruns_host::{
+    EventHistory, EventReadLimit, EventReadRequest, EventReader, HostEventEmitter,
+    InMemoryAgentStore, InMemoryEventLog, InMemoryHarnessStore, InMemoryProviderStore,
+    InMemorySessionStore, NoopEventSink,
+};
 
 // ============================================================================
 // Turn Result
@@ -387,8 +328,9 @@ impl InMemoryAgenticLoopBuilder {
         let harness_store = InMemoryHarnessStore::new();
         let agent_store = InMemoryAgentStore::new();
         let session_store = InMemorySessionStore::new();
-        let message_retriever = InMemoryMessageRetriever::new();
-        let event_emitter = BridgingEventEmitter::new(message_retriever.clone());
+        let event_log = Arc::new(InMemoryEventLog::new());
+        let message_retriever = EventHistory::new(event_log.clone());
+        let event_emitter = HostEventEmitter::new(event_log.clone(), Arc::new(NoopEventSink));
 
         // Build capability configs for the agent from capabilities
         let agent_capability_configs: Vec<AgentCapabilityConfig> = self
@@ -514,6 +456,7 @@ impl InMemoryAgenticLoopBuilder {
             harness_store,
             agent_store,
             session_store,
+            event_log,
             message_retriever,
             provider_store,
             event_emitter,
@@ -569,14 +512,15 @@ pub struct InMemoryAgenticLoop {
     agent_store: InMemoryAgentStore,
     #[allow(dead_code)]
     session_store: InMemorySessionStore,
-    message_retriever: InMemoryMessageRetriever,
+    event_log: Arc<InMemoryEventLog>,
+    message_retriever: EventHistory,
     #[allow(dead_code)]
     provider_store: InMemoryProviderStore,
-    event_emitter: BridgingEventEmitter,
+    event_emitter: HostEventEmitter,
     tool_registry: ToolRegistry,
-    input_atom: Arc<InputAtom<InMemoryMessageRetriever>>,
+    input_atom: Arc<InputAtom<EventHistory>>,
     reason_atom: Arc<ReasonAtom>,
-    act_atom: Arc<ActAtom<ToolRegistry, BridgingEventEmitter>>,
+    act_atom: Arc<ActAtom<ToolRegistry, HostEventEmitter>>,
     max_iterations: usize,
     reasoning_effort_handle: Option<everruns_core::traits::ReasoningEffortHandle>,
 }
@@ -637,11 +581,31 @@ impl InMemoryAgenticLoop {
             handle.set(None);
         }
 
-        // Add user message
-        let message = self
-            .message_retriever
-            .add(self.session_id, input.into())
-            .await?;
+        // Append the accepted input once. EventHistory supplies the read model
+        // consumed by every atom; there is no writable message-store facade.
+        let input = input.into();
+        let tags = input.tags.clone();
+        let message = Message {
+            id: MessageId::new(),
+            role: input.role,
+            content: input.content,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+            controls: input.controls,
+            metadata: input.metadata,
+            external_actor: None,
+            created_at: Utc::now(),
+        };
+        let mut request = EventRequest::new(
+            self.session_id,
+            EventContext::empty(),
+            InputMessageData::new(message.clone()),
+        );
+        if !tags.is_empty() {
+            request = request.with_tags(tags);
+        }
+        self.event_emitter.emit(request).await?;
 
         // Create turn context and state machine
         let turn_context = TurnContext::new(self.session_id, message.id, self.agent_id, 0);
@@ -739,7 +703,6 @@ impl InMemoryAgenticLoop {
                     let turn_id = state_machine.context().turn_id;
                     let mut result = TurnResult::from_outcome(outcome, turn_id);
                     result.llm_generations = self
-                        .event_emitter
                         .events()
                         .await
                         .into_iter()
@@ -782,12 +745,30 @@ impl InMemoryAgenticLoop {
 
     /// Get all emitted events
     pub async fn events(&self) -> Vec<Event> {
-        self.event_emitter.events().await
+        let limit = EventReadLimit::default();
+        let mut request = EventReadRequest::new(self.session_id, limit);
+        let mut events = Vec::new();
+        loop {
+            let page = self
+                .event_log
+                .read_page(request)
+                .await
+                .expect("in-memory canonical event reads are infallible");
+            events.extend(page.events);
+            let Some(cursor) = page.next_cursor else {
+                return events;
+            };
+            request = EventReadRequest::from_cursor(cursor, limit);
+        }
     }
 
     /// Get events of a specific type
     pub async fn events_by_type(&self, event_type: &str) -> Vec<Event> {
-        self.event_emitter.events_by_type(event_type).await
+        self.events()
+            .await
+            .into_iter()
+            .filter(|event| event.event_type == event_type)
+            .collect()
     }
 
     /// Get the count of messages
@@ -797,23 +778,7 @@ impl InMemoryAgenticLoop {
 
     /// Get the count of events
     pub async fn event_count(&self) -> usize {
-        self.event_emitter.event_count().await
-    }
-
-    /// Clear all events (useful between tests)
-    pub async fn clear_events(&self) {
-        self.event_emitter.clear().await;
-    }
-
-    /// Clear all messages (starts a fresh conversation)
-    pub async fn clear_messages(&self) {
-        self.message_retriever.clear_session(self.session_id).await;
-    }
-
-    /// Reset the loop (clear messages and events)
-    pub async fn reset(&self) {
-        self.clear_messages().await;
-        self.clear_events().await;
+        self.events().await.len()
     }
 
     /// Get conversation as a formatted string
@@ -829,7 +794,7 @@ impl InMemoryAgenticLoop {
     }
 
     /// Access the message retriever directly
-    pub fn message_retriever(&self) -> &InMemoryMessageRetriever {
+    pub fn message_retriever(&self) -> &EventHistory {
         &self.message_retriever
     }
 
@@ -1036,18 +1001,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reset() {
+    async fn conversation_messages_are_projected_from_single_canonical_writes() {
         let runner = InMemoryAgenticLoop::with_fixed_response("Response")
             .await
             .unwrap();
 
-        runner.run_turn("Test").await.unwrap();
-        assert!(runner.message_count().await.unwrap() > 0);
-        assert!(runner.event_count().await > 0);
+        runner.run_turn("Question").await.unwrap();
 
-        runner.reset().await;
-        assert_eq!(runner.message_count().await.unwrap(), 0);
-        assert_eq!(runner.event_count().await, 0);
+        let messages = runner.messages().await.unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].text(), Some("Question"));
+        assert_eq!(messages[1].text(), Some("Response"));
+
+        let events = runner.events().await;
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.event_type == everruns_core::events::INPUT_MESSAGE)
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.event_type == everruns_core::events::OUTPUT_MESSAGE_COMPLETED)
+                .count(),
+            1
+        );
+        assert!(events.iter().all(|event| event.sequence.is_some()));
     }
 
     #[tokio::test]

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -9,7 +9,9 @@
 //!   sequence, and scripted multi-turn responses, latency and error
 //!   injection, effort/message capture (`sim` feature)
 //! - [`in_memory_loop`] — a full in-memory agentic loop with no database or
-//!   network (`sim` feature)
+//!   network (`sim` + `host` features)
+//! - [`in_memory`] — deterministic message and event fixtures for isolated
+//!   tests; hosted loops use canonical event history instead
 //! - [`doubles`] — mock/echo/failing tool executors and a mock chat driver
 //! - [`capabilities`] — fake AWS/CRM/financial/warehouse demo capabilities
 //!   and the test math/weather, sample-data, and noop fixtures
@@ -44,8 +46,10 @@
 pub mod llmsim_driver;
 
 // In-memory agentic loop built on the llmsim driver.
-#[cfg(feature = "sim")]
+#[cfg(all(feature = "sim", feature = "host"))]
 pub mod in_memory_loop;
+
+pub mod in_memory;
 
 // Test doubles for the core execution traits.
 pub mod doubles;
@@ -58,7 +62,8 @@ pub mod capabilities;
 #[cfg(feature = "host")]
 mod runtime_ext;
 
-#[cfg(feature = "sim")]
+pub use in_memory::{InMemoryEventEmitter, InMemoryMessageRetriever};
+#[cfg(all(feature = "sim", feature = "host"))]
 pub use in_memory_loop::{InMemoryAgenticLoop, InMemoryAgenticLoopBuilder};
 #[cfg(feature = "sim")]
 pub use llmsim_driver::{

--- a/crates/test-support/tests/command_host_test.rs
+++ b/crates/test-support/tests/command_host_test.rs
@@ -20,15 +20,14 @@ use everruns_core::AgentDefinition;
 
 use everruns_core::driver_registry::LlmStreamEvent;
 use everruns_core::harness_definition::HarnessDefinition;
-use everruns_core::in_memory::{
-    InMemoryAgentStore, InMemoryHarnessStore, InMemoryMessageRetriever, InMemoryProviderStore,
-    InMemorySessionStore,
-};
 use everruns_core::message_retriever::InputMessage;
 use everruns_core::provider::DriverId;
 use everruns_core::session::SessionExecutionState;
 use everruns_core::typed_id::{AgentId, HarnessId};
-use everruns_test_support::{LlmSimConfig, LlmSimDriver};
+use everruns_host::{
+    InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore, InMemorySessionStore,
+};
+use everruns_test_support::{InMemoryMessageRetriever, LlmSimConfig, LlmSimDriver};
 use futures::StreamExt;
 
 #[tokio::test]

--- a/crates/test-support/tests/in_memory_fixtures_test.rs
+++ b/crates/test-support/tests/in_memory_fixtures_test.rs
@@ -1,0 +1,115 @@
+use everruns_core::events::{EventContext, EventRequest, InputMessageData};
+use everruns_core::{
+    EventEmitter, Message, MessageRetriever, MessageRole, SessionId, ToolCall, ToolResultImage,
+};
+use everruns_test_support::{InMemoryEventEmitter, InMemoryMessageRetriever};
+use serde_json::json;
+
+#[tokio::test]
+async fn message_fixture_preserves_tool_calls_in_seeded_history() {
+    let session_id = SessionId::new();
+    let fixture = InMemoryMessageRetriever::new();
+    let message = Message::assistant_with_tools(
+        "Checking.",
+        vec![ToolCall {
+            id: "call_weather".into(),
+            name: "get_weather".into(),
+            arguments: json!({"city": "Tokyo"}),
+        }],
+    );
+
+    fixture.store(session_id, message).await.unwrap();
+
+    let loaded = fixture.load(session_id).await.unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].tool_calls()[0].name, "get_weather");
+}
+
+#[tokio::test]
+async fn message_fixture_preserves_full_parallel_tool_conversation() {
+    let session_id = SessionId::new();
+    let fixture = InMemoryMessageRetriever::new();
+    let calls = ["Tokyo", "London", "New York"]
+        .into_iter()
+        .enumerate()
+        .map(|(index, city)| ToolCall {
+            id: format!("call_{index}"),
+            name: "get_weather".into(),
+            arguments: json!({"city": city}),
+        })
+        .collect::<Vec<_>>();
+
+    fixture
+        .store(
+            session_id,
+            Message::assistant_with_tools("Checking all cities.", calls.clone()),
+        )
+        .await
+        .unwrap();
+    for call in &calls {
+        fixture
+            .store(
+                session_id,
+                Message::tool_result(&call.id, Some(json!({"ok": true})), None),
+            )
+            .await
+            .unwrap();
+    }
+    fixture
+        .store(session_id, Message::assistant("All done."))
+        .await
+        .unwrap();
+
+    let loaded = fixture.load(session_id).await.unwrap();
+    assert_eq!(loaded.len(), 5);
+    assert_eq!(loaded[0].tool_calls().len(), 3);
+    assert_eq!(loaded[1].role, MessageRole::ToolResult);
+    assert_eq!(loaded[4].text(), Some("All done."));
+}
+
+#[tokio::test]
+async fn message_fixture_preserves_tool_result_images() {
+    let session_id = SessionId::new();
+    let fixture = InMemoryMessageRetriever::new();
+    fixture
+        .store(
+            session_id,
+            Message::tool_result_with_images(
+                "call_image",
+                Some(json!({"ok": true})),
+                vec![ToolResultImage {
+                    base64: "AAAA".into(),
+                    media_type: "image/png".into(),
+                }],
+            ),
+        )
+        .await
+        .unwrap();
+
+    let loaded = fixture.load(session_id).await.unwrap();
+    assert_eq!(loaded[0].role, MessageRole::ToolResult);
+    assert_eq!(loaded[0].tool_call_id(), Some("call_image"));
+    assert_eq!(loaded[0].content.len(), 2);
+}
+
+#[tokio::test]
+async fn event_fixture_supports_deterministic_isolated_assertions() {
+    let session_id = SessionId::new();
+    let fixture = InMemoryEventEmitter::new();
+
+    for text in ["one", "two"] {
+        fixture
+            .emit(EventRequest::new(
+                session_id,
+                EventContext::empty(),
+                InputMessageData::new(Message::user(text)),
+            ))
+            .await
+            .unwrap();
+    }
+
+    let events = fixture.events().await;
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].sequence, Some(1));
+    assert_eq!(events[1].sequence, Some(2));
+}

--- a/crates/test-support/tests/reason_atom_test.rs
+++ b/crates/test-support/tests/reason_atom_test.rs
@@ -13,16 +13,16 @@ use everruns_core::atoms::{Atom, AtomContext, ReasonAtom, ReasonInput};
 use everruns_core::capabilities::CapabilityRegistry;
 use everruns_core::driver_registry::{DriverId, DriverRegistry};
 use everruns_core::harness_definition::HarnessDefinition;
-use everruns_core::in_memory::{
-    InMemoryAgentStore, InMemoryHarnessStore, InMemoryMessageRetriever, InMemoryProviderStore,
-    InMemorySessionStore,
-};
 use everruns_core::runtime_agent::RuntimeAgent;
 use everruns_core::session::{ExecutionSession, SessionExecutionState};
 use everruns_core::traits::{NoopEventEmitter, ResolvedModel};
 use everruns_core::typed_id::{HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{CompactionCheckpointStore, Controls, Message, ToolCall};
+use everruns_host::{
+    InMemoryAgentStore, InMemoryHarnessStore, InMemoryProviderStore, InMemorySessionStore,
+};
 use everruns_test_support::llmsim_driver::{LlmSimConfig, LlmSimDriver, register_driver};
+use everruns_test_support::{InMemoryEventEmitter, InMemoryMessageRetriever};
 use futures::stream;
 use serde_json::json;
 use std::sync::Arc;
@@ -235,7 +235,7 @@ struct ProactiveTestRig {
     provider_store: InMemoryProviderStore,
     capability_registry: CapabilityRegistry,
     driver_registry: DriverRegistry,
-    event_emitter: everruns_core::in_memory::InMemoryEventEmitter,
+    event_emitter: InMemoryEventEmitter,
     checkpoint_store: Arc<everruns_core::InMemoryCompactionCheckpointStore>,
     harness_id: HarnessId,
     agent_id: Uuid,
@@ -328,7 +328,7 @@ impl ProactiveTestRig {
             provider_store,
             capability_registry,
             driver_registry,
-            event_emitter: everruns_core::in_memory::InMemoryEventEmitter::new(),
+            event_emitter: InMemoryEventEmitter::new(),
             checkpoint_store: Arc::new(everruns_core::InMemoryCompactionCheckpointStore::default()),
             harness_id,
             agent_id,
@@ -763,8 +763,6 @@ fn create_speed_capturing_driver_registry(
 
 #[tokio::test]
 async fn test_reason_atom_with_fixed_response() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -845,7 +843,6 @@ async fn test_reason_atom_with_fixed_response() {
 async fn native_compact_retry_reuses_ordered_opaque_output_without_previous_response_id() {
     use everruns_builtins::{COMPACTION_CAPABILITY_ID, CompactionCapability};
     use everruns_core::AgentCapabilityConfig;
-    use everruns_core::in_memory::InMemoryEventEmitter;
 
     let (
         harness_store,
@@ -1045,7 +1042,6 @@ async fn native_compact_retry_reuses_ordered_opaque_output_without_previous_resp
 async fn native_compact_failure_does_not_install_checkpoint() {
     use everruns_builtins::{COMPACTION_CAPABILITY_ID, CompactionCapability};
     use everruns_core::AgentCapabilityConfig;
-    use everruns_core::in_memory::InMemoryEventEmitter;
     use everruns_core::traits::SessionStore;
 
     let (
@@ -1756,8 +1752,6 @@ async fn proactive_attempt_watermark_failures_do_not_abort_model_turn() {
 
 #[tokio::test]
 async fn test_reason_atom_strips_speed_not_advertised_by_model_profile() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -1819,8 +1813,6 @@ async fn test_reason_atom_strips_speed_not_advertised_by_model_profile() {
 
 #[tokio::test]
 async fn test_reason_atom_preserves_speed_advertised_by_model_profile() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -2121,8 +2113,6 @@ async fn test_reason_atom_with_different_configs() {
 
 #[tokio::test]
 async fn test_reason_atom_with_multi_turn_conversation() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -2333,8 +2323,6 @@ async fn test_reason_atom_with_lorem_response() {
 
 #[tokio::test]
 async fn test_reason_atom_handles_llm_error() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -2432,8 +2420,6 @@ async fn test_reason_atom_handles_llm_error() {
 
 #[tokio::test]
 async fn test_reason_atom_emits_output_message_completed_on_success() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -2546,8 +2532,6 @@ async fn test_reason_atom_emits_output_message_completed_on_success() {
 
 #[tokio::test]
 async fn test_reason_atom_retries_structured_processing_error_before_output() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -2632,8 +2616,6 @@ async fn test_reason_atom_retries_structured_processing_error_before_output() {
 /// not surfaced as a failed turn — and without injecting artificial history.
 #[tokio::test(start_paused = true)]
 async fn test_reason_atom_retries_provider_stream_stall_before_output() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -2731,8 +2713,6 @@ async fn test_reason_atom_retries_provider_stream_stall_before_output() {
 /// retry budget and eventually return an error rather than retrying forever.
 #[tokio::test(start_paused = true)]
 async fn test_reason_atom_bounds_repeated_provider_stream_stalls() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -2863,8 +2843,6 @@ async fn test_driver_registry_integration() {
 
 #[tokio::test]
 async fn test_reason_atom_handles_model_not_available() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3209,8 +3187,6 @@ impl everruns_core::ChatDriver for ToolCallsThenErrorDriver {
 
 #[tokio::test]
 async fn test_reason_atom_preserves_tool_calls_on_trailing_stream_error() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3299,8 +3275,6 @@ impl everruns_core::ChatDriver for TextThenErrorDriver {
 
 #[tokio::test]
 async fn test_reason_atom_preserves_text_on_trailing_stream_error() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3390,8 +3364,6 @@ impl everruns_core::ChatDriver for PureErrorDriver {
 
 #[tokio::test]
 async fn test_reason_atom_exhausts_bounded_processing_error_retries() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3462,8 +3434,6 @@ async fn test_reason_atom_exhausts_bounded_processing_error_retries() {
 
 #[tokio::test]
 async fn test_reason_atom_does_not_retry_non_transient_provider_code() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3522,8 +3492,6 @@ async fn test_reason_atom_does_not_retry_non_transient_provider_code() {
 
 #[tokio::test]
 async fn test_reason_atom_strips_error_placeholder_messages() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3602,8 +3570,6 @@ async fn test_reason_atom_strips_error_placeholder_messages() {
 
 #[tokio::test]
 async fn test_reason_atom_strips_dynamic_error_placeholder_messages() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3668,8 +3634,6 @@ async fn test_reason_atom_strips_dynamic_error_placeholder_messages() {
 
 #[tokio::test]
 async fn test_reason_atom_keeps_non_placeholder_messages_that_share_prefixes() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3824,8 +3788,6 @@ fn create_conversation_capturing_driver_registry(
 
 #[tokio::test]
 async fn test_session_system_prompt_is_prepended_to_agent_prompt() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -3935,8 +3897,6 @@ async fn test_session_system_prompt_is_prepended_to_agent_prompt() {
 
 #[tokio::test]
 async fn test_empty_session_system_prompt_is_ignored() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,
@@ -4049,7 +4009,6 @@ async fn test_prompt_canary_guardrail_replaces_leaked_output() {
         REASON_CODE_SYSTEM_PROMPT_LEAK,
     };
     use everruns_core::AgentCapabilityConfig;
-    use everruns_core::in_memory::InMemoryEventEmitter;
 
     // Reuse the standard test environment, then patch the agent to (a) carry
     // a system prompt long enough to produce a canary needle and (b) enable
@@ -4202,7 +4161,6 @@ async fn test_prompt_canary_guardrail_replaces_leaked_thinking() {
         PROMPT_CANARY_GUARDRAIL_CAPABILITY_ID, PromptCanaryGuardrailCapability,
     };
     use everruns_core::AgentCapabilityConfig;
-    use everruns_core::in_memory::InMemoryEventEmitter;
 
     let (
         harness_store,
@@ -4315,8 +4273,6 @@ async fn test_prompt_canary_guardrail_replaces_leaked_thinking() {
 /// case — make sure the hot path doesn't regress.
 #[tokio::test]
 async fn test_no_guardrails_passes_through_unchanged() {
-    use everruns_core::in_memory::InMemoryEventEmitter;
-
     let (
         harness_store,
         agent_store,

--- a/docs/framework/custom-backends.md
+++ b/docs/framework/custom-backends.md
@@ -17,7 +17,7 @@ The low-level crates expose focused contracts for:
 
 - core agent, event, capability, and provider values;
 - the sans-I/O turn engine;
-- runtime host phases and in-memory reference stores;
+- runtime host phases, canonical event history, and in-memory reference stores;
 - local SQLite-backed task and schedule state;
 - platform/control-plane entities and durable deployment components.
 

--- a/docs/framework/workspace-security.md
+++ b/docs/framework/workspace-security.md
@@ -5,7 +5,7 @@ description: Configure safe read and write scopes for in-process Everruns agents
 
 `WorkspacePolicy` is the portable security boundary for files visible to an
 in-process agent. Applications configure it through `everruns`; they do not
-need `RealDiskFileStore`, `RuntimeBackends`, or a runtime-owned blocklist.
+need `RealDiskFileStore`, `HostBackends`, or a runtime-owned blocklist.
 
 ```rust
 use everruns::{Agent, Model, WorkspacePolicy};

--- a/docs/how-to/migrate-to-0-18.md
+++ b/docs/how-to/migrate-to-0-18.md
@@ -110,11 +110,18 @@ extensions.insert(Arc::new(SessionMutatorExt(mutator)));
 | HTTP transports | `everruns_http::` |
 | Telemetry init, exporter event listeners, `CompositeEventListener` | `everruns_observability::` |
 | `llmsim` driver, in-memory loop, fixture capabilities | `everruns_test_support::` |
+| `everruns_core::in_memory::{InMemoryAgentStore, InMemoryHarnessStore, InMemorySessionStore, InMemoryProviderStore}` | `everruns_host::{InMemoryAgentStore, InMemoryHarnessStore, InMemorySessionStore, InMemoryProviderStore}` |
+| `everruns_core::in_memory::{InMemoryMessageRetriever, InMemoryEventEmitter}` | `everruns_test_support::{InMemoryMessageRetriever, InMemoryEventEmitter}` for isolated deterministic tests |
 
 Product presets compose these explicitly. Core registries are now empty by
 default: use `everruns_host::runtime_capability_registry()` for the Framework
 preset or `everruns_platform::capabilities::hosted_capability_registry()` for
 the hosted product catalog.
+
+Hosted conversation history has no writable message-store replacement. Append
+canonical events through `everruns_host::EventLog` / `HostEventEmitter` and
+read messages through `EventHistory`. This avoids message/event dual writes and
+keeps resume and replay behavior identical across in-memory and durable hosts.
 
 ## Features
 

--- a/knowledge/foundations/architecture.md
+++ b/knowledge/foundations/architecture.md
@@ -432,9 +432,10 @@ The core crate provides DB-agnostic agent abstractions with pluggable backends:
    - `input_message_id` - User message that triggered this turn
    - `exec_id` - Unique identifier for this atom execution
 
-4. **In-Memory Implementations** (for testing/examples):
-   - `InMemoryMessageRetriever`
-   - In-memory stores for testing: `InMemoryAgentStore`, `InMemorySessionStore`, `InMemoryLlmProviderStore`
+4. **Concrete In-Memory Implementations**:
+   - `everruns-host` owns application stores and canonical event history
+   - `everruns-test-support` owns writable deterministic message/event fixtures
+   - `everruns-core` exposes traits and values, not concrete public backends
 
 ### OpenAI Provider (`everruns-openai`)
 

--- a/knowledge/foundations/code-organization.md
+++ b/knowledge/foundations/code-organization.md
@@ -87,6 +87,10 @@ math/weather, sample-data, noop). `everruns-core` carries no llmsim dependency
 or feature, product registries never register the fixtures, and
 `scripts/lib/check-test-support-isolation.sh` (pre-push + CI) enforces both.
 The facade's `Model::simulated` consumes only the crate's `sim` feature.
+Reusable writable message/event fixtures also live in test-support. Concrete
+application-grade agent, harness, session, and provider stores live in
+`everruns-host`; hosted conversation writes append only to its canonical
+`EventLog`, with `EventHistory` providing the read-only message projection.
 
 Telemetry initialization and exporter implementations live in
 `everruns-observability` (EVE-876): OTLP exporter wiring, tracing-subscriber

--- a/knowledge/foundations/llm-drivers.md
+++ b/knowledge/foundations/llm-drivers.md
@@ -850,7 +850,7 @@ single shared seam in `crates/core/src/credential_provider.rs`:
 
 Standalone/dev/CLI entrypoints opt in by constructing `EnvCredentialProvider` and
 passing it where credentials are needed — e.g.
-`InMemoryProviderStore::from_credential_provider(&EnvCredentialProvider)`, the
+`everruns_host::InMemoryProviderStore::from_credential_provider(&EnvCredentialProvider)`, the
 in-memory dev store used by `just start-dev`. **The server path never constructs
 an `EnvCredentialProvider`.**
 

--- a/knowledge/foundations/runtime.md
+++ b/knowledge/foundations/runtime.md
@@ -68,7 +68,7 @@ The builder must allow an embedder to:
 - Seed workspace files
 - Configure a credential-free default `ModelSpec`
 - Optionally register `llmsim` for deterministic local examples and tests
-- Swap the default in-memory stores for custom backends via `RuntimeBackends`
+- Swap the default in-memory stores for custom backends via `HostBackends`
 
 `everruns-host` also exposes `HarnessBuilder`, `AgentBuilder`, and
 `SessionBuilder` as the supported embedder construction path for those seed
@@ -221,19 +221,17 @@ and worker-backed hosts stay aligned.
 - Session store
 - Session virtual filesystem
 - Session key/value + secret store
-- Message retriever
 - Harness store
 - Agent store
 - Provider store
-- Memory store
-- Event emitter
+- Canonical event log and read-only message history projection
 
 These stores are intended to make embedded execution usable out of the box.
 
 ## Custom Backends
 
 Embedders that need persistence across process restarts may supply their own
-backend bundle through `RuntimeBackends`.
+backend bundle through `HostBackends`.
 
 `everruns-host` owns a small set of extension traits for mutable runtime
 domain stores:
@@ -241,23 +239,21 @@ domain stores:
 - `RuntimeHarnessStore`
 - `RuntimeAgentStore`
 - `RuntimeSessionStore`
-- `RuntimeMessageStore`
 - `RuntimeProviderStore`
-- `EventBus` (extends `EventEmitter`; default `collected_events` returns empty)
+- `EventLog` plus its `EventReader` half
 
 These extend the corresponding core traits with the minimal write operations the
 embedded runtime needs for:
 
 - seeding harnesses, agents, sessions, and initial files
-- storing input messages
-- persisting assistant and tool-result messages from emitted events
 - configuring the runtime default model
 
-The event bus is also the projection seam for semantic session mutations. For
-example, automatic or explicit title changes emit `session.title.updated` with
-the originating turn context when available. An embedder such as a desktop host
-can observe that event and update its own session index without replacing or
-forking the `session` capability.
+Conversation persistence is intentionally different: accepted inputs and
+assistant/tool outputs append once to the canonical `EventLog` through
+`HostEventEmitter`. `EventHistory` rebuilds the read-only `MessageRetriever`
+projection. There is no writable message-store backend and no dual-write path.
+The optional `EventSink` observes already-finalized envelopes after commit; it
+is never persistence.
 
 `RuntimeSessionStore` also inherits the live capability mutation methods from
 `SessionMutator`. A custom backend that wants to support
@@ -271,11 +267,11 @@ rebuilds the prompt, definitions, executable registry, and hooks before the
 next reason/act step. This preserves session identity and conversation history
 and avoids two independently mutable copies of the runtime surface.
 
-Use `RuntimeBackends::in_memory()` for the all-in-memory default, then chain
-`.with_message_store(...)`, `.with_storage_store(...)`, etc. to override
-individual non-filesystem stores.
+Use `HostBackends::in_memory()` for the all-in-memory default, then chain
+`.with_event_log(...)`, `.with_storage_store(...)`, etc. to override individual
+non-filesystem stores.
 
-`RuntimeBackends` also carries an optional
+`HostBackends` also carries an optional
 `connection_resolver: Option<Arc<dyn UserConnectionResolver>>`
 (set via `.with_connection_resolver(...)`). When supplied, the runtime exposes
 it through `ToolContext.connection_resolver` so connection-aware capabilities
@@ -333,7 +329,7 @@ externally implementable.
 
 ### Optional host-backend slots
 
-`RuntimeBackends` carries a uniform set of optional, additive backend slots that
+`HostBackends` carries a uniform set of optional, additive backend slots that
 the host forwards into `ActAtom` when present (see
 `crates/host/src/runtime.rs` and `crates/host/src/host.rs`):
 

--- a/knowledge/runtime-resources/file-store.md
+++ b/knowledge/runtime-resources/file-store.md
@@ -613,5 +613,5 @@ APIs or the `SessionFileSystem` trait.
 - `crates/server/src/storage/session_file_store.rs` — `DbSessionFileStore`
 - `knowledge/runtime-resources/workspace.md` — `/workspace` mount and session VFS
   semantics
-- `knowledge/foundations/runtime.md` — `RuntimeBackends` and the embedder seam
+- `knowledge/foundations/runtime.md` — `HostBackends` and the embedder seam
 - `knowledge/execution/capabilities.md` — `ToolContext` / `SystemPromptContext` wiring

--- a/scripts/lib/check-test-support-isolation.sh
+++ b/scripts/lib/check-test-support-isolation.sh
@@ -15,6 +15,9 @@
 # 4. Product binaries (server/worker) may carry test-support only through the
 #    `sim` surface (the worker's seeded LlmSim provider); the demo `fixtures`
 #    feature must never be linked.
+# 5. Public in-memory backend ownership stays split: application stores in
+#    host, deterministic message/event fixtures in test-support, and no
+#    conversation dual-write bridge.
 
 set -euo pipefail
 
@@ -44,12 +47,12 @@ if matches=$(grep -rnE "$FIXTURE_PATTERN" "${GUARDED_TREES[@]}" --include='*.rs'
   FAILED=1
 fi
 
-# 2. Core: no llmsim / test-support on ANY edge (including dev), so
+# 2. Core: no llmsim / host / test-support on ANY edge (including dev), so
 #    `cargo tree -p everruns-core` stays clean.
 CORE_TREE=$(cargo tree -p everruns-core --edges normal,build,dev --prefix none 2>/dev/null)
-if echo "$CORE_TREE" | grep -qE '^(llmsim|everruns-test-support) '; then
-  echo "everruns-core must not depend on llmsim or everruns-test-support (any edge):"
-  echo "$CORE_TREE" | grep -E '^(llmsim|everruns-test-support) '
+if echo "$CORE_TREE" | grep -qE '^(llmsim|everruns-host|everruns-test-support) '; then
+  echo "everruns-core must not depend on llmsim, everruns-host, or everruns-test-support (any edge):"
+  echo "$CORE_TREE" | grep -E '^(llmsim|everruns-host|everruns-test-support) '
   FAILED=1
 fi
 
@@ -73,6 +76,38 @@ for crate in "${PROVIDER_CRATES[@]}"; do
   fi
 done
 
+# 5. Concrete public backend ownership and canonical-conversation-write guard.
+if [ -e crates/core/src/in_memory.rs ] || grep -qE '^pub mod in_memory;' crates/core/src/lib.rs; then
+  echo "everruns-core must not expose or house the public in_memory backend module."
+  FAILED=1
+fi
+
+if matches=$(grep -rnE 'everruns_core::in_memory|everruns-core::in_memory' crates apps examples tests --include='*.rs' --include='*.md' 2>/dev/null); then
+  echo "Legacy everruns-core in-memory backend imports are forbidden:"
+  echo "$matches"
+  FAILED=1
+fi
+
+for symbol in InMemoryAgentStore InMemoryHarnessStore InMemorySessionStore InMemoryProviderStore; do
+  if ! grep -q "pub struct $symbol" crates/host/src/in_memory.rs; then
+    echo "$symbol must be owned by everruns-host."
+    FAILED=1
+  fi
+done
+
+for symbol in InMemoryMessageRetriever InMemoryEventEmitter; do
+  if ! grep -q "pub struct $symbol" crates/test-support/src/in_memory.rs; then
+    echo "$symbol must be owned by everruns-test-support."
+    FAILED=1
+  fi
+done
+
+if matches=$(grep -rnE 'RuntimeMessageStore|PersistingEventEmitter|BridgingEventEmitter' crates/host/src crates/test-support/src --include='*.rs' 2>/dev/null); then
+  echo "Writable message-store facades and conversation dual-write bridges are forbidden:"
+  echo "$matches"
+  FAILED=1
+fi
+
 # 4. Product binaries (server embeds the worker, which registers the seeded
 #    LlmSim provider): the test-support edge is allowed only with the `sim`
 #    surface — the demo `fixtures` feature must stay unlinked.
@@ -90,4 +125,4 @@ if [ "$FAILED" -ne 0 ]; then
   exit 1
 fi
 
-echo "Test-support isolation guard passed: no fixture capabilities or llmsim in production trees."
+echo "Test-support isolation guard passed: fixture and in-memory backend ownership is isolated."

--- a/scripts/test-external-consumer.sh
+++ b/scripts/test-external-consumer.sh
@@ -17,9 +17,9 @@
 #                             downstream providers fail here if they stop
 #                             compiling without core/host access.
 #   external-event-log        implements the canonical `EventLog`/`EventReader`
-#                             SPI from `everruns-host` and supplies it to host
-#                             composition, so the SPI fails here if it stops
-#                             being implementable without in-crate access.
+#                             SPI and replaces every default `HostBackends`
+#                             store through public traits, so downstream host
+#                             composition fails here if a seam closes.
 #
 # The fixtures are deliberately outside the workspace so they resolve the
 # published crates the way a downstream application does, and they build under

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -640,6 +641,7 @@ dependencies = [
  "async-trait",
  "everruns-core",
  "everruns-host",
+ "everruns-platform",
  "everruns-test-support",
  "tokio",
 ]

--- a/tests/fixtures/external-consumer/event-log/Cargo.toml
+++ b/tests/fixtures/external-consumer/event-log/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 async-trait = "0.1"
 everruns-core = { path = "../../../../crates/core" }
 everruns-host = { path = "../../../../crates/host" }
+everruns-platform = { path = "../../../../crates/platform" }
 
 [dev-dependencies]
 everruns-test-support = { path = "../../../../crates/test-support" }

--- a/tests/fixtures/external-consumer/event-log/tests/spi.rs
+++ b/tests/fixtures/external-consumer/event-log/tests/spi.rs
@@ -4,16 +4,236 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use everruns_core::error::Result as CoreResult;
 use everruns_core::events::{Event, EventContext, EventRequest, InputMessageData};
-use everruns_test_support::{LlmSimConfig, LlmSimRuntimeExt};
+use everruns_core::harness_definition::HarnessDefinition;
 use everruns_core::message::Message;
-use everruns_core::typed_id::SessionId;
-use everruns_core::{DriverId, ResolvedModel};
+use everruns_core::traits::{
+    AgentStore, HarnessStore, KeyInfo, ProviderStore, SecretInfo, SessionStorageStore, SessionStore,
+};
+use everruns_core::typed_id::{AgentId, HarnessId, ModelId, SessionId};
+use everruns_core::{
+    AgentCapabilityConfig, AgentDefinition, CompactionCheckpoint, CompactionCheckpointStore,
+    DriverId, ExecutionSession, ProactiveCompactionAttempt, ResolvedModel,
+};
 use everruns_host::{
     EventCursor, EventDurability, EventHistory, EventLog, EventLogError, EventPage, EventReadLimit,
-    EventReadRequest, EventReader, HostBackends, InProcessRuntimeBuilder,
+    EventReadRequest, EventReader, EventSink, EventSinkError, HostBackends,
+    InProcessRuntimeBuilder, RuntimeAgentStore, RuntimeHarnessStore, RuntimeProviderStore,
+    RuntimeSessionStore,
 };
+use everruns_platform::SessionMutator;
+use everruns_test_support::{LlmSimConfig, LlmSimRuntimeExt};
 use external_event_log::ExternalEventLog;
+
+struct ExternalAgentStore(Arc<dyn RuntimeAgentStore>);
+
+#[async_trait]
+impl AgentStore for ExternalAgentStore {
+    async fn get_agent(&self, agent_id: AgentId) -> CoreResult<Option<AgentDefinition>> {
+        self.0.get_agent(agent_id).await
+    }
+}
+
+#[async_trait]
+impl RuntimeAgentStore for ExternalAgentStore {
+    async fn add_agent(&self, agent: AgentDefinition) -> CoreResult<()> {
+        self.0.add_agent(agent).await
+    }
+}
+
+struct ExternalHarnessStore(Arc<dyn RuntimeHarnessStore>);
+
+#[async_trait]
+impl HarnessStore for ExternalHarnessStore {
+    async fn get_harness(&self, harness_id: HarnessId) -> CoreResult<Option<HarnessDefinition>> {
+        self.0.get_harness(harness_id).await
+    }
+}
+
+#[async_trait]
+impl RuntimeHarnessStore for ExternalHarnessStore {
+    async fn add_harness(
+        &self,
+        harness_id: HarnessId,
+        harness: HarnessDefinition,
+    ) -> CoreResult<()> {
+        self.0.add_harness(harness_id, harness).await
+    }
+}
+
+struct ExternalSessionStore(Arc<dyn RuntimeSessionStore>);
+
+#[async_trait]
+impl SessionStore for ExternalSessionStore {
+    async fn get_session(&self, session_id: SessionId) -> CoreResult<Option<ExecutionSession>> {
+        self.0.get_session(session_id).await
+    }
+}
+
+#[async_trait]
+impl SessionMutator for ExternalSessionStore {
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> CoreResult<ExecutionSession> {
+        self.0.update_session_title(session_id, title).await
+    }
+
+    async fn upsert_session_capability(
+        &self,
+        session_id: SessionId,
+        capability: AgentCapabilityConfig,
+    ) -> CoreResult<ExecutionSession> {
+        self.0
+            .upsert_session_capability(session_id, capability)
+            .await
+    }
+
+    async fn remove_session_capability(
+        &self,
+        session_id: SessionId,
+        capability_id: &str,
+    ) -> CoreResult<ExecutionSession> {
+        self.0
+            .remove_session_capability(session_id, capability_id)
+            .await
+    }
+}
+
+#[async_trait]
+impl RuntimeSessionStore for ExternalSessionStore {
+    async fn add_session(&self, session: ExecutionSession) -> CoreResult<()> {
+        self.0.add_session(session).await
+    }
+}
+
+struct ExternalProviderStore(Arc<dyn RuntimeProviderStore>);
+
+#[async_trait]
+impl ProviderStore for ExternalProviderStore {
+    async fn get_resolved_model(&self, model_id: ModelId) -> CoreResult<Option<ResolvedModel>> {
+        self.0.get_resolved_model(model_id).await
+    }
+
+    async fn get_default_model(&self) -> CoreResult<Option<ResolvedModel>> {
+        self.0.get_default_model().await
+    }
+}
+
+#[async_trait]
+impl RuntimeProviderStore for ExternalProviderStore {
+    async fn set_default_model(&self, model: ResolvedModel) -> CoreResult<()> {
+        self.0.set_default_model(model).await
+    }
+}
+
+struct ExternalCheckpointStore(Arc<dyn CompactionCheckpointStore>);
+
+#[async_trait]
+impl CompactionCheckpointStore for ExternalCheckpointStore {
+    async fn get_latest(
+        &self,
+        session_id: SessionId,
+        provider_type: &str,
+        model: &str,
+    ) -> CoreResult<Option<CompactionCheckpoint>> {
+        self.0.get_latest(session_id, provider_type, model).await
+    }
+
+    async fn install(&self, checkpoint: CompactionCheckpoint) -> CoreResult<bool> {
+        self.0.install(checkpoint).await
+    }
+
+    async fn get_proactive_attempt(
+        &self,
+        session_id: SessionId,
+        provider_type: &str,
+        model: &str,
+    ) -> CoreResult<Option<ProactiveCompactionAttempt>> {
+        self.0
+            .get_proactive_attempt(session_id, provider_type, model)
+            .await
+    }
+
+    async fn record_proactive_attempt(
+        &self,
+        session_id: SessionId,
+        provider_type: &str,
+        model: &str,
+        attempt: ProactiveCompactionAttempt,
+    ) -> CoreResult<()> {
+        self.0
+            .record_proactive_attempt(session_id, provider_type, model, attempt)
+            .await
+    }
+}
+
+struct ExternalStorageStore(Arc<dyn SessionStorageStore>);
+
+#[async_trait]
+impl SessionStorageStore for ExternalStorageStore {
+    async fn set_value(&self, session_id: SessionId, key: &str, value: &str) -> CoreResult<()> {
+        self.0.set_value(session_id, key, value).await
+    }
+
+    async fn get_value(&self, session_id: SessionId, key: &str) -> CoreResult<Option<String>> {
+        self.0.get_value(session_id, key).await
+    }
+
+    async fn delete_value(&self, session_id: SessionId, key: &str) -> CoreResult<bool> {
+        self.0.delete_value(session_id, key).await
+    }
+
+    async fn list_keys(&self, session_id: SessionId) -> CoreResult<Vec<KeyInfo>> {
+        self.0.list_keys(session_id).await
+    }
+
+    async fn set_secret(&self, session_id: SessionId, name: &str, value: &str) -> CoreResult<()> {
+        self.0.set_secret(session_id, name, value).await
+    }
+
+    async fn get_secret(&self, session_id: SessionId, name: &str) -> CoreResult<Option<String>> {
+        self.0.get_secret(session_id, name).await
+    }
+
+    async fn delete_secret(&self, session_id: SessionId, name: &str) -> CoreResult<bool> {
+        self.0.delete_secret(session_id, name).await
+    }
+
+    async fn list_secrets(&self, session_id: SessionId) -> CoreResult<Vec<SecretInfo>> {
+        self.0.list_secrets(session_id).await
+    }
+}
+
+struct ExternalEventSink;
+
+impl EventSink for ExternalEventSink {
+    fn try_send(&self, _event: Event) -> std::result::Result<(), EventSinkError> {
+        Ok(())
+    }
+}
+
+fn external_backends(log: Arc<ExternalEventLog>) -> HostBackends {
+    let defaults = HostBackends::in_memory();
+    HostBackends {
+        harness_store: Arc::new(ExternalHarnessStore(defaults.harness_store)),
+        agent_store: Arc::new(ExternalAgentStore(defaults.agent_store)),
+        session_store: Arc::new(ExternalSessionStore(defaults.session_store)),
+        event_log: log,
+        compaction_checkpoint_store: Arc::new(ExternalCheckpointStore(
+            defaults.compaction_checkpoint_store,
+        )),
+        provider_store: Arc::new(ExternalProviderStore(defaults.provider_store)),
+        event_sink: Arc::new(ExternalEventSink),
+        storage_store: Arc::new(ExternalStorageStore(defaults.storage_store)),
+        connection_resolver: defaults.connection_resolver,
+        session_task_registry: defaults.session_task_registry,
+        schedule_store_factory: defaults.schedule_store_factory,
+        platform_store_factory: defaults.platform_store_factory,
+    }
+}
 
 fn input(session_id: SessionId, text: &str) -> EventRequest {
     EventRequest::new(
@@ -103,10 +323,14 @@ async fn snapshot_pagination_excludes_concurrent_appends_and_polling_observes_th
 async fn sequence_gaps_are_accepted_and_stay_ordered() {
     let session = SessionId::new();
     let log = ExternalEventLog::new();
-    log.append(input(session, "visible one")).await.expect("append");
+    log.append(input(session, "visible one"))
+        .await
+        .expect("append");
     log.append_hidden(input(session, "internal record"));
     log.append_hidden(input(session, "internal record"));
-    log.append(input(session, "visible two")).await.expect("append");
+    log.append(input(session, "visible two"))
+        .await
+        .expect("append");
     log.append(input(session, "visible three"))
         .await
         .expect("append");
@@ -194,7 +418,10 @@ struct RecordingReader {
 
 #[async_trait]
 impl EventReader for RecordingReader {
-    async fn read_page(&self, request: EventReadRequest) -> Result<EventPage, EventLogError> {
+    async fn read_page(
+        &self,
+        request: EventReadRequest,
+    ) -> std::result::Result<EventPage, EventLogError> {
         self.seen.lock().expect("recorder mutex").push(
             request
                 .cursor()
@@ -244,7 +471,7 @@ async fn the_external_log_serves_host_composition_and_message_projection() {
             base_url: None,
             provider_metadata: None,
         })
-        .backends(HostBackends::in_memory().with_event_log(log.clone()))
+        .backends(external_backends(log.clone()))
         .single_session(|session| {
             session
                 .harness("chat", "You are concise.")


### PR DESCRIPTION
## What changed

Application-grade in-memory agent, harness, session, and provider stores now live in `everruns-host`. Reusable writable message/event fixtures now live in `everruns-test-support`, while `everruns-core::in_memory` is removed from the public kernel surface.

The deterministic agent loop now appends accepted inputs once to the canonical `EventLog` and reads messages through `EventHistory`; it no longer bridges events into a second writable message collection. Public migration docs, architecture guards, consumer tests, and an out-of-workspace custom-backend fixture cover the new ownership boundary.

## Why

EVE-902 completes the EVE-901 runtime boundary: core should own neutral contracts, host should own application backends, and test-support should own deterministic fixtures. Conversation writes must remain canonical-events-only so in-memory execution, resume, and durable hosts cannot diverge through dual writes.

## Before / After

Before:

```rust
use everruns_core::in_memory::{
    InMemoryAgentStore,
    InMemoryMessageRetriever,
};
```

After:

```rust
use everruns_host::InMemoryAgentStore;
use everruns_test_support::InMemoryMessageRetriever;
```

Hosted conversation history has no writable message-store replacement. Inputs and outputs append to `EventLog`; `EventHistory` supplies the read-only message projection.

## Risk

- Medium
- Direct `everruns_core::in_memory` consumers must update imports.
- Incorrect event projection wiring could lose or duplicate conversation messages; focused loop, host resume/recovery, event-log contract, and external-consumer tests cover this path.

## Security

- Threat categories reviewed: TM-AGENT, TM-TENANT, TM-LLM, TM-DOS
- Findings and resolutions:
  - TM-AGENT-016: canonical event history remains the only hosted conversation write, reducing duplicate plaintext copies.
  - TM-TENANT: no authorization boundary changed; embedded stores and custom backends retain the existing session/id scoping contract.
  - TM-LLM: provider credentials remain explicitly injected, process-local, and unlogged.
  - TM-DOS: volatile in-memory maps retain their existing embedded/test-only resource characteristics; no network-facing allocation path was added.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Linear: EVE-902
