### PR TITLE
perf(build): speed up worktree validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ env:
   # incremental artifacts are never reused — they just bloat the rust-cache
   # save/restore. Dependency caching (Swatinem/rust-cache) is unaffected.
   CARGO_INCREMENTAL: 0
+  # Local dev/test profiles omit debug metadata for faster worktree iteration.
+  # CI keeps source locations in failure backtraces without paying for full DWARF.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
   # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope: PR code
   # would inherit it and could exfiltrate the whole Doppler vault via
   # build.rs, proc-macros, or tests. Inject it per step under a push-only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ closer `AGENTS.md` (`apps/ui/`, `crates/server/migrations/`, `plugins/`, `.deeps
   them, and stage files by name rather than `git add -A`.
 - Rebases silently keep colliding migration numbers. After a rebase that touches
   `crates/server/migrations/`, run `bash scripts/lib/check-migration-ordering.sh` and renumber.
-- Run `just pre-push` before pushing.
+- Run `just pre-push` before pushing. It scopes expensive checks to changed surfaces and shares a
+  dedicated pre-push Rust target across worktrees; use `just pre-push-full` to force every check.
 - Knowledge captures why/what; link to source instead of copying fields, enum variants, SQL DDL,
   or API shapes. `docs/` holds public product documentation only — durable decisions and
   investigations belong in `knowledge/` or `proposals/`. Run `just check-okf` after knowledge

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,9 +252,12 @@ tar = "0.4"
 
 [profile.dev]
 opt-level = 0
-# line-tables-only: file:line in backtraces, drops full DWARF type/variable info
-# Saves ~5-6 GB across all binaries. Override locally: CARGO_PROFILE_DEV_DEBUG=2
-debug = "line-tables-only"
+# Local iteration does not consume debugger metadata. Keeping it out also lets
+# dev and test reuse compatible dependency artifacts instead of storing both.
+debug = 0
+
+[profile.test]
+debug = 0
 
 [profile.release]
 opt-level = 3
@@ -276,6 +279,6 @@ lto = false
 codegen-units = 256
 # Keep cheap line-number debug info and don't strip: these binaries are executed
 # by CI jobs (workflow/e2e/openapi) under RUST_BACKTRACE=1, so panic backtraces
-# must stay actionable. line-tables-only matches the dev profile — small and fast.
+# must stay actionable. line-tables-only keeps that signal at modest cost.
 debug = "line-tables-only"
 strip = false

--- a/crates/core/src/turn_completion.rs
+++ b/crates/core/src/turn_completion.rs
@@ -334,6 +334,7 @@ mod tests {
     fn an_elapsed_budget_stops_a_cheap_but_slow_loop() {
         // Turns and tokens both untouched; only wall-clock is exhausted.
         let mut budget = ContinuationBudget::new(100, u64::MAX, Duration::ZERO);
+        std::thread::sleep(Duration::from_millis(1));
         assert!(!budget.observe_turn(1));
     }
 }

--- a/justfile
+++ b/justfile
@@ -147,9 +147,13 @@ check:
     cargo clippy --all-targets -- -D warnings
     cargo test
 
-# Run fast pre-push checks (fmt, lint, lockfile — ~30s)
+# Run changed-surface checks with a dedicated Rust cache shared across worktrees.
 pre-push:
     ./scripts/lib/pre-push.sh
+
+# Run every pre-push check regardless of the changed files.
+pre-push-full:
+    EVERRUNS_PRE_PUSH_FULL=1 ./scripts/lib/pre-push.sh
 
 # Run all pre-PR checks (fmt, clippy, tests, UI, OpenAPI, docs)
 pre-pr:

--- a/scripts/lib/check-core-public-api.sh
+++ b/scripts/lib/check-core-public-api.sh
@@ -61,7 +61,8 @@ if ! grep -q -E '^#!\[deny\(rustdoc::broken_intra_doc_links\)\]' crates/core/src
   fail "everruns-core must deny broken rustdoc links"
 fi
 
-API_JSON="$PROJECT_ROOT/target/doc/everruns_core.json"
+TARGET_DIRECTORY="$(cargo metadata --no-deps --format-version 1 | jq -r '.target_directory')"
+API_JSON="$TARGET_DIRECTORY/doc/everruns_core.json"
 API_CURRENT="$(mktemp "${TMPDIR:-/tmp}/everruns-core-api.XXXXXX")"
 DOC_LOG="$(mktemp "${TMPDIR:-/tmp}/everruns-core-docs.XXXXXX")"
 trap 'rm -f "$API_CURRENT" "$DOC_LOG"' EXIT

--- a/scripts/lib/check-everruns-examples.sh
+++ b/scripts/lib/check-everruns-examples.sh
@@ -53,6 +53,11 @@ fi
 echo "Discovered public everruns examples:"
 sed 's/^/  - /' "$FILES"
 
+if [ "${EVERRUNS_EXAMPLES_SKIP_COMPILE:-0}" = "1" ]; then
+  echo "Example compilation covered by the caller."
+  exit 0
+fi
+
 # One Cargo command discovers and compiles the complete target set. No example
 # is executed here, so this check needs no provider credential or network call.
 cargo check --locked -p everruns --all-features --examples

--- a/scripts/lib/pre-push-context.sh
+++ b/scripts/lib/pre-push-context.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Scope expensive pre-push checks to the files that can affect them. The cheap
+# repository guards still run every time.
+
+pre_push_collect_changed_files() {
+  local base
+
+  if git rev-parse --verify -q '@{upstream}' >/dev/null 2>&1; then
+    base="$(git merge-base HEAD '@{upstream}')"
+  elif git rev-parse --verify -q 'origin/main' >/dev/null 2>&1; then
+    base="$(git merge-base HEAD origin/main)"
+  else
+    return 1
+  fi
+
+  {
+    git diff --name-only --diff-filter=ACDMRTUXB "$base" HEAD
+    git diff --name-only --diff-filter=ACDMRTUXB
+    git diff --cached --name-only --diff-filter=ACDMRTUXB
+    git ls-files --others --exclude-standard
+  } | sed '/^$/d' | LC_ALL=C sort -u
+}
+
+pre_push_changed_files_match() {
+  local pattern="$1"
+  printf '%s\n' "$PRE_PUSH_CHANGED_FILES" | grep -Eq -- "$pattern"
+}
+
+pre_push_workflow_changed() {
+  pre_push_changed_files_match '^(justfile|scripts/lib/pre-push(-context)?\.sh)$'
+}
+
+pre_push_rust_changed() {
+  pre_push_workflow_changed ||
+    pre_push_changed_files_match '(^|/)Cargo\.(toml|lock)$|(^|/)[^/]+\.rs$|^rust-toolchain(\.toml)?$|^\.cargo/'
+}
+
+pre_push_cargo_graph_changed() {
+  pre_push_workflow_changed ||
+    pre_push_changed_files_match '(^|/)Cargo\.(toml|lock)$|^rust-toolchain(\.toml)?$|^\.cargo/'
+}
+
+pre_push_ui_changed() {
+  pre_push_workflow_changed || pre_push_changed_files_match '^apps/ui/'
+}
+
+pre_push_core_api_changed() {
+  pre_push_workflow_changed ||
+    pre_push_changed_files_match '^crates/(core|engine)/|^scripts/lib/check-core-public-api\.sh$|^Cargo\.(toml|lock)$|^rust-toolchain(\.toml)?$'
+}
+
+pre_push_shared_target_dir() {
+  local cache_key common_git_dir temp_root
+
+  common_git_dir="$(git rev-parse --git-common-dir)"
+  if [[ "$common_git_dir" != /* ]]; then
+    common_git_dir="$PROJECT_ROOT/$common_git_dir"
+  fi
+  common_git_dir="$(cd "$common_git_dir" && pwd -P)"
+  cache_key="$(printf '%s' "$common_git_dir" | cksum | awk '{print $1}')"
+  temp_root="${TMPDIR:-/tmp}"
+  printf '%s\n' "${temp_root%/}/everruns-build-$cache_key/pre-push-target"
+}
+
+configure_pre_push_build_cache() {
+  if [ -z "${CARGO_TARGET_DIR:-}" ]; then
+    CARGO_TARGET_DIR="$(pre_push_shared_target_dir)"
+    export CARGO_TARGET_DIR
+  fi
+
+  # Pre-push artifacts are reused across worktrees, so incremental state only
+  # consumes space without improving the validation result.
+  : "${CARGO_INCREMENTAL:=0}"
+  export CARGO_INCREMENTAL
+}

--- a/scripts/lib/pre-push.sh
+++ b/scripts/lib/pre-push.sh
@@ -1,21 +1,55 @@
 #!/usr/bin/env bash
-# Pre-push checks: fast local validation to catch CI failures early (~30s).
+# Pre-push checks: changed-surface local validation to catch CI failures early.
 # Runs formatting, linting, lockfile, migration, test/example enumeration, knowledge,
 # architecture isolation guards, and attribution checks.
 # Usage: just pre-push (or: bash scripts/lib/pre-push.sh)
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/pre-push-context.sh"
 
 FAILED=0
 fail() { echo "   ❌ $1"; FAILED=1; }
 pass() { echo "   ✅ $1"; }
+skip() { echo "   ⏭️  skipped ($1)"; }
+
+PRE_PUSH_FULL="${EVERRUNS_PRE_PUSH_FULL:-0}"
+if [ "$PRE_PUSH_FULL" = "1" ]; then
+  PRE_PUSH_CHANGED_FILES=""
+  PRE_PUSH_SCOPE="full (requested)"
+elif PRE_PUSH_CHANGED_FILES="$(pre_push_collect_changed_files)"; then
+  PRE_PUSH_SCOPE="changed files"
+else
+  PRE_PUSH_FULL=1
+  PRE_PUSH_CHANGED_FILES=""
+  PRE_PUSH_SCOPE="full (no Git comparison base)"
+fi
+export PRE_PUSH_CHANGED_FILES
+
+RUST_CHANGED=0
+CARGO_GRAPH_CHANGED=0
+UI_CHANGED=0
+CORE_API_CHANGED=0
+if [ "$PRE_PUSH_FULL" = "1" ] || pre_push_rust_changed; then RUST_CHANGED=1; fi
+if [ "$PRE_PUSH_FULL" = "1" ] || pre_push_cargo_graph_changed; then CARGO_GRAPH_CHANGED=1; fi
+if [ "$PRE_PUSH_FULL" = "1" ] || pre_push_ui_changed; then UI_CHANGED=1; fi
+if [ "$PRE_PUSH_FULL" = "1" ] || pre_push_core_api_changed; then CORE_API_CHANGED=1; fi
+
+if [ "$RUST_CHANGED" = "1" ] || [ "$CORE_API_CHANGED" = "1" ]; then
+  configure_pre_push_build_cache
+fi
 
 echo "🔒 Running pre-push checks..."
+echo "   Scope: $PRE_PUSH_SCOPE"
+if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+  echo "   Rust cache: $CARGO_TARGET_DIR"
+fi
 echo ""
 
 # 1. Rust formatting
 echo "1/22 Rust formatting"
-if cargo fmt --check 2>/dev/null; then
+if [ "$RUST_CHANGED" != "1" ]; then
+  skip "no Rust changes"
+elif cargo fmt --check 2>/dev/null; then
   pass "cargo fmt"
 else
   fail "cargo fmt — run: cargo fmt"
@@ -23,7 +57,9 @@ fi
 
 # 2. Clippy
 echo "2/22 Rust linting"
-if cargo clippy --all-targets --all-features -- -D warnings 2>/dev/null; then
+if [ "$RUST_CHANGED" != "1" ]; then
+  skip "no Rust changes"
+elif cargo clippy --all-targets --all-features -- -D warnings 2>/dev/null; then
   pass "clippy"
 else
   fail "clippy — run: cargo clippy --fix --allow-dirty"
@@ -31,7 +67,9 @@ fi
 
 # 3. Cargo.lock freshness
 echo "3/22 Cargo.lock freshness"
-if cargo fetch --locked 2>/dev/null; then
+if [ "$CARGO_GRAPH_CHANGED" != "1" ]; then
+  skip "Cargo dependency graph unchanged"
+elif cargo fetch --locked 2>/dev/null; then
   pass "Cargo.lock up to date"
 else
   fail "Cargo.lock outdated — run: cargo fetch"
@@ -39,7 +77,9 @@ fi
 
 # 4. UI formatting (skip if node_modules missing)
 echo "4/22 UI formatting"
-if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
+if [ "$UI_CHANGED" != "1" ]; then
+  skip "no UI changes"
+elif [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && pnpm run format:check 2>/dev/null); then
     pass "UI format"
   else
@@ -51,7 +91,9 @@ fi
 
 # 5. UI linting (skip if node_modules missing)
 echo "5/22 UI linting"
-if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
+if [ "$UI_CHANGED" != "1" ]; then
+  skip "no UI changes"
+elif [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && pnpm run lint 2>/dev/null); then
     pass "UI lint"
   else
@@ -97,9 +139,13 @@ fi
 # 9. Public everruns example inventory and compile check
 echo "9/22 Public everruns examples"
 if EVERRUNS_EXAMPLES_OUTPUT="$(
-  bash "$PROJECT_ROOT/scripts/lib/check-everruns-examples.sh" 2>&1
+  EVERRUNS_EXAMPLES_SKIP_COMPILE=1 bash "$PROJECT_ROOT/scripts/lib/check-everruns-examples.sh" 2>&1
 )"; then
-  pass "public everruns examples use the facade and compile"
+  if [ "$RUST_CHANGED" = "1" ]; then
+    pass "public everruns example inventory uses the facade; compilation covered by clippy"
+  else
+    pass "public everruns example inventory uses the facade"
+  fi
 else
   printf '%s\n' "$EVERRUNS_EXAMPLES_OUTPUT" | sed 's/^/   /'
   fail "public everruns example check failed"
@@ -197,7 +243,9 @@ fi
 
 # 18. Core public API/semver and documentation guard (EVE-906)
 echo "18/22 Core public API guard"
-if CORE_PUBLIC_API_OUTPUT="$(
+if [ "$CORE_API_CHANGED" != "1" ]; then
+  skip "core API surface unchanged"
+elif CORE_PUBLIC_API_OUTPUT="$(
   bash "$PROJECT_ROOT/scripts/lib/check-core-public-api.sh" 2>&1
 )"; then
   pass "$CORE_PUBLIC_API_OUTPUT"

--- a/scripts/test-pre-push-context.sh
+++ b/scripts/test-pre-push-context.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+source "$PROJECT_ROOT/scripts/lib/pre-push-context.sh"
+
+assert_true() {
+  local description="$1"
+  shift
+  if ! "$@"; then
+    echo "FAIL: $description" >&2
+    exit 1
+  fi
+}
+
+assert_false() {
+  local description="$1"
+  shift
+  if "$@"; then
+    echo "FAIL: $description" >&2
+    exit 1
+  fi
+}
+
+PRE_PUSH_CHANGED_FILES=$'docs/guide.md\ncrates/server/src/lib.rs'
+assert_true "Rust source selects Rust checks" pre_push_rust_changed
+assert_false "server source does not select the core API guard" pre_push_core_api_changed
+assert_false "non-UI changes do not select UI checks" pre_push_ui_changed
+assert_false "source-only changes do not fetch the Cargo graph" pre_push_cargo_graph_changed
+
+PRE_PUSH_CHANGED_FILES=$'apps/ui/src/app/page.tsx'
+assert_true "UI source selects UI checks" pre_push_ui_changed
+assert_false "UI source does not select Rust checks" pre_push_rust_changed
+
+PRE_PUSH_CHANGED_FILES=$'crates/core/src/lib.rs'
+assert_true "core source selects the core API guard" pre_push_core_api_changed
+
+PRE_PUSH_CHANGED_FILES=$'integrations/example/Cargo.toml'
+assert_true "nested manifests select Rust checks" pre_push_rust_changed
+assert_true "nested manifests refresh the Cargo graph" pre_push_cargo_graph_changed
+
+PRE_PUSH_CHANGED_FILES=$'scripts/lib/pre-push.sh'
+assert_true "pre-push workflow changes exercise Rust checks" pre_push_rust_changed
+assert_true "pre-push workflow changes exercise UI checks" pre_push_ui_changed
+assert_true "pre-push workflow changes exercise the core API guard" pre_push_core_api_changed
+
+common_git_dir="$(cd "$(git rev-parse --git-common-dir)" && pwd -P)"
+cache_key="$(printf '%s' "$common_git_dir" | cksum | awk '{print $1}')"
+temp_root="${TMPDIR:-/tmp}"
+expected_target="${temp_root%/}/everruns-build-$cache_key/pre-push-target"
+actual_target="$(pre_push_shared_target_dir)"
+if [ "$actual_target" != "$expected_target" ]; then
+  echo "FAIL: shared target mismatch: $actual_target != $expected_target" >&2
+  exit 1
+fi
+
+(
+  CARGO_TARGET_DIR="/tmp/everruns-custom-target"
+  configure_pre_push_build_cache
+  if [ "$CARGO_TARGET_DIR" != "/tmp/everruns-custom-target" ]; then
+    echo "FAIL: explicit CARGO_TARGET_DIR was replaced" >&2
+    exit 1
+  fi
+)
+
+temp_repo="$(mktemp -d)"
+trap 'rm -rf "$temp_repo"' EXIT
+(
+  cd "$temp_repo"
+  git init -q
+  git config user.name "Mykhailo Chalyi"
+  git config user.email "mike@chaliy.name"
+  mkdir -p crates/example/src apps/ui
+  printf '%s\n' 'fn original() {}' > crates/example/src/lib.rs
+  printf '%s\n' '{}' > apps/ui/package.json
+  git add crates/example/src/lib.rs apps/ui/package.json
+  git commit -qm "test: establish comparison base"
+  git update-ref refs/remotes/origin/main HEAD
+  rm crates/example/src/lib.rs
+  printf '%s\n' 'export {}' > apps/ui/new.ts
+
+  changed_files="$(pre_push_collect_changed_files)"
+  if [ "$changed_files" != $'apps/ui/new.ts\ncrates/example/src/lib.rs' ]; then
+    echo "FAIL: changed-file collection missed deleted or untracked files: $changed_files" >&2
+    exit 1
+  fi
+)
+
+echo "Pre-push context tests passed."


### PR DESCRIPTION
## What changed
- Make `just pre-push` run expensive Rust, Cargo, UI, and core API checks only when relevant files changed, while keeping cheap repository guards unconditional.
- Reuse one debug-free, non-incremental pre-push Cargo target across worktrees without coupling normal dev builds.
- Remove local dev/test debug metadata and preserve line-table backtraces in CI.
- Make the elapsed-budget unit test deterministic.

## Why
Active Rust worktrees accumulated about 395 GB of duplicated target data, and every pre-push paid a cold full-workspace compile.

## Before / After
- Six worktrees: about 395 GB of target data; largest 140 GB (72 GB incremental).
- Shared pre-push cache: 1.8 GB.
- Cross-worktree full Clippy: cold about 3m -> 79.5s with shared dependency artifacts.
- Representative dev-to-test: 1,316,672 KB -> 553,508 KB (-58%); follow-up test build 23.1s -> 11.9s.
- Non-Rust changes now skip Rust compilation; `just pre-push-full` preserves full validation.

## Risk
- Low.
- Local backtraces lose file/line metadata; CI explicitly retains line tables.
- Concurrent pre-push runs share one Cargo target and may serialize, but normal worktree builds remain isolated.
- System temp cleanup may evict the cache, causing a safe cold rebuild.

## Security
- Threat categories reviewed: TM-FS, TM-DOS.
- Cache paths are derived without shell evaluation and scoped to a repository-keyed system-temp location. One Cargo target per repository replaces per-worktree duplication. No authentication, API, tenancy, data, secret, or runtime surface changed. No threat-model update is needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
