### PR TITLE
feat(embeddings): ledger index-sync embedding spend against the org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Chats is now core functionality for every organization: it is always present in navigation and search, requires no feature opt-in, and retains voice as a separately controlled capability.
+- Knowledge-index sync embedding spend is now ledgered. `llm_generations.session_id`
+  is nullable so org-attributed background inference has a home, and the reporting
+  projection left-joins sessions so those rows reach `fact_llm_generation` with null
+  session dimensions instead of being dropped. Sync spend is org-attributed but not
+  debited against a session budget.
 - `InMemoryAgenticLoop::seed_events` replays pre-recorded conversation
   envelopes into a fixture session's event log. It is the supported way to
   give an in-memory loop a prior conversation now that history projects from

--- a/crates/server/migrations/120_llm_generations_optional_session.sql
+++ b/crates/server/migrations/120_llm_generations_optional_session.sql
@@ -1,0 +1,31 @@
+-- Org-attributed inference with no session.
+--
+-- `llm_generations` is the single source of truth for inference spend, but it
+-- assumed every call belongs to a conversation. Knowledge-index sync embeds
+-- every chunk of every indexed document as host-triggered background work with
+-- no session, so the larger half of embedding spend had nowhere to land and was
+-- only logged (EVE-894, EVE-898).
+--
+-- Making `session_id` nullable keeps one ledger rather than a parallel
+-- org-scoped table that every usage query would have to union in. Rows without
+-- a session are org-attributed: `org_id` stays NOT NULL, so org usage reporting
+-- and cost totals see them.
+--
+-- Session-scoped consumers are unaffected: the denormalized `sessions` /
+-- `agents` totals and the session budget debit are keyed by session and simply
+-- have no subject for these rows. Host-triggered background indexing does not
+-- consume a cap the user did not spend against.
+--
+-- Additive only: every existing row has a session and keeps it.
+
+ALTER TABLE llm_generations ALTER COLUMN session_id DROP NOT NULL;
+
+COMMENT ON COLUMN llm_generations.session_id IS
+    'Owning conversation, or NULL for org-attributed background inference (e.g. knowledge-index sync embeddings) that no session triggered.';
+
+-- Org usage reporting reads these rows by org and time; `idx_llm_generations_org_created`
+-- already serves that. This partial index serves the narrower "what background
+-- spend did this org incur" question without scanning session-bound rows.
+CREATE INDEX idx_llm_generations_org_sessionless
+    ON llm_generations (org_id, created_at)
+    WHERE session_id IS NULL;

--- a/crates/server/src/domains/knowledge_indexes/source_sync.rs
+++ b/crates/server/src/domains/knowledge_indexes/source_sync.rs
@@ -281,8 +281,8 @@ impl KnowledgeIndexSyncService {
         let mut documents = Vec::with_capacity(docs.len());
         let mut records = Vec::new();
         let mut vector_dim: Option<i32> = None;
-        // EVE-894: embedding usage for this sync run. Previously discarded
-        // outright; accumulated here so the spend is at least observable.
+        // Embedding usage for this sync run, aggregated across every batch of
+        // every document and ledgered once at the end (EVE-894, EVE-898).
         let mut embed_tokens: u64 = 0;
         let mut embed_cost_usd: Option<f64> = None;
 
@@ -329,10 +329,6 @@ impl KnowledgeIndexSyncService {
             while let Some(result) = embed_stream.next().await {
                 let (i, batch_embeddings, usage_tokens, actual_cost_usd) = result?;
                 batch_results[i] = Some(batch_embeddings);
-                // EVE-894: sync-time embedding usage is accumulated per run and
-                // reported below. It is not yet written to `llm_generations`:
-                // that table requires a session and index sync is host-triggered
-                // background work with none. See the follow-up issue.
                 embed_tokens = embed_tokens.saturating_add(u64::from(usage_tokens.unwrap_or(0)));
                 if let Some(cost) = actual_cost_usd {
                     embed_cost_usd = Some(embed_cost_usd.unwrap_or(0.0) + cost);
@@ -382,20 +378,98 @@ impl KnowledgeIndexSyncService {
             });
         }
 
-        tracing::info!(
-            index_id = %index.public_id,
-            model = %model_id,
-            provider = %embedder.provider_type,
+        self.ledger_sync_embedding_usage(
+            index,
+            &model_id,
+            &embedder.provider_type,
             embed_tokens,
             embed_cost_usd,
-            "knowledge index sync embedding usage"
-        );
+        )
+        .await;
 
         Ok(PreparedSync {
             documents,
             records,
             vector_dim,
         })
+    }
+
+    /// Record a sync run's embedding spend against the org (EVE-898).
+    ///
+    /// Sync is host-triggered background work with no session, so this writes
+    /// `llm_generations` directly rather than emitting an `llm.generation`
+    /// event — `EventRequest` requires a session, and the usage listener
+    /// derives `org_id` from one. The row is org-attributed with a null
+    /// session, which reaches org usage reporting and cost totals.
+    ///
+    /// Deliberately *not* debited against a budget: the session-scoped
+    /// denormalized totals and budget debit have no subject here, and a user's
+    /// cap should not be consumed by indexing they did not trigger. Whether a
+    /// separate org-level indexing cap should exist is a product question this
+    /// ledger row is the prerequisite for, not a decision it makes.
+    ///
+    /// One aggregate row per run, not per batch: a run embeds every chunk of
+    /// every document, and per-call rows would swamp the ledger with thousands
+    /// of entries carrying no dimension the aggregate lacks.
+    ///
+    /// Best-effort. Losing the ledger row must not fail a sync that already
+    /// produced valid embeddings — the spend is logged either way.
+    async fn ledger_sync_embedding_usage(
+        &self,
+        index: &KnowledgeIndexRow,
+        model_id: &str,
+        provider_type: &str,
+        embed_tokens: u64,
+        embed_cost_usd: Option<f64>,
+    ) {
+        tracing::info!(
+            index_id = %index.public_id,
+            model = %model_id,
+            provider = %provider_type,
+            embed_tokens,
+            embed_cost_usd,
+            "knowledge index sync embedding usage"
+        );
+
+        // Nothing billable happened (empty index, or a provider that reports
+        // neither tokens nor cost). A zero row would only add noise.
+        if embed_tokens == 0 && embed_cost_usd.is_none() {
+            return;
+        }
+
+        if let Err(e) = self
+            .db
+            .create_llm_generation(
+                index.org_id,
+                None,
+                None,
+                None,
+                model_id.to_string(),
+                Some(provider_type.to_string()),
+                // Embeddings consume input tokens and produce vectors, not
+                // output tokens.
+                i64::try_from(embed_tokens).unwrap_or(i64::MAX),
+                0,
+                0,
+                0,
+                embed_cost_usd,
+                None,
+                None,
+                None,
+                // No single provider response id: this aggregates many calls.
+                // Reconciliation skips rows without one.
+                None,
+                chrono::Utc::now(),
+            )
+            .await
+        {
+            tracing::warn!(
+                index_id = %index.public_id,
+                org_id = index.org_id,
+                error = %e,
+                "failed to ledger knowledge index sync embedding usage"
+            );
+        }
     }
 }
 

--- a/crates/server/src/services/usage_tracking.rs
+++ b/crates/server/src/services/usage_tracking.rs
@@ -84,7 +84,7 @@ impl EventListener for UsageTrackingListener {
             .db
             .create_llm_generation(
                 org_id,
-                event.session_id.uuid(),
+                Some(event.session_id.uuid()),
                 event.context.turn_id.as_ref().map(|id| id.uuid()),
                 Some(event.id.uuid()),
                 data.metadata.model.clone(),

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -2873,7 +2873,7 @@ impl StorageBackend {
     pub async fn create_llm_generation(
         &self,
         org_id: i64,
-        session_id: Uuid,
+        session_id: Option<Uuid>,
         turn_id: Option<Uuid>,
         event_id: Option<Uuid>,
         model: String,

--- a/crates/server/src/storage/memory/providers.rs
+++ b/crates/server/src/storage/memory/providers.rs
@@ -582,7 +582,7 @@ impl InMemoryDatabase {
     pub async fn create_llm_generation(
         &self,
         _org_id: i64,
-        _session_id: Uuid,
+        _session_id: Option<Uuid>,
         _turn_id: Option<Uuid>,
         _event_id: Option<Uuid>,
         _model: String,

--- a/crates/server/src/storage/reporting/outbox.rs
+++ b/crates/server/src/storage/reporting/outbox.rs
@@ -724,7 +724,11 @@ impl PostgresReportingProjector {
                 0,
                 NOW()
             FROM llm_generations lg
-            JOIN sessions s ON s.id = lg.session_id AND s.org_id = lg.org_id
+            -- LEFT JOIN, not JOIN: org-attributed background inference has no
+            -- session (EVE-898), and an inner join would silently drop those
+            -- rows out of the fact table instead of projecting them with null
+            -- session dimensions.
+            LEFT JOIN sessions s ON s.id = lg.session_id AND s.org_id = lg.org_id
             LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = lg.org_id
             LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = lg.org_id
             WHERE lg.id = $1 AND lg.org_id = $2

--- a/crates/server/src/storage/repositories/providers.rs
+++ b/crates/server/src/storage/repositories/providers.rs
@@ -480,10 +480,17 @@ impl Database {
     // ============================================
 
     #[allow(clippy::too_many_arguments)]
+    /// Record one inference call.
+    ///
+    /// `session_id` is `None` for org-attributed background inference that no
+    /// conversation triggered (e.g. knowledge-index sync embeddings, EVE-898).
+    /// Such a row still carries `org_id`, so org usage reporting sees it; the
+    /// session-keyed denormalized totals and budget debit have no subject and
+    /// are the caller's business to skip.
     pub async fn create_llm_generation(
         &self,
         org_id: i64,
-        session_id: Uuid,
+        session_id: Option<Uuid>,
         turn_id: Option<Uuid>,
         event_id: Option<Uuid>,
         model: String,

--- a/crates/server/tests/reporting_integration_test.rs
+++ b/crates/server/tests/reporting_integration_test.rs
@@ -1003,3 +1003,78 @@ async fn fact_session_projection_uses_denormalized_counts_for_large_histories() 
         repeat_elapsed.as_millis()
     );
 }
+
+/// EVE-898: knowledge-index sync embeds every chunk of every indexed document as
+/// host-triggered background work with no session, so its spend is ledgered with
+/// `llm_generations.session_id = NULL`. The projection must carry those rows into
+/// `fact_llm_generation` with null session dimensions — an inner join on sessions
+/// dropped them silently, which is worse than not ledgering at all.
+#[tokio::test]
+async fn session_less_generation_projects_with_null_session_dimensions() {
+    let server = TestServer::new().await;
+    let org = server
+        .db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: format!("Session-less generation org {}", Uuid::now_v7()),
+            created_by: None,
+        })
+        .await
+        .expect("create session-less generation org");
+
+    // Mirrors the sync ledger write: org-attributed, no session, no turn, no
+    // event, aggregate input tokens, provider-reported cost.
+    server
+        .db
+        .create_llm_generation(
+            org.org_id,
+            None,
+            None,
+            None,
+            "text-embedding-3-small".to_string(),
+            Some("openai".to_string()),
+            4_096,
+            0,
+            0,
+            0,
+            Some(0.000_41),
+            None,
+            None,
+            None,
+            None,
+            Utc::now(),
+        )
+        .await
+        .expect("ledger session-less embedding usage");
+
+    PostgresReportingProjector::new(server.pool.clone())
+        .run_once(org.org_id, 16)
+        .await
+        .expect("project session-less generation");
+
+    let (session_id, user_id, agent_id, model, input_tokens, total_tokens): (
+        Option<Uuid>,
+        Option<Uuid>,
+        Option<Uuid>,
+        Option<String>,
+        i64,
+        i64,
+    ) = sqlx::query_as(
+        r#"
+        SELECT session_id, user_id, agent_id, model, input_tokens, total_tokens
+          FROM fact_llm_generation
+         WHERE org_id = $1
+        "#,
+    )
+    .bind(org.org_id)
+    .fetch_one(&server.pool)
+    .await
+    .expect("session-less generation reaches fact_llm_generation");
+
+    assert_eq!(session_id, None, "no session to attribute the spend to");
+    assert_eq!(user_id, None, "session-derived dimensions stay null");
+    assert_eq!(agent_id, None, "session-derived dimensions stay null");
+    assert_eq!(model.as_deref(), Some("text-embedding-3-small"));
+    assert_eq!(input_tokens, 4_096);
+    assert_eq!(total_tokens, 4_096);
+}

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -3753,3 +3753,59 @@ async fn list_org_session_tasks_pg() {
         "root filter must never cross the org boundary"
     );
 }
+
+/// EVE-898: knowledge-index sync has no session to attribute its embedding
+/// spend to, so `llm_generations.session_id` is nullable. The row must still
+/// insert and stay org-attributed — `org_id` is what usage reporting reads.
+#[tokio::test]
+async fn test_llm_generation_without_session_is_org_attributed() {
+    let backend = create_test_backend().await;
+    let model = format!("text-embedding-test-{}", &Uuid::now_v7().to_string()[..8]);
+
+    backend
+        .create_llm_generation(
+            TEST_ORG_ID,
+            None,
+            None,
+            None,
+            model.clone(),
+            Some("openai".to_string()),
+            8_192,
+            0,
+            0,
+            0,
+            Some(0.000_82),
+            None,
+            None,
+            None,
+            None,
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("session-less generation inserts");
+
+    let pool = create_test_pool().await;
+    let (org_id, session_id, input_tokens, output_tokens, actual_cost_usd): (
+        i64,
+        Option<Uuid>,
+        i64,
+        i64,
+        Option<f64>,
+    ) = sqlx::query_as(
+        r#"
+        SELECT org_id, session_id, input_tokens, output_tokens, actual_cost_usd
+          FROM llm_generations
+         WHERE model = $1
+        "#,
+    )
+    .bind(&model)
+    .fetch_one(&pool)
+    .await
+    .expect("session-less generation is readable");
+
+    assert_eq!(org_id, TEST_ORG_ID, "spend stays attributed to the org");
+    assert_eq!(session_id, None, "no conversation triggered this call");
+    assert_eq!(input_tokens, 8_192);
+    assert_eq!(output_tokens, 0, "embeddings produce vectors, not tokens");
+    assert_eq!(actual_cost_usd, Some(0.000_82));
+}

--- a/knowledge/runtime-resources/knowledge-indexes.md
+++ b/knowledge/runtime-resources/knowledge-indexes.md
@@ -313,9 +313,23 @@ budget debits on the same path chat generations use.
 Usage is reported even when retrieval matches nothing: the embedding call was
 billed regardless of whether any chunk scored.
 
-Sync-time embedding spend is **not** ledgered yet. Sync is background work with
-no session, and `llm_generations` requires one; the run's totals are logged only.
-See EVE-898.
+Sync-time embedding spend is ledgered too, but on a different path. Sync is
+host-triggered background work with no session, so it writes `llm_generations`
+directly instead of emitting an event: `EventRequest` requires a session, and the
+usage listener derives the org from one. `llm_generations.session_id` is nullable
+for exactly this case, and the reporting projection left-joins sessions so a
+session-less row still reaches `fact_llm_generation` with null session
+dimensions.
+
+A run writes one aggregate row rather than one per embedding call — a run embeds
+every chunk of every document, and per-call rows carry no dimension the aggregate
+lacks.
+
+Sync spend is org-attributed but **not** debited against a budget. The
+denormalized session/agent totals and the budget debit are session-keyed and have
+no subject here, and a user's cap should not be consumed by indexing they did not
+trigger. An org-level indexing cap would read this ledger; the ledger row is its
+prerequisite, not its decision.
 
 ## Capability: `knowledge_index`
 


### PR DESCRIPTION
## What changed

Knowledge-index sync embedding spend now reaches the usage ledger and org reporting instead of only a log line.

Sync embeds every chunk of every indexed document — the larger half of embedding spend — as host-triggered background work with no session. `llm_generations.session_id` becomes nullable so one ledger covers org-attributed background inference, and the reporting projection left-joins sessions so those rows land in `fact_llm_generation` with null session dimensions instead of being silently dropped by the inner join. A sync run writes one aggregate row directly rather than emitting an `llm.generation` event, because `EventRequest` requires a session and the usage listener derives `org_id` from one.

**Budget decision (EVE-898 item 2).** Sync spend is org-attributed but **not** debited against a budget. `BudgetService` and the denormalized `sessions`/`agents` totals are session-keyed listeners on `llm.generation` and have no subject for a session-less call, and a user's cap should not be consumed by indexing they did not trigger. An org-level indexing cap would read this ledger; the row is that cap's prerequisite, not its decision. This is recorded in `knowledge/runtime-resources/knowledge-indexes.md` so the next reader does not have to re-derive it.

## Why

EVE-894 metered the retrieval half of embedding spend through the `search_index` tool, which holds session and turn context. Sync cannot take that path, so its usage was accumulated per run and logged only. Sync is where the bulk of embedding tokens go.

## Before / After

Against local PostgreSQL with all 120 migrations applied.

**Before** — a session-less generation cannot exist (`session_id` is `NOT NULL`), and had one existed the projection's inner join would have dropped it. Measured on the same row the new test writes:

```
sessionless llm_generations rows:            1
projected into fact_llm_generation:          1
would project under the old INNER JOIN:      0
```

The third line is the old projection's `FROM llm_generations lg JOIN sessions s ON s.id = lg.session_id` restricted to session-less rows: zero. That is the silent drop this PR removes — and because `backfill_llm_generations` re-enqueues any generation whose fact is missing, such a row would have been re-enqueued forever without ever projecting.

**After** — both new tests, plus the full reporting suite with no regression:

```
$ cargo test -p everruns-server --test reporting_integration_test -- --test-threads=1
test bounded_event_repair_enqueues_only_missing_projections ... ok
test fact_session_projection_uses_denormalized_counts_for_large_histories ... ok
test report_exports_reject_invalid_semantic_queries ... ok
test reporting_backfill_endpoint_is_admin_scoped ... ok
test reporting_backfill_enqueues_missing_postgres_session_fact ... ok
test reporting_backfill_skips_malformed_capability_usage_records ... ok
test reporting_diagnostics_are_admin_scoped ... ok
test saved_reports_are_crud_runnable_and_exportable ... ok
test session_less_generation_projects_with_null_session_dimensions ... ok
test result: ok. 9 passed; 0 failed; 1 ignored

$ cargo test -p everruns-server --test repository_integration_test test_llm_generation_without_session
test test_llm_generation_without_session_is_org_attributed ... ok
test result: ok. 1 passed; 0 failed
```

`just pre-push`: all 22 checks pass, including the new Core public API guard (this PR does not touch `everruns-core`) and migration ordering `001..120`.

## Risk

- Medium
- **Schema.** `ALTER COLUMN session_id DROP NOT NULL` is additive — every existing row has a session and keeps it. Nothing reads `llm_generations.session_id` expecting non-null: the reconciler selects `id, org_id, provider_response_id`, and `backfill_llm_generations` does not join sessions at all.
- **Reporting shape.** Reports grouped by a session-derived dimension (user, agent, harness, app) now get a NULL bucket for background spend. That is the honest answer — the spend has no user — and `fact_llm_generation.session_id` was already nullable, so downstream tolerated nulls before this change. The `llm_generations` dataset is a single-table spec with no joins, so nulls simply form their own group.
- **Cost totals move.** Org-level embedding cost will step up once sync starts recording. That is the point of the change, but it is a visible number change, not a silent one.

## Security

- Threat categories reviewed: tenant isolation (org scoping of ledger and reporting facts), TM-API data exposure, and secret handling.
- Findings and resolutions:
  - **Tenant isolation, checked closely because the join changed.** `lg.org_id` stays `NOT NULL` and remains the authoritative scope: `fact_llm_generation` is keyed `(org_id, source_key)` from `lg.org_id`, and the backfill/projection filters are org-scoped. The inner join previously dropped a row whose `session_id` pointed at another org's session; the left join now projects it under `lg.org_id` with **null** session dimensions rather than joining that session's `user_id`/`agent_id`. So the change cannot leak a foreign org's session attributes — it is strictly less joining — and it makes such a corrupt row visible instead of invisible. Such a row should not exist anyway: `org_id` and `session_id` are written together from the session.
  - The new ledger write carries no credentials. `model_id` and `provider_type` come from the resolved embedder descriptor, not from the credential envelope, and no provider response id is recorded.
  - No new endpoint, no new user input path, no change to authentication or authorization.

## Follow-ups

No follow-ups.

- Smoke-test scope, stated plainly: the affected persistence path is covered end to end against real PostgreSQL by the two tests above. Driving a real sync run end to end additionally needs a GitHub source and live embedding credentials, which this environment does not have; the existing `embed_persists_documents_chunks_and_vectors` test exercises `embed_documents` with the ledger call in place against the in-memory backend, where `create_llm_generation` is a no-op, so it proves the call site is wired but not what it writes. The write itself is proven by the repository test.
- Considered and rejected: recording one ledger row per embedding batch. A run embeds every chunk of every document, so per-call rows would add thousands of entries carrying no dimension the per-run aggregate lacks.
- Considered and rejected: a separate org-scoped ledger table. Every usage query would have to union it in; a nullable column on the existing source of truth keeps one ledger.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nry6S3PUeNUrinvsYrVbcH)_