### PR TITLE
ci(actions): move every action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ard.yml
+++ b/.github/workflows/ard.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -78,7 +78,7 @@ jobs:
       ARD_LIVE_REGISTRY_URL: https://agenticresourcediscovery.org/api/v1
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -89,7 +89,7 @@ jobs:
           shared-key: "debug"
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       # Optional bearer token for the registry. The reference registry is
       # anonymous-read; the token is only used if configured in Doppler.

--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -63,7 +63,7 @@ jobs:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -74,7 +74,7 @@ jobs:
           shared-key: "debug"
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Fetch Brave Search API key from Doppler
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       skip_docker: ${{ steps.ci_opt_outs.outputs.skip_docker }}
       skip_integration_workflows: ${{ steps.ci_opt_outs.outputs.skip_integration_workflows }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check release workflow security
         run: bash scripts/test-release-workflow-security.sh
@@ -131,7 +131,7 @@ jobs:
           set_output skip_docker "ci:skip-docker"
           set_output skip_integration_workflows "ci:skip-integration-workflows"
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: core_filter
         with:
           filters: |
@@ -268,7 +268,7 @@ jobs:
       # Exclusion filters need `predicate-quantifier: every`; with the default
       # `some`, a rule like `!integrations/foo/**/*.md` matches almost every
       # non-markdown file and incorrectly enables the live paid matrix.
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: live_filter
         with:
           predicate-quantifier: every
@@ -300,7 +300,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -316,7 +316,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -334,7 +334,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust MSRV toolchain
         uses: dtolnay/rust-toolchain@1.94.0
@@ -367,7 +367,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.knowledge == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install okf-lint
         run: cargo install okf-lint --version 0.1.1 --locked
@@ -387,7 +387,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check capability contract ownership
         run: bash scripts/lib/check-capability-contract.sh
@@ -403,7 +403,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -421,7 +421,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -440,7 +440,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -458,7 +458,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -478,7 +478,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -497,7 +497,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -515,7 +515,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -533,7 +533,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install pinned rustdoc JSON toolchain
         uses: dtolnay/rust-toolchain@master
@@ -555,7 +555,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -570,7 +570,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -588,7 +588,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check every server test file is run by CI or allowlisted
         run: bash scripts/lib/check-server-test-enumeration.sh
@@ -600,7 +600,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -628,7 +628,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # This job builds the most of any single CI job: provider crates, the full
       # runtime, the CLI, and all integration crates share one target/ dir. Their
@@ -718,7 +718,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -740,7 +740,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.shell == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install shell test dependencies
         run: |
@@ -784,10 +784,10 @@ jobs:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -811,10 +811,10 @@ jobs:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -838,10 +838,10 @@ jobs:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -866,10 +866,10 @@ jobs:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -915,7 +915,7 @@ jobs:
       # and inject DOPPLER_TOKEN via step env below.
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -927,7 +927,7 @@ jobs:
           shared-key: "test"
 
       - name: Cache cargo binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/cargo-binstall
@@ -1030,7 +1030,7 @@ jobs:
       # code (build.rs, proc-macros, test bodies) would see it via env.
       - name: Install Doppler CLI
         if: github.event_name == 'push'
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Run Slack integration tests (real API via Doppler)
         if: github.event_name == 'push'
@@ -1106,7 +1106,7 @@ jobs:
       STORAGE_S3_FORCE_PATH_STYLE: "true"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -1117,7 +1117,7 @@ jobs:
           shared-key: "test"
 
       - name: Cache cargo binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/cargo-binstall
@@ -1195,7 +1195,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -1212,28 +1212,28 @@ jobs:
         run: cargo build --profile release-ci -p everruns-server -p everruns-worker -p everruns-cli
 
       - name: Upload server binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: everruns-server
           path: target/release-ci/everruns-server
           retention-days: 1
 
       - name: Upload worker binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: everruns-worker
           path: target/release-ci/everruns-worker
           retention-days: 1
 
       - name: Upload CLI binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: everruns-cli
           path: target/release-ci/everruns
           retention-days: 1
 
       - name: Upload export-openapi binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: export-openapi
           path: target/release-ci/export-openapi
@@ -1285,7 +1285,7 @@ jobs:
       AUTH_MODE: none
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -1297,7 +1297,7 @@ jobs:
           shared-key: "test"
 
       - name: Cache cargo binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/cargo-binstall
@@ -1317,13 +1317,13 @@ jobs:
         run: sqlx migrate run --source crates/server/migrations
 
       - name: Download server binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: everruns-server
           path: ./bin
 
       - name: Download worker binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: everruns-worker
           path: ./bin
@@ -1403,7 +1403,7 @@ jobs:
       RATE_LIMIT_API_REQUESTS_PER_MINUTE: "0"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Ensure jq is available
         run: |
@@ -1417,13 +1417,13 @@ jobs:
           sudo apt-get install -y jq
 
       - name: Download server binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: everruns-server
           path: ./bin
 
       - name: Download CLI binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: everruns-cli
           path: ./bin
@@ -1464,7 +1464,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Resolve SDK version matrix
         id: matrix
@@ -1493,17 +1493,17 @@ jobs:
       EVERRUNS_BASE_URL: http://localhost:9000
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         if: matrix.language == 'typescript'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Setup Python
         if: matrix.language == 'python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -1512,7 +1512,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Download server binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: everruns-server
           path: ./bin
@@ -1560,10 +1560,10 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Download export-openapi binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: export-openapi
           path: ./bin
@@ -1599,15 +1599,15 @@ jobs:
         working-directory: apps/ui
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -1617,7 +1617,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: apps/ui/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('apps/ui/pnpm-lock.yaml') }}-${{ hashFiles('apps/ui/src/**/*', 'apps/ui/app/**/*') }}
@@ -1654,15 +1654,15 @@ jobs:
         working-directory: apps/ui
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -1672,7 +1672,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('apps/ui/pnpm-lock.yaml') }}
@@ -1687,7 +1687,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: apps/ui/e2e/playwright-report
@@ -1704,22 +1704,22 @@ jobs:
         working-directory: apps/docs
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: apps/docs/pnpm-lock.yaml
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -1799,19 +1799,19 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_docker != 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Download server binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: everruns-server
           path: ./bin
 
       - name: Download worker binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: everruns-worker
           path: ./bin
@@ -1819,7 +1819,7 @@ jobs:
       # No host chmod needed: Dockerfile.prebuilt uses COPY --chmod, and the
       # image is only built here (never run in CI).
       - name: Build server Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.prebuilt
@@ -1828,7 +1828,7 @@ jobs:
           tags: everruns-server:ci
 
       - name: Build worker Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.prebuilt

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -48,7 +48,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag }}
 
@@ -193,7 +193,7 @@ jobs:
           cat everruns.rb
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
 
       - name: Push formula to homebrew-tap
         env:

--- a/.github/workflows/container-sandbox-integration.yml
+++ b/.github/workflows/container-sandbox-integration.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -64,7 +64,7 @@ jobs:
       CONTAINER_SANDBOX_DOCKER_HOST: http://localhost:2375
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0

--- a/.github/workflows/cursor-integration.yml
+++ b/.github/workflows/cursor-integration.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -58,10 +58,10 @@ jobs:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,18 +52,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # QEMU needed for multi-arch builds (ARM64 cross-compilation)
       - name: Set up QEMU
         if: github.event_name != 'pull_request'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -131,7 +131,7 @@ jobs:
       # --- Server image ---
       - name: Extract metadata (server)
         id: meta-server
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE_BASE }}/everruns-server
           tags: |
@@ -142,7 +142,7 @@ jobs:
             type=raw,value=${{ steps.sha.outputs.sha }}
 
       - name: Build and push server
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: docker/Dockerfile.unified
@@ -157,7 +157,7 @@ jobs:
       # --- Worker image ---
       - name: Extract metadata (worker)
         id: meta-worker
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE_BASE }}/everruns-worker
           tags: |
@@ -168,7 +168,7 @@ jobs:
             type=raw,value=${{ steps.sha.outputs.sha }}
 
       - name: Build and push worker
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: docker/Dockerfile.unified
@@ -184,7 +184,7 @@ jobs:
       - name: Extract metadata (admin)
         if: github.event_name != 'pull_request'
         id: meta-admin
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE_BASE }}/everruns-admin
           tags: |
@@ -196,7 +196,7 @@ jobs:
 
       - name: Build and push admin
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: docker/Dockerfile.unified
@@ -218,17 +218,17 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up QEMU
         if: github.event_name != 'pull_request'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -291,7 +291,7 @@ jobs:
 
       - name: Extract metadata (ui)
         id: meta-ui
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE_BASE }}/everruns-ui
           tags: |
@@ -302,7 +302,7 @@ jobs:
             type=raw,value=${{ steps.sha.outputs.sha }}
 
       - name: Build and push UI
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: apps/ui
           file: apps/ui/Dockerfile

--- a/.github/workflows/duckduckgo-integration.yml
+++ b/.github/workflows/duckduckgo-integration.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0

--- a/.github/workflows/examples-check.yml
+++ b/.github/workflows/examples-check.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0

--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -62,10 +62,10 @@ jobs:
           # See EVE-659.
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -97,7 +97,7 @@ jobs:
             command: cargo test -p everruns-integrations-parallel --features integration
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -128,7 +128,7 @@ jobs:
       CONTAINER_SANDBOX_DOCKER_HOST: http://localhost:2375
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -31,13 +31,13 @@ jobs:
     name: Check Dependency Licenses
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-cargo-deny-registry-
 
       - name: Cache cargo-deny binary
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-deny
           key: ${{ runner.os }}-cargo-deny-${{ env.CARGO_DENY_VERSION }}

--- a/.github/workflows/parallel-integration.yml
+++ b/.github/workflows/parallel-integration.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -64,7 +64,7 @@ jobs:
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
           echo "expected_sha=$DISPATCH_SHA" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/server-worker-binaries.yml
+++ b/.github/workflows/server-worker-binaries.yml
@@ -59,7 +59,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.tag }}
 

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0
@@ -63,10 +63,10 @@ jobs:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
+        uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0


### PR DESCRIPTION
## What changed

Every third-party action used in `.github/workflows/` now runs on the `node24` runtime. GitHub emits a deprecation warning on each step whose action declares `using: node20`, and 13 distinct actions across 16 workflows still did.

| Action | Was | Now |
|---|---|---|
| `actions/setup-node` | v4 | v7 |
| `actions/setup-python` | v5 | v7 |
| `actions/cache` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `dorny/paths-filter` | v3 | v4 |
| `pnpm/action-setup` | v4 | v6 |
| `dopplerhq/cli-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/build-push-action` | v5 | v7 |
| `actions/checkout` | v5 | v7 |

`actions/checkout` was already on `node24` at v5; it moves anyway so the SHA-pinned release workflows stop carrying a two-major-old pin. `Swatinem/rust-cache` stays on v2 — its 2.9.2 head is already `node24` — and `dtolnay/rust-toolchain` is a composite action, so neither warns.

The five SHA-pinned workflows (`release.yml`, `publish-crates.yml`, `server-worker-binaries.yml`, `cli-binaries.yml`, `docker-publish.yml`) keep SHA pinning; only the target SHA and its `# vN` comment change.

## Why

Node 20 reached end-of-life and GitHub Actions now annotates every step running a `node20` action. The warnings are noise on every run today and become hard failures when the runner drops the Node 20 binary.

## Before / After

Resolving every `uses:` reference in the workflow tree to the runtime its upstream `action.yml` declares:

**Before (`origin/main`)** — 13 entries on `node20`:

```
Swatinem/rust-cache                      6323deb102c3 node24
Swatinem/rust-cache                      v2           node24
actions/cache                            v4           node20
actions/checkout                         fbc6f3992d24 node24
actions/checkout                         v5           node24
actions/download-artifact                v4           node20
actions/setup-node                       v4           node20
actions/setup-python                     v5           node20
actions/upload-artifact                  v4           node20
docker/build-push-action                 ca052bb54ab0 node20
docker/build-push-action                 v5           node20
docker/login-action                      c94ce9fb4685 node20
docker/metadata-action                   c299e40c6544 node20
docker/setup-buildx-action               8d2750c68a42 node20
docker/setup-buildx-action               v3           node20
docker/setup-qemu-action                 c7c53464625b node20
dopplerhq/cli-action                     014df23b1329 node20
dopplerhq/cli-action                     v3           node20
dorny/paths-filter                       v3           node20
dtolnay/rust-toolchain                   01ba1edad32c composite
dtolnay/rust-toolchain                   1.94.0       composite
dtolnay/rust-toolchain                   1.96.0       composite
dtolnay/rust-toolchain                   master       composite
pnpm/action-setup                        v4           node20
```

**After (this branch)** — zero:

```
Swatinem/rust-cache                      6323deb102c3 node24
Swatinem/rust-cache                      v2           node24
actions/cache                            v6           node24
actions/checkout                         3d3c42e5aac5 node24
actions/checkout                         v7           node24
actions/download-artifact                v8           node24
actions/setup-node                       v7           node24
actions/setup-python                     v7           node24
actions/upload-artifact                  v7           node24
docker/build-push-action                 53b7df96c91f node24
docker/build-push-action                 v7           node24
docker/login-action                      dbcb813823bd node24
docker/metadata-action                   dc8028041006 node24
docker/setup-buildx-action               bb05f3f5519d node24
docker/setup-buildx-action               v4           node24
docker/setup-qemu-action                 96fe6ef7f335 node24
dopplerhq/cli-action                     4819d808ab99 node24
dopplerhq/cli-action                     v4           node24
dorny/paths-filter                       v4           node24
dtolnay/rust-toolchain                   01ba1edad32c composite
dtolnay/rust-toolchain                   1.94.0       composite
dtolnay/rust-toolchain                   1.96.0       composite
dtolnay/rust-toolchain                   master       composite
pnpm/action-setup                        v6           node24
```

Compatibility was checked by diffing the `inputs` map of each action between the old and new major, not assumed:

- Only removals anywhere were `actions/setup-node.always-auth` and `docker/setup-buildx-action.{config,config-inline,install}`. None are used in this repo.
- `actions/checkout` v7 blocks fork checkout under `pull_request_target` and `workflow_run`. No workflow here uses either trigger.
- `pnpm/action-setup` v6 still accepts `version:`, which stays required here because there is no root `package.json` carrying `packageManager`.
- `dorny/paths-filter` v4 only widens `predicate-quantifier`; existing filter definitions are unaffected.

Other evidence:

- `actionlint 1.7.7` clean across all 16 workflows (exit 0).
- All 16 workflows parse as YAML.
- Every SHA pin verified to equal its commented tag upstream via `git ls-remote` (8/8 OK).
- `bash scripts/lib/check-migration-ordering.sh` → `migrations sequential (001..120)`; neither this branch nor `origin/main` touched `crates/server/migrations/` since the merge base.

`just pre-push` was not run — `just` is not installed in this environment. The checks above cover the changed surface, and CI on this PR exercises the workflows directly, which is the real proof.

## Risk

- **Medium**
- Multi-major bumps can carry undocumented runtime behavior changes even when the input surface is unchanged. The blast radius is CI itself, and this PR's own run exercises most of it: checkout, paths-filter, cache, setup-node/python, pnpm, upload/download-artifact, and the Docker build path all execute on PR triggers.
- Not covered by PR CI, and therefore the residual risk: the push/tag-only release paths — `release.yml`, `publish-crates.yml`, `server-worker-binaries.yml`, `cli-binaries.yml`, and the credentialed publish jobs in `docker-publish.yml`. Their action set is a subset of what PR CI runs, except `dopplerhq/cli-action@v4` in `cli-binaries.yml`, which PR CI does reach through other workflows.

## Security

- **Threat categories reviewed:** TM-CI (CI / build pipeline). This is a config-only change to `.github/workflows/`, which the threat model treats as part of the trust boundary. No application code, no secret scoping, no trigger conditions, and no job/step `if:` guards changed — the diff is `uses:` lines only, so TM-CI-001 through TM-CI-007 are untouched.
- **Findings and resolutions:**
  - TM-CI-008 requires third-party actions in the write-scoped publish workflows to be pinned to reviewed commit SHAs. The mitigation still holds: `cli-binaries.yml` and `docker-publish.yml` remain fully SHA-pinned, and each new SHA was resolved from the upstream tag with `git ls-remote` and re-verified after editing (8/8 match). No pin was converted to a mutable tag.
  - Supply-chain note: moving a pin to a newer upstream commit means trusting new upstream code. Mitigated by pinning to immutable SHAs of published release tags from first-party (`actions/`, `docker/`, `pnpm/`) or previously-trusted vendors, with no vendor added or removed.
  - `actions/checkout` v7 is a net security improvement here: it blocks fork-PR checkout under `pull_request_target`/`workflow_run`, closing a class of pwn-request footgun ahead of anyone adding such a trigger.
- No threat-model update needed: no new threat, and no mitigation changed in kind.

## Follow-ups

- `pnpm/action-setup` is in maintenance — upstream now points to `pnpm/setup` for pnpm v11+. This repo pins pnpm 10.33.0, so `action-setup` remains correct; migrating is a separate change that belongs with a pnpm 11 bump.
- `.github/dependabot.yml` has no `github-actions` ecosystem entry, which is why these pins drifted this far unattended. Adding one is a policy decision (it would open weekly PRs against SHA-pinned release workflows) and out of scope here.

## Checklist

- [x] Tests added or updated — n/a; no test surface. CI running these workflows is the test.
- [x] Backward compatibility considered — input surfaces diffed across every major bump; removed inputs confirmed unused.
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — no `ci:skip-*` labels applied.
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeJ9UVEAsnwTg8ZAij43Gg)_