### PR TITLE
chore(agents): document PR evidence publishing

### DIFF
--- a/.agents/skills/ship/references/pr-and-merge.md
+++ b/.agents/skills/ship/references/pr-and-merge.md
@@ -8,8 +8,35 @@
   exactly and fill every applicable section — including Before/After proof, risk, the security
   review, and **Follow-ups**. Do not substitute ad-hoc headings, even for small changes.
 - For the Before/After, attach evidence a skeptical reviewer can check, not just a claim — CLI/API
-  output, logs, or metrics, and screenshots for UI changes (`apps/ui`). State explicitly when a
-  change has no observable behavior.
+  output, logs, or metrics, and screenshots or recordings for UI changes (`apps/ui`). State
+  explicitly when a change has no observable behavior.
+
+## Publish evidence assets
+
+- Keep proof assets outside the repository, preferably under `/tmp`. Never commit or push them to a
+  product branch, including under `.github/pr-assets/`.
+- Upload PR/issue images and video to GitHub's user-attachments CDN. Resolve the numeric repository
+  ID with `gh api repos/{owner}/{repo} --jq .id`, then upload the file:
+  ```bash
+  curl -sS \
+    "https://uploads.github.com/user-attachments/assets?name=<filename>&content_type=<mime>&repository_id=<repository-id>" \
+    -X POST \
+    -H "Authorization: Bearer $(gh auth token)" \
+    -H "Accept: application/json" \
+    --data-binary @<file> | jq -r .url
+  ```
+  This is the same CDN GitHub uses for drag-and-drop attachments, follows repository visibility,
+  and does not require browser or computer use. URL-encode the filename when it contains reserved
+  characters. HTTP `422` means the media type is unsupported; `404` usually means the repository
+  ID is wrong or the token lacks push access.
+- Embed an image's returned `.url` with Markdown image syntax. For `video/mp4` or `video/webm`, put
+  the returned URL on its own bare line so GitHub renders a player; `![]()` does not render video.
+  Playwright records WebM. For broad playback support, transcode before uploading:
+  ```bash
+  ffmpeg -i in.webm -c:v libx264 -pix_fmt yuv420p out.mp4
+  ```
+- For non-media artifacts, or when the attachment endpoint fails, publish through Crabbox and link
+  the artifact manifest URL in the PR.
 
 ## CI
 

--- a/.agents/skills/ui-screenshots/SKILL.md
+++ b/.agents/skills/ui-screenshots/SKILL.md
@@ -8,14 +8,16 @@ metadata:
 # UI Screenshots
 
 Capture UI state for review evidence with [agent-browser](https://github.com/vercel-labs/agent-browser).
-Screenshots are never committed — they are uploaded to Cloudinary and embedded in a PR comment.
+Screenshots are never committed — the helper uploads them to GitHub's user-attachments CDN and
+embeds them in a PR comment. The general media and video rules live in
+[`../ship/references/pr-and-merge.md`](../ship/references/pr-and-merge.md#publish-evidence-assets).
 
 ## Scripts
 
 Each script documents its own usage and requirements in its header; read it if the flags matter.
 
 ```bash
-.agents/skills/ui-screenshots/scripts/check-config.sh                       # GITHUB_TOKEN, CLOUDINARY_URL, agent-browser
+.agents/skills/ui-screenshots/scripts/check-config.sh                       # GitHub auth, agent-browser
 .agents/skills/ui-screenshots/scripts/take-screenshot.sh <URL> <OUTPUT>
 .agents/skills/ui-screenshots/scripts/upload-screenshot.sh <PATH> <PR> [DESCRIPTION]
 ```
@@ -30,7 +32,8 @@ npm install -g agent-browser
 agent-browser install            # add --with-deps on Linux when system libs are missing
 ```
 
-Uploading needs `CLOUDINARY_URL` (`cloudinary://API_KEY:API_SECRET@CLOUD_NAME`) and `GITHUB_TOKEN`.
+Uploading needs `GITHUB_TOKEN` or an authenticated `gh` CLI session. The token must have push access
+to `everruns/everruns`.
 
 ## Non-obvious failures
 

--- a/.agents/skills/ui-screenshots/scripts/check-config.sh
+++ b/.agents/skills/ui-screenshots/scripts/check-config.sh
@@ -1,32 +1,21 @@
 #!/usr/bin/env bash
-# Check if cloud agent is configured for UI screenshots
+# Check if the environment is configured for UI screenshots
 
 MISSING=()
 
 echo "🔍 Checking UI Screenshots configuration..."
 echo ""
 
-# Check GITHUB_TOKEN
+# Check GitHub authentication
 if [ -z "${GITHUB_TOKEN:-}" ]; then
-  MISSING+=("GITHUB_TOKEN")
-  echo "❌ GITHUB_TOKEN - not set"
-else
-  echo "✅ GITHUB_TOKEN - set"
-fi
-
-# Check CLOUDINARY_URL
-if [ -z "${CLOUDINARY_URL:-}" ]; then
-  MISSING+=("CLOUDINARY_URL")
-  echo "❌ CLOUDINARY_URL - not set"
-else
-  # Validate format
-  if [[ "$CLOUDINARY_URL" =~ ^cloudinary://[^:]+:[^@]+@.+$ ]]; then
-    CLOUD_NAME="${CLOUDINARY_URL##*@}"
-    echo "✅ CLOUDINARY_URL - set (cloud: $CLOUD_NAME)"
+  if command -v gh &> /dev/null && gh auth token &> /dev/null; then
+    echo "✅ GitHub authentication - gh auth token"
   else
-    MISSING+=("CLOUDINARY_URL (invalid format)")
-    echo "❌ CLOUDINARY_URL - invalid format (expected: cloudinary://API_KEY:API_SECRET@CLOUD_NAME)"
+    MISSING+=("GITHUB_TOKEN or authenticated gh CLI")
+    echo "❌ GitHub authentication - unavailable"
   fi
+else
+  echo "✅ GitHub authentication - GITHUB_TOKEN"
 fi
 
 # Check agent-browser
@@ -42,7 +31,7 @@ fi
 echo ""
 
 if [ ${#MISSING[@]} -eq 0 ]; then
-  echo "✅ Cloud agent is configured for UI screenshots"
+  echo "✅ Environment is configured for UI screenshots"
   exit 0
 else
   echo "❌ Missing configuration:"
@@ -50,6 +39,6 @@ else
     echo "   - $item"
   done
   echo ""
-  echo "Add missing secrets to cloud agent environment."
+  echo "Configure the missing dependency or credential."
   exit 1
 fi

--- a/.agents/skills/ui-screenshots/scripts/upload-screenshot.sh
+++ b/.agents/skills/ui-screenshots/scripts/upload-screenshot.sh
@@ -3,13 +3,12 @@ set -euo pipefail
 
 # Upload a screenshot and add a PR comment with the embedded image
 #
-# Uses Cloudinary for image hosting (signed upload)
+# Uses GitHub's user-attachments CDN, the same storage as drag-and-drop uploads.
 #
 # Usage: upload-screenshot.sh <SCREENSHOT_PATH> <PR_NUMBER> [DESCRIPTION]
 #
 # Environment variables:
-#   GITHUB_TOKEN   - Required for PR comments
-#   CLOUDINARY_URL - Cloudinary URL: cloudinary://API_KEY:API_SECRET@CLOUD_NAME
+#   GITHUB_TOKEN - Optional when `gh auth token` is available; must have push access
 #
 # Example:
 #   ./upload-screenshot.sh screenshot.png 195 "Dev components page"
@@ -28,55 +27,49 @@ if [ ! -f "$SCREENSHOT_PATH" ]; then
   exit 1
 fi
 
-if [ -z "${GITHUB_TOKEN:-}" ]; then
-  echo "❌ GITHUB_TOKEN environment variable not set"
-  exit 1
-fi
-
-if [ -z "${CLOUDINARY_URL:-}" ]; then
-  echo "❌ CLOUDINARY_URL environment variable not set"
-  echo "   Format: cloudinary://API_KEY:API_SECRET@CLOUD_NAME"
-  exit 1
-fi
-
-# Parse CLOUDINARY_URL: cloudinary://API_KEY:API_SECRET@CLOUD_NAME
-CLOUDINARY_URL_PARSED="${CLOUDINARY_URL#cloudinary://}"
-API_KEY="${CLOUDINARY_URL_PARSED%%:*}"
-REMAINDER="${CLOUDINARY_URL_PARSED#*:}"
-API_SECRET="${REMAINDER%%@*}"
-CLOUD_NAME="${REMAINDER#*@}"
-
-if [ -z "$API_KEY" ] || [ -z "$API_SECRET" ] || [ -z "$CLOUD_NAME" ]; then
-  echo "❌ Invalid CLOUDINARY_URL format"
-  echo "   Expected: cloudinary://API_KEY:API_SECRET@CLOUD_NAME"
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  TOKEN="$GITHUB_TOKEN"
+elif command -v gh &> /dev/null && TOKEN=$(gh auth token 2>/dev/null); then
+  :
+else
+  echo "❌ Set GITHUB_TOKEN or authenticate the gh CLI"
   exit 1
 fi
 
 FILENAME=$(basename "$SCREENSHOT_PATH")
-TIMESTAMP=$(date +%s)
+CONTENT_TYPE=$(file -b --mime-type "$SCREENSHOT_PATH")
 
 echo "📤 Uploading screenshot: $FILENAME"
 
-# Generate signature for signed upload
-# Parameters must be sorted alphabetically
-PARAMS_TO_SIGN="folder=pr-screenshots&timestamp=${TIMESTAMP}"
-SIGNATURE=$(echo -n "${PARAMS_TO_SIGN}${API_SECRET}" | sha1sum | cut -d' ' -f1)
+REPOSITORY_RESPONSE=$(curl -sS \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/everruns/everruns")
+REPOSITORY_ID=$(echo "$REPOSITORY_RESPONSE" | jq -r '.id // empty')
 
-# Upload to Cloudinary (signed upload)
-echo "   Uploading to Cloudinary..."
-UPLOAD_RESPONSE=$(curl -s -X POST \
-  "https://api.cloudinary.com/v1_1/${CLOUD_NAME}/image/upload" \
-  -F "file=@$SCREENSHOT_PATH" \
-  -F "api_key=${API_KEY}" \
-  -F "timestamp=${TIMESTAMP}" \
-  -F "signature=${SIGNATURE}" \
-  -F "folder=pr-screenshots")
+if [ -z "$REPOSITORY_ID" ]; then
+  echo "❌ Failed to resolve the everruns/everruns repository ID"
+  echo "$REPOSITORY_RESPONSE" | jq .
+  exit 1
+fi
 
-IMAGE_URL=$(echo "$UPLOAD_RESPONSE" | jq -r '.secure_url // empty')
+ENCODED_FILENAME=$(jq -rn --arg value "$FILENAME" '$value | @uri')
+ENCODED_CONTENT_TYPE=$(jq -rn --arg value "$CONTENT_TYPE" '$value | @uri')
+UPLOAD_URL="https://uploads.github.com/user-attachments/assets?name=${ENCODED_FILENAME}&content_type=${ENCODED_CONTENT_TYPE}&repository_id=${REPOSITORY_ID}"
+UPLOAD_RESPONSE=$(curl -sS \
+  -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/json" \
+  --data-binary "@$SCREENSHOT_PATH" \
+  "$UPLOAD_URL")
+
+IMAGE_URL=$(echo "$UPLOAD_RESPONSE" | jq -r '.url // empty')
 
 if [ -z "$IMAGE_URL" ]; then
   echo "❌ Upload failed"
   echo "$UPLOAD_RESPONSE" | jq .
+  echo "   HTTP 422 means unsupported media; HTTP 404 usually means a bad repository ID or no push access."
   exit 1
 fi
 
@@ -93,7 +86,7 @@ COMMENT_BODY="## 📸 UI Screenshot
 
 # Post comment
 COMMENT_RESPONSE=$(curl -s -X POST \
-  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   "https://api.github.com/repos/everruns/everruns/issues/$PR_NUMBER/comments" \

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Problem or motivation.
 
 ## Before / After
 Show the effect with evidence. Include before and after whenever behavior changes —
-CLI/API output, logs, metrics, or screenshots for UI (attach working screenshots
+CLI/API output, logs, metrics, or screenshots/recordings for UI (attach working media
 when possible). For changes with no observable behavior (pure refactor, docs), say so.
 
 ## Risk

--- a/knowledge/project/shipping.md
+++ b/knowledge/project/shipping.md
@@ -70,7 +70,8 @@ rather than running every check mechanically. Whatever set is chosen, the eviden
 - impacted flows were smoke tested against the repository's canonical local startup contract
 - performance impact was considered where relevant: indexes, scans, N+1 patterns, pagination, and
   bounded result sets
-- UI changes were captured as screenshots in validation or PR comments — never committed to the repo
+- UI changes were captured as screenshots or recordings in validation or PR comments — never
+  committed to the repo
 
 ## CI Opt-Out Labels
 


### PR DESCRIPTION
## What
Document the canonical process for publishing PR evidence and update the UI screenshot helper to use GitHub user attachments instead of Cloudinary. The PR template and shipping specification now accept screenshots or recordings.

## Why
Agents had an evidence-quality requirement but no repository-owned procedure for uploading images and video, embedding video correctly, handling upload failures, or keeping proof assets out of product branches.

## Before / After
Before: the ship workflow requested screenshots but did not explain how to publish them, while the screenshot helper required `CLOUDINARY_URL`.

After: the ship reference documents GitHub attachment uploads, visibility and error behavior, image/video embedding, WebM transcoding, Crabbox fallback, and the no-commit rule. The existing screenshot helper keeps its CLI shape while using GitHub authentication and the native attachment CDN.

Validation:
- `just pre-push` — all scoped checks passed
- `just check-okf` — 143 concepts conformant
- `bash -n` and `shellcheck` — both updated scripts passed
- `check-config.sh` — passed with the authenticated GitHub CLI and agent-browser 0.31.1
- `upload-screenshot.sh` offline end-to-end smoke test — verified repository lookup, URL encoding, attachment response parsing, and PR comment generation without publishing user media
- PR CI — affected shell tests, OKF check, CodeQL, policy checks, and aggregate Build Check passed

## Risk
- Low
- Developer-only evidence uploads could fail if GitHub changes the user-attachments endpoint or a token lacks push access; the helper reports the documented failure modes.

## Security
- Threat categories reviewed: TM-AUTH, TM-API, TM-FS
- Findings and resolutions: no findings. Tokens are used only in authorization headers and are not logged; local paths are quoted; filenames and MIME types are URL-encoded; no dependencies were added.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — not applicable; shell and workflow validation cover this developer tooling change
- [x] Backward compatibility considered — the helper CLI is unchanged
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning) — no comments were posted