### PR TITLE
fix(ui): bump the nanoid override to the actual GHSA-2v37-7h3g-55p8 fix

### DIFF
--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   fast-uri: 3.1.5
   js-yaml: 4.3.1
   mermaid: 11.16.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   postcss: 8.5.23
   prismjs: 1.30.0
   sharp: 0.35.3
@@ -3572,8 +3572,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8317,7 +8317,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -8531,7 +8531,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/apps/ui/pnpm-workspace.yaml
+++ b/apps/ui/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ overrides:
   fast-uri: 3.1.5
   js-yaml: 4.3.1
   mermaid: 11.16.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   postcss: 8.5.23
   prismjs: 1.30.0
   sharp: 0.35.3
@@ -34,8 +34,11 @@ minimumReleaseAgeStrict: true
 # executable subtree — XSS, via @streamdown/mermaid > mermaid), mermaid 11.16.1
 # (prototype pollution in the config APIs and in architecture diagrams, CSS
 # injection into sibling elements, and XY-chart/radar DoS — one release fixes
-# all five), and nanoid 3.3.17 (custom generators loop indefinitely at size 0,
-# via @tailwindcss/postcss > postcss).
+# all five), and nanoid 3.3.18 (custom generators loop indefinitely at size 0,
+# via @tailwindcss/postcss > postcss). GHSA-2v37-7h3g-55p8 was widened to
+# `<3.3.18` on 2026-08-13 after 3.3.17 proved an incomplete fix, so 3.3.17 —
+# pinned here as the patched release — was still inside the advisory. 3.3.18 is
+# the actual fix.
 # All exact-pinned via the overrides above, so an exemption cannot pull any other
 # freshly published version; it only lets the security fix land before maturity.
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## What changed

`apps/ui` has no open advisories again. The `overrides` block pinned `nanoid: 3.3.17` and its comment recorded that pin as the fix for GHSA-2v37-7h3g-55p8. It is not — the advisory was widened to `<3.3.18` on 2026-08-13 after 3.3.17 proved an incomplete fix, so the override was holding the tree at a version the advisory still covers.

Bumped to 3.3.18 (the actual patched release, published 2026-08-07) and corrected the comment so the next reader is not misled the same way.

## Why

`pnpm audit` reported it as the workspace's only finding, and a pinned override that claims to be a security fix while sitting inside the advisory is worse than no pin — it reads as handled.

## Before / After

**Before** (`origin/main`):

```
$ pnpm audit --json     # apps/ui
vulnerabilities: {'info': 0, 'low': 0, 'moderate': 0, 'high': 1, 'critical': 0}
advisories: ['1139427']   # GHSA-2v37-7h3g-55p8, nanoid 3.3.17 via .>@tailwindcss/postcss>postcss>nanoid
totalDependencies: 926
```

**After** (this branch):

```
$ pnpm audit --json     # apps/ui
vulnerabilities: {'info': 0, 'low': 0, 'moderate': 0, 'high': 0, 'critical': 0}
advisories: []
totalDependencies: 926
```

The resolution is clean — same major, same minor, one patch forward — so the lockfile delta is 5 lines and the dependency count is unchanged:

```
$ git diff --stat
 apps/ui/pnpm-lock.yaml      | 10 +++++-----
 apps/ui/pnpm-workspace.yaml |  9 ++++++---
```

Verified against a real install and build, not just the lockfile:

```
$ pnpm install --frozen-lockfile     # exit 0
$ ls node_modules/.pnpm | grep nanoid
nanoid@3.3.18
$ pnpm run build                     # exit 0, all routes emitted
$ pnpm run format:check              # All matched files use the correct format (709 files)
$ pnpm run lint                      # exit 0
```

## Risk

- Low
- Patch-level bump of a build-time transitive dependency. `postcss` uses `nanoid` for source-map identifiers; the UI build succeeds and the bundle is unaffected (`nanoid` does not ship to the browser through this path).
- The 7-day `minimumReleaseAge` gate does not block it: `nanoid` is already in `minimumReleaseAgeExclude`, and 3.3.18 clears the window on its own from 2026-08-14T16:41Z regardless.

## Security

- Threat categories reviewed: supply chain / dependency advisories (the subject of the change), and TM-UI client-side execution.
- Findings and resolutions:
  - **The advisory itself is not exploitable here, and the bump is hygiene rather than remediation.** GHSA-2v37-7h3g-55p8 needs `customAlphabet` or `customRandom` called with an attacker-controlled `size` of 0. `postcss` calls the default `nanoid()` export with no size argument, and the path is build-time only — no attacker-controlled input reaches it. Stated plainly so nobody reads this PR as closing a live exposure.
  - The exemption surface does not widen: `nanoid` was already in `minimumReleaseAgeExclude` and stays exact-pinned, so nothing else can float in behind it.
  - No application code changed; no new dependency entered the tree (926 before and after).

## Follow-ups

No follow-ups.

- Tracked as EVE-909, filed during this run with the full triage.
- Related but deliberately untouched: EVE-896 records the CopilotKit advisories in the SaaS repo, which have no clean resolution. This one is the opposite case — a clean in-range patch — which is why it is fixed rather than carried.

## Checklist
- [x] Tests added or updated — n/a; `pnpm audit` going 1 high → 0 plus a green build/lint/format is the evidence, and there is no code change to test
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nry6S3PUeNUrinvsYrVbcH)_