### PR TITLE
fix(engine): retry stalls after reasoning output

### DIFF
--- a/crates/engine/src/execution/reason.rs
+++ b/crates/engine/src/execution/reason.rs
@@ -301,9 +301,9 @@ fn should_retry_stream_error(
     error: &crate::driver_registry::LlmStreamError,
     retry_attempts: u32,
     max_retries: u32,
-    has_output: bool,
+    has_final_output: bool,
 ) -> bool {
-    retry_attempts < max_retries && !has_output && is_transient_stream_error(error)
+    retry_attempts < max_retries && !has_final_output && is_transient_stream_error(error)
 }
 
 fn merge_retry_metadata(
@@ -2762,7 +2762,7 @@ impl ReasonAtom {
             let mut thinking_signature: Option<String> = None;
             let mut tool_calls = Vec::new();
             let mut completion_metadata: Option<LlmCompletionMetadata> = None;
-            let mut stream_has_output = false;
+            let mut stream_has_final_output = false;
             let mut pending_delta = String::new();
             let mut pending_thinking_delta = String::new();
             let mut last_delta_emit = Instant::now();
@@ -2818,7 +2818,7 @@ impl ReasonAtom {
                             &stall_error,
                             stream_retry_metadata.attempts,
                             retry_config.max_retries,
-                            stream_has_output,
+                            stream_has_final_output,
                         ) {
                             let proposed_wait = retry_config
                                 .calculate_backoff(stream_retry_metadata.attempts);
@@ -2876,7 +2876,7 @@ impl ReasonAtom {
                         if delta.is_empty() {
                             continue;
                         }
-                        stream_has_output = true;
+                        stream_has_final_output = true;
                         // Track time-to-first-token on first non-empty delta
                         if time_to_first_token_ms.is_none() {
                             let ttft = llm_start.elapsed().as_millis() as u64;
@@ -2948,7 +2948,6 @@ impl ReasonAtom {
                         if delta.is_empty() {
                             continue;
                         }
-                        stream_has_output = true;
                         if let Some(t) = append_guarded_thinking_delta(
                             &mut armed_guardrails,
                             &mut thinking,
@@ -3000,7 +2999,6 @@ impl ReasonAtom {
                         }
                     }
                     LlmStreamEvent::ThinkingSignature(signature) => {
-                        stream_has_output = true;
                         // Capture the cryptographic signature for thinking content (required to send it back)
                         tracing::debug!(
                             session_id = %session_id,
@@ -3017,7 +3015,6 @@ impl ReasonAtom {
                         summary,
                         token_count,
                     } => {
-                        stream_has_output = true;
                         // Preserve the opaque artifact as the assistant message's
                         // thinking_signature so the next request can replay
                         // reasoning context, and emit a durable reason.item event
@@ -3058,7 +3055,7 @@ impl ReasonAtom {
                         }
                     }
                     LlmStreamEvent::ToolCalls(calls) => {
-                        stream_has_output |= !calls.is_empty();
+                        stream_has_final_output |= !calls.is_empty();
                         tool_calls = calls;
                     }
                     LlmStreamEvent::MessagePhase(phase) => {
@@ -3173,7 +3170,7 @@ impl ReasonAtom {
                             &err,
                             stream_retry_metadata.attempts,
                             retry_config.max_retries,
-                            stream_has_output,
+                            stream_has_final_output,
                         ) {
                             let proposed_wait =
                                 retry_config.calculate_backoff(stream_retry_metadata.attempts);
@@ -3858,7 +3855,9 @@ impl ReasonAtom {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::driver_registry::{LlmCallConfig, PromptCacheConfig, PromptCacheStrategy};
+    use crate::driver_registry::{
+        LlmCallConfig, LlmStreamError, PromptCacheConfig, PromptCacheStrategy,
+    };
     use std::collections::HashMap;
 
     #[test]
@@ -3991,6 +3990,17 @@ mod tests {
                 && record.capability_id == "cap:demo"
                 && record.tool_name.as_deref() == Some("demo_tool")
         }));
+    }
+
+    #[test]
+    fn reasoning_only_output_keeps_transient_stall_retryable() {
+        let stall = LlmStreamError::new("provider stream stall: no tokens for 120s");
+
+        // Thinking deltas do not set stream_has_final_output, because retrying
+        // them cannot duplicate an answer or a tool side effect.
+        assert!(should_retry_stream_error(&stall, 0, 2, false));
+        assert!(!should_retry_stream_error(&stall, 2, 2, false));
+        assert!(!should_retry_stream_error(&stall, 0, 2, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep transient provider-stream stalls retryable after reasoning-only output.
- Continue suppressing retries after answer text or tool calls, where replay could duplicate visible output or side effects.
- Clarify the retry-safety state as `stream_has_final_output` and cover retry budget/final-output classification.

## Why

Yolop session `session_019fbaa9e9c17f638f820780d0c89275` emitted reasoning, then received no provider tokens for 120 seconds. The stream watchdog correctly raised a transient stall, but `ReasonAtom` treated reasoning as output that made replay unsafe. This bypassed the bounded recovery added for provider stalls.

Reasoning is diagnostic progress; replaying it cannot duplicate a final answer or execute a tool. Final answer text and tool calls remain the safety boundary.

## How

`ReasonAtom` now records whether a stream has produced *final* output rather than any output. Content deltas and non-empty tool-call batches cross that boundary. Thinking deltas, signatures, and reasoning summaries do not.

## Before / After

**Before:** reasoning delta → 120-second provider stall → terminal `reason.completed` error; no retry.

**After:** reasoning delta → transient provider stall → bounded retry using the existing provider recovery policy. A stall after answer text or a tool call still terminates without replay.

## Validation

- `cargo test -p everruns-engine reasoning_only_output_keeps_transient_stall_retryable`
- Result: 1 passed, 0 failed.
- Required repository checks run in CI: formatting, clippy, workspace tests, feature checks, doc tests, security audit, and knowledge validation.

## Risk

Low. The change only broadens retry eligibility for transient errors before final output. Existing retry count, backoff, total-delay budget, and stream-stall timeout remain unchanged.

## Security

- Reviewed the applicable provider/agent execution and availability/resource-exhaustion surfaces in `knowledge/project/security.md`.
- Tool-side-effect replay remains blocked because non-empty tool calls set `stream_has_final_output`.
- Final-answer duplication remains blocked because content deltas set `stream_has_final_output`.
- Retry attempts and cumulative delay remain bounded by the existing recovery policy.
- No filesystem, shell, secret-handling, capability-registration, or dependency changes.

## Knowledge

No knowledge update required. This corrects retry classification to match the existing documented bounded provider-recovery policy; it does not change architecture or maintainer policy.

## Follow-ups

After the fix is released, Yolop must update all `everruns-*` crates in lockstep and validate the affected live-provider flow.

## Checklist

- [x] Focused regression test added and passed
- [x] Final-output and tool-side-effect replay protections preserved
- [x] Security review completed
- [x] No knowledge update required

Produced by [yolop](https://everruns.com/yolop)
