### PR TITLE
fix(ci): prevent shell injection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,11 @@ jobs:
         id: check
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Use env var to safely handle multiline commit messages
           FIRST_LINE=$(echo "$COMMIT_MSG" | head -n1)
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] || \
              [[ "$FIRST_LINE" == chore\(release\):\ prepare\ v* ]]; then
             echo "is_release=true" >> $GITHUB_OUTPUT
             echo "This is a release commit, proceeding with release"
@@ -56,36 +57,46 @@ jobs:
         id: version
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
+          set -euo pipefail
           # Use input version if manual trigger, otherwise extract from commit message
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
           else
             # Extract version from commit message like "chore(release): prepare v0.4.0"
-            VERSION=$(echo "$COMMIT_MSG" | head -n1 | grep -oP 'prepare v\K[0-9]+\.[0-9]+\.[0-9]+')
+            VERSION=$(echo "$COMMIT_MSG" | head -n1 | grep -oP 'prepare v\K[0-9]+\.[0-9]+\.[0-9]+' || true)
           fi
           if [ -z "$VERSION" ]; then
             echo "::error::Could not extract version from commit message or input"
             exit 1
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          # Reject non-semver shapes so tainted inputs cannot inject shell via later steps
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be semver X.Y.Z: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION"
 
       - name: Check if tag already exists
         id: check_tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag v${{ steps.version.outputs.version }} already exists"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$VERSION already exists"
             exit 1
           fi
           echo "Tag does not exist, proceeding..."
 
       - name: Extract release notes from CHANGELOG.md
         id: changelog
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Extract the section for this version from CHANGELOG.md
           # Matches from "## [X.Y.Z]" until the next "## [" or end of significant content
           NOTES=$(awk -v ver="$VERSION" '
@@ -111,21 +122,23 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET_SHA: ${{ github.sha }}
         run: |
-          gh release create "v${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }}" \
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
             --notes-file release_notes.md \
-            --target "${{ github.sha }}"
+            --target "$TARGET_SHA"
 
-          echo "Created release v${{ steps.version.outputs.version }}"
+          echo "Created release v$VERSION"
 
       # GITHUB_TOKEN tag pushes don't trigger other workflows (GitHub anti-recursion).
       # Explicitly dispatch Docker Publish to build version-tagged images.
       - name: Trigger Docker Publish for release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
           echo "Triggering Docker Publish for tag $TAG..."
           gh workflow run docker-publish.yml --ref "$TAG" -f "tag=$TAG"
           echo "Docker Publish triggered for $TAG"
@@ -133,8 +146,8 @@ jobs:
       - name: Trigger CLI binary builds for release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
           echo "Triggering CLI binary builds for tag $TAG..."
           gh workflow run cli-binaries.yml --ref "$TAG" -f "tag=$TAG"
           echo "CLI binary builds triggered for $TAG"
@@ -142,21 +155,23 @@ jobs:
       - name: Trigger crates.io publish for release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          TARGET_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
           echo "Triggering crates.io publish for tag $TAG..."
-          gh api "repos/${{ github.repository }}/dispatches" \
+          gh api "repos/$REPOSITORY/dispatches" \
             --method POST \
             --field event_type=publish-crates \
             --field "client_payload[tag]=$TAG" \
-            --field "client_payload[sha]=${{ github.sha }}"
+            --field "client_payload[sha]=$TARGET_SHA"
           echo "crates.io publish triggered for $TAG"
 
       - name: Trigger server & worker binary builds for release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
           echo "Triggering server & worker binary builds for tag $TAG..."
           gh workflow run server-worker-binaries.yml --ref "$TAG" -f "tag=$TAG"
           echo "Server & worker binary builds triggered for $TAG"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
Hardens `.github/workflows/release.yml` against CodeQL **Cache Poisoning via code injection** alerts: version/tag and related contexts are passed through `env:` and referenced as shell variables in `run:` steps, instead of `${{ }}` interpolation into the script body. Manual `workflow_dispatch` versions are also validated as strict `X.Y.Z` before outputs are written.

## Why
Code scanning opened 10 High alerts on the Release workflow. Interpolating step outputs / event inputs into `run:` scripts is shell injection; with `actions: write` on the release job that can escalate to Actions cache poisoning.

## Before / After
**Before:** `run:` steps embedded `${{ steps.version.outputs.version }}`, `${{ github.event.inputs.version }}`, etc. directly in the script (CodeQL alerts #20–#29).

**After:** Same values arrive via `env:` and are used as `"$VERSION"` / `"$TAG"`; dispatch input is rejected unless it matches `^[0-9]+\.[0-9]+\.[0-9]+$`.

Local simulation of the new validation accepted `0.5.0` and rejected injection-shaped and malformed versions. PR CodeQL / Analyze (actions) completed successfully on this branch.

No runtime product behavior change — workflow config only. App smoke test skipped for that reason.

## Risk
- Low
- Release automation could fail if a previously accepted non-`X.Y.Z` dispatch version is used (intentional; matches crates publish tag expectations). Commit-message extraction already produced that shape.

## Security
- Threat categories reviewed: supply-chain / CI script injection (CodeQL `actions/cache-poisoning` class); adjacent to TM-API injection guidance for untrusted input at trust boundaries. No product API/auth surface in this diff.
- Findings and resolutions: all `${{ }}` interpolations of tainted version/tag (and related) values into `run:` bodies removed in favor of env vars; added semver shape check at the version extraction boundary.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (local validation of the new version gate; no app test surface)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning) — none received after post-green sweep

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61512776-85dd-4316-aaae-51ba86bac917?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61512776-85dd-4316-aaae-51ba86bac917&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

