### PR TITLE
fix(server): preserve credentialless gRPC provider type

### DIFF
--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -143,6 +143,44 @@ async fn test_worker_service_with_completing_runner() -> WorkerServiceImpl {
     )
 }
 
+#[tokio::test]
+async fn exact_provider_config_preserves_credentialless_driver_type() {
+    use crate::storage::models::CreateProviderRow;
+
+    let service = test_worker_service().await;
+    let provider = service
+        .db
+        .create_provider(
+            everruns_core::DEFAULT_ORG_ID,
+            CreateProviderRow {
+                name: "Credentialless LlmSim".to_string(),
+                provider_type: "llmsim".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .expect("create credentialless provider");
+
+    let response = service
+        .get_default_provider_credentials(tonic::Request::new(
+            GetDefaultProviderCredentialsRequest {
+                org_id: everruns_core::DEFAULT_ORG_ID,
+                provider_type: String::new(),
+                provider_id: provider.id.to_string(),
+            },
+        ))
+        .await
+        .expect("resolve exact provider config")
+        .into_inner();
+
+    assert!(response.found);
+    assert_eq!(response.provider_type, "llmsim");
+    assert!(response.api_key.is_empty());
+    assert!(response.base_url.is_empty());
+}
+
 struct AllowingConnectionResolver;
 
 #[async_trait::async_trait]

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -2372,12 +2372,24 @@ impl WorkerService for WorkerServiceImpl {
             self.provider_resolver_service
                 .resolve_provider_credentials(req.org_id, &req.provider_type)
                 .await
-                .map(|value| value.map(|credentials| (req.provider_type.clone(), credentials)))
+                .map(|value| {
+                    value.map(|credentials| {
+                        (
+                            req.provider_type.clone(),
+                            Some(credentials.api_key),
+                            credentials.base_url,
+                        )
+                    })
+                })
         } else {
             self.provider_resolver_service
-                .resolve_runtime_provider(req.org_id, &req.provider_id)
+                .resolve_runtime_provider_config(req.org_id, &req.provider_id)
                 .await
-                .map(|value| value.map(|provider| (provider.provider_type, provider.credentials)))
+                .map(|value| {
+                    value.map(|provider| {
+                        (provider.provider_type, provider.api_key, provider.base_url)
+                    })
+                })
         }
         .map_err(|e| {
             tracing::error!(
@@ -2389,10 +2401,10 @@ impl WorkerService for WorkerServiceImpl {
         })?;
 
         Ok(Response::new(match resolved {
-            Some((provider_type, credentials)) => GetDefaultProviderCredentialsResponse {
+            Some((provider_type, api_key, base_url)) => GetDefaultProviderCredentialsResponse {
                 found: true,
-                api_key: credentials.api_key,
-                base_url: credentials.base_url.unwrap_or_default(),
+                api_key: api_key.unwrap_or_default(),
+                base_url: base_url.unwrap_or_default(),
                 provider_type,
             },
             None => GetDefaultProviderCredentialsResponse {


### PR DESCRIPTION
## Summary

- resolve exact provider configuration over gRPC without requiring an API key
- preserve the persisted driver type for credentialless drivers such as LlmSim
- add a regression test proving the worker receives `llmsim` instead of falling back to the provider record ID

## Context

EVE-906 exact-main CI exposed this in `Workflow Tests (Server + Worker)`: five agent-response tests timed out while the worker logged `No driver registered for provider type provider_<uuid>`. The direct-worker path already used optional-credential runtime configuration; the gRPC endpoint still used the credential-required resolver and returned not-found for LlmSim.

## Validation

- `cargo test -p everruns-server exact_provider_config_preserves_credentialless_driver_type --lib`
- `cargo fmt --all --check`
- `git diff --check`
- `just pre-push` (22/22)

Related: EVE-906, EVE-888

No release or tag.