### PR TITLE
refactor(example): use Framework workspace heads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
             rust:
               - 'crates/**'
               - 'integrations/**'
+              # Public application examples are workspace members and must
+              # compile/test whenever their own code changes.
+              - 'examples/coding-cli/**'
               - 'scripts/cli-e2e-test.sh'
               - 'scripts/lib/check-everruns-examples.sh'
               - 'Cargo.toml'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,6 +2540,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "everruns",
  "serde_json",
  "tempfile",

--- a/examples/coding-cli/Cargo.toml
+++ b/examples/coding-cli/Cargo.toml
@@ -20,15 +20,16 @@ name = "ercode"
 path = "src/main.rs"
 
 [dependencies]
-# The only Everruns dependency: the public facade, with the real-provider edge.
-everruns = { path = "../../crates/everruns", features = ["openai"] }
+# The only Everruns dependency: the public facade, with local Git heads and the
+# real-provider edge enabled through public features.
+everruns = { path = "../../crates/everruns", features = ["local", "openai"] }
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1.50", features = ["macros", "rt-multi-thread", "fs", "io-std", "io-util"] }
+dirs.workspace = true
+tokio = { version = "1.50", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }
 
 [dev-dependencies]
-# Exercise opt-in application profiles without pulling SQLite or local-process
-# MCP support into the shipped coding CLI binary.
+# Add local-process MCP support only for the existing application-parity fixture.
 everruns = { path = "../../crates/everruns", features = ["local", "mcp-stdio"] }
+serde_json = "1.0"
 tempfile = "3"

--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -1,51 +1,118 @@
-# ercode — a minimal coding agent on the `everruns` library
+# ercode — Framework workspace heads from the public `everruns` API
 
-`ercode` is a small terminal coding agent built **only** on the public
-[`everruns`](../../crates/everruns) crate. It is the executable acceptance test
-for the OSS library surface: it depends on `everruns` alone — never on
-`everruns-core` or `everruns-host` — so it demonstrates the exact dependency
-and import path an application uses to embed an agent.
+`ercode` is a small terminal coding agent built only on the public
+[`everruns`](../../crates/everruns) crate. It demonstrates provider-owned Git
+workspace heads, typed session resume, `Environment` binding, `WorkspacePolicy`,
+and Framework `session_file_system` tools without importing `everruns-core`,
+`everruns-host`, or `everruns-local` directly.
 
-It shows the whole public loop:
+The important safety model is simple:
 
-- build an agent with `everruns::Agent::builder()`;
-- register file tools (`read_file`, `write_file`, `list_dir`) defined with the
-  `#[everruns::tool]` attribute macro — no hand-written JSON Schema;
-- open a `Session`, observe its `events()` (tool activity), and run prompts that
-  accumulate history across turns.
+- a new invocation gets a new **isolated** Git head by default;
+- the selected head is bound permanently before the session runs;
+- filesystem tools operate under `/workspace` on that exact head;
+- the default coding policy permits ordinary reads and writes but continues to
+  protect hidden, sensitive, dependency, and build paths;
+- `--read-only` denies all writes;
+- dropping the process never destroys a worktree or branch.
 
-## Run
+The CLI prints its typed session id, workspace/head ids, access mode, base, and
+state directory before the first prompt. Keep the session id when you want to
+resume or explicitly share that recorded head.
 
-Offline (deterministic simulator — no credentials, no network):
+## Run offline or with OpenAI
+
+Offline mode is deterministic and needs no credential or network:
 
 ```bash
-cargo run -p everruns-coding-cli -- --offline "list the files in src"
+cargo run -p everruns-coding-cli -- --offline --head review --base main \
+  "inspect the repository"
 ```
 
-Against a real model (set `OPENAI_API_KEY`; optionally pick a model):
+For a real model, set `OPENAI_API_KEY` and optionally choose a model:
 
 ```bash
 export OPENAI_API_KEY=sk-...
-cargo run -p everruns-coding-cli -- --model gpt-5-mini "add a doc comment to lib.rs"
+cargo run -p everruns-coding-cli -- --model gpt-5-mini \
+  --head docs --base main "improve the README"
 ```
 
-With no prompt argument it starts an interactive REPL (`Ctrl-D` to exit). Use
-`-C/--cwd <dir>` to point the file tools at a workspace other than the current
-directory; the tools reject absolute paths and `..` traversal so a tool call
-cannot escape that root.
+`-C/--cwd <REPOSITORY>` selects a trusted local Git repository when creating a
+new head. Resume and shared-head modes reopen the workspace recorded in durable
+Framework state and therefore do not accept `--cwd`. Framework state defaults
+to the operating system's user state directory; `--state-dir <DIR>` selects an
+explicit persistent location. With no prompt, `ercode` starts a REPL (`Ctrl-D`
+exits). Every REPL turn uses the same session and head.
 
-## Test
+## Two isolated heads from the same base
+
+Run these in separate terminals. The visible names are descriptive; the local
+provider creates distinct durable branches and worktrees, so writes do not
+collide and the original checkout is not edited.
+
+```bash
+cargo run -p everruns-coding-cli -- --offline --head left --base main
+cargo run -p everruns-coding-cli -- --offline --head right --base main
+```
+
+Reusing the same `--head` name creates another isolated head. Identity is the
+printed `head` id, not the display name.
+
+## Resume the exact recorded head
+
+Copy the printed typed session id from an earlier run:
+
+```bash
+cargo run -p everruns-coding-cli -- --offline \
+  --resume session_0123456789abcdef0123456789abcdef
+```
+
+Resume continues that session's history and reopens its exact recorded head.
+It never substitutes the repository checkout or a newly created head. If the
+recorded head is archived, destroyed, or otherwise unavailable, resume fails
+clearly.
+
+## Explicit shared-head behavior
+
+Sharing has two explicit steps. First create a head as shared and keep the
+printed session id:
+
+```bash
+cargo run -p everruns-coding-cli -- --offline --head team --shared
+```
+
+Then start a distinct session on the head recorded by that session id:
+
+```bash
+cargo run -p everruns-coding-cli -- --offline \
+  --shared-head session_0123456789abcdef0123456789abcdef
+```
+
+`--shared-head` rejects a session recorded on an isolated head; use `--resume`
+for that case. Shared sessions intentionally address the same mutable files, so
+the application—not Framework—must coordinate concurrent edits.
+
+## Lifecycle and cleanup
+
+`ercode` never removes a worktree or branch on normal exit, handle drop, failed
+turn, or resume. Inspect provider-created worktrees with `git worktree list`.
+The public lifecycle operation `WorkspaceHead::destroy()` is the explicit way
+for an embedding application to remove provider-owned worktree storage; the
+local Git provider retains its branch for recovery. Archive and destroy are not
+implicit CLI exit behavior, and deleting the state directory is not a safe
+substitute for lifecycle APIs.
+
+## Test and CI contract
 
 ```bash
 cargo test -p everruns-coding-cli
+cargo run -p everruns-coding-cli -- --help
 ```
 
-The tests cover the file tools (round-trip and traversal rejection), an offline
-turn and a two-prompt session, and a source/manifest scan that fails if the
-example ever reaches for `everruns-core`/`everruns-host`.
-
-## Scope
-
-This example favors a focused public-API loop over breadth. The previous
-ratatui TUI, local MCP servers, and provider-specific wiring depended on host
-internals the facade does not expose; they are intentionally omitted here.
+The package tests create temporary Git repositories and prove isolated writes,
+selected-head paths, policy enforcement, typed reopen/resume, missing-head
+errors, explicit sharing, and no implicit deletion. Source and manifest guards
+reject internal Everruns dependencies, process-global workspace state, direct
+`tokio::fs`, and duplicate filesystem tools. Changes under this example are in
+the Rust CI path filter, so workspace Clippy/tests compile the binary and all
+example tests on pull requests.

--- a/examples/coding-cli/src/lib.rs
+++ b/examples/coding-cli/src/lib.rs
@@ -1,162 +1,283 @@
-//! A minimal coding agent built **only** on the public `everruns` library.
+//! A minimal coding agent built only on the public `everruns` library.
 //!
-//! This example is the executable acceptance test for the OSS library surface
-//! (EVE-835): it depends on `everruns` alone — never on `everruns-core` or
-//! `everruns-host` — and exercises the exact import path an application uses.
-//! It builds an [`Agent`](everruns::Agent) with example-local file tools defined
-//! via [`#[everruns::tool]`](everruns::tool), opens a [`Session`], streams the
-//! session's events, and runs one or more prompts.
-//!
-//! The heavy TUI/MCP variant this replaced needed host internals the public
-//! facade intentionally does not expose. Keeping the example inside the facade
-//! keeps it honest about what a library user can actually build today.
+//! The example opens provider-owned Git workspace heads, binds them through a
+//! Framework [`Environment`], and uses the built-in `session_file_system`
+//! capability. It deliberately contains no process-global workspace state and
+//! no application-defined filesystem tools.
 
-use std::path::{Component, Path, PathBuf};
-use std::sync::OnceLock;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use everruns::{Agent, AgentBuilder};
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Parser;
+use everruns::{
+    Agent, AgentBuilder, Environment, LocalConfig, LocalGitWorkspaceProvider, Session, SessionId,
+    Workspace, WorkspaceHead, WorkspaceHeadAccess, WorkspacePolicy,
+};
 
-/// System prompt describing the agent and the tools it can call.
+/// System prompt for the coding agent.
 pub const SYSTEM_PROMPT: &str = "\
-You are a terminal coding assistant operating inside a workspace directory. \
-Use the `read_file`, `write_file`, and `list_dir` tools to inspect and edit \
-files relative to the workspace root. Prefer small, verifiable changes and \
-explain what you did.";
+You are a terminal coding assistant operating in the selected Git workspace head. \
+Use the Framework `read_file`, `write_file`, `edit_file`, `list_directory`, and \
+related session filesystem tools with paths under `/workspace`. Prefer small, \
+verifiable changes and explain what you did.";
 
-/// The workspace root the file tools resolve paths against.
-///
-/// Set once at startup with [`set_workspace`]; defaults to the process working
-/// directory when unset (e.g. in tests that call the tool impls directly).
-static WORKSPACE: OnceLock<PathBuf> = OnceLock::new();
+/// Command-line interface shared by the binary and its help-contract tests.
+#[derive(Parser, Debug)]
+#[command(
+    name = "ercode",
+    version,
+    about = "Everruns coding CLI on durable Framework workspace heads",
+    long_about = "Run a coding agent in a provider-owned Git workspace head. New heads are \
+isolated by default and survive process exit. Resume reopens the exact head recorded for a typed \
+session; shared-head mode is an explicit opt-in for a second session on an existing shared head.",
+    after_long_help = "Examples:\n  \
+ercode --offline --head feature --base main \"inspect the repository\"\n  \
+ercode --offline --head left --base main\n  \
+ercode --offline --resume session_0123456789abcdef0123456789abcdef\n  \
+ercode --offline --head team --shared\n  \
+ercode --offline --shared-head session_0123456789abcdef0123456789abcdef"
+)]
+pub struct Cli {
+    /// Trusted local Git repository for a new head (default: current directory).
+    #[arg(
+        short = 'C',
+        long = "cwd",
+        value_name = "REPOSITORY",
+        conflicts_with_all = ["resume", "shared_head"]
+    )]
+    cwd: Option<PathBuf>,
 
-/// Point the file tools at `root`. The first call wins; later calls are ignored.
-pub fn set_workspace(root: PathBuf) {
-    let _ = WORKSPACE.set(root);
+    /// Persistent Framework state (default: the OS user state directory).
+    #[arg(long, value_name = "DIRECTORY")]
+    state_dir: Option<PathBuf>,
+
+    /// Create a new named head (isolated unless --shared is also present).
+    #[arg(long, value_name = "NAME", conflicts_with_all = ["resume", "shared_head"])]
+    head: Option<String>,
+
+    /// Git revision used as the base for a new --head.
+    #[arg(long, value_name = "REVISION", requires = "head")]
+    base: Option<String>,
+
+    /// Create the new --head as explicitly shared instead of isolated.
+    #[arg(long, requires = "head")]
+    shared: bool,
+
+    /// Start a new session on the shared head recorded by this typed session id.
+    #[arg(
+        long,
+        value_name = "SESSION_ID",
+        conflicts_with_all = ["head", "resume"]
+    )]
+    shared_head: Option<SessionId>,
+
+    /// Resume this typed session on its exact recorded workspace head.
+    #[arg(
+        long,
+        value_name = "SESSION_ID",
+        conflicts_with_all = ["head", "shared_head"]
+    )]
+    resume: Option<SessionId>,
+
+    /// Deny workspace writes; new isolated heads are read/write by default.
+    #[arg(long)]
+    read_only: bool,
+
+    /// Model id to use with OpenAI (requires OPENAI_API_KEY). Ignored with --offline.
+    #[arg(long, default_value = "gpt-5-mini")]
+    model: String,
+
+    /// Run fully offline with the deterministic simulator (no credentials or network).
+    #[arg(long)]
+    offline: bool,
+
+    /// One-shot prompt. Omit to start an interactive REPL on the selected head.
+    #[arg(value_name = "PROMPT", trailing_var_arg = true)]
+    prompt: Vec<String>,
 }
 
-fn workspace() -> PathBuf {
-    WORKSPACE
-        .get()
-        .cloned()
-        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
-}
-
-/// Resolve a caller-supplied relative path against the workspace root, rejecting
-/// absolute paths and any `..` traversal so a tool call cannot escape the
-/// workspace.
-fn safe_path(rel: &str) -> Result<PathBuf, String> {
-    let path = Path::new(rel);
-    if path.is_absolute() {
-        return Err(format!("path must be relative to the workspace: {rel:?}"));
+impl Cli {
+    pub fn repository(&self) -> Result<PathBuf> {
+        self.cwd
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(|| std::env::current_dir().context("resolve current directory"))
     }
-    if path
-        .components()
-        .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
-    {
-        return Err(format!("path must not contain `..`: {rel:?}"));
+
+    pub fn state_dir(&self) -> Result<PathBuf> {
+        if let Some(path) = &self.state_dir {
+            return Ok(path.clone());
+        }
+        dirs::state_dir()
+            .or_else(dirs::data_local_dir)
+            .map(|root| root.join("everruns").join("ercode"))
+            .ok_or_else(|| anyhow!("cannot resolve an OS user state directory; pass --state-dir"))
     }
-    Ok(workspace().join(path))
+
+    pub fn session_mode(&self) -> SessionMode {
+        if let Some(session_id) = self.resume {
+            SessionMode::Resume { session_id }
+        } else if let Some(recorded_session) = self.shared_head {
+            SessionMode::SharedHead { recorded_session }
+        } else {
+            SessionMode::NewHead {
+                name: self.head.clone().unwrap_or_else(|| "ercode".to_string()),
+                base: self.base.clone(),
+                shared: self.shared,
+            }
+        }
+    }
+
+    pub fn workspace_policy(&self) -> WorkspacePolicy {
+        if self.read_only {
+            WorkspacePolicy::read_only()
+        } else {
+            WorkspacePolicy::read_write()
+        }
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub fn offline(&self) -> bool {
+        self.offline
+    }
+
+    pub fn prompt(&self) -> &[String] {
+        &self.prompt
+    }
 }
 
-// --- Tool implementations (plain, directly testable) --------------------
-//
-// The `#[everruns::tool]` attribute replaces the annotated function with a
-// zero-argument constructor, so the real logic lives in these `_impl` helpers
-// that the tools call and the tests exercise directly.
-
-async fn read_file_impl(path: &str) -> Result<String, String> {
-    let resolved = safe_path(path)?;
-    tokio::fs::read_to_string(&resolved)
-        .await
-        .map_err(|e| format!("read {path:?}: {e}"))
+/// Mutually exclusive ways to select the session and workspace head.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SessionMode {
+    NewHead {
+        name: String,
+        base: Option<String>,
+        shared: bool,
+    },
+    SharedHead {
+        recorded_session: SessionId,
+    },
+    Resume {
+        session_id: SessionId,
+    },
 }
 
-async fn write_file_impl(path: &str, contents: &str) -> Result<String, String> {
-    let resolved = safe_path(path)?;
-    if let Some(parent) = resolved.parent() {
-        tokio::fs::create_dir_all(parent)
+/// Public-API wrapper for one trusted local Git repository and its durable state.
+pub struct CodingWorkspace {
+    provider: Arc<LocalGitWorkspaceProvider>,
+    workspace: Option<Workspace>,
+    local: LocalConfig,
+}
+
+impl CodingWorkspace {
+    /// Open durable Framework state without selecting a new repository.
+    ///
+    /// Typed resume and shared-head reuse reopen the recorded workspace through
+    /// its opaque provider binding, so they intentionally use this constructor.
+    pub fn from_state(state_dir: impl AsRef<Path>) -> Result<Self> {
+        let state_dir = state_dir.as_ref();
+        let provider = Arc::new(
+            LocalGitWorkspaceProvider::new(state_dir.join("workspace-provider"))
+                .context("initialize the local Git workspace provider")?,
+        );
+        Ok(Self {
+            provider,
+            workspace: None,
+            local: LocalConfig::new(state_dir.join("runtime")),
+        })
+    }
+
+    /// Open a trusted Git repository through the public local workspace provider.
+    pub async fn open(repository: impl AsRef<Path>, state_dir: impl AsRef<Path>) -> Result<Self> {
+        let mut context = Self::from_state(state_dir)?;
+        let locator = repository.as_ref().to_str().ok_or_else(|| {
+            anyhow!("local Git repository path must be valid UTF-8 for durable resume")
+        })?;
+        let workspace = Workspace::open(context.provider.clone(), locator)
             .await
-            .map_err(|e| format!("create {}: {e}", parent.display()))?;
+            .context("open the trusted local Git repository")?;
+        context.workspace = Some(workspace);
+        Ok(context)
     }
-    tokio::fs::write(&resolved, contents.as_bytes())
-        .await
-        .map_err(|e| format!("write {path:?}: {e}"))?;
-    Ok(format!("wrote {} bytes to {path}", contents.len()))
-}
 
-async fn list_dir_impl(path: &str) -> Result<Vec<String>, String> {
-    let resolved = safe_path(path)?;
-    let mut reader = tokio::fs::read_dir(&resolved)
-        .await
-        .map_err(|e| format!("list {path:?}: {e}"))?;
-    let mut entries = Vec::new();
-    while let Some(entry) = reader
-        .next_entry()
-        .await
-        .map_err(|e| format!("list {path:?}: {e}"))?
-    {
-        entries.push(entry.file_name().to_string_lossy().into_owned());
+    /// Attach durable local session state, the workspace provider, and policy.
+    pub fn configure_agent(&self, builder: AgentBuilder, policy: WorkspacePolicy) -> AgentBuilder {
+        builder
+            .local(self.local.clone())
+            .workspace_provider(self.provider.clone())
+            .workspace_policy(policy)
     }
-    entries.sort();
-    Ok(entries)
+
+    /// Create a provider-owned head. Dropping the handle never destroys it.
+    pub async fn create_head(
+        &self,
+        name: impl Into<String>,
+        base: Option<&str>,
+        shared: bool,
+    ) -> Result<WorkspaceHead> {
+        let workspace = self
+            .workspace
+            .as_ref()
+            .ok_or_else(|| anyhow!("creating a head requires a trusted local Git repository"))?;
+        let mut builder = workspace.head(name);
+        if let Some(base) = base {
+            builder = builder.from_revision(base);
+        }
+        if shared {
+            builder = builder.shared();
+        }
+        builder.create().await.context("create Git workspace head")
+    }
+
+    /// Permanently bind a new session to the selected head before execution.
+    pub async fn start_session(&self, agent: &Agent, head: WorkspaceHead) -> Result<Session> {
+        let environment = Environment::builder()
+            .workspace(head)
+            .build()
+            .context("build the workspace environment")?;
+        agent
+            .session()
+            .environment(environment)
+            .start()
+            .await
+            .context("bind the session to its workspace head")
+    }
+
+    /// Resume a typed session on its exact persisted head.
+    pub async fn resume_session(&self, agent: &Agent, session_id: SessionId) -> Result<Session> {
+        agent
+            .resume(session_id)
+            .await
+            .with_context(|| format!("resume session {session_id} on its recorded head"))
+    }
+
+    /// Start a distinct session on an existing head that was created as shared.
+    pub async fn start_shared_session(
+        &self,
+        agent: &Agent,
+        recorded_session: SessionId,
+    ) -> Result<Session> {
+        let recorded = self.resume_session(agent, recorded_session).await?;
+        let head = recorded
+            .workspace_head()
+            .cloned()
+            .ok_or_else(|| anyhow!("session {recorded_session} has no recorded workspace head"))?;
+        if head.access() != WorkspaceHeadAccess::Shared {
+            bail!(
+                "session {recorded_session} records an isolated head; use --resume for that session or create a head with --shared"
+            );
+        }
+        self.start_session(agent, head).await
+    }
 }
 
-// --- Tools (public library surface via the attribute macro) -------------
-
-/// Read a UTF-8 text file, relative to the workspace root.
-#[everruns::tool]
-async fn read_file(path: String) -> Result<String, String> {
-    read_file_impl(&path).await
-}
-
-/// Create or replace a UTF-8 text file, relative to the workspace root.
-#[everruns::tool]
-async fn write_file(path: String, contents: String) -> Result<String, String> {
-    write_file_impl(&path, &contents).await
-}
-
-/// List the entries of a directory relative to the workspace root (defaults to
-/// the root itself).
-#[everruns::tool]
-async fn list_dir(path: Option<String>) -> Result<serde_json::Value, String> {
-    let rel = path.unwrap_or_else(|| ".".to_string());
-    let entries = list_dir_impl(&rel).await?;
-    Ok(serde_json::json!({ "path": rel, "entries": entries }))
-}
-
-/// Start a coding [`Agent`] builder wired with the file tools.
+/// Start a coding [`Agent`] builder using Framework filesystem tools.
 pub fn agent_builder() -> AgentBuilder {
     Agent::builder()
         .instructions(SYSTEM_PROMPT)
-        .tool(read_file())
-        .tool(write_file())
-        .tool(list_dir())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    #[tokio::test]
-    async fn write_then_read_round_trips() {
-        let dir = tempdir().unwrap();
-        set_workspace(dir.path().to_path_buf());
-
-        let msg = write_file_impl("notes/hello.txt", "hi there")
-            .await
-            .unwrap();
-        assert!(msg.contains("wrote"), "{msg}");
-        let back = read_file_impl("notes/hello.txt").await.unwrap();
-        assert_eq!(back, "hi there");
-
-        let entries = list_dir_impl(".").await.unwrap();
-        assert!(entries.contains(&"notes".to_string()), "{entries:?}");
-    }
-
-    #[tokio::test]
-    async fn rejects_traversal_and_absolute_paths() {
-        assert!(read_file_impl("../secret").await.is_err());
-        assert!(read_file_impl("/etc/passwd").await.is_err());
-    }
+        .capability("session_file_system")
 }

--- a/examples/coding-cli/src/main.rs
+++ b/examples/coding-cli/src/main.rs
@@ -1,73 +1,74 @@
-//! `ercode` — a minimal terminal coding agent built only on the `everruns`
-//! public library (EVE-835).
-//!
-//! Run one prompt and exit, or drop into a REPL that keeps one [`Session`]'s
-//! history across turns. Offline by default (deterministic simulator); pass a
-//! real model with `--model` once `OPENAI_API_KEY` is set.
+//! `ercode` — a terminal coding agent on public Framework workspace APIs.
 
 use std::io::Write;
-use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use everruns::Model;
-use everruns::{OpenAI, Session, SessionEventKind};
-use everruns_coding_cli::{agent_builder, set_workspace};
+use everruns::{Model, OpenAI, Session, SessionEventKind, WorkspaceHeadAccess};
+use everruns_coding_cli::{Cli, CodingWorkspace, SessionMode, agent_builder};
 use tokio::io::{AsyncBufReadExt, BufReader};
-
-#[derive(Parser, Debug)]
-#[command(
-    name = "ercode",
-    version,
-    about = "Everruns coding CLI — a minimal coding agent built on the everruns library"
-)]
-struct Cli {
-    /// Workspace root the agent's file tools operate inside (default: current dir).
-    #[arg(short = 'C', long = "cwd")]
-    cwd: Option<PathBuf>,
-
-    /// Model id to use with OpenAI (requires OPENAI_API_KEY). Ignored with --offline.
-    #[arg(long, default_value = "gpt-5-mini")]
-    model: String,
-
-    /// Run fully offline with the deterministic simulator (no credentials, no network).
-    #[arg(long)]
-    offline: bool,
-
-    /// One-shot prompt. Omit to start an interactive REPL.
-    #[arg(trailing_var_arg = true)]
-    prompt: Vec<String>,
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-
-    let root = match cli.cwd {
-        Some(dir) => dir,
-        None => std::env::current_dir().context("resolve current directory")?,
+    let state_dir = cli.state_dir()?;
+    let session_mode = cli.session_mode();
+    let workspace = match &session_mode {
+        SessionMode::NewHead { .. } => CodingWorkspace::open(cli.repository()?, &state_dir).await?,
+        SessionMode::SharedHead { .. } | SessionMode::Resume { .. } => {
+            CodingWorkspace::from_state(&state_dir)?
+        }
     };
-    set_workspace(root);
 
-    let agent = if cli.offline {
-        agent_builder()
+    let builder = workspace.configure_agent(agent_builder(), cli.workspace_policy());
+    let agent = if cli.offline() {
+        builder
             .model(Model::simulated(
-                "Offline simulator: set up a real model with --model to use the tools.",
+                "Offline simulator: configure a real model to execute coding tool calls.",
             ))
             .build()
     } else {
         let provider = OpenAI::from_env()
             .context("configure OpenAI (set OPENAI_API_KEY, or pass --offline)")?;
-        agent_builder().provider(provider).model(cli.model).build()
+        builder.provider(provider).model(cli.model()).build()
     }
     .context("build the coding agent")?;
 
-    let session = agent.session();
+    let session = match session_mode {
+        SessionMode::NewHead { name, base, shared } => {
+            let head = workspace.create_head(name, base.as_deref(), shared).await?;
+            workspace.start_session(&agent, head).await?
+        }
+        SessionMode::SharedHead { recorded_session } => {
+            workspace
+                .start_shared_session(&agent, recorded_session)
+                .await?
+        }
+        SessionMode::Resume { session_id } => workspace.resume_session(&agent, session_id).await?,
+    };
 
-    if cli.prompt.is_empty() {
+    let head = session
+        .workspace_head()
+        .context("session did not bind a workspace head")?;
+    let access = match head.access() {
+        WorkspaceHeadAccess::Isolated => "isolated",
+        WorkspaceHeadAccess::Shared => "shared",
+    };
+    eprintln!(
+        "session={} workspace={} head={} name={:?} access={} base={}",
+        session.session_id(),
+        head.workspace_id(),
+        head.id(),
+        head.name(),
+        access,
+        head.base().unwrap_or("HEAD")
+    );
+    eprintln!("state={}", state_dir.display());
+
+    if cli.prompt().is_empty() {
         repl(&session).await
     } else {
-        run_prompt(&session, &cli.prompt.join(" ")).await
+        run_prompt(&session, &cli.prompt().join(" ")).await
     }
 }
 
@@ -76,7 +77,6 @@ async fn run_prompt(session: &Session, prompt: &str) -> Result<()> {
     let mut events = session.events();
     let turn = session.run(prompt).await.context("run turn")?;
 
-    // Events emitted during the turn are buffered on the stream; drain them.
     while let Some(event) = events.try_recv().context("read turn events")? {
         match event.kind {
             SessionEventKind::ToolStarted { tool_name, .. } => eprintln!("  → {tool_name}"),
@@ -98,7 +98,7 @@ async fn run_prompt(session: &Session, prompt: &str) -> Result<()> {
     Ok(())
 }
 
-/// Interactive REPL: each line is a turn; history accumulates in the session.
+/// Interactive REPL: each line is a turn on the same session and exact head.
 async fn repl(session: &Session) -> Result<()> {
     let mut lines = BufReader::new(tokio::io::stdin()).lines();
     eprintln!("ercode — type a prompt, or Ctrl-D to exit.");

--- a/examples/coding-cli/tests/cli_help.rs
+++ b/examples/coding-cli/tests/cli_help.rs
@@ -1,0 +1,54 @@
+use clap::{CommandFactory, Parser};
+use everruns_coding_cli::{Cli, SessionMode};
+
+#[test]
+fn long_help_teaches_head_resume_and_shared_flows() {
+    let help = Cli::command().render_long_help().to_string();
+    for expected in [
+        "--head <NAME>",
+        "--base <REVISION>",
+        "--shared",
+        "--shared-head <SESSION_ID>",
+        "--resume <SESSION_ID>",
+        "--read-only",
+        "survive process exit",
+    ] {
+        assert!(help.contains(expected), "missing {expected:?} in:\n{help}");
+    }
+}
+
+#[test]
+fn head_modes_are_mutually_exclusive_and_safe_by_default() {
+    let default = Cli::try_parse_from(["ercode", "--offline"]).expect("default args");
+    assert_eq!(
+        default.session_mode(),
+        SessionMode::NewHead {
+            name: "ercode".into(),
+            base: None,
+            shared: false,
+        }
+    );
+
+    assert!(
+        Cli::try_parse_from([
+            "ercode",
+            "--head",
+            "one",
+            "--resume",
+            "session_00000000000000000000000000000001",
+        ])
+        .is_err()
+    );
+    assert!(Cli::try_parse_from(["ercode", "--shared"]).is_err());
+    assert!(Cli::try_parse_from(["ercode", "--base", "main"]).is_err());
+    assert!(
+        Cli::try_parse_from([
+            "ercode",
+            "--cwd",
+            "/tmp/other",
+            "--resume",
+            "session_00000000000000000000000000000001",
+        ])
+        .is_err()
+    );
+}

--- a/examples/coding-cli/tests/facade_only.rs
+++ b/examples/coding-cli/tests/facade_only.rs
@@ -1,8 +1,7 @@
 //! Acceptance tests for the coding-cli example (EVE-835).
 //!
-//! These prove the example works through the public `everruns` surface and,
-//! crucially, that it never reaches for `everruns-core`/`everruns-host` —
-//! the whole point of the example.
+//! These prove the example works through the public `everruns` surface and
+//! never recreates Framework-owned workspace or filesystem behavior.
 
 use std::path::Path;
 
@@ -48,8 +47,7 @@ async fn session_history_persists_across_two_prompts() {
     assert!(!session.id().is_empty());
 }
 
-/// The example must depend only on `everruns`. Scan its own sources and manifest
-/// for any direct use of the internal crates and fail loudly if one creeps in.
+/// Scan sources and the manifest for internal dependencies or duplicate file tools.
 #[test]
 fn sources_do_not_reference_core_or_host() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -67,16 +65,49 @@ fn sources_do_not_reference_core_or_host() {
         }
     }
 
+    let duplicate_workspace_mechanisms = [
+        "set_workspace",
+        "OnceLock<PathBuf>",
+        "safe_path",
+        "tokio::fs",
+        "#[everruns::tool]",
+    ];
+    for file in ["src/lib.rs", "src/main.rs"] {
+        let text = std::fs::read_to_string(root.join(file)).unwrap_or_default();
+        for needle in duplicate_workspace_mechanisms {
+            assert!(
+                !text.contains(needle),
+                "{file} contains `{needle}`; workspace I/O must stay Framework-owned"
+            );
+        }
+    }
+
     // Check dependency declarations, not prose — strip `#` comments per line so a
     // crate named in an explanatory comment is not a false positive.
     let manifest = std::fs::read_to_string(root.join("Cargo.toml")).unwrap();
     for line in manifest.lines() {
         let code = line.split('#').next().unwrap_or("");
-        for needle in ["everruns-core", "everruns-host", "everruns-anthropic"] {
+        for needle in [
+            "everruns-core",
+            "everruns-host",
+            "everruns-anthropic",
+            "everruns-local",
+        ] {
             assert!(
                 !code.contains(needle),
                 "Cargo.toml declares `{needle}`; the example must depend only on `everruns`"
             );
         }
     }
+}
+
+#[test]
+fn coding_cli_changes_trigger_workspace_rust_ci() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let workflow =
+        std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read CI workflow");
+    assert!(
+        workflow.contains("- 'examples/coding-cli/**'"),
+        "coding CLI changes must trigger workspace Rust compilation and tests"
+    );
 }

--- a/examples/coding-cli/tests/workspace_heads.rs
+++ b/examples/coding-cli/tests/workspace_heads.rs
@@ -1,0 +1,317 @@
+//! Temporary-Git acceptance tests for the coding CLI's public workspace flow.
+
+use std::path::Path;
+use std::process::Command;
+
+use everruns::{
+    Agent, LlmSimConfig, Model, SessionId, ToolCall, WorkspaceHeadAccess, WorkspacePolicy,
+};
+use everruns_coding_cli::{CodingWorkspace, agent_builder};
+use serde_json::json;
+
+fn git(repository: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repository)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn repository() -> tempfile::TempDir {
+    let repository = tempfile::tempdir().expect("repository");
+    git(repository.path(), &["init", "--quiet"]);
+    git(
+        repository.path(),
+        &["config", "user.name", "Coding CLI Test"],
+    );
+    git(
+        repository.path(),
+        &["config", "user.email", "coding-cli@example.test"],
+    );
+    std::fs::write(repository.path().join("README.md"), "base\n").expect("base file");
+    git(repository.path(), &["add", "README.md"]);
+    git(repository.path(), &["commit", "--quiet", "-m", "base"]);
+    repository
+}
+
+fn writing_agent(workspace: &CodingWorkspace, content: &'static str, read_only: bool) -> Agent {
+    let model =
+        Model::simulated_with_config(LlmSimConfig::fixed("done").with_tool_call_sequence(vec![
+            vec![ToolCall {
+                id: format!("write-{content}"),
+                name: "write_file".into(),
+                arguments: json!({
+                    "path": "/workspace/result.txt",
+                    "content": content
+                }),
+            }],
+            vec![],
+        ]));
+    let policy = if read_only {
+        WorkspacePolicy::read_only()
+    } else {
+        WorkspacePolicy::read_write()
+    };
+    workspace
+        .configure_agent(agent_builder().model(model), policy)
+        .build()
+        .expect("agent builds")
+}
+
+#[test]
+fn binary_opens_a_named_git_head_in_offline_mode() {
+    let repository = repository();
+    let state = tempfile::tempdir().expect("state");
+    let output = Command::new(env!("CARGO_BIN_EXE_ercode"))
+        .args([
+            "--offline",
+            "--cwd",
+            repository.path().to_str().expect("UTF-8 repository"),
+            "--state-dir",
+            state.path().to_str().expect("UTF-8 state"),
+            "--head",
+            "smoke",
+            "--base",
+            "HEAD",
+            "hello",
+        ])
+        .output()
+        .expect("run ercode");
+    assert!(
+        output.status.success(),
+        "ercode failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("name=\"smoke\""), "{stderr}");
+    assert!(stderr.contains("access=isolated"), "{stderr}");
+    assert!(stderr.contains("session=session_"), "{stderr}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Offline simulator: configure a real model to execute coding tool calls."
+    );
+}
+
+#[tokio::test]
+async fn isolated_heads_from_one_base_write_without_colliding() {
+    let repository = repository();
+    let state = tempfile::tempdir().expect("state");
+    let workspace = CodingWorkspace::open(repository.path(), state.path())
+        .await
+        .expect("workspace opens");
+    let base = git(repository.path(), &["rev-parse", "HEAD"]);
+    let left = workspace
+        .create_head("left", Some(&base), false)
+        .await
+        .expect("left head");
+    let right = workspace
+        .create_head("right", Some(&base), false)
+        .await
+        .expect("right head");
+
+    assert_ne!(left.id(), right.id());
+    assert_eq!(left.access(), WorkspaceHeadAccess::Isolated);
+    assert_eq!(right.access(), WorkspaceHeadAccess::Isolated);
+
+    let left_session = workspace
+        .start_session(&writing_agent(&workspace, "left", false), left.clone())
+        .await
+        .expect("left session");
+    let right_session = workspace
+        .start_session(&writing_agent(&workspace, "right", false), right.clone())
+        .await
+        .expect("right session");
+    let (left_turn, right_turn) = tokio::join!(
+        left_session.run("write the result"),
+        right_session.run("write the result")
+    );
+    left_turn.expect("left turn");
+    right_turn.expect("right turn");
+
+    let left_file = left
+        .file_system()
+        .read_file(left_session.session_id(), "/workspace/result.txt")
+        .await
+        .expect("read left")
+        .expect("left result");
+    let right_file = right
+        .file_system()
+        .read_file(right_session.session_id(), "/workspace/result.txt")
+        .await
+        .expect("read right")
+        .expect("right result");
+    assert_eq!(left_file.content.as_deref(), Some("left"));
+    assert_eq!(right_file.content.as_deref(), Some("right"));
+    assert!(!repository.path().join("result.txt").exists());
+
+    let base_file = left
+        .file_system()
+        .read_file(left_session.session_id(), "/workspace/README.md")
+        .await
+        .expect("read base file")
+        .expect("README in selected head");
+    assert_eq!(base_file.content.as_deref(), Some("base\n"));
+}
+
+#[tokio::test]
+async fn framework_policy_denies_writes_on_the_selected_head() {
+    let repository = repository();
+    let state = tempfile::tempdir().expect("state");
+    let workspace = CodingWorkspace::open(repository.path(), state.path())
+        .await
+        .expect("workspace opens");
+    let head = workspace
+        .create_head("read-only", None, false)
+        .await
+        .expect("head");
+    let session = workspace
+        .start_session(&writing_agent(&workspace, "blocked", true), head.clone())
+        .await
+        .expect("session");
+
+    session
+        .run("write the result")
+        .await
+        .expect("turn completes");
+    assert!(
+        head.file_system()
+            .read_file(session.session_id(), "/workspace/result.txt")
+            .await
+            .expect("read result")
+            .is_none(),
+        "WorkspacePolicy::read_only must be enforced by Framework tools"
+    );
+}
+
+#[tokio::test]
+async fn typed_resume_reopens_the_recorded_head_and_drop_does_not_delete_it() {
+    let repository = repository();
+    let state = tempfile::tempdir().expect("state");
+    let workspace = CodingWorkspace::open(repository.path(), state.path())
+        .await
+        .expect("workspace opens");
+    let head = workspace
+        .create_head("resume", None, false)
+        .await
+        .expect("head");
+    let agent = writing_agent(&workspace, "persisted", false);
+    let session = workspace
+        .start_session(&agent, head.clone())
+        .await
+        .expect("session");
+    session.run("write the result").await.expect("materialize");
+    let session_id = session.session_id();
+    let head_id = head.id();
+    let branch = head.status().await.expect("head status").metadata["branch"].clone();
+    drop(session);
+    drop(agent);
+    drop(head);
+    drop(workspace);
+
+    let worktrees = git(repository.path(), &["worktree", "list", "--porcelain"]);
+    assert!(
+        worktrees.contains(&format!("branch refs/heads/{branch}")),
+        "dropping CLI handles must not remove the provider-owned worktree"
+    );
+
+    let reopened = CodingWorkspace::from_state(state.path()).expect("Framework state reopens");
+    let resumed = reopened
+        .resume_session(&writing_agent(&reopened, "unused", false), session_id)
+        .await
+        .expect("typed resume");
+    assert_eq!(
+        resumed.workspace_head().expect("recorded head").id(),
+        head_id
+    );
+    let file = resumed
+        .workspace_head()
+        .expect("recorded head")
+        .file_system()
+        .read_file(session_id, "/workspace/result.txt")
+        .await
+        .expect("read result")
+        .expect("persisted result");
+    assert_eq!(file.content.as_deref(), Some("persisted"));
+
+    resumed
+        .workspace_head()
+        .expect("recorded head")
+        .clone()
+        .destroy()
+        .await
+        .expect("explicit destroy");
+    drop(resumed);
+    drop(reopened);
+
+    let missing_workspace =
+        CodingWorkspace::from_state(state.path()).expect("Framework state reopens");
+    let missing_agent = writing_agent(&missing_workspace, "unused", false);
+    let missing = missing_workspace
+        .resume_session(&missing_agent, session_id)
+        .await
+        .err()
+        .expect("destroyed recorded head must not be substituted");
+    assert!(
+        format!("{missing:#}").contains("recorded workspace head is unavailable"),
+        "unexpected resume error: {missing:#}"
+    );
+}
+
+#[tokio::test]
+async fn shared_head_requires_explicit_creation_and_existing_session_id() {
+    let repository = repository();
+    let state = tempfile::tempdir().expect("state");
+    let workspace = CodingWorkspace::open(repository.path(), state.path())
+        .await
+        .expect("workspace opens");
+    let shared = workspace
+        .create_head("team", None, true)
+        .await
+        .expect("shared head");
+    let agent = writing_agent(&workspace, "shared", false);
+    let first = workspace
+        .start_session(&agent, shared.clone())
+        .await
+        .expect("first session");
+    first.run("write the result").await.expect("materialize");
+    let second = workspace
+        .start_shared_session(&agent, first.session_id())
+        .await
+        .expect("second shared session");
+    assert_ne!(first.session_id(), second.session_id());
+    assert_eq!(
+        first.workspace_head().expect("first head").id(),
+        second.workspace_head().expect("second head").id()
+    );
+
+    let isolated = workspace
+        .create_head("private", None, false)
+        .await
+        .expect("isolated head");
+    let isolated_session = workspace
+        .start_session(&agent, isolated)
+        .await
+        .expect("isolated session");
+    isolated_session
+        .run("materialize")
+        .await
+        .expect("materialize isolated session");
+    let error = workspace
+        .start_shared_session(&agent, isolated_session.session_id())
+        .await
+        .err()
+        .expect("isolated head must not be shared implicitly");
+    assert!(format!("{error:#}").contains("records an isolated head"));
+}
+
+#[test]
+fn typed_session_ids_are_required_for_resume_inputs() {
+    assert!("not-a-session".parse::<SessionId>().is_err());
+}


### PR DESCRIPTION
## Summary

- replace the coding CLI's process-global workspace and custom file tools with public `Workspace`, `WorkspaceHead`, `Environment`, `WorkspacePolicy`, and Framework `session_file_system` APIs
- add safe CLI flows for isolated named heads, base revisions, explicit shared-head creation/reuse, and typed resume on the exact recorded head
- preserve offline/OpenAI modes, event rendering, and the multi-turn REPL; never destroy provider worktrees or branches implicitly
- document complete head, resume, sharing, policy, state, and cleanup semantics and make coding-CLI changes trigger workspace Rust CI

## Validation

- `cargo test --locked -p everruns-coding-cli` (17 tests plus doctests)
- `cargo clippy -p everruns-coding-cli --all-targets --all-features -- -D warnings`
- rendered `ercode --help` contract and offline binary smoke
- temporary Git coverage for isolated writes, selected-head contents, read-only policy, durable reopen/resume, unavailable heads, explicit sharing, and no implicit deletion
- `just pre-push` (22/22)

## Security

- repository/base/head inputs remain trusted application configuration and are passed through the public local Git provider
- model-visible filesystem access is exclusively Framework-owned and policy-enforced; no direct `tokio::fs`, global root, traversal helper, or duplicate file tool remains
- shared mutation requires both shared head creation and a typed recorded session id; isolated heads reject shared reuse
- resume loads provider state directly and cannot substitute an unrelated current repository

Linear: EVE-908

No release or tag.
