### PR TITLE
fix(research): replay seeded conversation events into the session log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Chats is now core functionality for every organization: it is always present in navigation and search, requires no feature opt-in, and retains voice as a separately controlled capability.
+- `InMemoryAgenticLoop::seed_events` replays pre-recorded conversation
+  envelopes into a fixture session's event log. It is the supported way to
+  give an in-memory loop a prior conversation now that history projects from
+  canonical events and `EventHistory` is read-only.
 
 ## [0.17.26] - 2026-08-10
 

--- a/crates/test-support/src/in_memory_loop.rs
+++ b/crates/test-support/src/in_memory_loop.rs
@@ -840,6 +840,26 @@ impl InMemoryAgenticLoop {
         &self.message_retriever
     }
 
+    /// Replay pre-recorded conversation envelopes into this session's log.
+    ///
+    /// Conversation state is event-sourced and [`EventHistory`] is a read
+    /// model, so fixtures that need a prior conversation cannot write messages
+    /// directly. They emit the envelopes through the same emitter the loop
+    /// uses, which makes the projected history identical to live traffic.
+    /// Only [`EventData`] variants that project to messages contribute.
+    pub async fn seed_events(&self, events: impl IntoIterator<Item = EventData>) -> Result<()> {
+        for data in events {
+            self.event_emitter
+                .emit(EventRequest::new(
+                    self.session_id,
+                    EventContext::empty(),
+                    data,
+                ))
+                .await?;
+        }
+        Ok(())
+    }
+
     /// Access the tool registry directly
     pub fn tool_registry(&self) -> &ToolRegistry {
         &self.tool_registry

--- a/crates/test-support/tests/seed_events_test.rs
+++ b/crates/test-support/tests/seed_events_test.rs
@@ -1,0 +1,67 @@
+// Seeding a fixture session with a prior conversation.
+//
+// Conversation history is event-sourced: `EventHistory` is a read model over
+// the session's event log, so a fixture that needs a prior conversation must
+// replay envelopes rather than write messages. This test pins that contract —
+// seeded envelopes project into history in order, and a subsequent turn
+// appends on top of them instead of replacing them.
+//
+// Run with: cargo test -p everruns-test-support --test seed_events_test
+
+use everruns_core::MessageRetriever;
+use everruns_core::events::{EventData, InputMessageData, OutputMessageCompletedData};
+use everruns_core::message::{Message, MessageRole};
+use everruns_test_support::{InMemoryAgenticLoop, LlmSimConfig};
+
+#[tokio::test]
+async fn seeded_events_project_into_history_before_the_next_turn() {
+    let agent_loop = InMemoryAgenticLoop::builder()
+        .with_llm_sim(LlmSimConfig::echo())
+        .build()
+        .await
+        .expect("loop builds");
+
+    agent_loop
+        .seed_events([
+            EventData::InputMessage(InputMessageData::new(Message::user("first question"))),
+            EventData::OutputMessageCompleted(OutputMessageCompletedData::new(Message::assistant(
+                "first answer",
+            ))),
+        ])
+        .await
+        .expect("seed events append");
+
+    let seeded = agent_loop
+        .message_retriever()
+        .load(agent_loop.session_id())
+        .await
+        .expect("messages load");
+    let seeded_text: Vec<_> = seeded.iter().filter_map(|m| m.text()).collect();
+    assert_eq!(seeded_text, vec!["first question", "first answer"]);
+
+    agent_loop
+        .run_turn("second question")
+        .await
+        .expect("turn runs");
+
+    let after = agent_loop
+        .message_retriever()
+        .load(agent_loop.session_id())
+        .await
+        .expect("messages load");
+    let after_text: Vec<_> = after.iter().filter_map(|m| m.text()).collect();
+    assert_eq!(
+        &after_text[..2],
+        &["first question", "first answer"],
+        "the turn appends to seeded history instead of replacing it"
+    );
+    assert!(
+        after_text.contains(&"second question"),
+        "the new input is appended, got: {after_text:?}"
+    );
+    assert_eq!(
+        after.first().map(|m| &m.role),
+        Some(&MessageRole::User),
+        "seeded roles survive projection"
+    );
+}

--- a/research/infinity_context/src/runner.rs
+++ b/research/infinity_context/src/runner.rs
@@ -433,8 +433,8 @@ async fn execute_with_agentic_loop(
         let model = ModelSpec::on((provider_type.clone()).as_str(), config.model.clone());
 
         // Build the agentic loop. Seed events are not a builder input; they are
-        // converted to conversation messages and seeded into the in-memory
-        // message retriever after build (see seed_messages_from_events below).
+        // replayed into the session's event log after build (see seed_events
+        // below), which is what the conversation history projects from.
         let mut builder = InMemoryAgenticLoop::builder()
             .agent_name("Eval Agent")
             .system_prompt(build_system_prompt(config.approach))
@@ -463,11 +463,11 @@ async fn execute_with_agentic_loop(
 
         // Pre-populate the session's conversation history from the scenario's
         // seed events. `run_turn` then appends the task on top of this history.
-        let seed_messages = messages_from_events(&record.input.events);
+        // History is event-sourced, so the scenario's envelopes are replayed
+        // into the session log rather than written as messages.
         agentic_loop
-            .message_retriever()
-            .seed(agentic_loop.session_id(), seed_messages)
-            .await;
+            .seed_events(record.input.events.iter().map(|event| event.data.clone()))
+            .await?;
 
         // Run the turn with the task as user input
         let result = agentic_loop.run_turn(record.task.as_str()).await?;
@@ -503,34 +503,6 @@ async fn execute_with_agentic_loop(
         let metrics = extract_metrics_from_events(&agentic_loop, record.input.events.len()).await;
         return Ok((result.response, metrics));
     }
-}
-
-/// Convert a scenario's seed events into the conversation messages that make up
-/// the session's prior history. Only the event variants the dataset emits
-/// (`make_input_event`, `make_output_event`, `make_tool_event`) carry messages;
-/// any other event types are ignored.
-fn messages_from_events(events: &[everruns_core::events::Event]) -> Vec<everruns_core::Message> {
-    events
-        .iter()
-        .filter_map(|event| match &event.data {
-            EventData::InputMessage(data) => Some(data.message.clone()),
-            EventData::OutputMessageCompleted(data) => Some(data.message.clone()),
-            EventData::ToolCompleted(data) => Some(everruns_core::Message::tool_result(
-                data.tool_call_id.clone(),
-                data.result.as_ref().map(|parts| {
-                    serde_json::Value::String(
-                        parts
-                            .iter()
-                            .filter_map(|part| part.as_text())
-                            .collect::<Vec<_>>()
-                            .join("\n"),
-                    )
-                }),
-                data.error.clone(),
-            )),
-            _ => None,
-        })
-        .collect()
 }
 
 /// Extract evaluation metrics from events emitted during execution.


### PR DESCRIPTION
## What changed

The weekly **Examples Compile Check** sweep is green again. `research/infinity_context` seeded a scenario's prior conversation through `EventHistory::seed`, which no longer exists — history became event-sourced and `EventHistory` became a read model. The crate is workspace-excluded, so nothing built it until the weekly sweep swept it and went red.

`InMemoryAgenticLoop::seed_events` is the supported replacement: it replays envelopes through the same emitter the loop uses, so seeded history projects exactly like live traffic. The eval now replays the scenario's recorded events directly instead of flattening them into messages first, which also drops a hand-written event→message converter that duplicated the projection.

## Why

The sweep has been red since the `HostComposition`/event-sourcing refactors. A permanently red scheduled job cannot signal anything when something genuine breaks.

## Before / After

All five workspace-excluded crates, checked locally against this branch (the same list the workflow derives from the root `Cargo.toml` `exclude` array):

**Before** (`origin/main`, cd4cc54):

```
=== research/infinity_context ===
error[E0599]: no method named `seed` found for reference `&everruns_host::events::EventHistory` in the current scope
error: could not compile `everruns-evals` (bin "eval") due to 1 previous error
error: could not compile `everruns-evals` (bin "eval" test) due to 1 previous error
=== research/lua-vs-bash ===
=== examples/weekend-concierge-host ===
=== evals/platform-capability ===
=== evals/generic ===
```

**After** (this branch) — `cargo check --manifest-path <crate>/Cargo.toml --all-targets` for each of the five, no errors:

```
=== research/infinity_context ===
=== research/lua-vs-bash ===
=== examples/weekend-concierge-host ===
=== evals/platform-capability ===
=== evals/generic ===
DONE
```

New regression test for the seeding contract:

```
$ cargo test -p everruns-test-support --test seed_events_test
running 1 test
test seeded_events_project_into_history_before_the_next_turn ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Risk

- Low
- `seed_events` is additive on a test-only fixture crate; the only production-shaped code touched is a workspace-excluded research binary. The failure mode if the projection contract changes again is the same weekly sweep going red, now with a workspace unit test that catches it on the PR hot path instead.

## Security

- Threat categories reviewed: none applicable. The diff touches a test-support fixture (in-memory event log, no I/O, no credentials) and a workspace-excluded research eval binary. No authentication, authorization, network, persistence, secret-handling, or user-input surface is involved, and nothing here ships in a deployed artifact.
- Findings and resolutions: none.

## Follow-ups

No follow-ups.

- Considered and rejected: refreshing the stale `Cargo.lock` files in `evals/generic` and `examples/weekend-concierge-host` (`cargo check` prunes ~4k lines from each). It is unrelated churn, and the sweep does not build with `--locked`, so staleness costs nothing today.
- Considered and rejected: running the sweep per-PR when `crates/` changes. The workflow header already explains why it is weekly — each excluded crate resolves a separate dependency tree with no shared `target/`, so a per-PR build adds minutes of cold compilation for code that changes rarely.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nry6S3PUeNUrinvsYrVbcH)_