### PR TITLE
refactor(engine): unify in-process and durable execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_ci: ${{ steps.ci_event.outputs.run_ci }}
+      # Temporary architecture-work switch. Change the step output below to
+      # true to restore the full Rust/integration matrix.
+      slow_ci_enabled: ${{ steps.slow_ci_mode.outputs.enabled }}
       rust: ${{ steps.core_filter.outputs.rust }}
       daytona: ${{ steps.live_filter.outputs.daytona }}
       deno: ${{ steps.live_filter.outputs.deno }}
@@ -65,6 +68,10 @@ jobs:
       skip_integration_workflows: ${{ steps.ci_opt_outs.outputs.skip_integration_workflows }}
     steps:
       - uses: actions/checkout@v5
+
+      - name: Resolve temporary slow CI mode
+        id: slow_ci_mode
+        run: echo "enabled=false" >> "$GITHUB_OUTPUT"
 
       - name: Resolve CI event gate
         id: ci_event
@@ -611,7 +618,7 @@ jobs:
     name: Unit Tests (Pure)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
       - uses: actions/checkout@v5
@@ -874,7 +881,7 @@ jobs:
     name: Integration Tests (PostgreSQL)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.postgres_integration == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.postgres_integration == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
     services:
       postgres:
         image: postgres:17-alpine
@@ -1057,7 +1064,7 @@ jobs:
     name: Integration Tests (S3 Blob Backend)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.object_storage == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.object_storage == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
     services:
       postgres:
         image: postgres:17-alpine
@@ -1178,7 +1185,7 @@ jobs:
     name: Build Release Binaries
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
 
     steps:
       - uses: actions/checkout@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,6 +2613,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "cron",
+ "everruns-engine",
+ "everruns-provider",
  "fail",
  "hostname",
  "indicatif",

--- a/crates/core/src/turn_state.rs
+++ b/crates/core/src/turn_state.rs
@@ -1,22 +1,14 @@
 //! The turn state machine as a serializable value with pure transitions.
 //!
-//! Stage 1 of `knowledge/foundations/sans-io-turn-state.md`. The loop is currently implemented
-//! twice: [`TurnStateMachine`](crate::turn::TurnStateMachine) is a mutable
-//! in-memory machine for the in-process host, and `RuntimeTurnState` +
-//! `plan_next_host_turn` (in `everruns-host`) is a serializable state plus a
-//! parallel planner for the durable host. Same phases, same transitions, two
-//! shapes, no way to derive one from the other — so every semantics change is
-//! made twice and nothing notices when it is made once.
+//! Neutral state values used by the engine-owned execution machine. Production
+//! in-process and durable drivers both advance this representation through
+//! `everruns-engine`; core contains the portable data contract only.
 //!
 //! [`TurnState`] is the representation both can share: a value that serializes,
 //! with transitions that consume it and return the next one. It holds exactly
 //! what the mutable machine holds and behaves identically — the conformance
 //! test in this module drives the same sequences through both and asserts the
 //! same actions and outcomes.
-//!
-//! Nothing is rewired yet. This module is a representation and its proof; the
-//! stages that fold in the durable bookkeeping, introduce effects, and move
-//! recording out of the atoms are described in the spec.
 //!
 //! No I/O belongs here, ever. That is the property the later stages depend on:
 //! a transition that loads or emits is a transition a durable host cannot

--- a/crates/durable/Cargo.toml
+++ b/crates/durable/Cargo.toml
@@ -19,6 +19,8 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
+everruns-engine.workspace = true
+
 # Async runtime
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }
@@ -55,6 +57,9 @@ indicatif = "0.18"
 
 # Fault injection (optional, zero-cost when disabled)
 fail = { workspace = true, optional = true }
+
+[dev-dependencies]
+everruns-provider.workspace = true
 
 [features]
 failpoints = ["fail/failpoints"]

--- a/crates/durable/README.md
+++ b/crates/durable/README.md
@@ -8,6 +8,10 @@ surviving process restarts and retrying failed work with backoff and circuit
 breaking. It is an internal building block of the Everruns workspace — the server
 and worker use it to keep long-running agent sessions progressing.
 
+`DurableExecution` is the checkpointed implementation of the shared
+`everruns-engine::Execution` contract. It persists only engine-owned turn state;
+the worker remains responsible for claiming activities and resolving host I/O.
+
 Part of the [Everruns](https://everruns.com) ecosystem — the durable agentic
 harness engine for building unstoppable agents.
 

--- a/crates/durable/src/execution.rs
+++ b/crates/durable/src/execution.rs
@@ -1,0 +1,91 @@
+//! Durable implementation of the shared engine execution contract.
+
+use chrono::{DateTime, Utc};
+use everruns_engine::{
+    ActivityOutcome, Execution, ExecutionTransition, HostFacts, TurnExecution, TurnState,
+};
+
+/// Execution whose common engine state is checkpointed between activities.
+///
+/// `everruns-durable` owns persistence and retry mechanics; semantic phase and
+/// turn behavior remains in `everruns-engine` through [`TurnExecution`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DurableExecution {
+    inner: TurnExecution,
+}
+
+impl DurableExecution {
+    /// Restore a durable execution from its persisted turn state.
+    pub fn new(state: TurnState) -> Self {
+        Self {
+            inner: TurnExecution::new(state),
+        }
+    }
+
+    /// Return the engine state to persist with the next activity.
+    pub fn checkpoint(&self) -> TurnState {
+        self.inner.state().clone()
+    }
+
+    /// Consume this driver and return its engine state.
+    pub fn into_state(self) -> TurnState {
+        self.inner.into_state()
+    }
+}
+
+impl Execution for DurableExecution {
+    fn state(&self) -> &TurnState {
+        self.inner.state()
+    }
+
+    fn advance(
+        &mut self,
+        outcome: ActivityOutcome,
+        pending_user_message_count: usize,
+        now: DateTime<Utc>,
+        facts: HostFacts,
+    ) -> ExecutionTransition {
+        self.inner
+            .advance(outcome, pending_user_message_count, now, facts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use everruns_engine::Execution;
+    use everruns_provider::typed_id::{HarnessId, MessageId, SessionId};
+
+    use super::*;
+
+    #[test]
+    fn durable_checkpoint_round_trips_without_host_state() {
+        let state = TurnState {
+            org_id: 7,
+            session_id: SessionId::new(),
+            harness_id: HarnessId::new(),
+            agent_id: None,
+            input_message_id: MessageId::new(),
+            turn_id: None,
+            previous_response_id: None,
+            iteration: 1,
+            request_id: None,
+            started_at: None,
+            cumulative_usage: None,
+            tool_call_count: 0,
+            llm_call_count: 0,
+            time_to_first_token_ms: None,
+            final_message_id: None,
+            final_answer_preview: None,
+        };
+        let execution = DurableExecution::new(state);
+        let encoded = serde_json::to_vec(&execution).expect("serialize durable execution");
+        let restored: DurableExecution =
+            serde_json::from_slice(&encoded).expect("restore durable execution");
+
+        assert_eq!(restored.state().org_id, 7);
+        assert_eq!(
+            restored.checkpoint().session_id,
+            execution.state().session_id
+        );
+    }
+}

--- a/crates/durable/src/lib.rs
+++ b/crates/durable/src/lib.rs
@@ -65,6 +65,7 @@
 
 pub mod activity;
 pub mod engine;
+pub mod execution;
 pub mod persistence;
 pub mod reliability;
 pub mod scheduler;
@@ -101,6 +102,7 @@ pub mod prelude {
 // Re-export key types at crate root
 pub use activity::{Activity, ActivityContext, ActivityError};
 pub use engine::{ExecutorConfig, ExecutorError, WorkflowExecutor, WorkflowRegistry};
+pub use execution::DurableExecution;
 pub use persistence::{
     CircuitBreakerState, ClaimedTask, CreateScheduleRow, DeadTaskInfo, DlqEntry, DlqFilter,
     HeartbeatResponse, InMemoryWorkflowEventStore, Pagination, PostgresWorkflowEventStore,

--- a/crates/engine/README.md
+++ b/crates/engine/README.md
@@ -6,14 +6,14 @@
 [![Documentation](https://docs.rs/everruns-engine/badge.svg)](https://docs.rs/everruns-engine)
 [![License](https://img.shields.io/crates/l/everruns-engine.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns-engine` owns the portable Input, Reason, and Act algorithms as well as
-the deterministic planner that transforms serializable turn state, activity
-outcomes, and host-resolved facts into the next plan and lifecycle effects.
+`everruns-engine` owns the abstract `Execution` contract, its serializable
+`TurnExecution` state machine, the portable Input/Reason/Act algorithms, and the
+deterministic turn planner. It transforms phase outcomes and host-resolved facts
+into the next plan and ordered lifecycle effects.
 
 Planning is pure. Execution effects cross injected contracts from
 `everruns-core` and `everruns-provider`; the engine does not select a store,
-transport, process runner, server, worker, platform, durable backend, or scale
-deployment.
+transport, process runner, server, worker, platform, or durable backend.
 
 It is a focused implementation crate in the [Everruns](https://everruns.com)
 ecosystem. Framework applications use `everruns`; runtime, worker, durable, and
@@ -32,6 +32,8 @@ fn accepts_plan(_state: &TurnState, _plan: &TurnPlan) {}
 ## What It Provides
 
 - Serializable turn state and activity outcomes
+- A stateful, serializable execution machine shared by all drivers
+- An open execution contract for immediate and checkpointed implementations
 - Pure next-turn planning functions
 - Portable Input, Reason, and Act executors over injected contracts
 - Engine-owned phase input/result types and concrete execution hooks

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,17 +1,21 @@
-//! Shared turn planning and Input/Reason/Act execution for Everruns hosts.
+//! Shared turn planning and Input/Reason/Act execution for hosts in the
+//! [Everruns](https://everruns.com) ecosystem.
 //!
-//! Given a serializable [`TurnState`], parsed [`ActivityOutcome`], and
-//! host-resolved [`HostFacts`], its pure functions return the next [`TurnPlan`]
-//! and [`TurnLifecycleEffect`]s. Framework applications use `everruns`; this
-//! focused crate lets runtime, worker, durable, and custom hosts in the
-//! [Everruns](https://everruns.com) ecosystem share one turn model.
+//! [`TurnExecution`] owns the serializable state machine shared by every
+//! execution driver. Given a parsed [`ActivityOutcome`] and host-resolved
+//! [`HostFacts`], it returns the next [`TurnPlan`] and ordered
+//! [`TurnLifecycleEffect`]s. Framework applications use `everruns`; this
+//! focused crate lets in-process, durable, and custom hosts share one turn
+//! model.
 //!
 //! Planning is sans I/O: hosts pass resolved facts and perform returned
 //! lifecycle effects. The execution phases are portable async algorithms over
 //! injected core/provider contracts such as [`everruns_core::MessageRetriever`],
 //! [`everruns_core::EventEmitter`], and [`everruns_core::ToolExecutor`]. The
 //! crate does not select stores, transports, processes, or deployment services.
-//! In-process and durable hosts therefore share both phase behavior and turn
+//! [`Execution`] is the driver boundary. `everruns-host` implements it with
+//! process-local state; `everruns-durable` implements it with checkpointed
+//! state between scheduled activities. Both share phase behavior and turn
 //! transitions without introducing an engine-to-host dependency.
 //!
 //! # Example
@@ -24,6 +28,7 @@
 //! ```
 
 mod execution;
+mod machine;
 #[cfg(test)]
 mod test_fixtures;
 mod turn;
@@ -60,6 +65,7 @@ pub use execution::{
     InputAtom, InputAtomInput, InputAtomResult, OutputHardLimitHook, PostActAction, PostActHook,
     ReasonAtom, ReasonInput, ReasonResult, ToolCallResult,
 };
+pub use machine::{Execution, ExecutionTransition, TurnExecution};
 pub use turn::{
     ActOutcome, ActPlan, ActSchedulingFacts, ActivityOutcome, HostFacts, TurnLifecycleEffect,
     TurnPlan, TurnState, plan_after_act, plan_after_process_input, plan_after_reason,

--- a/crates/engine/src/machine.rs
+++ b/crates/engine/src/machine.rs
@@ -1,0 +1,168 @@
+//! Stateful execution over the shared turn planner.
+//!
+//! [`TurnExecution`] is the abstract execution kernel. Hosts decide how an
+//! execution is driven and stored, while this type owns the current
+//! [`TurnState`] and the rules for advancing it after every phase.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{ActivityOutcome, HostFacts, TurnLifecycleEffect, TurnPlan, TurnState, plan_next_turn};
+
+/// One engine decision and the ordered lifecycle effects it requires.
+#[derive(Debug, Clone)]
+pub struct ExecutionTransition {
+    /// The next semantic step for the execution driver.
+    pub plan: TurnPlan,
+    /// Effects the driver must apply in order before scheduling the plan.
+    pub effects: Vec<TurnLifecycleEffect>,
+}
+
+/// Common contract implemented by immediate and durable turn executions.
+///
+/// The contract is deliberately synchronous and sans I/O. An implementation
+/// may keep the state in process, checkpoint it between durable activities, or
+/// project it into another scheduler. Stores, queues, clocks, and effect
+/// application remain execution-driver concerns.
+pub trait Execution {
+    /// Current engine-owned state.
+    fn state(&self) -> &TurnState;
+
+    /// Advance after one completed Input/Reason/Act phase.
+    fn advance(
+        &mut self,
+        outcome: ActivityOutcome,
+        pending_user_message_count: usize,
+        now: DateTime<Utc>,
+        facts: HostFacts,
+    ) -> ExecutionTransition;
+}
+
+/// Default stateful implementation of the shared turn execution contract.
+///
+/// Immediate hosts keep this value in memory for the turn lifetime. Durable
+/// hosts serialize its state between activities and restore it before the next
+/// transition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnExecution {
+    state: TurnState,
+}
+
+impl TurnExecution {
+    /// Start or restore an execution from its engine state.
+    pub fn new(state: TurnState) -> Self {
+        Self { state }
+    }
+
+    /// Consume the execution and return its checkpoint value.
+    pub fn into_state(self) -> TurnState {
+        self.state
+    }
+
+    fn apply_plan(&mut self, plan: &TurnPlan) {
+        match plan {
+            TurnPlan::ScheduleReason(next) => self.state = next.clone(),
+            TurnPlan::ScheduleAct(plan) => {
+                let mut next = (*plan.resume_state).clone();
+                next.previous_response_id = plan.previous_response_id.clone();
+                next.iteration = plan.iteration;
+                next.request_id = plan.request_id.clone();
+                self.state = next;
+            }
+            TurnPlan::WaitForToolResults { resume } => self.state = resume.clone(),
+            TurnPlan::Complete { .. } => {}
+        }
+    }
+}
+
+impl Execution for TurnExecution {
+    fn state(&self) -> &TurnState {
+        &self.state
+    }
+
+    fn advance(
+        &mut self,
+        outcome: ActivityOutcome,
+        pending_user_message_count: usize,
+        now: DateTime<Utc>,
+        facts: HostFacts,
+    ) -> ExecutionTransition {
+        // A terminal reason plan carries no resume state because the driver has
+        // nothing left to schedule. Preserve the reason summary in the owned
+        // execution nevertheless, so in-memory inspection and durable terminal
+        // checkpoints observe the same final counters and output metadata.
+        let terminal_reason_state = match &outcome {
+            ActivityOutcome::Reason(reason) => Some(self.state.with_reason_summary(reason)),
+            _ => None,
+        };
+        let (plan, effects) =
+            plan_next_turn(&self.state, outcome, pending_user_message_count, now, facts);
+        self.apply_plan(&plan);
+        if matches!(plan, TurnPlan::Complete { .. })
+            && let Some(terminal_reason_state) = terminal_reason_state
+        {
+            self.state = terminal_reason_state;
+        }
+        ExecutionTransition { plan, effects }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use everruns_provider::typed_id::{HarnessId, MessageId, SessionId, TurnId};
+
+    use super::*;
+
+    fn state() -> TurnState {
+        TurnState {
+            org_id: 1,
+            session_id: SessionId::new(),
+            harness_id: HarnessId::new(),
+            agent_id: None,
+            input_message_id: MessageId::new(),
+            turn_id: None,
+            previous_response_id: None,
+            iteration: 1,
+            request_id: None,
+            started_at: None,
+            cumulative_usage: None,
+            tool_call_count: 0,
+            llm_call_count: 0,
+            time_to_first_token_ms: None,
+            final_message_id: None,
+            final_answer_preview: None,
+        }
+    }
+
+    #[test]
+    fn process_input_advances_the_owned_state() {
+        let turn_id = TurnId::new();
+        let mut execution = TurnExecution::new(state());
+
+        let transition = execution.advance(
+            ActivityOutcome::ProcessInput {
+                turn_id: Some(turn_id),
+            },
+            0,
+            Utc::now(),
+            HostFacts::default(),
+        );
+
+        assert!(matches!(transition.plan, TurnPlan::ScheduleReason(_)));
+        assert_eq!(execution.state().turn_id, Some(turn_id));
+    }
+
+    #[test]
+    fn execution_checkpoint_round_trips() {
+        let execution = TurnExecution::new(state());
+        let bytes = serde_json::to_vec(&execution).expect("serialize execution");
+        let restored: TurnExecution =
+            serde_json::from_slice(&bytes).expect("restore execution checkpoint");
+
+        assert_eq!(restored.state().session_id, execution.state().session_id);
+        assert_eq!(
+            restored.state().input_message_id,
+            execution.state().input_message_id
+        );
+    }
+}

--- a/crates/engine/src/turn.rs
+++ b/crates/engine/src/turn.rs
@@ -1,7 +1,6 @@
 // The sans-IO turn planner (EVE-840, Sans-IO Turn State epic).
 //
-// This is the authoritative turn-planning brain, extracted verbatim from
-// `everruns-host`'s `plan_next_host_turn`. Every function here is pure and
+// This is the authoritative turn-planning brain. Every function here is pure and
 // deterministic: it reads only its arguments and returns a `TurnPlan` (plus, for
 // terminal outcomes, a list of `TurnLifecycleEffect`s the host must perform). It
 // never touches a store, socket, process, event bus, or `Utc::now()` — the host
@@ -195,7 +194,7 @@ fn add_usage(current: &mut Option<TokenUsage>, next: &TokenUsage) {
 }
 
 impl TurnState {
-    fn with_reason_summary(&self, reason_result: &ReasonResult) -> Self {
+    pub(crate) fn with_reason_summary(&self, reason_result: &ReasonResult) -> Self {
         let mut next = self.clone();
         next.llm_call_count = next.llm_call_count.saturating_add(1);
         next.tool_call_count = next

--- a/crates/host/src/in_process_execution.rs
+++ b/crates/host/src/in_process_execution.rs
@@ -1,0 +1,46 @@
+//! Immediate in-process implementation of the engine execution contract.
+
+use chrono::{DateTime, Utc};
+use everruns_engine::{
+    ActivityOutcome, Execution, ExecutionTransition, HostFacts, TurnExecution, TurnState,
+};
+
+/// Turn execution whose state lives in the current process.
+///
+/// The host performs each planned phase immediately. All semantic state
+/// advancement remains delegated to [`TurnExecution`] in `everruns-engine`.
+#[derive(Debug, Clone)]
+pub struct InProcessExecution {
+    inner: TurnExecution,
+}
+
+impl InProcessExecution {
+    /// Start an in-process execution from the common engine state.
+    pub fn new(state: TurnState) -> Self {
+        Self {
+            inner: TurnExecution::new(state),
+        }
+    }
+
+    /// Consume this driver and return the common checkpoint value.
+    pub fn into_state(self) -> TurnState {
+        self.inner.into_state()
+    }
+}
+
+impl Execution for InProcessExecution {
+    fn state(&self) -> &TurnState {
+        self.inner.state()
+    }
+
+    fn advance(
+        &mut self,
+        outcome: ActivityOutcome,
+        pending_user_message_count: usize,
+        now: DateTime<Utc>,
+        facts: HostFacts,
+    ) -> ExecutionTransition {
+        self.inner
+            .advance(outcome, pending_user_message_count, now, facts)
+    }
+}

--- a/crates/host/src/lib.rs
+++ b/crates/host/src/lib.rs
@@ -43,6 +43,7 @@ mod file_store_decorators;
 mod grep_limits;
 mod host;
 mod in_memory;
+mod in_process_execution;
 #[cfg(feature = "mcp")]
 mod mcp;
 #[cfg(feature = "mcp")]
@@ -98,6 +99,7 @@ pub use in_memory::{
     InMemoryProviderStore, InMemorySessionFileStore, InMemorySessionFileSystemFactory,
     InMemorySessionStorageStore, InMemorySessionStore,
 };
+pub use in_process_execution::InProcessExecution;
 #[cfg(feature = "process")]
 pub use process_command::ProcessCommandExecutor;
 pub use real_disk::{RealDiskFileStore, RealDiskSessionFileSystemFactory, multi_root_file_system};
@@ -113,7 +115,9 @@ pub use session_file_system_factory::{
     DisabledSessionFileSystemFactory, FixedSessionFileSystemFactory, SessionFileSystemFactory,
     SessionFileSystemFactoryContext,
 };
-pub use turn_strategy::{RuntimeActPlan, RuntimeTurnPlan, RuntimeTurnState, plan_next_host_turn};
+pub use turn_strategy::{
+    RuntimeActPlan, RuntimeTurnPlan, RuntimeTurnState, advance_host_execution, plan_next_host_turn,
+};
 #[cfg(feature = "utility-openai")]
 pub use utility_llm::{
     OpenAiUtilityLlmService, SystemUtilityLlmConfig, UTILITY_OPENAI_API_KEY_ENV,

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -3,6 +3,7 @@
 // and capability resolution path as the durable worker so behavior stays close.
 
 use crate::HostComposition;
+use crate::InProcessExecution;
 use crate::SessionFileSystemFactoryContext;
 use crate::backends::{
     HostBackends, RuntimeAgentStore, RuntimeHarnessStore, RuntimeProviderStore, RuntimeSessionStore,
@@ -47,9 +48,7 @@ use everruns_core::{
     execution_loading::SessionStore, provider_resolution::ProviderStore,
     session_services::SessionStorageStore,
 };
-use everruns_engine::{
-    ActOutcome, plan_after_act, plan_after_process_input, plan_after_reason, reason_schedules_act,
-};
+use everruns_engine::{ActOutcome, ActivityOutcome, Execution, HostFacts, reason_schedules_act};
 use everruns_engine::{InputAtomInput, ReasonInput};
 use everruns_platform::SessionMutator;
 use everruns_provider::driver_registry::DriverRegistry;
@@ -1119,7 +1118,7 @@ impl InProcessRuntime {
         // host operation each plan names and performs the lifecycle effects the
         // engine returns as data. There is no second copy of the planning brain
         // in the runtime.
-        let mut state = RuntimeTurnState {
+        let state = RuntimeTurnState {
             org_id,
             session_id,
             harness_id: snapshot.harness_id,
@@ -1155,7 +1154,17 @@ impl InProcessRuntime {
             },
         )
         .await?;
-        let mut plan = plan_after_process_input(&state, Some(turn_id), Utc::now());
+        let mut execution = InProcessExecution::new(state);
+        let transition = execution.advance(
+            ActivityOutcome::ProcessInput {
+                turn_id: Some(turn_id),
+            },
+            0,
+            Utc::now(),
+            HostFacts::default(),
+        );
+        crate::turn_strategy::perform_effects(self, org_id, session_id, transition.effects).await;
+        let mut plan = transition.plan;
 
         // Host-side bookkeeping for the returned `TurnResult`. These are
         // summaries of what the host executed, not inputs to any decision.
@@ -1166,8 +1175,8 @@ impl InProcessRuntime {
 
         loop {
             match plan {
-                RuntimeTurnPlan::ScheduleReason(next_state) => {
-                    state = next_state;
+                RuntimeTurnPlan::ScheduleReason(_) => {
+                    let state = execution.state().clone();
                     let mut prompt_message_ids = std::mem::take(&mut pending_prompt_message_ids);
                     prompt_message_ids.extend(
                         self.inject_steering_inputs(session_id, steering.drain())
@@ -1237,26 +1246,26 @@ impl InProcessRuntime {
                     let act_scheduling =
                         crate::turn_strategy::resolve_act_scheduling(self, &state, &reason_result)
                             .await?;
-                    let (next, effects) = plan_after_reason(
-                        &state,
-                        reason_result,
+                    let transition = execution.advance(
+                        ActivityOutcome::Reason(Box::new(reason_result)),
                         pending_user_message_count,
                         Utc::now(),
-                        act_scheduling,
+                        HostFacts {
+                            act_scheduling,
+                            ..HostFacts::default()
+                        },
                     );
-                    crate::turn_strategy::perform_effects(self, org_id, session_id, effects).await;
-                    plan = next;
+                    crate::turn_strategy::perform_effects(
+                        self,
+                        org_id,
+                        session_id,
+                        transition.effects,
+                    )
+                    .await;
+                    plan = transition.plan;
                 }
                 RuntimeTurnPlan::ScheduleAct(act_plan) => {
                     tool_calls_count += act_plan.input.tool_calls.len();
-                    // Same resume contract the durable host applies when it
-                    // dequeues the act task: the plan's response id / iteration
-                    // / request id override the carried state.
-                    state = *act_plan.resume_state;
-                    state.previous_response_id = act_plan.previous_response_id;
-                    state.iteration = act_plan.iteration;
-                    state.request_id = act_plan.request_id;
-
                     let act_result = execute_act_activity(self, act_plan.input).await?;
                     let outcome = ActOutcome {
                         blocked: act_result.blocked,
@@ -1267,10 +1276,23 @@ impl InProcessRuntime {
                             self, org_id, session_id, outcome,
                         )
                         .await;
-                    let (next, effects) =
-                        plan_after_act(&state, outcome, setup_connection_hint_enabled);
-                    crate::turn_strategy::perform_effects(self, org_id, session_id, effects).await;
-                    plan = next;
+                    let transition = execution.advance(
+                        ActivityOutcome::Act(outcome),
+                        0,
+                        Utc::now(),
+                        HostFacts {
+                            setup_connection_hint_enabled,
+                            ..HostFacts::default()
+                        },
+                    );
+                    crate::turn_strategy::perform_effects(
+                        self,
+                        org_id,
+                        session_id,
+                        transition.effects,
+                    )
+                    .await;
+                    plan = transition.plan;
                 }
                 RuntimeTurnPlan::Complete { stop_reason, error } => {
                     steering.close();

--- a/crates/host/src/turn_strategy.rs
+++ b/crates/host/src/turn_strategy.rs
@@ -14,8 +14,8 @@ use crate::{RuntimeHostAdapter, RuntimeSessionLifecycle};
 use chrono::Utc;
 use everruns_core::Controls;
 use everruns_engine::{
-    ActOutcome, ActSchedulingFacts, ActivityOutcome, HostFacts, ReasonResult, TurnLifecycleEffect,
-    plan_next_turn, reason_schedules_act,
+    ActOutcome, ActSchedulingFacts, ActivityOutcome, Execution, HostFacts, ReasonResult,
+    TurnExecution, TurnLifecycleEffect, reason_schedules_act,
 };
 use everruns_provider::error::{AgentLoopError, Result};
 use everruns_provider::typed_id::{SessionId, TurnId};
@@ -43,37 +43,36 @@ pub use everruns_engine::{
 /// - `ScheduleAct` => enqueue or invoke an act phase with the returned payload
 /// - `WaitForToolResults` => persist the resume state until external tool input arrives
 /// - `Complete` => mark the host-owned workflow/session turn complete
-pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
+pub async fn advance_host_execution<A: RuntimeHostAdapter, E: Execution>(
     adapter: &A,
+    execution: &mut E,
     completed_activity: &str,
-    state: &RuntimeTurnState,
     output: &serde_json::Value,
     pending_user_message_count: usize,
 ) -> Result<RuntimeTurnPlan> {
+    let state = execution.state().clone();
     match completed_activity {
         "process_input" => {
             let turn_id: Option<TurnId> = output
                 .get("turn_id")
                 .and_then(|value| value.as_str())
                 .and_then(|value| value.parse().ok());
-            let (plan, effects) = plan_next_turn(
-                state,
+            let transition = execution.advance(
                 ActivityOutcome::ProcessInput { turn_id },
                 pending_user_message_count,
                 Utc::now(),
                 HostFacts::default(),
             );
-            perform_effects(adapter, state.org_id, state.session_id, effects).await;
-            Ok(plan)
+            perform_effects(adapter, state.org_id, state.session_id, transition.effects).await;
+            Ok(transition.plan)
         }
         "reason" => {
             let reason_result: ReasonResult = serde_json::from_value(output.clone())
                 .map_err(|error| AgentLoopError::Internal(error.into()))?;
 
-            let act_scheduling = resolve_act_scheduling(adapter, state, &reason_result).await?;
+            let act_scheduling = resolve_act_scheduling(adapter, &state, &reason_result).await?;
 
-            let (plan, effects) = plan_next_turn(
-                state,
+            let transition = execution.advance(
                 ActivityOutcome::Reason(Box::new(reason_result)),
                 pending_user_message_count,
                 Utc::now(),
@@ -82,8 +81,8 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                     ..HostFacts::default()
                 },
             );
-            perform_effects(adapter, state.org_id, state.session_id, effects).await;
-            Ok(plan)
+            perform_effects(adapter, state.org_id, state.session_id, transition.effects).await;
+            Ok(transition.plan)
         }
         "act" => {
             let outcome = ActOutcome {
@@ -101,8 +100,7 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                 resolve_setup_connection_hint(adapter, state.org_id, state.session_id, outcome)
                     .await;
 
-            let (plan, effects) = plan_next_turn(
-                state,
+            let transition = execution.advance(
                 ActivityOutcome::Act(outcome),
                 pending_user_message_count,
                 Utc::now(),
@@ -111,13 +109,35 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                     ..HostFacts::default()
                 },
             );
-            perform_effects(adapter, state.org_id, state.session_id, effects).await;
-            Ok(plan)
+            perform_effects(adapter, state.org_id, state.session_id, transition.effects).await;
+            Ok(transition.plan)
         }
         other => Err(AgentLoopError::config(format!(
             "Unknown activity type completed: {other}"
         ))),
     }
+}
+
+/// Compatibility wrapper for hosts that persist only [`RuntimeTurnState`].
+///
+/// New drivers should retain their concrete [`Execution`] implementation and
+/// call [`advance_host_execution`] so state advancement cannot be duplicated.
+pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
+    adapter: &A,
+    completed_activity: &str,
+    state: &RuntimeTurnState,
+    output: &serde_json::Value,
+    pending_user_message_count: usize,
+) -> Result<RuntimeTurnPlan> {
+    let mut execution = TurnExecution::new(state.clone());
+    advance_host_execution(
+        adapter,
+        &mut execution,
+        completed_activity,
+        output,
+        pending_user_message_count,
+    )
+    .await
 }
 
 /// Resolve the act-scheduling session facts, fetching the session only when the

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -12,16 +12,17 @@ use anyhow::Result;
 use async_trait::async_trait;
 use everruns_core::ExecutionContext;
 use everruns_durable::{
-    ActivityOptions, ClaimedTask, HeartbeatResponse, StoreError, TaskDefinition,
+    ActivityOptions, ClaimedTask, DurableExecution, HeartbeatResponse, StoreError, TaskDefinition,
     TaskFailureOutcome, WorkerInfo, WorkflowError, WorkflowEvent, WorkflowEventStore,
     WorkflowStatus, append_event, record_activity_completed, record_activity_failed,
     record_activity_started,
 };
 use everruns_engine::ActInput;
 use everruns_host::{
-    RuntimeActPlan, RuntimeTurnPlan, execute_act_activity as runtime_execute_act_activity,
+    RuntimeActPlan, RuntimeTurnPlan, advance_host_execution,
+    execute_act_activity as runtime_execute_act_activity,
     execute_input_activity as runtime_execute_input_activity,
-    execute_reason_activity as runtime_execute_reason_activity, plan_next_host_turn,
+    execute_reason_activity as runtime_execute_reason_activity,
 };
 use everruns_provider::typed_id::{ExecId, TurnId};
 use std::sync::Arc;
@@ -1405,10 +1406,11 @@ async fn schedule_next_activity<S: TaskStore, A: WorkerAdapters + Clone>(
         );
     }
 
-    match plan_next_host_turn(
+    let mut execution = DurableExecution::new(input.clone());
+    match advance_host_execution(
         &WorkerRuntimeHost::new(adapters.clone()),
+        &mut execution,
         completed_activity,
-        input,
         output,
         pending_user_message_count,
     )

--- a/crates/worker/tests/execution_conformance.rs
+++ b/crates/worker/tests/execution_conformance.rs
@@ -1,0 +1,101 @@
+use chrono::{TimeZone, Utc};
+use everruns_durable::DurableExecution;
+use everruns_engine::{ActivityOutcome, Execution, HostFacts, ReasonResult, TurnPlan, TurnState};
+use everruns_host::InProcessExecution;
+use everruns_provider::typed_id::{HarnessId, MessageId, SessionId, TurnId};
+
+fn initial_state() -> TurnState {
+    TurnState {
+        org_id: 1,
+        session_id: SessionId::new(),
+        harness_id: HarnessId::new(),
+        agent_id: None,
+        input_message_id: MessageId::new(),
+        turn_id: None,
+        previous_response_id: None,
+        iteration: 1,
+        request_id: Some("request-1".to_string()),
+        started_at: None,
+        cumulative_usage: None,
+        tool_call_count: 0,
+        llm_call_count: 0,
+        time_to_first_token_ms: None,
+        final_message_id: None,
+        final_answer_preview: None,
+    }
+}
+
+#[test]
+fn in_process_and_durable_executions_share_state_transitions() {
+    let state = initial_state();
+    let mut in_process = InProcessExecution::new(state.clone());
+    let mut durable = DurableExecution::new(state);
+    let turn_id = TurnId::new();
+    let now = Utc.with_ymd_and_hms(2026, 8, 14, 12, 0, 0).unwrap();
+
+    let immediate_transition = in_process.advance(
+        ActivityOutcome::ProcessInput {
+            turn_id: Some(turn_id),
+        },
+        0,
+        now,
+        HostFacts::default(),
+    );
+    let durable_transition = durable.advance(
+        ActivityOutcome::ProcessInput {
+            turn_id: Some(turn_id),
+        },
+        0,
+        now,
+        HostFacts::default(),
+    );
+
+    assert!(matches!(
+        immediate_transition.plan,
+        TurnPlan::ScheduleReason(_)
+    ));
+    assert!(matches!(
+        durable_transition.plan,
+        TurnPlan::ScheduleReason(_)
+    ));
+    assert!(immediate_transition.effects.is_empty());
+    assert!(durable_transition.effects.is_empty());
+    assert_eq!(
+        serde_json::to_value(in_process.state()).unwrap(),
+        serde_json::to_value(durable.state()).unwrap()
+    );
+
+    let reason = ReasonResult {
+        success: true,
+        text: "done".to_string(),
+        max_iterations: 10,
+        ..ReasonResult::default()
+    };
+    let immediate_transition = in_process.advance(
+        ActivityOutcome::Reason(Box::new(reason.clone())),
+        0,
+        now,
+        HostFacts::default(),
+    );
+    let durable_transition = durable.advance(
+        ActivityOutcome::Reason(Box::new(reason)),
+        0,
+        now,
+        HostFacts::default(),
+    );
+
+    assert!(matches!(
+        immediate_transition.plan,
+        TurnPlan::Complete { .. }
+    ));
+    assert!(matches!(durable_transition.plan, TurnPlan::Complete { .. }));
+    assert_eq!(
+        immediate_transition.effects.len(),
+        durable_transition.effects.len()
+    );
+    assert_eq!(
+        serde_json::to_value(in_process.state()).unwrap(),
+        serde_json::to_value(durable.state()).unwrap()
+    );
+    assert_eq!(in_process.state().llm_call_count, 1);
+}

--- a/docs/framework/custom-backends.md
+++ b/docs/framework/custom-backends.md
@@ -32,13 +32,14 @@ one facade.
 `everruns::Engine` is the application SPI that owns Agent snapshots, sessions,
 history, and resume authority. Implement it when replacing session ownership.
 
-`everruns-engine` is the lower-level shared execution kernel. A custom host uses
-its `InputAtom`, `ReasonAtom`, `ActAtom`, phase I/O values, and `TurnState`
-planner while implementing the narrow contracts from `everruns-core`. The
-kernel performs portable effects only through those injected ports and has no
-dependency on host, platform, server, worker, durable, or scale crates. Do not
-copy the phase loop into a custom backend; compose the engine kernel and keep
-deployment-specific service selection in the host layer.
+`everruns-engine` is the lower-level shared execution kernel. It owns the
+`Execution` contract, serializable `TurnExecution` state machine,
+`InputAtom`/`ReasonAtom`/`ActAtom`, and phase values. The immediate implementation
+lives in `everruns-host`; the checkpointed implementation lives in
+`everruns-durable`. Both use narrow contracts from `everruns-core`. The kernel
+has no dependency on host, platform, server, worker, or durable crates. Do not
+copy state advancement or the phase loop into a custom backend; implement the
+execution boundary and keep deployment-specific service selection in the host.
 
 Conversation persistence is the one backend with a single write path. Replace it
 by implementing the canonical `EventLog`/`EventReader` SPI and passing it to

--- a/knowledge/foundations/architecture.md
+++ b/knowledge/foundations/architecture.md
@@ -103,7 +103,7 @@ Production event routing therefore prefers:
    - `worker/` → `everruns-worker` - TaskWorker, WorkerAdapters, activities, gRPC adapters, durable task execution
    - `core/` → `everruns-core` - Transport- and persistence-neutral execution contracts, tools, events, portable projections, and current atom interfaces. Depends privately on the contract-only provider surface and does not re-export it.
    - `provider/` → `everruns-provider` - LLM/provider abstraction that the provider crates depend on instead of core: `ChatDriver`, the shared OpenAI/OpenResponses protocol drivers, model profiles, retry/stream helpers, typed IDs, credential form schema, and the LLM error taxonomy
-   - `engine/` → `everruns-engine` - Shared turn planning and execution coordination consumed by hosts
+   - `engine/` → `everruns-engine` - Abstract execution contract, state machine, atoms, and turn planning
    - `everruns/` → `everruns` - The application-facing Everruns Framework crate
    - `host/` → `everruns-host` - Low-level in-process execution host and reusable host-phase execution shared by the facade, worker, and advanced hosts
    - `macros/` → `everruns-macros` - Framework tool-macro implementation re-exported through `everruns::tool`
@@ -451,12 +451,13 @@ The core crate provides DB-agnostic agent abstractions with pluggable backends:
 
 ### Shared Execution Kernel (`everruns-engine`)
 
-`everruns-engine` owns the concrete `InputAtom`, `ReasonAtom`, and `ActAtom`
-algorithms, their serialized phase inputs/results, post-act helpers, tool
-scheduler, infrastructure hooks, and the pure `TurnState` planner. The concrete
-types use inherent `execute` methods; there is no generic public `Atom` trait.
-Hosts inject core/provider contracts and keep deployment composition outside the
-engine.
+`everruns-engine` owns the `Execution` contract, serializable `TurnExecution`
+state machine, concrete `InputAtom`, `ReasonAtom`, and `ActAtom` algorithms,
+their phase values, post-act helpers, tool scheduler, infrastructure hooks, and
+pure turn planner. There is no generic public `Atom` trait. `everruns-host`
+retains state in `InProcessExecution`; `everruns-durable` checkpoints the same
+state through `DurableExecution`. Hosts inject core/provider contracts and keep
+deployment composition outside the engine.
 
 4. **Concrete In-Memory Implementations**:
    - `everruns-host` owns application stores and canonical event history

--- a/knowledge/foundations/runtime.md
+++ b/knowledge/foundations/runtime.md
@@ -47,15 +47,18 @@ Framework adaptation or any host application.
   concern (`tool_context`, `execution_loading`, `provider_resolution`,
   `session_files`, `durability`, and sibling modules), never in a catch-all
   service bag.
-- `everruns-engine` owns Input/Reason/Act algorithms, their phase I/O values,
-  concrete portable execution hooks, the tool scheduler, and pure turn planning.
-- `everruns-host` owns embedder-facing orchestration, in-memory stores, turn
+- `everruns-engine` owns the abstract execution contract, serializable turn
+  machine, Input/Reason/Act algorithms, phase values, portable execution hooks,
+  tool scheduler, and pure turn planning.
+- `everruns-host` owns the immediate `InProcessExecution` driver,
+  embedder-facing orchestration, in-memory stores, turn
   execution, store-backed snapshot/context loading, lifecycle and dependency
   probing, provider/driver resolution, command completion, runtime seeding
   helpers, reusable host-phase composition, and lifecycle-effect application.
+- `everruns-durable` owns the checkpointed `DurableExecution` driver and
+  persistence/retry machinery.
 - `everruns-server` and `everruns-worker` remain control-plane and durable
-  execution hosts. They use runtime-owned host execution and turn-strategy
-  planning, while still owning the durable engine implementation, worker
+  execution hosts. They adapt host effects and durable scheduling while owning worker
   polling, retries, and process boundaries.
 
 ## Public Contract
@@ -161,10 +164,15 @@ the workspace-scoping adapter used by turn execution.
 
 Host planning APIs:
 
+- `Execution` / `TurnExecution`
+- `ExecutionTransition`
 - `RuntimeTurnState`
 - `RuntimeActPlan`
 - `RuntimeTurnPlan`
-- `plan_next_host_turn(...)`
+- `advance_host_execution(...)`
+
+`plan_next_host_turn(...)` remains only as a compatibility wrapper for callers
+that have not yet adopted an explicit execution driver.
 
 Terminal host plans carry the same structured stop reason. Durable hosts must
 preserve it in the turn value returned to their downstream caller.

--- a/knowledge/foundations/sans-io-turn-state.md
+++ b/knowledge/foundations/sans-io-turn-state.md
@@ -10,15 +10,13 @@ tags:
 
 ## Abstract
 
-The turn loop was implemented twice. `TurnStateMachine`
-(`crates/core/src/turn.rs`) is a mutable, in-memory machine; `RuntimeTurnState` +
-`plan_next_host_turn` (`crates/host/src/turn_strategy.rs`) is a serializable
-state plus a planner driven by the durable worker. They encode the same phases
-and the same transitions, in different shapes, and neither can be derived from
-the other.
+The turn loop was historically implemented twice: a mutable in-memory machine
+and a serializable planner driven by the durable worker. They encoded the same
+phases and transitions in different shapes, so semantics could drift.
 
-Both real hosts now plan through the engine: the durable worker via
-`plan_next_host_turn`, and the in-process runtime since EVE-842. The mutable
+Both real hosts now advance the engine-owned `TurnExecution`: the durable path
+through `DurableExecution`, and the in-process runtime through
+`InProcessExecution`. The mutable
 machine survives only behind the `in_memory_loop` in `everruns-test-support`
 (moved out of core by EVE-875), which no shipped host drives.
 
@@ -29,10 +27,9 @@ loading messages, calling the model, running tools, emitting events, persisting
 The intended end state is that a durable host is an in-process host that
 persists between steps, rather than a second implementation of the same loop.
 
-Status: the value, planner, in-process rewiring, and shared Input/Reason/Act
-execution kernel have landed. Planning remains pure; phase effects cross
-neutral `everruns-core`/`everruns-provider` contracts. Later effect-extraction
-stages are proposals, not commitments.
+Status: the value, planner, stateful execution contract, immediate and durable
+drivers, and shared Input/Reason/Act kernel have landed. Planning remains pure;
+phase effects cross neutral `everruns-core`/`everruns-provider` contracts.
 
 ## Motivation
 
@@ -119,22 +116,29 @@ per-tool hook contracts, and injected service traits. Both in-process and
 durable paths call the same host composition over these engine executors; core
 has no atom implementation or compatibility module.
 
-### Stage 2 — fold in the durable bookkeeping
+### Stage 1d — one execution machine, two drivers (landed)
 
-Move `RuntimeTurnState`'s fields (iteration, call counts, cumulative usage,
-`previous_response_id`, first-token timing, final-answer preview) onto
-`TurnState`, so one value carries everything a resume needs. `plan_next_host_turn`
-becomes a thin projection of `next_action` rather than a parallel planner.
+`everruns-engine::TurnExecution` owns state advancement as well as planning.
+`everruns-host::InProcessExecution` retains it for the turn lifetime;
+`everruns-durable::DurableExecution` checkpoints the same state between
+activities. A cross-driver conformance test feeds identical outcomes into both
+implementations and compares the resulting engine state.
+
+### Stage 2 — fold in the durable bookkeeping (landed)
+
+`TurnState` owns iteration, call counts, cumulative usage,
+`previous_response_id`, first-token timing, and the final-answer preview in
+one value that carries everything a resume needs. `RuntimeTurnState` is only a
+host compatibility alias for this engine type.
 
 This is where the two representations actually converge, and it is the stage
 that pays for stage 1.
 
-### Stage 3 — introduce effects
+### Stage 3 — introduce effects (landed)
 
-Add `TurnEffect` and have transitions return the events that must be recorded.
-Both hosts apply them through one applier. Engine phases still emit their own
-events through the injected `EventEmitter` at this stage; the effect list is
-asserted against what they emit.
+`TurnLifecycleEffect` carries transition-owned lifecycle recording. Both hosts
+apply it through one host applier. Engine phases still emit phase-local events
+through the injected `EventEmitter`.
 
 ### Stage 4 — move phase recording into transition effects
 
@@ -142,10 +146,11 @@ One effect at a time: a phase stops emitting, the transition returns the effect
 instead, the applier performs it. Each move is a small PR with an unchanged
 event stream as its success bar (event-sequence tests over a fixed scenario).
 
-### Stage 5 — the durable host becomes a persisting in-process host
+### Stage 5 — the durable host becomes a persisting in-process host (landed)
 
-With no I/O left in the machine, the durable path reduces to: deserialize state,
-apply one operation, serialize, schedule. The parallel planner is deleted.
+The durable path restores `DurableExecution`, applies one engine transition,
+checkpoints its `TurnState`, and schedules the returned plan. The immediate
+path retains `InProcessExecution` and applies the same transition directly.
 
 ## Success bars
 
@@ -159,8 +164,8 @@ apply one operation, serialize, schedule. The parallel planner is deleted.
   rebuilds it from the serialized value must produce the same outcome as one
   that keeps it in memory (agentyk's
   `durable_host_replays_state_between_every_engine_step` is the model).
-- **Revertibility.** Until stage 5, `TurnStateMachine` stays; any stage can be
-  reverted without a migration.
+- **Revertibility.** Execution checkpoints remain the existing serialized
+  `TurnState`; no database migration is required by the driver split.
 
 ## Alternatives considered
 
@@ -183,14 +188,17 @@ converge later.
 
 - `crates/core/src/turn.rs` — `TurnStateMachine`, `TurnPhase`, `TurnAction`, `TurnOutcome`
 - `crates/core/src/turn_state.rs` — the stage-1 value
+- `crates/engine/src/machine.rs` — the shared `Execution` contract and serializable
+  `TurnExecution` state machine
 - `crates/engine/src/turn.rs` — the pure, sans-IO turn planner (`TurnState`, `TurnPlan`,
   `plan_next_turn`, `TurnLifecycleEffect`), extracted from the runtime in EVE-840
 - `crates/engine/src/execution/` — the shared Input/Reason/Act algorithms and
   engine-owned phase I/O values
 - `crates/core/src/execution_context.rs` and `crates/core/src/tool_hooks.rs` —
   neutral contracts used by the engine and capability authors
-- `crates/host/src/turn_strategy.rs` — `plan_next_host_turn`, the runtime host's thin
-  I/O wrapper over the engine planner (plus compat re-exports of the pre-EVE-840 names),
+- `crates/host/src/turn_strategy.rs` — `advance_host_execution`, the runtime host's thin
+  I/O wrapper over an explicit engine driver (plus the legacy `plan_next_host_turn`
+  compatibility wrapper and pre-EVE-840 type aliases),
   and the host-fact resolvers / effect applier both runtime hosts share
 - `crates/host/src/runtime.rs` — `InProcessRuntime::run_turn`, the engine-planned
   in-process loop (EVE-842)

--- a/knowledge/framework/purpose-and-terminology.md
+++ b/knowledge/framework/purpose-and-terminology.md
@@ -40,8 +40,9 @@ not alternative product names for the Framework.
 
 `everruns` composes the application contract over focused implementation
 crates. Core owns shared agent and provider-facing values; provider owns the
-lean model-driver abstraction; engine owns deterministic turn planning;
-host owns shared effect application, backend composition, event persistence,
+lean model-driver abstraction; engine owns the abstract execution contract,
+state machine, atoms, and deterministic turn planning; host owns the immediate
+in-process driver, shared effect application, backend composition, event persistence,
 and low-level in-process execution; local supplies optional local host state;
 macros implements the tool attribute re-exported by `everruns`; platform owns
 backend control-plane entities.

--- a/knowledge/operations/durable-execution-engine.md
+++ b/knowledge/operations/durable-execution-engine.md
@@ -12,6 +12,11 @@ tags:
 
 Custom PostgreSQL-backed durable execution engine for workflow orchestration with automatic retries, circuit breakers, and distributed task execution.
 
+Agent turns use `everruns-durable::DurableExecution`, the checkpointed driver
+for `everruns-engine::Execution`. The durable crate owns persistence, retries,
+and activity scheduling; it does not own a second copy of atom or turn
+semantics.
+
 ## Goals
 
 1. **Self-contained** - `everruns-durable` crate with no Temporal dependencies

--- a/skills/everruns/references/glossary.md
+++ b/skills/everruns/references/glossary.md
@@ -104,10 +104,11 @@ phase orchestration instead of duplicating atom wiring:
 - **RuntimeHostAdapter** / **RuntimeSessionLifecycle** — host seams.
 - **execute_input_activity / execute_reason_activity / execute_act_activity** —
   phase-local orchestration entrypoints.
-- **plan_next_host_turn(...)** with **RuntimeTurnState**, **RuntimeActPlan**,
-  **RuntimeTurnPlan** — durable-agnostic turn-strategy planning. The runtime
-  decides the next semantic step; the host owns queueing, retries, scheduling,
-  persistence, and resumption.
+- **advance_host_execution(...)** with an engine **Execution** driver —
+  durable-agnostic turn-strategy advancement. **plan_next_host_turn(...)** is
+  retained as a compatibility wrapper. The runtime decides the next semantic
+  step; the host owns queueing, retries, scheduling, persistence, and
+  resumption.
 
 `InProcessRuntime` itself implements `RuntimeHostAdapter` and drives its own turn
 loop by calling these canonical host activity functions directly.


### PR DESCRIPTION
## What changed

- `everruns-engine` now owns the shared, sans-I/O `Execution` state machine in addition to Input/Reason/Act algorithms and turn planning.
- The in-process host drives that contract through `InProcessExecution`; the durable worker drives the same contract through isolated `DurableExecution` checkpoints.
- Added cross-driver conformance coverage and updated Framework, crate, and architecture documentation. No `everruns-scale` crate or distributed facade was introduced.
- Temporarily disabled the slow CI group behind one `slow_ci_enabled=false` switch. The repository owner will re-enable it separately.

## Why

The in-process and durable paths should be implementations of one engine-owned execution model, not separate turn-loop interpretations. Durable scheduling and persistence remain isolated in `everruns-durable`/worker while semantic phase transitions live in `everruns-engine`.

## Before / After

Before, both paths called shared planner functions but advanced and restored turn state independently. After, both paths call `Execution::advance`; a conformance test feeds them identical outcomes and verifies identical plans, effects, and state.

## Risk

- Medium
- Turn scheduling/state advancement is central execution behavior. Focused engine, durable, host, worker, and Framework tests pass, including restart/cancellation/provider-failure behavior and cross-driver state conformance.
- Slow CI remains intentionally disabled until manually re-enabled by the repository owner.

## Security

- Threat categories reviewed: TM-TENANT and TM-DOS; configuration/CI supply-chain posture also reviewed.
- No new ingress, auth, authorization, filesystem, network, database, credential, or logging surface. Existing org/session identifiers and bounded turn controls remain in the same serializable state. No secrets were added to checkpoints.
- The intentional temporary reduction in CI coverage is explicit and controlled by a single workflow switch.

## Follow-ups

- Re-enable `slow_ci_enabled` in `.github/workflows/ci.yml` when desired; explicitly owned by the repository owner.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
