### PR TITLE
refactor(engine): split reason execution states

### DIFF
--- a/crates/engine/src/execution/reason.rs
+++ b/crates/engine/src/execution/reason.rs
@@ -18,53 +18,68 @@
 
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
-use sha2::{Digest, Sha256};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 use uuid::Uuid;
 
 use super::ExecutionContext;
-use crate::annotation_hook::{
-    AnnotationProvider, VerifierProvider, collect_annotations, verify_annotations,
-};
+use crate::annotation_hook::{collect_annotations, verify_annotations};
 use crate::capabilities::CapabilityRegistry;
-use crate::compact::{CompactRequest, messages_to_compact_input};
-use crate::driver_registry::{
-    LlmCompletionMetadata, LlmMessage, LlmMessageContent, LlmMessageRole, LlmStreamEvent,
-};
+use crate::driver_registry::{LlmMessage, LlmMessageContent, LlmMessageRole, LlmStreamEvent};
 use crate::error::{AgentLoopError, Result};
 use crate::events::{
-    CapabilityUsageData, CapabilityUsageKind, CapabilityUsageRecord, EventContext, EventRequest,
-    LlmCompactionInfo, LlmGenerationData, LlmPromptCacheInfo, LlmRequestOptions, LlmRetryInfo,
-    LlmToolSearchInfo, OutputMessageCompletedData, OutputMessageDeltaData,
-    OutputMessageReplacedData, OutputMessageStartedData, ReasonCompletedData, ReasonItemData,
-    ReasonRecoveredData, ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,
+    CapabilityUsageData, EventContext, EventRequest, LlmCompactionInfo, LlmGenerationData,
+    LlmRetryInfo, OutputMessageCompletedData, OutputMessageDeltaData, OutputMessageReplacedData,
+    OutputMessageStartedData, ReasonCompletedData, ReasonItemData, ReasonRecoveredData,
+    ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,
     ReasonThinkingStartedData, RecoveryMode, TokenUsage, ToolDefinitionSummary,
-    TranscriptRepairAction, TranscriptRepairedData,
 };
 use crate::llm_retry::{
-    LlmRetryConfig, RetryMetadata, is_transient_error_message, is_transient_stream_error,
-    remaining_retry_time, reserve_retry_wait,
+    LlmRetryConfig, RetryMetadata, is_transient_error_message, remaining_retry_time,
+    reserve_retry_wait,
 };
 use crate::message::{Message, MessageRole};
 use crate::message_retriever::MessageRetriever;
 use crate::output_guardrail::{
-    ArmedGuardrail, OutputGuardrailContext, PostGenerationOutputContext, PostGenerationProvider,
-    TrippedGuardrail, evaluate_guardrails, evaluate_post_generation_guardrails,
-    post_generation_guardrail_text,
+    ArmedGuardrail, OutputGuardrailContext, PostGenerationOutputContext, evaluate_guardrails,
+    evaluate_post_generation_guardrails, post_generation_guardrail_text,
 };
 use crate::phase_effects::{PhaseEffectEmitter, PhaseEffectSink};
 use crate::runtime_context::{AssembledTurnContext, TurnContextRequest, TurnContextResolver};
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::typed_id::{AgentId, HarnessId, MessageId, SessionId};
-use crate::{ErrorDisclosure, UserFacingError, UserFacingErrorContext, user_facing_error_codes};
+use crate::{ErrorDisclosure, UserFacingError, UserFacingErrorContext};
 use crate::{
-    durability::DurableToolCallStatus, durability::DurableToolResultStore,
-    durability::PartialStreamState, durability::PartialStreamStore, event_emitter::EventEmitter,
-    image_services::ImageResolver, image_services::ResolvedImage,
+    durability::DurableToolResultStore, durability::PartialStreamState,
+    durability::PartialStreamStore, event_emitter::EventEmitter, image_services::ImageResolver,
+    image_services::ResolvedImage,
 };
+
+mod compaction;
+mod error_policy;
+mod observability;
+mod output_hooks;
+mod request_controls;
+mod stream_state;
+mod transcript;
+
+use compaction::{
+    ProactiveCompactionContext, ReactiveCompactionContext, apply_proactive_compaction,
+    apply_reactive_compaction,
+};
+use error_policy::{
+    error_disclosure_override, filter_response_text, is_error_placeholder_message,
+    resolve_error_disclosure,
+};
+use observability::{build_request_options, capability_usage_snapshot_records};
+use output_hooks::collect_output_hooks;
+use request_controls::resolve_request_controls;
+use stream_state::{
+    StreamReplayState, StreamTermination, advances_stall_deadline, append_guarded_thinking_delta,
+    merge_retry_metadata,
+};
+use transcript::repair_dangling_tool_calls;
 
 // ============================================================================
 // Helper Functions
@@ -100,382 +115,12 @@ async fn apply_finalized_tool_calls_hooks(
     }
 }
 
-/// Repair dangling tool calls (EVE-533): for every assistant tool_call with no matching
-/// ToolResult, synthesize a well-formed result so the next LLM call does not reject the
-/// transcript. Consults `durable_tool_results` (EVE-530) when available:
-///
-/// - `Settled` row found   → replay the stored result directly.
-/// - `Interrupted` row     → replay the stored interrupted error.
-/// - `Running` (stale)     → synthesize an "interrupted – uncertain – do not retry" placeholder.
-/// - Row not found         → synthesize an "interrupted – not executed – safe to retry" placeholder.
-/// - Store error           → synthesize an "interrupted – status unknown – do not retry" placeholder.
-///
-/// Emits `transcript.repaired` events via `event_emitter` for each repaired call.
-async fn repair_dangling_tool_calls(
-    messages: &[Message],
-    durable_store: Option<&dyn DurableToolResultStore>,
-    event_emitter: &dyn EventEmitter,
-    session_id: crate::typed_id::SessionId,
-    event_context: &EventContext,
-    turn_id: &str,
-) -> Vec<Message> {
-    let mut result = Vec::new();
-
-    for (i, msg) in messages.iter().enumerate() {
-        result.push(msg.clone());
-
-        if msg.role != MessageRole::Agent || !msg.has_tool_calls() {
-            continue;
-        }
-
-        for tc in msg.tool_calls() {
-            let has_result = messages[(i + 1)..]
-                .iter()
-                .any(|m| m.role == MessageRole::ToolResult && m.tool_call_id() == Some(&tc.id));
-
-            if has_result {
-                continue;
-            }
-
-            // Consult durable_tool_results to determine the best repair strategy.
-            let (repair_msg, action) = if let Some(store) = durable_store {
-                match store.get_tool_call_status(turn_id, &tc.id).await {
-                    Ok(Some(DurableToolCallStatus::Settled { result_json })) => {
-                        // A settled result exists in durable storage; deserialize and replay it.
-                        let repair = match serde_json::from_value::<crate::tool_types::ToolResult>(
-                            result_json.clone(),
-                        ) {
-                            Ok(tr) => Message::tool_result(&tc.id, tr.result, tr.error),
-                            Err(_) => Message::tool_result(&tc.id, Some(result_json), None),
-                        };
-                        (repair, TranscriptRepairAction::Replay)
-                    }
-                    Ok(Some(DurableToolCallStatus::Interrupted { result_json })) => {
-                        // Settled as interrupted by a prior recovery.
-                        let err = result_json
-                            .as_ref()
-                            .and_then(|v| {
-                                serde_json::from_value::<crate::tool_types::ToolResult>(v.clone())
-                                    .ok()
-                            })
-                            .and_then(|tr| tr.error)
-                            .unwrap_or_else(|| {
-                                "tool execution did not complete before recovery; result unknown"
-                                    .to_string()
-                            });
-                        (
-                            Message::tool_result(&tc.id, None, Some(err)),
-                            TranscriptRepairAction::Replay,
-                        )
-                    }
-                    Ok(Some(DurableToolCallStatus::Running)) => {
-                        // Stale running claim from a dead worker; safe to synthesize.
-                        (
-                            Message::tool_result(
-                                &tc.id,
-                                None,
-                                Some(
-                                    "interrupted - tool execution was interrupted by worker \
-                                     failure and the result is uncertain; do not retry \
-                                     automatically"
-                                        .to_string(),
-                                ),
-                            ),
-                            TranscriptRepairAction::Synthesize,
-                        )
-                    }
-                    Ok(None) => {
-                        // No durable record: tool was never dispatched before recovery.
-                        (
-                            Message::tool_result(
-                                &tc.id,
-                                None,
-                                Some(
-                                    "interrupted - tool was not executed before recovery; \
-                                     safe to retry"
-                                        .to_string(),
-                                ),
-                            ),
-                            TranscriptRepairAction::Synthesize,
-                        )
-                    }
-                    Err(e) => {
-                        // Store temporarily unavailable: we cannot know whether the tool ran.
-                        tracing::warn!(
-                            tool_call_id = %tc.id,
-                            error = %e,
-                            "transcript repair: durable store error; status unknown"
-                        );
-                        (
-                            Message::tool_result(
-                                &tc.id,
-                                None,
-                                Some(
-                                    "interrupted - tool execution status unknown due to \
-                                     store error; do not retry automatically"
-                                        .to_string(),
-                                ),
-                            ),
-                            TranscriptRepairAction::Synthesize,
-                        )
-                    }
-                }
-            } else {
-                // No durable store; fall back to generic cancelled.
-                (
-                    Message::tool_result(
-                        &tc.id,
-                        None,
-                        Some(
-                            "cancelled - another message came in before it could be completed"
-                                .to_string(),
-                        ),
-                    ),
-                    TranscriptRepairAction::Synthesize,
-                )
-            };
-
-            // Emit transcript.repaired event for observability.
-            let repair_event = EventRequest::new(
-                session_id,
-                event_context.clone(),
-                TranscriptRepairedData {
-                    tool_call_id: tc.id.clone(),
-                    tool_name: Some(tc.name.clone()),
-                    action,
-                },
-            );
-            if let Err(e) = event_emitter.emit(repair_event).await {
-                tracing::warn!(
-                    tool_call_id = %tc.id,
-                    error = %e,
-                    "transcript repair: failed to emit transcript.repaired event"
-                );
-            }
-
-            result.push(repair_msg);
-        }
-    }
-
-    result
-}
-
-/// Known error placeholder texts emitted by the DLQ handler and user_facing_message().
-/// These add no conversational value and inflate subsequent LLM requests.
-const ERROR_PLACEHOLDER_MESSAGES: &[&str] = &[
-    "I encountered an error while processing your request. Please try again later.",
-    "The AI provider is experiencing issues. Please try again shortly.",
-    "Rate limited by the AI provider. Please wait a moment.",
-    "The conversation has become too long for the model to process. Please start a new session or reduce the context size.",
-    "There is a misconfiguration with the AI provider. Please contact support.",
-    "The AI provider account is out of credits or quota. Add credits or raise the provider account limits to continue.",
-];
-
-/// Returns true when a stream event carries assistant output progress.
-fn stream_event_advances_stall_deadline(event: &LlmStreamEvent) -> bool {
-    match event {
-        LlmStreamEvent::TextDelta(delta) | LlmStreamEvent::ThinkingDelta(delta) => {
-            !delta.is_empty()
-        }
-        LlmStreamEvent::ReasonItem {
-            encrypted_content,
-            summary,
-            token_count,
-            ..
-        } => {
-            encrypted_content
-                .as_ref()
-                .is_some_and(|content| !content.is_empty())
-                || summary.iter().any(|item| !item.is_empty())
-                || token_count.is_some_and(|count| count > 0)
-        }
-        LlmStreamEvent::ToolCalls(calls) => !calls.is_empty(),
-        // MessagePhase is a metadata hint, not assistant output progress.
-        LlmStreamEvent::MessagePhase(_)
-        | LlmStreamEvent::ThinkingSignature(_)
-        | LlmStreamEvent::Done(_)
-        | LlmStreamEvent::Error(_) => false,
-    }
-}
-
-/// Retry safety is deliberately narrower than stream progress. Thinking and
-/// signed reasoning can be replayed; answer text and tool calls cannot, because
-/// replay could duplicate user-visible output or side effects. Keep that
-/// classification in one place so new stream variants cannot acquire an
-/// independent flag update in the main reason loop.
-#[derive(Default)]
-struct StreamRetrySafety {
-    has_final_output: bool,
-}
-
-impl StreamRetrySafety {
-    fn observe(&mut self, event: &LlmStreamEvent) {
-        self.has_final_output |= match event {
-            LlmStreamEvent::TextDelta(delta) => !delta.is_empty(),
-            LlmStreamEvent::ToolCalls(calls) => !calls.is_empty(),
-            LlmStreamEvent::ThinkingDelta(_)
-            | LlmStreamEvent::ThinkingSignature(_)
-            | LlmStreamEvent::ReasonItem { .. }
-            | LlmStreamEvent::MessagePhase(_)
-            | LlmStreamEvent::Done(_)
-            | LlmStreamEvent::Error(_) => false,
-        };
-    }
-
-    fn has_final_output(&self) -> bool {
-        self.has_final_output
-    }
-}
-
-fn should_retry_stream_error(
-    error: &crate::driver_registry::LlmStreamError,
-    retry_attempts: u32,
-    max_retries: u32,
-    has_final_output: bool,
-) -> bool {
-    retry_attempts < max_retries && !has_final_output && is_transient_stream_error(error)
-}
-
-fn merge_retry_metadata(
-    existing: Option<RetryMetadata>,
-    additional: &RetryMetadata,
-) -> Option<RetryMetadata> {
-    if !additional.had_retries() {
-        return existing;
-    }
-
-    let mut merged = existing.unwrap_or_default();
-    merged.attempts += additional.attempts;
-    merged.total_retry_wait += additional.total_retry_wait;
-    if additional.last_rate_limit_info.is_some() {
-        merged.last_rate_limit_info = additional.last_rate_limit_info.clone();
-    }
-    Some(merged)
-}
-
 fn unix_now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
 }
-
-/// Returns true if the message is an error placeholder that should be stripped
-/// from the conversation history before sending to the LLM.
-fn is_error_placeholder_message(msg: &Message) -> bool {
-    if msg.role != MessageRole::Agent {
-        return false;
-    }
-    // Must have no tool calls (pure text-only error message)
-    if msg.has_tool_calls() {
-        return false;
-    }
-    if let Some(metadata) = &msg.metadata
-        && let Some(serde_json::Value::String(code)) = metadata.get("error_code")
-    {
-        return matches!(
-            code.as_str(),
-            user_facing_error_codes::BUDGET_EXHAUSTED
-                | user_facing_error_codes::BUDGET_PAUSED
-                | user_facing_error_codes::MODEL_UNAVAILABLE
-                | user_facing_error_codes::REQUEST_TOO_LARGE
-                | user_facing_error_codes::PROVIDER_RATE_LIMITED
-                | user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED
-                | user_facing_error_codes::PROVIDER_MISCONFIGURED
-                | user_facing_error_codes::PROVIDER_QUOTA_EXHAUSTED
-                | user_facing_error_codes::PROVIDER_UNAVAILABLE
-                | user_facing_error_codes::DEPENDENCY_UNAVAILABLE
-                | user_facing_error_codes::PROCESSING_ERROR
-        );
-    }
-    let text = msg.text().unwrap_or("");
-    ERROR_PLACEHOLDER_MESSAGES.contains(&text) || is_dynamic_error_placeholder(text)
-}
-
-fn append_guarded_thinking_delta(
-    armed_guardrails: &mut [ArmedGuardrail],
-    thinking: &mut String,
-    pending_thinking_delta: &mut String,
-    delta: &str,
-) -> Option<TrippedGuardrail> {
-    thinking.push_str(delta);
-
-    // Thinking streams are user-visible and persisted on completion, so they
-    // must pass the same output guardrails as assistant text before any delta
-    // is emitted.
-    if let Some(t) = evaluate_guardrails(armed_guardrails, thinking, delta) {
-        pending_thinking_delta.clear();
-        Some(t)
-    } else {
-        pending_thinking_delta.push_str(delta);
-        None
-    }
-}
-
-/// Per-message error-disclosure override from the most recent user message's
-/// controls (mirrors how reasoning effort is resolved). The value is clamped
-/// against the capability-configured ceiling in `resolve_error_disclosure`.
-fn error_disclosure_override(messages: &[Message]) -> Option<String> {
-    messages
-        .iter()
-        .rev()
-        .find(|m| m.role == MessageRole::User)?
-        .controls
-        .as_ref()?
-        .error_disclosure
-        .clone()
-}
-
-/// Resolve the message-requested disclosure against the ceiling contributed
-/// by the active capability set. The engine consumes the contribution through
-/// the neutral `Capability` contract and does not know the implementation ID.
-fn resolve_error_disclosure(
-    registry: &CapabilityRegistry,
-    configs: &[crate::CapabilityRef],
-    requested: Option<&str>,
-) -> ErrorDisclosure {
-    let ceiling = configs
-        .iter()
-        .find_map(|config| {
-            registry
-                .get(config.capability_id())?
-                .error_disclosure(config.config_value())
-        })
-        .unwrap_or_default();
-
-    // THREAT[TM-LLM-024]: client controls may narrow disclosure but never
-    // widen it beyond the operator-selected capability ceiling.
-    requested
-        .and_then(ErrorDisclosure::parse)
-        .map_or(ceiling, |requested| requested.min(ceiling))
-}
-
-fn filter_response_text(
-    registry: &CapabilityRegistry,
-    configs: &[crate::CapabilityRef],
-    mut text: String,
-) -> String {
-    for config in configs {
-        if let Some(capability) = registry.get(config.capability_id()) {
-            text = capability.filter_response_text(text, config.config_value());
-        }
-    }
-    text
-}
-
-fn is_dynamic_error_placeholder(text: &str) -> bool {
-    (text.starts_with("Budget exhausted.") && text.ends_with("Increase the budget to continue."))
-        || (text.starts_with("Budget paused.")
-            && text.ends_with("Increase or resume the budget to continue."))
-        || (text.starts_with("Budget paused with ")
-            && text.ends_with("Increase or resume the budget to continue."))
-        || (text.starts_with("Soft limit reached.") && text.ends_with("soft limit."))
-        || (text.starts_with("The model `") && text.ends_with("Please select a different model."))
-}
-
-// ============================================================================
-// Input and Output Types
-// ============================================================================
 
 /// Input for ReasonAtom
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -568,324 +213,6 @@ pub struct ReasonResult {
 
 fn default_max_iterations() -> usize {
     500
-}
-
-const CHECKPOINT_REARM_MIN_SUFFIX_MESSAGES: usize = 4;
-const PROACTIVE_RETRY_MIN_TOKEN_GROWTH: u64 = 4_096;
-const PROACTIVE_RETRY_GROWTH_DIVISOR: u64 = 20;
-
-fn proactive_source_fingerprint(
-    provider_opaque_context: Option<&crate::ProviderOpaqueContext>,
-    messages: &[LlmMessage],
-) -> [u8; 32] {
-    let mut input = match provider_opaque_context {
-        Some(crate::ProviderOpaqueContext::OpenResponsesCompact { output }) => {
-            output.iter().map(crate::CompactInputItem::from).collect()
-        }
-        None => Vec::new(),
-    };
-    input.extend(messages_to_compact_input(messages));
-    let bytes = serde_json::to_vec(&input).unwrap_or_default();
-    Sha256::digest(bytes).into()
-}
-
-#[derive(Debug)]
-struct AppliedNativeCompaction {
-    checkpoint_id: Option<String>,
-    input_items_before: usize,
-    output_items_after: usize,
-    tokens_before: Option<u64>,
-    tokens_after: Option<u64>,
-    bytes_before: Option<u64>,
-    bytes_after: Option<u64>,
-    duration_ms: u64,
-    /// Provider-reported cost of the compaction call, when reported (EVE-895).
-    cost_usd: Option<f64>,
-}
-
-fn materially_reduced(before: u64, after: u64) -> bool {
-    const MIN_REDUCTION_UNITS: u64 = 32;
-    let five_percent = before.div_ceil(20);
-    let required_reduction = five_percent.max(MIN_REDUCTION_UNITS).min(before);
-    after < before && before - after >= required_reduction
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn try_apply_native_compaction(
-    chat_driver: &dyn crate::ChatDriver,
-    compaction_policy: &dyn crate::compaction_policy::CompactionPolicy,
-    checkpoint_store: Option<&Arc<dyn crate::CompactionCheckpointStore>>,
-    session_id: SessionId,
-    source_sequence: Option<i64>,
-    provider_type: &str,
-    model: &str,
-    system_prompt: Option<&str>,
-    stateful_response_continuation: bool,
-    llm_messages: &mut Vec<LlmMessage>,
-    llm_config: &mut crate::driver_registry::LlmCallConfig,
-) -> Result<Option<AppliedNativeCompaction>> {
-    if !chat_driver.supports_compact() {
-        return Ok(None);
-    }
-
-    let started = Instant::now();
-    let has_system_prompt = system_prompt.is_some();
-    let messages_to_compact = if has_system_prompt {
-        &llm_messages[1..]
-    } else {
-        &llm_messages[..]
-    };
-    let (mut standalone_input, has_prior_opaque_context) =
-        match llm_config.provider_opaque_context.as_ref() {
-            Some(crate::ProviderOpaqueContext::OpenResponsesCompact { output }) => (
-                output.iter().map(crate::CompactInputItem::from).collect(),
-                true,
-            ),
-            None => (Vec::new(), false),
-        };
-    standalone_input.extend(messages_to_compact_input(messages_to_compact));
-    let input_items_before = standalone_input.len();
-    let local_tokens_before = (!stateful_response_continuation && !has_prior_opaque_context)
-        .then(|| compaction_policy.estimate_total_tokens(messages_to_compact) as u64);
-    let bytes_before = (!stateful_response_continuation || has_prior_opaque_context)
-        .then(|| {
-            serde_json::to_vec(&standalone_input)
-                .ok()
-                .map(|value| value.len() as u64)
-        })
-        .flatten();
-    // Reconstruct standalone input even for a stateful continuation. Compacting
-    // only the previous response handle would omit the fresh request delta, then
-    // clearing that handle for the retry would make the omission permanent.
-    let (input, compact_previous_response_id) = (standalone_input, None);
-
-    let compact_response = match chat_driver
-        .compact(
-            &crate::ProviderEndpoint::default(),
-            CompactRequest {
-                model: model.to_string(),
-                input,
-                previous_response_id: compact_previous_response_id,
-                instructions: system_prompt.map(str::to_string),
-            },
-        )
-        .await
-    {
-        Ok(Some(response)) => response,
-        Ok(None) => return Ok(None),
-        Err(error) => {
-            tracing::warn!(
-                session_id = %session_id,
-                error = %error,
-                "ReasonAtom: native compaction failed"
-            );
-            return Ok(None);
-        }
-    };
-
-    let tokens_before = compact_response
-        .usage
-        .as_ref()
-        .and_then(|usage| usage.input_tokens)
-        .map(u64::from)
-        .or(local_tokens_before);
-    let tokens_after = compact_response
-        .usage
-        .as_ref()
-        .and_then(|usage| usage.output_tokens)
-        .map(u64::from);
-    let cost_usd = compact_response.usage.as_ref().and_then(|usage| usage.cost);
-    let bytes_after = serde_json::to_vec(&compact_response.output)
-        .ok()
-        .map(|value| value.len() as u64);
-    let effective = match (tokens_before, tokens_after) {
-        (Some(before), Some(after)) => materially_reduced(before, after),
-        _ => match (bytes_before, bytes_after) {
-            (Some(before), Some(after)) => materially_reduced(before, after),
-            _ => false,
-        },
-    };
-    if !effective {
-        tracing::info!(
-            session_id = %session_id,
-            ?tokens_before,
-            ?tokens_after,
-            ?bytes_before,
-            ?bytes_after,
-            "ReasonAtom: native compaction produced no material reduction"
-        );
-        return Ok(None);
-    }
-
-    let output_items_after = compact_response.output.len();
-    let opaque_context = crate::driver_registry::ProviderOpaqueContext::OpenResponsesCompact {
-        output: compact_response.output,
-    };
-    let checkpoint_id =
-        if let (Some(store), Some(source_sequence)) = (checkpoint_store, source_sequence) {
-            let id = Uuid::now_v7();
-            let installed = store
-                .install(crate::CompactionCheckpoint {
-                    id,
-                    session_id,
-                    source_sequence,
-                    provider_type: provider_type.to_string(),
-                    model: model.to_string(),
-                    format_version: crate::COMPACTION_CHECKPOINT_FORMAT_VERSION,
-                    payload: crate::CompactionCheckpointPayload::ProviderOpaque {
-                        context: opaque_context.clone(),
-                    },
-                })
-                .await?;
-            if !installed {
-                return Err(AgentLoopError::store(
-                    "a newer compaction checkpoint was installed concurrently",
-                ));
-            }
-            Some(id.to_string())
-        } else {
-            None
-        };
-
-    // Apply only after the durable install succeeds, so checkpoint failures do
-    // not partially mutate the retry request.
-    llm_config.previous_response_id = None;
-    llm_config.provider_opaque_context = Some(opaque_context);
-    llm_messages.retain(|message| message.role == LlmMessageRole::System);
-
-    Ok(Some(AppliedNativeCompaction {
-        checkpoint_id,
-        input_items_before,
-        output_items_after,
-        tokens_before,
-        tokens_after,
-        bytes_before,
-        bytes_after,
-        duration_ms: started.elapsed().as_millis() as u64,
-        cost_usd,
-    }))
-}
-
-fn build_request_options(
-    config: &crate::driver_registry::LlmCallConfig,
-    provider: &str,
-) -> Option<LlmRequestOptions> {
-    let prompt_cache = config
-        .prompt_cache
-        .as_ref()
-        .filter(|cfg| cfg.enabled)
-        .map(|cfg| LlmPromptCacheInfo {
-            enabled: true,
-            strategy: cfg.strategy,
-            provider_mode: match provider {
-                "openai" => Some("prompt_cache_key".to_string()),
-                "anthropic" => Some("cache_control".to_string()),
-                "gemini" => Some(
-                    if cfg.gemini_cached_content.is_some() {
-                        "cached_content"
-                    } else {
-                        "implicit"
-                    }
-                    .to_string(),
-                ),
-                _ => None,
-            },
-        });
-
-    let tool_search = config
-        .tool_search
-        .as_ref()
-        .filter(|cfg| cfg.enabled)
-        .map(|cfg| LlmToolSearchInfo {
-            enabled: true,
-            threshold: cfg.threshold,
-        });
-
-    let mut provider_options = HashMap::new();
-    if provider == "openai" && config.previous_response_id.is_some() {
-        provider_options.insert(
-            "openai".to_string(),
-            json!({ "previous_response_id": true }),
-        );
-    }
-    if provider == "gemini"
-        && config
-            .prompt_cache
-            .as_ref()
-            .filter(|cfg| cfg.enabled)
-            .and_then(|cfg| cfg.gemini_cached_content.as_ref())
-            .is_some()
-    {
-        provider_options.insert("gemini".to_string(), json!({ "cached_content": true }));
-    }
-
-    let request_options = LlmRequestOptions {
-        prompt_cache,
-        tool_search,
-        provider_options,
-        metadata: config.metadata.clone(),
-    };
-
-    (!request_options.is_empty()).then_some(request_options)
-}
-
-fn capability_name_snapshot(registry: &CapabilityRegistry, capability_id: &str) -> Option<String> {
-    registry
-        .get(capability_id)
-        .map(|capability| capability.name().to_string())
-}
-
-fn capability_usage_snapshot_records(
-    registry: &CapabilityRegistry,
-    resolved_capability_configs: &[crate::CapabilityRef],
-    tool_definitions: &[ToolDefinition],
-) -> Vec<CapabilityUsageRecord> {
-    let mut records = Vec::new();
-    let mut seen = BTreeSet::new();
-
-    for config in resolved_capability_configs {
-        let capability_id = config.capability_id().to_string();
-        if seen.insert((
-            "resolved".to_string(),
-            capability_id.clone(),
-            None::<String>,
-        )) {
-            records.push(CapabilityUsageRecord {
-                capability_name: capability_name_snapshot(registry, &capability_id),
-                capability_id,
-                usage_kind: CapabilityUsageKind::Resolved,
-                tool_name: None,
-                usage_count: Some(1),
-                duration_ms: None,
-            });
-        }
-    }
-
-    for tool in tool_definitions {
-        let Some((capability_id, capability_name)) = tool.capability_attribution() else {
-            continue;
-        };
-        let capability_id = capability_id.to_string();
-        let tool_name = tool.name().to_string();
-        if seen.insert((
-            "exposed".to_string(),
-            capability_id.clone(),
-            Some(tool_name.clone()),
-        )) {
-            records.push(CapabilityUsageRecord {
-                capability_name: capability_name
-                    .map(str::to_string)
-                    .or_else(|| capability_name_snapshot(registry, &capability_id)),
-                capability_id,
-                usage_kind: CapabilityUsageKind::Exposed,
-                tool_name: Some(tool_name),
-                usage_count: Some(1),
-                duration_ms: None,
-            });
-        }
-    }
-
-    records
 }
 
 // ============================================================================
@@ -1513,103 +840,12 @@ impl ReasonAtom {
         )
         .await;
 
-        // Collect streaming output guardrail providers contributed by enabled
-        // capabilities. Each tuple carries the contributing capability id, a
-        // borrow of that capability's per-agent config (so arming below doesn't
-        // need a second scan), and the provider itself. Capabilities that
-        // contribute no guardrails — the common case — are skipped at zero
-        // allocation cost.
-        let guardrail_providers: Vec<(
-            &str,
-            &serde_json::Value,
-            Arc<dyn crate::output_guardrail::OutputGuardrail>,
-        )> = resolved_capability_configs
-            .iter()
-            .filter_map(|cfg| {
-                let cap_id = cfg.capability_id();
-                let cap = self.capability_registry.get(cap_id)?;
-                let guards = cap.output_guardrails();
-                if guards.is_empty() {
-                    return None;
-                }
-                Some(
-                    guards
-                        .into_iter()
-                        .map(move |g| (cap_id, cfg.config_value(), g))
-                        .collect::<Vec<_>>(),
-                )
-            })
-            .flatten()
-            .collect();
-
-        // End-of-message (post-generation) output guardrail providers (EVE-573).
-        // Collected here alongside the streaming providers, but evaluated once
-        // on the finalized assistant message after the stream ends. Capabilities
-        // contribute nothing unless an applicable output check is configured, so
-        // the common case stays free of work.
-        let post_output_providers: Vec<PostGenerationProvider> = resolved_capability_configs
-            .iter()
-            .filter_map(|cfg| {
-                let cap_id = cfg.capability_id();
-                let cap = self.capability_registry.get(cap_id)?;
-                let providers = cap.post_output_guardrails_with_config(cfg.config_value());
-                if providers.is_empty() {
-                    return None;
-                }
-                Some(
-                    providers
-                        .into_iter()
-                        .map(move |provider| PostGenerationProvider {
-                            capability_id: cap_id.to_string(),
-                            provider,
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            })
-            .flatten()
-            .collect();
-
-        // End-of-message citation annotation hooks (see knowledge/runtime-resources/citations.md).
-        // Collected here alongside the guardrail providers; evaluated once on
-        // the finalized final-answer message to attach claim-level citations.
-        // Empty unless a citation capability is configured.
-        let annotation_providers: Vec<AnnotationProvider> = resolved_capability_configs
-            .iter()
-            .filter_map(|cfg| {
-                let cap_id = cfg.capability_id();
-                let cap = self.capability_registry.get(cap_id)?;
-                let providers = cap.post_output_annotation_hooks_with_config(cfg.config_value());
-                if providers.is_empty() {
-                    return None;
-                }
-                Some(
-                    providers
-                        .into_iter()
-                        .map(move |provider| AnnotationProvider {
-                            capability_id: cap_id.to_string(),
-                            provider,
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            })
-            .flatten()
-            .collect();
-
-        // Citation verifiers (see knowledge/runtime-resources/citations.md). Decoupled from the feeds:
-        // run once over the collected annotations to stamp faithfulness verdicts.
-        // Empty unless the citation_verification capability is configured.
-        let citation_verifiers: Vec<VerifierProvider> = resolved_capability_configs
-            .iter()
-            .filter_map(|cfg| {
-                let cap_id = cfg.capability_id();
-                let cap = self.capability_registry.get(cap_id)?;
-                let verifier = cap.citation_verifier_with_config(cfg.config_value())?;
-                Some(VerifierProvider {
-                    capability_id: cap_id.to_string(),
-                    provider: verifier,
-                })
-            })
-            .collect();
+        let output_hooks =
+            collect_output_hooks(&self.capability_registry, &resolved_capability_configs);
+        let guardrail_providers = output_hooks.streaming;
+        let post_output_providers = output_hooks.post_generation;
+        let annotation_providers = output_hooks.annotations;
+        let citation_verifiers = output_hooks.citation_verifiers;
 
         // 7. Create LLM driver using factory
         let chat_driver = Arc::clone(&model_with_provider.driver);
@@ -1655,124 +891,15 @@ impl ReasonAtom {
             restored_checkpoint = Some(checkpoint);
         }
 
-        // 8. Resolve the reasoning effort for THIS LLM step.
-        //    Source priority (re-evaluated on every step so mid-turn changes
-        //    take effect, EVE-595):
-        //      1. The live reasoning-effort handle, when set with a value. A
-        //         tool can mutate this handle mid-turn; because we re-read it on
-        //         each step, the next step in the same turn uses the new value.
-        //      2. Otherwise the latest user message's `controls.reasoning.effort`.
-        //    The chosen value is then gated against the model profile, exactly
-        //    as before, so unsupported `reasoning` params are never sent to
-        //    non-thinking models like gpt-4o-mini.
-        let handle_effort = self
-            .reasoning_effort_handle
-            .as_ref()
-            .and_then(|handle| handle.get());
-        let raw_reasoning_effort = handle_effort.or_else(|| {
-            messages
-                .iter()
-                .rev()
-                .find(|m| m.role == MessageRole::User)
-                .and_then(|m| m.controls.as_ref())
-                .and_then(|c| c.reasoning.as_ref())
-                .and_then(|r| r.effort.clone())
-        });
-        let reasoning_effort = raw_reasoning_effort.filter(|effort| {
-            // Skip "none" — it means "don't use reasoning"
-            if effort.eq_ignore_ascii_case("none") {
-                return false;
-            }
-            // Check model profile; if profile exists and reasoning is false, strip it.
-            // Unknown models (no profile) pass through — let the API decide.
-            let profile = crate::model_profiles::get_model_profile(
-                &model_with_provider.provider_type,
-                &model_with_provider.model,
-            );
-            match profile {
-                Some(p) if !p.reasoning => {
-                    tracing::warn!(
-                        model = %model_with_provider.model,
-                        effort = %effort,
-                        "Stripping reasoning_effort: model does not support reasoning"
-                    );
-                    false
-                }
-                _ => true,
-            }
-        });
-
-        // Resolve the speed (service tier) from the latest user message's
-        // `controls.speed`, gated against the selected model profile. Sending
-        // a tier outside a model's advertised set causes provider-side 400s.
-        // Unknown models pass through — let the API decide.
-        let speed = messages
-            .iter()
-            .rev()
-            .find(|m| m.role == MessageRole::User)
-            .and_then(|m| m.controls.as_ref())
-            .and_then(|c| c.speed.clone())
-            .filter(|speed| {
-                let profile = crate::model_profiles::get_model_profile(
-                    &model_with_provider.provider_type,
-                    &model_with_provider.model,
-                );
-                let Some(p) = profile else {
-                    return true;
-                };
-                let Some(speed_config) = p.speed else {
-                    tracing::warn!(
-                        model = %model_with_provider.model,
-                        speed = %speed,
-                        "Stripping speed: model does not support service tiers"
-                    );
-                    return false;
-                };
-                let supported = speed_config.values.iter().any(|value| {
-                    matches!(
-                        (&value.value, speed.as_str()),
-                        (crate::model::Speed::Flex, "flex")
-                            | (crate::model::Speed::Default, "default")
-                            | (crate::model::Speed::Priority, "priority")
-                    )
-                });
-                if !supported {
-                    tracing::warn!(
-                        model = %model_with_provider.model,
-                        speed = %speed,
-                        "Stripping speed: model does not support requested service tier"
-                    );
-                }
-                supported
-            });
-
-        // Resolve verbosity from the latest user message's `controls.verbosity`,
-        // gated the same way: a model whose profile has no verbosity config
-        // never gets a `verbosity` field (sending it to an unsupported model is
-        // a 400). Unknown models pass through — let the API decide.
-        let verbosity = messages
-            .iter()
-            .rev()
-            .find(|m| m.role == MessageRole::User)
-            .and_then(|m| m.controls.as_ref())
-            .and_then(|c| c.verbosity.clone())
-            .filter(|verbosity| {
-                let profile = crate::model_profiles::get_model_profile(
-                    &model_with_provider.provider_type,
-                    &model_with_provider.model,
-                );
-                match profile {
-                    Some(p) if p.verbosity.is_none() => {
-                        tracing::warn!(
-                            model = %model_with_provider.model,
-                            verbosity = %verbosity,
-                            "Stripping verbosity: model does not support verbosity control"
-                        );
-                        false
-                    }
-                    _ => true,
-                }
-            });
+        let controls = resolve_request_controls(
+            &messages,
+            self.reasoning_effort_handle.as_ref(),
+            &model_with_provider.provider_type,
+            &model_with_provider.model,
+        );
+        let reasoning_effort = controls.reasoning_effort;
+        let speed = controls.speed;
+        let verbosity = controls.verbosity;
 
         // 9. Check for an in-flight partial assistant stream from a previous worker (EVE-532).
         // If found, apply the ContinuePartial recovery policy: finalize from accumulated
@@ -2029,13 +1156,12 @@ impl ReasonAtom {
             let guardrail_id = provider.id().to_string();
             if let Some(run) = provider.arm(&ctx) {
                 armed_guardrails.push(ArmedGuardrail {
-                    capability_id: (*cap_id).to_string(),
+                    capability_id: cap_id.clone(),
                     guardrail_id,
                     run,
                 });
             }
         }
-        let mut tripped: Option<TrippedGuardrail> = None;
         // Blocking post-generation guardrails need the full assistant message
         // before they can decide. When active, withhold text deltas until the
         // seam allows the finalized output so blocked tokens are never emitted
@@ -2121,228 +1247,30 @@ impl ReasonAtom {
         let mut compaction_info: Option<LlmCompactionInfo> = None;
         let mut llm_messages_for_call = llm_messages.clone();
 
-        // 13b. Proactive native compaction. A stateful continuation carries only
-        // the request delta, so its reconstructed transcript is not a valid
-        // pressure signal. A restored checkpoint also stays disarmed until a
-        // meaningful raw suffix has accumulated.
-        if let Some(ref policy) = compaction_policy {
-            use crate::compaction_policy::CompactionStrategy;
-            let settings = policy.settings();
-            let context_window = chat_driver
-                .effective_context_window(&model_with_provider.model)
-                .or_else(|| {
-                    crate::model_profiles::get_model_profile(
-                        &model_with_provider.provider_type,
-                        &model_with_provider.model,
-                    )
-                    .and_then(|profile| profile.limits.map(|limits| limits.context as usize))
-                })
-                .unwrap_or(128_000);
-            let checkpoint_rearmed = restored_checkpoint.is_none()
-                || checkpoint_suffix_message_count >= CHECKPOINT_REARM_MIN_SUFFIX_MESSAGES;
-            let native_strategy = matches!(
-                settings.strategy,
-                CompactionStrategy::Auto | CompactionStrategy::Native
-            );
-            let durable_source_available =
-                self.compaction_checkpoint_store.is_some() && message_source_sequence.is_some();
-            let estimated_tokens_before =
-                policy.estimate_total_tokens(&llm_messages_for_call) as u64;
-            let native_attempt_rearmed = if let (Some(store), Some(source_sequence)) = (
-                self.compaction_checkpoint_store.as_ref(),
-                message_source_sequence,
-            ) {
-                match store
-                    .get_proactive_attempt(
-                        session_id,
-                        model_with_provider.provider_type.as_str(),
-                        &model_with_provider.model,
-                    )
-                    .await
-                {
-                    Ok(attempt) => attempt.is_none_or(|attempt| {
-                        if source_sequence < attempt.source_sequence
-                            || llm_messages_for_call.len() < attempt.input_message_count
-                        {
-                            return true;
-                        }
-                        let same_source_lineage = proactive_source_fingerprint(
-                            llm_config.provider_opaque_context.as_ref(),
-                            &llm_messages_for_call[..attempt.input_message_count],
-                        ) == attempt.source_fingerprint;
-                        if !same_source_lineage {
-                            return true;
-                        }
-                        if source_sequence == attempt.source_sequence {
-                            return false;
-                        }
-                        let required_growth = PROACTIVE_RETRY_MIN_TOKEN_GROWTH
-                            .max(attempt.estimated_input_tokens / PROACTIVE_RETRY_GROWTH_DIVISOR);
-                        estimated_tokens_before.saturating_sub(attempt.estimated_input_tokens)
-                            >= required_growth
-                    }),
-                    Err(error) => {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %error,
-                            "ReasonAtom: proactive compaction attempt watermark lookup failed"
-                        );
-                        true
-                    }
-                }
-            } else {
-                true
-            };
-            let window_pressure =
-                policy.should_compact_proactively(&llm_messages_for_call, context_window);
-            let cost_pressure = policy.should_compact_for_cost(
-                estimated_tokens_before as usize,
-                raw_tool_result_bytes,
-                prior_usage.as_ref(),
-            );
-            let local_pressure = !stateful_response_continuation
-                && checkpoint_rearmed
-                && (window_pressure || cost_pressure);
-            let should_attempt = native_strategy
-                && chat_driver.supports_compact()
-                && durable_source_available
-                && native_attempt_rearmed
-                && local_pressure;
-            let mut native_applied = false;
-
-            if should_attempt {
-                use crate::events::{
-                    CompactionReason, CompactionStepData, ContextCompactedData,
-                    ContextCompactingData,
-                };
-                let messages_before = llm_messages_for_call.len();
-                let input_message_count = llm_messages_for_call.len();
-                let source_fingerprint = proactive_source_fingerprint(
-                    llm_config.provider_opaque_context.as_ref(),
-                    &llm_messages_for_call,
-                );
-                if let Err(error) = self
-                    .compaction_checkpoint_store
-                    .as_ref()
-                    .expect("durable source availability checked above")
-                    .record_proactive_attempt(
-                        session_id,
-                        model_with_provider.provider_type.as_str(),
-                        &model_with_provider.model,
-                        crate::ProactiveCompactionAttempt {
-                            source_sequence: message_source_sequence
-                                .expect("durable source availability checked above"),
-                            estimated_input_tokens: estimated_tokens_before,
-                            input_message_count,
-                            source_fingerprint,
-                        },
-                    )
-                    .await
-                {
-                    tracing::warn!(
-                        session_id = %session_id,
-                        error = %error,
-                        "ReasonAtom: proactive compaction attempt watermark write failed"
-                    );
-                }
-                let _ = self
-                    .event_emitter
-                    .emit(EventRequest::new(
-                        session_id,
-                        streaming_event_context.clone(),
-                        ContextCompactingData {
-                            reason: CompactionReason::ProactiveBudget,
-                            strategy: settings.strategy.to_string(),
-                            messages_before,
-                            tokens_before: Some(estimated_tokens_before),
-                            bytes_before: None,
-                        },
-                    ))
-                    .await;
-
-                if let Some(applied) = try_apply_native_compaction(
-                    chat_driver.as_ref(),
-                    policy.as_ref(),
-                    self.compaction_checkpoint_store.as_ref(),
+        if let Some(policy) = compaction_policy.as_deref() {
+            compaction_info = apply_proactive_compaction(
+                ProactiveCompactionContext {
+                    chat_driver: chat_driver.as_ref(),
+                    policy,
+                    checkpoint_store: self.compaction_checkpoint_store.as_ref(),
+                    event_emitter: self.event_emitter.as_ref(),
+                    event_context: &streaming_event_context,
                     session_id,
                     message_source_sequence,
-                    model_with_provider.provider_type.as_str(),
-                    &model_with_provider.model,
-                    has_system_prompt.then_some(runtime_agent.system_prompt.as_str()),
-                    false,
-                    &mut llm_messages_for_call,
-                    &mut llm_config,
-                )
-                .await?
-                {
-                    native_applied = true;
-                    compaction_info = Some(LlmCompactionInfo::new(
-                        Some(applied.input_items_before as u32),
-                        applied
-                            .tokens_after
-                            .and_then(|value| u32::try_from(value).ok()),
-                        Some(applied.duration_ms),
-                        applied.cost_usd,
-                    ));
-                    let steps = vec![CompactionStepData {
-                        strategy: "native".to_string(),
-                        messages_after: applied.output_items_after,
-                        duration_ms: applied.duration_ms,
-                    }];
-                    let _ = self
-                        .event_emitter
-                        .emit(EventRequest::new(
-                            session_id,
-                            streaming_event_context.clone(),
-                            ContextCompactedData {
-                                checkpoint_id: applied.checkpoint_id,
-                                strategy_used: "native".to_string(),
-                                messages_before,
-                                messages_after: applied.output_items_after,
-                                tokens_before: applied.tokens_before,
-                                tokens_after: applied.tokens_after,
-                                bytes_before: applied.bytes_before,
-                                bytes_after: applied.bytes_after,
-                                duration_ms: applied.duration_ms,
-                                steps,
-                            },
-                        ))
-                        .await;
-                }
-            }
-
-            // Preserve the provider-neutral outbound fallback. This is a model
-            // view optimization only: it does not install a replacement or
-            // claim a successful durable compaction event.
-            if local_pressure && !native_applied {
-                if matches!(
-                    settings.strategy,
-                    CompactionStrategy::Auto | CompactionStrategy::ObservationMasking
-                ) {
-                    let conversation = if has_system_prompt {
-                        &llm_messages_for_call[1..]
-                    } else {
-                        &llm_messages_for_call[..]
-                    };
-                    let masked = policy.apply_observation_masking(conversation);
-                    if masked.masked_count > 0 {
-                        let mut model_view = Vec::new();
-                        if has_system_prompt {
-                            model_view.push(llm_messages_for_call[0].clone());
-                        }
-                        model_view.extend(masked.messages);
-                        llm_messages_for_call = model_view;
-                    }
-                }
-                let budget_tokens = (context_window as f32 * settings.budget_percent) as usize;
-                if policy.estimate_total_tokens(&llm_messages_for_call) > budget_tokens {
-                    llm_messages_for_call = policy.aggressive_trim(
-                        &llm_messages_for_call,
-                        budget_tokens,
-                        has_system_prompt,
-                    );
-                }
-            }
+                    provider_type: model_with_provider.provider_type.as_str(),
+                    model: &model_with_provider.model,
+                    system_prompt: has_system_prompt
+                        .then_some(runtime_agent.system_prompt.as_str()),
+                    stateful_response_continuation,
+                    checkpoint_restored: restored_checkpoint.is_some(),
+                    checkpoint_suffix_message_count,
+                    raw_tool_result_bytes,
+                    prior_usage: prior_usage.as_ref(),
+                },
+                &mut llm_messages_for_call,
+                &mut llm_config,
+            )
+            .await?;
         }
 
         // 14. Process stream with batched output.message.delta emissions
@@ -2364,6 +1292,7 @@ impl ReasonAtom {
             completion_metadata,
             time_to_first_token_ms,
             pending_delta,
+            mut tripped,
         ) = 'stream_attempt: loop {
             let stream_result = if let Some(remaining) =
                 remaining_retry_time(&retry_config, retry_started_at)
@@ -2403,14 +1332,7 @@ impl ReasonAtom {
             let mut stream = match stream_result {
                 Ok(stream) => stream,
                 Err(e) if e.is_request_too_large() => {
-                    // Context too large — run compaction cascade
-                    use crate::compaction_policy::CompactionStrategy;
-                    use crate::events::{
-                        CompactionReason, CompactionStepData, ContextCompactedData,
-                        ContextCompactingData,
-                    };
-
-                    let Some(policy) = compaction_policy.clone() else {
+                    let Some(policy) = compaction_policy.as_deref() else {
                         tracing::warn!(
                             session_id = %session_id,
                             turn_id = %context.turn_id,
@@ -2418,330 +1340,32 @@ impl ReasonAtom {
                         );
                         return Err(e);
                     };
-                    let settings = policy.settings();
-                    let messages_before = llm_messages_for_call.len();
-
-                    tracing::info!(
-                        session_id = %session_id,
-                        turn_id = %context.turn_id,
-                        strategy = %settings.strategy,
-                        messages = messages_before,
-                        "ReasonAtom: context too large, attempting compaction"
-                    );
-
-                    // Emit context.compacting event
-                    let _ = self
-                        .event_emitter
-                        .emit(EventRequest::new(
-                            session_id,
-                            streaming_event_context.clone(),
-                            ContextCompactingData {
-                                reason: CompactionReason::RequestTooLarge,
-                                strategy: settings.strategy.to_string(),
-                                messages_before,
-                                tokens_before: Some(
-                                    policy.estimate_total_tokens(&llm_messages_for_call) as u64,
-                                ),
-                                bytes_before: None,
-                            },
-                        ))
-                        .await;
-
-                    let cascade_start = Instant::now();
-                    let mut steps: Vec<CompactionStepData> = Vec::new();
-                    let mut strategies_used: Vec<String> = Vec::new();
-                    let mut checkpoint_id: Option<String> = None;
-                    let mut tokens_before =
-                        Some(policy.estimate_total_tokens(&llm_messages_for_call) as u64);
-                    let mut tokens_after = None;
-                    let mut bytes_before = None;
-                    let mut bytes_after = None;
-
-                    // Determine which strategies to run based on config
-                    let run_masking = matches!(
-                        settings.strategy,
-                        CompactionStrategy::Auto | CompactionStrategy::ObservationMasking
-                    );
-                    let run_native = matches!(
-                        settings.strategy,
-                        CompactionStrategy::Auto | CompactionStrategy::Native
-                    ) && chat_driver.supports_compact();
-                    let run_summarization = matches!(
-                        settings.strategy,
-                        CompactionStrategy::Auto | CompactionStrategy::Summarization
-                    );
-
-                    // Step 1: Observation masking (free, no LLM call)
-                    if run_masking {
-                        let step_start = Instant::now();
-                        let conversation_msgs = if has_system_prompt {
-                            &llm_messages_for_call[1..]
-                        } else {
-                            &llm_messages_for_call[..]
-                        };
-
-                        let masking_result = policy.apply_observation_masking(conversation_msgs);
-
-                        if masking_result.masked_count > 0 {
-                            let mut new_messages = Vec::new();
-                            if has_system_prompt {
-                                new_messages.push(llm_messages_for_call[0].clone());
-                            }
-                            new_messages.extend(masking_result.messages);
-                            llm_messages_for_call = new_messages;
-
-                            let step_duration = step_start.elapsed().as_millis() as u64;
-                            strategies_used.push("observation_masking".to_string());
-                            steps.push(CompactionStepData {
-                                strategy: "observation_masking".to_string(),
-                                messages_after: llm_messages_for_call.len(),
-                                duration_ms: step_duration,
-                            });
-
-                            tracing::info!(
-                                session_id = %session_id,
-                                masked_count = masking_result.masked_count,
-                                duration_ms = step_duration,
-                                "ReasonAtom: observation masking applied"
-                            );
-                        }
-                    }
-
-                    // Step 2: Native provider compaction
-                    if run_native
-                        && let Some(applied) = try_apply_native_compaction(
-                            chat_driver.as_ref(),
-                            policy.as_ref(),
-                            self.compaction_checkpoint_store.as_ref(),
+                    let outcome = apply_reactive_compaction(
+                        ReactiveCompactionContext {
+                            chat_driver: chat_driver.as_ref(),
+                            policy,
+                            checkpoint_store: self.compaction_checkpoint_store.as_ref(),
+                            event_emitter: self.event_emitter.as_ref(),
+                            event_context: &streaming_event_context,
                             session_id,
                             message_source_sequence,
-                            model_with_provider.provider_type.as_str(),
-                            &model_with_provider.model,
-                            has_system_prompt.then_some(runtime_agent.system_prompt.as_str()),
+                            provider_type: model_with_provider.provider_type.as_str(),
+                            model: &model_with_provider.model,
+                            summarization_model_fallback: &runtime_agent.model,
+                            system_prompt: has_system_prompt
+                                .then_some(runtime_agent.system_prompt.as_str()),
                             stateful_response_continuation,
-                            &mut llm_messages_for_call,
-                            &mut llm_config,
-                        )
-                        .await?
-                    {
-                        compaction_info = Some(LlmCompactionInfo::new(
-                            Some(applied.input_items_before as u32),
-                            applied
-                                .tokens_after
-                                .and_then(|value| u32::try_from(value).ok()),
-                            Some(applied.duration_ms),
-                            applied.cost_usd,
-                        ));
-                        checkpoint_id = applied.checkpoint_id;
-                        tokens_before = applied.tokens_before;
-                        tokens_after = applied.tokens_after;
-                        bytes_before = applied.bytes_before;
-                        bytes_after = applied.bytes_after;
-                        strategies_used.push("native".to_string());
-                        steps.push(CompactionStepData {
-                            strategy: "native".to_string(),
-                            messages_after: applied.output_items_after,
-                            duration_ms: applied.duration_ms,
-                        });
-                    }
-
-                    // Step 3: Summarization (if configured, and native didn't run or isn't available)
-                    // Only run if we haven't done native compaction (which already compressed everything)
-                    if run_summarization && !strategies_used.contains(&"native".to_string()) {
-                        let step_start = Instant::now();
-                        let conversation_msgs = if has_system_prompt {
-                            &llm_messages_for_call[1..]
-                        } else {
-                            &llm_messages_for_call[..]
-                        };
-
-                        // Keep the last few messages verbatim, summarize the rest
-                        let keep_recent = 10.min(conversation_msgs.len());
-                        let to_summarize =
-                            &conversation_msgs[..conversation_msgs.len() - keep_recent];
-                        let recent = &conversation_msgs[conversation_msgs.len() - keep_recent..];
-
-                        if !to_summarize.is_empty() {
-                            let summary_prompt = policy.summarization_prompt();
-                            let messages_text =
-                                policy.format_messages_for_summarization(to_summarize);
-
-                            // Use the LLM to generate a summary
-                            let summary_messages = vec![
-                                LlmMessage {
-                                    role: LlmMessageRole::System,
-                                    content: LlmMessageContent::Text(summary_prompt),
-                                    tool_calls: None,
-                                    tool_call_id: None,
-                                    phase: None,
-                                    thinking: None,
-                                    thinking_signature: None,
-                                },
-                                LlmMessage {
-                                    role: LlmMessageRole::User,
-                                    content: LlmMessageContent::Text(messages_text),
-                                    tool_calls: None,
-                                    tool_call_id: None,
-                                    phase: None,
-                                    thinking: None,
-                                    thinking_signature: None,
-                                },
-                            ];
-
-                            let summary_config = crate::driver_registry::LlmCallConfig {
-                                speed: None,
-                                verbosity: None,
-                                model: settings
-                                    .summarization_model
-                                    .clone()
-                                    .unwrap_or_else(|| runtime_agent.model.clone()),
-                                temperature: Some(0.0),
-                                max_tokens: Some(2000),
-                                tools: vec![],
-                                reasoning_effort: None,
-                                metadata: HashMap::new(),
-                                previous_response_id: None,
-                                provider_opaque_context: None,
-                                tool_search: None,
-                                prompt_cache: None,
-                                openrouter_routing: None,
-                                parallel_tool_calls: None,
-                                volatile_suffix_len: 0,
-                            };
-
-                            match chat_driver
-                                .chat_completion(
-                                    &crate::ProviderEndpoint::default(),
-                                    summary_messages,
-                                    &summary_config,
-                                )
-                                .await
-                            {
-                                Ok(response) => {
-                                    let summary_text = response.text;
-                                    let system_message =
-                                        has_system_prompt.then(|| llm_messages_for_call[0].clone());
-                                    llm_messages_for_call = policy.compose_summary_with_recent(
-                                        system_message,
-                                        &summary_text,
-                                        recent,
-                                    );
-
-                                    let step_duration = step_start.elapsed().as_millis() as u64;
-                                    strategies_used.push("summarization".to_string());
-                                    steps.push(CompactionStepData {
-                                        strategy: "summarization".to_string(),
-                                        messages_after: llm_messages_for_call.len(),
-                                        duration_ms: step_duration,
-                                    });
-
-                                    tracing::info!(
-                                        session_id = %session_id,
-                                        duration_ms = step_duration,
-                                        messages_after = llm_messages_for_call.len(),
-                                        "ReasonAtom: summarization applied"
-                                    );
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        session_id = %session_id,
-                                        error = %e,
-                                        "ReasonAtom: summarization failed, continuing"
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    // Step 4: Aggressive trim (last resort — drop oldest messages)
-                    // Only run if previous strategies didn't reduce context enough.
-                    // Use a generous target (half the estimated original size).
-                    if strategies_used.is_empty()
-                        || llm_messages_for_call.len() > messages_before / 2
-                    {
-                        let step_start = Instant::now();
-                        // Target: keep roughly half the messages by token budget
-                        let estimated_total = policy.estimate_total_tokens(&llm_messages_for_call);
-                        let target = estimated_total / 2;
-                        let trimmed = policy.aggressive_trim(
-                            &llm_messages_for_call,
-                            target,
-                            has_system_prompt,
-                        );
-                        if trimmed.len() < llm_messages_for_call.len() {
-                            llm_messages_for_call = trimmed;
-                            let step_duration = step_start.elapsed().as_millis() as u64;
-                            strategies_used.push("aggressive_trim".to_string());
-                            steps.push(CompactionStepData {
-                                strategy: "aggressive_trim".to_string(),
-                                messages_after: llm_messages_for_call.len(),
-                                duration_ms: step_duration,
-                            });
-                            tracing::info!(
-                                session_id = %session_id,
-                                messages_after = llm_messages_for_call.len(),
-                                "ReasonAtom: aggressive trim applied (last resort)"
-                            );
-                        }
-                    }
-
-                    let cascade_duration = cascade_start.elapsed().as_millis() as u64;
-                    let messages_after = llm_messages_for_call.len();
-                    if tokens_after.is_none() {
-                        tokens_after =
-                            Some(policy.estimate_total_tokens(&llm_messages_for_call) as u64);
-                    }
-                    let effective = match (tokens_before, tokens_after) {
-                        (Some(before), Some(after)) => materially_reduced(before, after),
-                        _ => match (bytes_before, bytes_after) {
-                            (Some(before), Some(after)) => materially_reduced(before, after),
-                            _ => false,
                         },
-                    };
-                    if !effective {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            ?tokens_before,
-                            ?tokens_after,
-                            "ReasonAtom: compaction cascade made no material reduction"
-                        );
+                        &mut llm_messages_for_call,
+                        &mut llm_config,
+                    )
+                    .await?;
+                    let Some(outcome) = outcome else {
                         return Err(e);
+                    };
+                    if outcome.generation_info.is_some() {
+                        compaction_info = outcome.generation_info;
                     }
-
-                    let strategy_used = strategies_used.join("+");
-                    let durable_semantic_compaction = strategies_used
-                        .iter()
-                        .any(|strategy| strategy != "observation_masking");
-                    if durable_semantic_compaction {
-                        let _ = self
-                            .event_emitter
-                            .emit(EventRequest::new(
-                                session_id,
-                                streaming_event_context.clone(),
-                                ContextCompactedData {
-                                    checkpoint_id,
-                                    strategy_used: strategy_used.clone(),
-                                    messages_before,
-                                    messages_after,
-                                    tokens_before,
-                                    tokens_after,
-                                    bytes_before,
-                                    bytes_after,
-                                    duration_ms: cascade_duration,
-                                    steps,
-                                },
-                            ))
-                            .await;
-                    }
-
-                    tracing::info!(
-                        session_id = %session_id,
-                        strategy = %strategy_used,
-                        messages_before,
-                        messages_after,
-                        duration_ms = cascade_duration,
-                        "ReasonAtom: compaction cascade completed, retrying LLM call"
-                    );
 
                     chat_driver
                         .chat_completion_stream(
@@ -2791,8 +1415,8 @@ impl ReasonAtom {
             let mut thinking = String::new();
             let mut thinking_signature: Option<String> = None;
             let mut tool_calls = Vec::new();
-            let mut completion_metadata: Option<LlmCompletionMetadata> = None;
-            let mut stream_retry_safety = StreamRetrySafety::default();
+            let mut termination = StreamTermination::Exhausted;
+            let mut replay_state = StreamReplayState::default();
             let mut pending_delta = String::new();
             let mut pending_thinking_delta = String::new();
             let mut last_delta_emit = Instant::now();
@@ -2844,11 +1468,10 @@ impl ReasonAtom {
                             stall_secs = stall_timeout.as_secs(),
                             "ReasonAtom: provider stream stall timeout"
                         );
-                        if should_retry_stream_error(
+                        if replay_state.should_retry(
                             &stall_error,
                             stream_retry_metadata.attempts,
                             retry_config.max_retries,
-                            stream_retry_safety.has_final_output(),
                         ) {
                             let proposed_wait = retry_config
                                 .calculate_backoff(stream_retry_metadata.attempts);
@@ -2894,9 +1517,9 @@ impl ReasonAtom {
                     },
                 };
                 let event = event?;
-                stream_retry_safety.observe(&event);
-                let advances_stall_deadline = stream_event_advances_stall_deadline(&event);
-                if advances_stall_deadline {
+                replay_state.observe(&event);
+                let advanced_stall_deadline = advances_stall_deadline(&event);
+                if advanced_stall_deadline {
                     stall_sleep
                         .as_mut()
                         .reset(tokio::time::Instant::now() + stall_timeout);
@@ -2939,7 +1562,7 @@ impl ReasonAtom {
                                 "ReasonAtom: output guardrail tripped, replacing assistant message"
                             );
                             pending_delta.clear();
-                            tripped = Some(t);
+                            termination = StreamTermination::GuardrailBlocked(t);
                             break;
                         }
 
@@ -2990,7 +1613,7 @@ impl ReasonAtom {
                                 guardrail_id = %t.guardrail_id,
                                 "ReasonAtom: output guardrail tripped on thinking stream, replacing assistant message"
                             );
-                            tripped = Some(t);
+                            termination = StreamTermination::GuardrailBlocked(t);
                             break;
                         }
                         tracing::debug!(
@@ -3171,7 +1794,7 @@ impl ReasonAtom {
                                 "ReasonAtom: failed to emit reason.thinking.completed event"
                             );
                         }
-                        completion_metadata = Some(*metadata);
+                        termination = StreamTermination::Completed(*metadata);
                         break;
                     }
                     LlmStreamEvent::Error(err) => {
@@ -3192,14 +1815,14 @@ impl ReasonAtom {
                             // Break out of the stream loop and use the output
                             // we already collected. completion_metadata will be
                             // None since we never got a Done event.
+                            termination = StreamTermination::PartialSuccess;
                             break;
                         }
 
-                        if should_retry_stream_error(
+                        if replay_state.should_retry(
                             &err,
                             stream_retry_metadata.attempts,
                             retry_config.max_retries,
-                            stream_retry_safety.has_final_output(),
                         ) {
                             let proposed_wait =
                                 retry_config.calculate_backoff(stream_retry_metadata.attempts);
@@ -3276,6 +1899,7 @@ impl ReasonAtom {
                     last_stream_heartbeat = Instant::now();
                 }
             }
+            let (mut completion_metadata, tripped) = termination.into_parts();
             if let Some(metadata) = completion_metadata.as_mut() {
                 metadata.retry_metadata =
                     merge_retry_metadata(metadata.retry_metadata.take(), &stream_retry_metadata);
@@ -3289,6 +1913,7 @@ impl ReasonAtom {
                 completion_metadata,
                 time_to_first_token_ms,
                 pending_delta,
+                tripped,
             );
         };
         let (mut text, mut thinking, thinking_signature, mut tool_calls) =
@@ -3882,822 +2507,4 @@ impl ReasonAtom {
 // ============================================================================
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::driver_registry::{
-        LlmCallConfig, LlmStreamError, PromptCacheConfig, PromptCacheStrategy,
-    };
-    use std::collections::HashMap;
-
-    #[test]
-    fn material_reduction_requires_five_percent_at_normal_sizes() {
-        assert!(!materially_reduced(1_000, 951));
-        assert!(materially_reduced(1_000, 950));
-    }
-
-    #[test]
-    fn material_reduction_uses_absolute_floor_for_small_sizes() {
-        assert!(!materially_reduced(0, 0));
-        assert!(!materially_reduced(100, 69));
-        assert!(materially_reduced(100, 68));
-    }
-
-    struct BlockWhenDeltaContains {
-        needle: &'static str,
-    }
-
-    impl crate::output_guardrail::OutputGuardrailRun for BlockWhenDeltaContains {
-        fn check(
-            &mut self,
-            _accumulated: &str,
-            delta: &str,
-        ) -> crate::output_guardrail::GuardrailDecision {
-            if delta.contains(self.needle) {
-                crate::output_guardrail::GuardrailDecision::block("test_leak", "[blocked]")
-            } else {
-                crate::output_guardrail::GuardrailDecision::Pass
-            }
-        }
-    }
-
-    fn test_armed_guardrail() -> ArmedGuardrail {
-        ArmedGuardrail {
-            capability_id: "test_capability".to_string(),
-            guardrail_id: "test_guardrail".to_string(),
-            run: Box::new(BlockWhenDeltaContains { needle: "secret" }),
-        }
-    }
-
-    #[test]
-    fn test_append_guarded_thinking_delta_blocks_before_pending_emit() {
-        let mut guardrails = vec![test_armed_guardrail()];
-        let mut thinking = "safe ".to_string();
-        let mut pending = "safe ".to_string();
-
-        let tripped = append_guarded_thinking_delta(
-            &mut guardrails,
-            &mut thinking,
-            &mut pending,
-            "secret instructions",
-        )
-        .expect("thinking delta should trip guardrail");
-
-        assert_eq!(tripped.capability_id, "test_capability");
-        assert_eq!(tripped.guardrail_id, "test_guardrail");
-        assert_eq!(tripped.block.reason_code, "test_leak");
-        assert_eq!(tripped.block.replacement, "[blocked]");
-        assert_eq!(thinking, "safe secret instructions");
-        assert!(pending.is_empty());
-    }
-
-    #[test]
-    fn test_append_guarded_thinking_delta_allows_safe_pending_emit() {
-        let mut guardrails = vec![test_armed_guardrail()];
-        let mut thinking = String::new();
-        let mut pending = String::new();
-
-        let tripped = append_guarded_thinking_delta(
-            &mut guardrails,
-            &mut thinking,
-            &mut pending,
-            "ordinary reasoning",
-        );
-
-        assert!(tripped.is_none());
-        assert_eq!(thinking, "ordinary reasoning");
-        assert_eq!(pending, "ordinary reasoning");
-    }
-
-    #[test]
-    fn test_reason_result_default() {
-        let result = ReasonResult::default();
-        assert!(!result.success);
-        assert!(result.text.is_empty());
-        assert!(result.tool_calls.is_empty());
-        assert!(!result.has_tool_calls);
-        // Default derive gives 0, but serde deserialization gives 100 via default_max_iterations()
-        assert_eq!(result.max_iterations, 0);
-    }
-
-    #[test]
-    fn test_reason_result_serde_default() {
-        // Test that serde uses the default_max_iterations function
-        let json = r#"{"success":true,"text":"","has_tool_calls":false}"#;
-        let result: ReasonResult = serde_json::from_str(json).unwrap();
-        assert_eq!(result.max_iterations, 500);
-    }
-
-    #[test]
-    fn test_capability_usage_snapshot_keeps_resolved_and_exposed_separate() {
-        let registry = CapabilityRegistry::new();
-        let tool = ToolDefinition::Builtin(crate::tool_types::BuiltinTool {
-            name: "demo_tool".to_string(),
-            display_name: None,
-            description: "demo".to_string(),
-            parameters: json!({"type": "object"}),
-            policy: crate::tool_types::ToolPolicy::Auto,
-            category: None,
-            deferrable: crate::tool_types::DeferrablePolicy::default(),
-            hints: crate::tool_types::ToolHints::default(),
-            full_parameters: None,
-        })
-        .with_capability_attribution("cap:demo", Some("Demo Capability"));
-
-        let records = capability_usage_snapshot_records(
-            &registry,
-            &[crate::CapabilityRef::new("current_time")],
-            &[tool],
-        );
-
-        assert!(records.iter().any(|record| {
-            matches!(record.usage_kind, CapabilityUsageKind::Resolved)
-                && record.capability_id == "current_time"
-                && record.tool_name.is_none()
-        }));
-        assert!(records.iter().any(|record| {
-            matches!(record.usage_kind, CapabilityUsageKind::Exposed)
-                && record.capability_id == "cap:demo"
-                && record.tool_name.as_deref() == Some("demo_tool")
-        }));
-    }
-
-    #[test]
-    fn reasoning_only_output_keeps_transient_stall_retryable() {
-        let stall = LlmStreamError::new("provider stream stall: no tokens for 120s");
-
-        // Thinking deltas do not set stream_has_final_output, because retrying
-        // them cannot duplicate an answer or a tool side effect.
-        assert!(should_retry_stream_error(&stall, 0, 2, false));
-        assert!(!should_retry_stream_error(&stall, 2, 2, false));
-        assert!(!should_retry_stream_error(&stall, 0, 2, true));
-    }
-
-    #[test]
-    fn stream_retry_safety_centralizes_the_final_output_boundary() {
-        let mut safety = StreamRetrySafety::default();
-        safety.observe(&LlmStreamEvent::ThinkingDelta("diagnostic".into()));
-        safety.observe(&LlmStreamEvent::ThinkingSignature("signature".into()));
-        assert!(!safety.has_final_output());
-
-        safety.observe(&LlmStreamEvent::TextDelta("answer".into()));
-        assert!(safety.has_final_output());
-
-        let mut tool_safety = StreamRetrySafety::default();
-        tool_safety.observe(&LlmStreamEvent::ToolCalls(vec![ToolCall {
-            id: "call-1".into(),
-            name: "write".into(),
-            arguments: serde_json::json!({}),
-        }]));
-        assert!(tool_safety.has_final_output());
-    }
-
-    #[test]
-    fn stream_stall_deadline_ignores_empty_keepalive_events() {
-        assert!(!stream_event_advances_stall_deadline(
-            &LlmStreamEvent::TextDelta(String::new())
-        ));
-        assert!(!stream_event_advances_stall_deadline(
-            &LlmStreamEvent::ThinkingDelta(String::new())
-        ));
-        assert!(!stream_event_advances_stall_deadline(
-            &LlmStreamEvent::ThinkingSignature("signature".to_string())
-        ));
-        assert!(!stream_event_advances_stall_deadline(
-            &LlmStreamEvent::ReasonItem {
-                provider: "openai".to_string(),
-                model: None,
-                item_id: "item_1".to_string(),
-                encrypted_content: None,
-                summary: vec![String::new()],
-                token_count: Some(0),
-            }
-        ));
-    }
-
-    #[test]
-    fn stream_stall_deadline_advances_on_output_progress() {
-        assert!(stream_event_advances_stall_deadline(
-            &LlmStreamEvent::TextDelta("hello".to_string())
-        ));
-        assert!(stream_event_advances_stall_deadline(
-            &LlmStreamEvent::ThinkingDelta("thinking".to_string())
-        ));
-        assert!(stream_event_advances_stall_deadline(
-            &LlmStreamEvent::ReasonItem {
-                provider: "openai".to_string(),
-                model: Some("gpt-5.4".to_string()),
-                item_id: "item_1".to_string(),
-                encrypted_content: Some("encrypted".to_string()),
-                summary: vec![],
-                token_count: None,
-            }
-        ));
-        assert!(stream_event_advances_stall_deadline(
-            &LlmStreamEvent::ReasonItem {
-                provider: "openai".to_string(),
-                model: None,
-                item_id: "item_2".to_string(),
-                encrypted_content: None,
-                summary: vec!["summary".to_string()],
-                token_count: None,
-            }
-        ));
-        assert!(stream_event_advances_stall_deadline(
-            &LlmStreamEvent::ReasonItem {
-                provider: "openai".to_string(),
-                model: None,
-                item_id: "item_3".to_string(),
-                encrypted_content: None,
-                summary: vec![],
-                token_count: Some(1),
-            }
-        ));
-        assert!(stream_event_advances_stall_deadline(
-            &LlmStreamEvent::ToolCalls(vec![ToolCall {
-                id: "call_1".to_string(),
-                name: "demo".to_string(),
-                arguments: json!({}),
-            }])
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_repair_dangling_tool_calls_no_tool_calls() {
-        use crate::events::EventContext;
-        use crate::typed_id::SessionId;
-        let messages = vec![Message::user("Hello"), Message::assistant("Hi there!")];
-        let emitter = crate::test_fixtures::NoopEventEmitter;
-        let session_id = SessionId::new();
-        let ctx = EventContext::empty();
-        let patched =
-            repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01")
-                .await;
-        assert_eq!(patched.len(), 2);
-    }
-
-    #[tokio::test]
-    async fn test_repair_dangling_tool_calls_with_result() {
-        use crate::events::EventContext;
-        use crate::typed_id::SessionId;
-        let tool_call = ToolCall {
-            id: "call_123".to_string(),
-            name: "get_weather".to_string(),
-            arguments: serde_json::json!({"city": "NYC"}),
-        };
-
-        let messages = vec![
-            Message::user("What's the weather?"),
-            Message::assistant_with_tools("Let me check", vec![tool_call]),
-            Message::tool_result("call_123", Some(serde_json::json!({"temp": 72})), None),
-        ];
-
-        let emitter = crate::test_fixtures::NoopEventEmitter;
-        let session_id = SessionId::new();
-        let ctx = EventContext::empty();
-        let patched =
-            repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01")
-                .await;
-        assert_eq!(patched.len(), 3);
-    }
-
-    #[tokio::test]
-    async fn test_repair_dangling_tool_calls_missing_result_no_store() {
-        use crate::events::EventContext;
-        use crate::typed_id::SessionId;
-        let tool_call = ToolCall {
-            id: "call_456".to_string(),
-            name: "search_web".to_string(),
-            arguments: serde_json::json!({"query": "rust"}),
-        };
-
-        let messages = vec![
-            Message::user("Search for rust"),
-            Message::assistant_with_tools("Searching...", vec![tool_call]),
-            Message::user("Actually, never mind"),
-        ];
-
-        let emitter = crate::test_fixtures::NoopEventEmitter;
-        let session_id = SessionId::new();
-        let ctx = EventContext::empty();
-        let patched =
-            repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01")
-                .await;
-        // Should have added a cancelled result
-        assert_eq!(patched.len(), 4);
-        assert_eq!(patched[2].role, MessageRole::ToolResult);
-        assert_eq!(patched[2].tool_call_id(), Some("call_456"));
-    }
-
-    #[tokio::test]
-    async fn test_repair_dangling_tool_calls_settled_result_replayed() {
-        use crate::events::EventContext;
-        use crate::typed_id::SessionId;
-        use crate::{
-            durability::DurableToolCallStatus, durability::DurableToolResultStore,
-            durability::ToolCallClaimResult,
-        };
-
-        struct MockSettledStore;
-        #[async_trait::async_trait]
-        impl DurableToolResultStore for MockSettledStore {
-            async fn try_claim_tool_call(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> crate::error::Result<ToolCallClaimResult> {
-                Ok(ToolCallClaimResult::Claimed {
-                    claim_token: uuid::Uuid::new_v4(),
-                })
-            }
-            async fn settle_tool_call(
-                &self,
-                _: &str,
-                _: &str,
-                _: serde_json::Value,
-                _: &str,
-                _: uuid::Uuid,
-            ) -> crate::error::Result<bool> {
-                Ok(true)
-            }
-            async fn get_tool_call_status(
-                &self,
-                _turn_id: &str,
-                _tool_call_id: &str,
-            ) -> crate::error::Result<Option<DurableToolCallStatus>> {
-                Ok(Some(DurableToolCallStatus::Settled {
-                    result_json: serde_json::json!({
-                        "tool_call_id": "call_789",
-                        "result": {"answer": 42},
-                        "error": null,
-                        "images": null,
-                        "connection_required": null,
-                        "raw_output": null
-                    }),
-                }))
-            }
-        }
-
-        let tool_call = ToolCall {
-            id: "call_789".to_string(),
-            name: "compute".to_string(),
-            arguments: serde_json::json!({"x": 21}),
-        };
-        let messages = vec![
-            Message::user("Compute"),
-            Message::assistant_with_tools("Computing...", vec![tool_call]),
-        ];
-
-        let store = MockSettledStore;
-        let emitter = crate::test_fixtures::NoopEventEmitter;
-        let session_id = SessionId::new();
-        let ctx = EventContext::empty();
-        let patched = repair_dangling_tool_calls(
-            &messages,
-            Some(&store as &dyn DurableToolResultStore),
-            &emitter,
-            session_id,
-            &ctx,
-            "turn_01",
-        )
-        .await;
-
-        // Settled result should be replayed (not cancelled message)
-        assert_eq!(patched.len(), 3);
-        assert_eq!(patched[2].role, MessageRole::ToolResult);
-        assert_eq!(patched[2].tool_call_id(), Some("call_789"));
-    }
-
-    #[tokio::test]
-    async fn test_repair_dangling_tool_calls_interrupted_result_replayed() {
-        use crate::events::EventContext;
-        use crate::typed_id::SessionId;
-        use crate::{
-            durability::DurableToolCallStatus, durability::DurableToolResultStore,
-            durability::ToolCallClaimResult,
-        };
-
-        struct MockInterruptedStore;
-        #[async_trait::async_trait]
-        impl DurableToolResultStore for MockInterruptedStore {
-            async fn try_claim_tool_call(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> crate::error::Result<ToolCallClaimResult> {
-                Ok(ToolCallClaimResult::Claimed {
-                    claim_token: uuid::Uuid::new_v4(),
-                })
-            }
-            async fn settle_tool_call(
-                &self,
-                _: &str,
-                _: &str,
-                _: serde_json::Value,
-                _: &str,
-                _: uuid::Uuid,
-            ) -> crate::error::Result<bool> {
-                Ok(true)
-            }
-            async fn get_tool_call_status(
-                &self,
-                _turn_id: &str,
-                _tool_call_id: &str,
-            ) -> crate::error::Result<Option<DurableToolCallStatus>> {
-                Ok(Some(DurableToolCallStatus::Interrupted {
-                    result_json: None,
-                }))
-            }
-        }
-
-        let tool_call = ToolCall {
-            id: "call_int".to_string(),
-            name: "slow_op".to_string(),
-            arguments: serde_json::json!({}),
-        };
-        let messages = vec![
-            Message::user("Do it"),
-            Message::assistant_with_tools("Doing...", vec![tool_call]),
-        ];
-
-        let store = MockInterruptedStore;
-        let emitter = crate::test_fixtures::NoopEventEmitter;
-        let session_id = SessionId::new();
-        let ctx = EventContext::empty();
-        let patched = repair_dangling_tool_calls(
-            &messages,
-            Some(&store as &dyn DurableToolResultStore),
-            &emitter,
-            session_id,
-            &ctx,
-            "turn_01",
-        )
-        .await;
-
-        assert_eq!(patched.len(), 3);
-        let repair = &patched[2];
-        assert_eq!(repair.role, MessageRole::ToolResult);
-        assert_eq!(repair.tool_call_id(), Some("call_int"));
-        // Interrupted replay uses the stored error or fallback text; must contain "interrupted"
-        let content = format!("{:?}", repair);
-        assert!(
-            content.contains("interrupted") || content.contains("not complete"),
-            "expected interrupted message, got: {content}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_repair_dangling_tool_calls_running_synthesized() {
-        use crate::events::EventContext;
-        use crate::typed_id::SessionId;
-        use crate::{
-            durability::DurableToolCallStatus, durability::DurableToolResultStore,
-            durability::ToolCallClaimResult,
-        };
-
-        struct MockRunningStore;
-        #[async_trait::async_trait]
-        impl DurableToolResultStore for MockRunningStore {
-            async fn try_claim_tool_call(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> crate::error::Result<ToolCallClaimResult> {
-                Ok(ToolCallClaimResult::Claimed {
-                    claim_token: uuid::Uuid::new_v4(),
-                })
-            }
-            async fn settle_tool_call(
-                &self,
-                _: &str,
-                _: &str,
-                _: serde_json::Value,
-                _: &str,
-                _: uuid::Uuid,
-            ) -> crate::error::Result<bool> {
-                Ok(true)
-            }
-            async fn get_tool_call_status(
-                &self,
-                _turn_id: &str,
-                _tool_call_id: &str,
-            ) -> crate::error::Result<Option<DurableToolCallStatus>> {
-                Ok(Some(DurableToolCallStatus::Running))
-            }
-        }
-
-        let tool_call = ToolCall {
-            id: "call_run".to_string(),
-            name: "long_job".to_string(),
-            arguments: serde_json::json!({}),
-        };
-        let messages = vec![
-            Message::user("Start job"),
-            Message::assistant_with_tools("Starting...", vec![tool_call]),
-        ];
-
-        let store = MockRunningStore;
-        let emitter = crate::test_fixtures::NoopEventEmitter;
-        let session_id = SessionId::new();
-        let ctx = EventContext::empty();
-        let patched = repair_dangling_tool_calls(
-            &messages,
-            Some(&store as &dyn DurableToolResultStore),
-            &emitter,
-            session_id,
-            &ctx,
-            "turn_01",
-        )
-        .await;
-
-        assert_eq!(patched.len(), 3);
-        let repair = &patched[2];
-        assert_eq!(repair.role, MessageRole::ToolResult);
-        assert_eq!(repair.tool_call_id(), Some("call_run"));
-        // Running stale claim must warn "uncertain; do not retry automatically"
-        let content = format!("{:?}", repair);
-        assert!(
-            content.contains("uncertain") || content.contains("do not retry"),
-            "expected uncertain/do-not-retry message, got: {content}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_repair_dangling_tool_calls_store_error_unknown() {
-        use crate::error::AgentLoopError;
-        use crate::events::EventContext;
-        use crate::typed_id::SessionId;
-        use crate::{durability::DurableToolResultStore, durability::ToolCallClaimResult};
-
-        struct MockErrorStore;
-        #[async_trait::async_trait]
-        impl DurableToolResultStore for MockErrorStore {
-            async fn try_claim_tool_call(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &str,
-            ) -> crate::error::Result<ToolCallClaimResult> {
-                Ok(ToolCallClaimResult::Claimed {
-                    claim_token: uuid::Uuid::new_v4(),
-                })
-            }
-            async fn settle_tool_call(
-                &self,
-                _: &str,
-                _: &str,
-                _: serde_json::Value,
-                _: &str,
-                _: uuid::Uuid,
-            ) -> crate::error::Result<bool> {
-                Ok(true)
-            }
-            async fn get_tool_call_status(
-                &self,
-                _turn_id: &str,
-                _tool_call_id: &str,
-            ) -> crate::error::Result<Option<crate::durability::DurableToolCallStatus>>
-            {
-                Err(AgentLoopError::tool("simulated store failure"))
-            }
-        }
-
-        let tool_call = ToolCall {
-            id: "call_err".to_string(),
-            name: "risky_op".to_string(),
-            arguments: serde_json::json!({}),
-        };
-        let messages = vec![
-            Message::user("Do risky op"),
-            Message::assistant_with_tools("On it...", vec![tool_call]),
-        ];
-
-        let store = MockErrorStore;
-        let emitter = crate::test_fixtures::NoopEventEmitter;
-        let session_id = SessionId::new();
-        let ctx = EventContext::empty();
-        let patched = repair_dangling_tool_calls(
-            &messages,
-            Some(&store as &dyn DurableToolResultStore),
-            &emitter,
-            session_id,
-            &ctx,
-            "turn_01",
-        )
-        .await;
-
-        assert_eq!(patched.len(), 3);
-        let repair = &patched[2];
-        assert_eq!(repair.role, MessageRole::ToolResult);
-        assert_eq!(repair.tool_call_id(), Some("call_err"));
-        // Store error must NOT say "safe to retry"
-        let content = format!("{:?}", repair);
-        assert!(
-            !content.contains("safe to retry"),
-            "store error must not say 'safe to retry', got: {content}"
-        );
-        assert!(
-            content.contains("do not retry") || content.contains("status unknown"),
-            "expected do-not-retry/status-unknown message, got: {content}"
-        );
-    }
-
-    #[test]
-    fn test_build_request_options_for_openai_prompt_cache() {
-        let config = LlmCallConfig {
-            speed: None,
-            verbosity: None,
-            model: "gpt-5.4".to_string(),
-            temperature: None,
-            max_tokens: None,
-            tools: vec![],
-            reasoning_effort: None,
-            metadata: HashMap::new(),
-            previous_response_id: Some("resp_123".to_string()),
-            provider_opaque_context: None,
-            tool_search: None,
-            prompt_cache: Some(PromptCacheConfig {
-                enabled: true,
-                strategy: PromptCacheStrategy::Auto,
-                gemini_cached_content: None,
-            }),
-            openrouter_routing: None,
-            parallel_tool_calls: None,
-            volatile_suffix_len: 0,
-        };
-
-        let request_options = build_request_options(&config, "openai").unwrap();
-        assert_eq!(
-            request_options
-                .prompt_cache
-                .and_then(|info| info.provider_mode),
-            Some("prompt_cache_key".to_string())
-        );
-        assert_eq!(
-            request_options.provider_options.get("openai"),
-            Some(&json!({ "previous_response_id": true }))
-        );
-    }
-
-    #[test]
-    fn test_build_request_options_for_gemini_explicit_cache() {
-        let config = LlmCallConfig {
-            speed: None,
-            verbosity: None,
-            model: "gemini-2.5-pro".to_string(),
-            temperature: None,
-            max_tokens: None,
-            tools: vec![],
-            reasoning_effort: None,
-            metadata: HashMap::new(),
-            previous_response_id: None,
-            provider_opaque_context: None,
-            tool_search: None,
-            prompt_cache: Some(PromptCacheConfig {
-                enabled: true,
-                strategy: PromptCacheStrategy::Auto,
-                gemini_cached_content: Some("cachedContents/demo-cache".to_string()),
-            }),
-            openrouter_routing: None,
-            parallel_tool_calls: None,
-            volatile_suffix_len: 0,
-        };
-
-        let request_options = build_request_options(&config, "gemini").unwrap();
-        assert_eq!(
-            request_options
-                .prompt_cache
-                .and_then(|info| info.provider_mode),
-            Some("cached_content".to_string())
-        );
-        assert_eq!(
-            request_options.provider_options.get("gemini"),
-            Some(&json!({ "cached_content": true }))
-        );
-    }
-
-    #[test]
-    fn test_build_request_options_omits_gemini_cache_flag_when_disabled() {
-        let config = LlmCallConfig {
-            speed: None,
-            verbosity: None,
-            model: "gemini-2.5-pro".to_string(),
-            temperature: None,
-            max_tokens: None,
-            tools: vec![],
-            reasoning_effort: None,
-            metadata: HashMap::new(),
-            previous_response_id: None,
-            provider_opaque_context: None,
-            tool_search: None,
-            prompt_cache: Some(PromptCacheConfig {
-                enabled: false,
-                strategy: PromptCacheStrategy::Auto,
-                gemini_cached_content: Some("cachedContents/demo-cache".to_string()),
-            }),
-            openrouter_routing: None,
-            parallel_tool_calls: None,
-            volatile_suffix_len: 0,
-        };
-
-        assert!(build_request_options(&config, "gemini").is_none());
-    }
-
-    #[test]
-    fn system_keys_override_embedder_keys_in_metadata() {
-        // Pins the injection order: embedder keys inserted first, then system
-        // keys overwrite any collision. A harness author cannot shadow session_id,
-        // turn_id, etc. by including them in embedder_metadata.
-        let embedder_metadata: HashMap<String, String> = [
-            ("session_id".to_string(), "attacker_value".to_string()),
-            ("custom_key".to_string(), "custom_value".to_string()),
-        ]
-        .into();
-
-        let mut metadata: HashMap<String, String> = HashMap::new();
-
-        // Inject embedder metadata first (mirrors execute_single_turn logic)
-        for (k, v) in &embedder_metadata {
-            metadata.insert(k.clone(), v.clone());
-        }
-
-        // System key injected second — must overwrite
-        metadata.insert("session_id".to_string(), "real_session_id".to_string());
-
-        assert_eq!(
-            metadata.get("session_id").map(String::as_str),
-            Some("real_session_id"),
-            "system key must overwrite embedder key with same name"
-        );
-        assert_eq!(
-            metadata.get("custom_key").map(String::as_str),
-            Some("custom_value"),
-            "non-colliding embedder key must be preserved"
-        );
-    }
-
-    // =========================================================================
-    // ContinuePartial recovery tests (EVE-532)
-    // =========================================================================
-
-    use crate::test_fixtures::NoopPartialStreamStore;
-    use crate::{durability::PartialStreamState, durability::PartialStreamStore};
-
-    struct MockPartialStore(Option<PartialStreamState>);
-
-    #[async_trait::async_trait]
-    impl PartialStreamStore for MockPartialStore {
-        async fn get_partial_stream(
-            &self,
-            _session_id: crate::typed_id::SessionId,
-            _turn_id: &str,
-        ) -> crate::error::Result<Option<PartialStreamState>> {
-            Ok(self.0.clone())
-        }
-    }
-
-    #[tokio::test]
-    async fn test_noop_partial_stream_store_returns_none() {
-        let store = NoopPartialStreamStore;
-        let result = store
-            .get_partial_stream(crate::typed_id::SessionId::new(), "turn_01")
-            .await
-            .unwrap();
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_partial_stream_store_returns_accumulated_when_partial_exists() {
-        let message_id = MessageId::new();
-        let store = MockPartialStore(Some(PartialStreamState {
-            message_id,
-            accumulated: "partial text so far".to_string(),
-        }));
-        let result = store
-            .get_partial_stream(crate::typed_id::SessionId::new(), "turn_01")
-            .await
-            .unwrap();
-        let partial = result.unwrap();
-        assert_eq!(partial.message_id, message_id);
-        assert_eq!(partial.accumulated, "partial text so far");
-    }
-
-    #[tokio::test]
-    async fn test_partial_stream_store_returns_empty_when_started_no_delta() {
-        let store = MockPartialStore(Some(PartialStreamState {
-            message_id: MessageId::new(),
-            accumulated: String::new(),
-        }));
-        let result = store
-            .get_partial_stream(crate::typed_id::SessionId::new(), "turn_01")
-            .await
-            .unwrap();
-        assert!(result.unwrap().accumulated.is_empty());
-    }
-}
+mod tests;

--- a/crates/engine/src/execution/reason/compaction.rs
+++ b/crates/engine/src/execution/reason/compaction.rs
@@ -1,0 +1,767 @@
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+use uuid::Uuid;
+
+use crate::compact::{CompactRequest, messages_to_compact_input};
+use crate::driver_registry::{LlmMessage, LlmMessageContent, LlmMessageRole};
+use crate::error::{AgentLoopError, Result};
+use crate::event_emitter::EventEmitter;
+use crate::events::{
+    CompactionReason, CompactionStepData, ContextCompactedData, ContextCompactingData,
+    EventContext, EventRequest, LlmCompactionInfo, TokenUsage,
+};
+use crate::typed_id::SessionId;
+
+pub(super) const CHECKPOINT_REARM_MIN_SUFFIX_MESSAGES: usize = 4;
+pub(super) const PROACTIVE_RETRY_MIN_TOKEN_GROWTH: u64 = 4_096;
+pub(super) const PROACTIVE_RETRY_GROWTH_DIVISOR: u64 = 20;
+
+pub(super) fn proactive_source_fingerprint(
+    provider_opaque_context: Option<&crate::ProviderOpaqueContext>,
+    messages: &[LlmMessage],
+) -> [u8; 32] {
+    let mut input = match provider_opaque_context {
+        Some(crate::ProviderOpaqueContext::OpenResponsesCompact { output }) => {
+            output.iter().map(crate::CompactInputItem::from).collect()
+        }
+        None => Vec::new(),
+    };
+    input.extend(messages_to_compact_input(messages));
+    let bytes = serde_json::to_vec(&input).unwrap_or_default();
+    Sha256::digest(bytes).into()
+}
+
+#[derive(Debug)]
+pub(super) struct AppliedNativeCompaction {
+    pub(super) checkpoint_id: Option<String>,
+    pub(super) input_items_before: usize,
+    pub(super) output_items_after: usize,
+    pub(super) tokens_before: Option<u64>,
+    pub(super) tokens_after: Option<u64>,
+    pub(super) bytes_before: Option<u64>,
+    pub(super) bytes_after: Option<u64>,
+    pub(super) duration_ms: u64,
+    /// Provider-reported cost of the compaction call, when reported (EVE-895).
+    pub(super) cost_usd: Option<f64>,
+}
+
+pub(super) fn materially_reduced(before: u64, after: u64) -> bool {
+    const MIN_REDUCTION_UNITS: u64 = 32;
+    let five_percent = before.div_ceil(20);
+    let required_reduction = five_percent.max(MIN_REDUCTION_UNITS).min(before);
+    after < before && before - after >= required_reduction
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn try_apply_native_compaction(
+    chat_driver: &dyn crate::ChatDriver,
+    compaction_policy: &dyn crate::compaction_policy::CompactionPolicy,
+    checkpoint_store: Option<&Arc<dyn crate::CompactionCheckpointStore>>,
+    session_id: SessionId,
+    source_sequence: Option<i64>,
+    provider_type: &str,
+    model: &str,
+    system_prompt: Option<&str>,
+    stateful_response_continuation: bool,
+    llm_messages: &mut Vec<LlmMessage>,
+    llm_config: &mut crate::driver_registry::LlmCallConfig,
+) -> Result<Option<AppliedNativeCompaction>> {
+    if !chat_driver.supports_compact() {
+        return Ok(None);
+    }
+
+    let started = Instant::now();
+    let has_system_prompt = system_prompt.is_some();
+    let messages_to_compact = if has_system_prompt {
+        &llm_messages[1..]
+    } else {
+        &llm_messages[..]
+    };
+    let (mut standalone_input, has_prior_opaque_context) =
+        match llm_config.provider_opaque_context.as_ref() {
+            Some(crate::ProviderOpaqueContext::OpenResponsesCompact { output }) => (
+                output.iter().map(crate::CompactInputItem::from).collect(),
+                true,
+            ),
+            None => (Vec::new(), false),
+        };
+    standalone_input.extend(messages_to_compact_input(messages_to_compact));
+    let input_items_before = standalone_input.len();
+    let local_tokens_before = (!stateful_response_continuation && !has_prior_opaque_context)
+        .then(|| compaction_policy.estimate_total_tokens(messages_to_compact) as u64);
+    let bytes_before = (!stateful_response_continuation || has_prior_opaque_context)
+        .then(|| {
+            serde_json::to_vec(&standalone_input)
+                .ok()
+                .map(|value| value.len() as u64)
+        })
+        .flatten();
+    // Reconstruct standalone input even for a stateful continuation. Compacting
+    // only the previous response handle would omit the fresh request delta, then
+    // clearing that handle for the retry would make the omission permanent.
+    let (input, compact_previous_response_id) = (standalone_input, None);
+
+    let compact_response = match chat_driver
+        .compact(
+            &crate::ProviderEndpoint::default(),
+            CompactRequest {
+                model: model.to_string(),
+                input,
+                previous_response_id: compact_previous_response_id,
+                instructions: system_prompt.map(str::to_string),
+            },
+        )
+        .await
+    {
+        Ok(Some(response)) => response,
+        Ok(None) => return Ok(None),
+        Err(error) => {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %error,
+                "ReasonAtom: native compaction failed"
+            );
+            return Ok(None);
+        }
+    };
+
+    let tokens_before = compact_response
+        .usage
+        .as_ref()
+        .and_then(|usage| usage.input_tokens)
+        .map(u64::from)
+        .or(local_tokens_before);
+    let tokens_after = compact_response
+        .usage
+        .as_ref()
+        .and_then(|usage| usage.output_tokens)
+        .map(u64::from);
+    let cost_usd = compact_response.usage.as_ref().and_then(|usage| usage.cost);
+    let bytes_after = serde_json::to_vec(&compact_response.output)
+        .ok()
+        .map(|value| value.len() as u64);
+    let effective = match (tokens_before, tokens_after) {
+        (Some(before), Some(after)) => materially_reduced(before, after),
+        _ => match (bytes_before, bytes_after) {
+            (Some(before), Some(after)) => materially_reduced(before, after),
+            _ => false,
+        },
+    };
+    if !effective {
+        tracing::info!(
+            session_id = %session_id,
+            ?tokens_before,
+            ?tokens_after,
+            ?bytes_before,
+            ?bytes_after,
+            "ReasonAtom: native compaction produced no material reduction"
+        );
+        return Ok(None);
+    }
+
+    let output_items_after = compact_response.output.len();
+    let opaque_context = crate::driver_registry::ProviderOpaqueContext::OpenResponsesCompact {
+        output: compact_response.output,
+    };
+    let checkpoint_id =
+        if let (Some(store), Some(source_sequence)) = (checkpoint_store, source_sequence) {
+            let id = Uuid::now_v7();
+            let installed = store
+                .install(crate::CompactionCheckpoint {
+                    id,
+                    session_id,
+                    source_sequence,
+                    provider_type: provider_type.to_string(),
+                    model: model.to_string(),
+                    format_version: crate::COMPACTION_CHECKPOINT_FORMAT_VERSION,
+                    payload: crate::CompactionCheckpointPayload::ProviderOpaque {
+                        context: opaque_context.clone(),
+                    },
+                })
+                .await?;
+            if !installed {
+                return Err(AgentLoopError::store(
+                    "a newer compaction checkpoint was installed concurrently",
+                ));
+            }
+            Some(id.to_string())
+        } else {
+            None
+        };
+
+    // Apply only after the durable install succeeds, so checkpoint failures do
+    // not partially mutate the retry request.
+    llm_config.previous_response_id = None;
+    llm_config.provider_opaque_context = Some(opaque_context);
+    llm_messages.retain(|message| message.role == LlmMessageRole::System);
+
+    Ok(Some(AppliedNativeCompaction {
+        checkpoint_id,
+        input_items_before,
+        output_items_after,
+        tokens_before,
+        tokens_after,
+        bytes_before,
+        bytes_after,
+        duration_ms: started.elapsed().as_millis() as u64,
+        cost_usd,
+    }))
+}
+
+pub(super) struct ProactiveCompactionContext<'a> {
+    pub(super) chat_driver: &'a dyn crate::ChatDriver,
+    pub(super) policy: &'a dyn crate::compaction_policy::CompactionPolicy,
+    pub(super) checkpoint_store: Option<&'a Arc<dyn crate::CompactionCheckpointStore>>,
+    pub(super) event_emitter: &'a dyn EventEmitter,
+    pub(super) event_context: &'a EventContext,
+    pub(super) session_id: SessionId,
+    pub(super) message_source_sequence: Option<i64>,
+    pub(super) provider_type: &'a str,
+    pub(super) model: &'a str,
+    pub(super) system_prompt: Option<&'a str>,
+    pub(super) stateful_response_continuation: bool,
+    pub(super) checkpoint_restored: bool,
+    pub(super) checkpoint_suffix_message_count: usize,
+    pub(super) raw_tool_result_bytes: usize,
+    pub(super) prior_usage: Option<&'a TokenUsage>,
+}
+
+pub(super) async fn apply_proactive_compaction(
+    context: ProactiveCompactionContext<'_>,
+    messages: &mut Vec<LlmMessage>,
+    config: &mut crate::driver_registry::LlmCallConfig,
+) -> Result<Option<LlmCompactionInfo>> {
+    use crate::compaction_policy::CompactionStrategy;
+
+    let settings = context.policy.settings();
+    let context_window = context
+        .chat_driver
+        .effective_context_window(context.model)
+        .or_else(|| {
+            crate::model_profiles::get_model_profile(
+                &everruns_provider::DriverId::external(context.provider_type),
+                context.model,
+            )
+            .and_then(|profile| profile.limits.map(|limits| limits.context as usize))
+        })
+        .unwrap_or(128_000);
+    let checkpoint_rearmed = !context.checkpoint_restored
+        || context.checkpoint_suffix_message_count >= CHECKPOINT_REARM_MIN_SUFFIX_MESSAGES;
+    let native_strategy = matches!(
+        settings.strategy,
+        CompactionStrategy::Auto | CompactionStrategy::Native
+    );
+    let durable_source = context
+        .checkpoint_store
+        .zip(context.message_source_sequence);
+    let estimated_tokens_before = context.policy.estimate_total_tokens(messages) as u64;
+    let native_attempt_rearmed = if let Some((store, source_sequence)) = durable_source {
+        match store
+            .get_proactive_attempt(context.session_id, context.provider_type, context.model)
+            .await
+        {
+            Ok(attempt) => attempt.is_none_or(|attempt| {
+                if source_sequence < attempt.source_sequence
+                    || messages.len() < attempt.input_message_count
+                {
+                    return true;
+                }
+                let same_source_lineage = proactive_source_fingerprint(
+                    config.provider_opaque_context.as_ref(),
+                    &messages[..attempt.input_message_count],
+                ) == attempt.source_fingerprint;
+                if !same_source_lineage {
+                    return true;
+                }
+                if source_sequence == attempt.source_sequence {
+                    return false;
+                }
+                let required_growth = PROACTIVE_RETRY_MIN_TOKEN_GROWTH
+                    .max(attempt.estimated_input_tokens / PROACTIVE_RETRY_GROWTH_DIVISOR);
+                estimated_tokens_before.saturating_sub(attempt.estimated_input_tokens)
+                    >= required_growth
+            }),
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %context.session_id,
+                    error = %error,
+                    "ReasonAtom: proactive compaction attempt watermark lookup failed"
+                );
+                true
+            }
+        }
+    } else {
+        true
+    };
+    let window_pressure = context
+        .policy
+        .should_compact_proactively(messages, context_window);
+    let cost_pressure = context.policy.should_compact_for_cost(
+        estimated_tokens_before as usize,
+        context.raw_tool_result_bytes,
+        context.prior_usage,
+    );
+    let local_pressure = !context.stateful_response_continuation
+        && checkpoint_rearmed
+        && (window_pressure || cost_pressure);
+    let should_attempt = native_strategy
+        && context.chat_driver.supports_compact()
+        && durable_source.is_some()
+        && native_attempt_rearmed
+        && local_pressure;
+
+    let applied = if let (true, Some((store, source_sequence))) = (should_attempt, durable_source) {
+        let messages_before = messages.len();
+        let input_message_count = messages.len();
+        let source_fingerprint =
+            proactive_source_fingerprint(config.provider_opaque_context.as_ref(), messages);
+        if let Err(error) = store
+            .record_proactive_attempt(
+                context.session_id,
+                context.provider_type,
+                context.model,
+                crate::ProactiveCompactionAttempt {
+                    source_sequence,
+                    estimated_input_tokens: estimated_tokens_before,
+                    input_message_count,
+                    source_fingerprint,
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                session_id = %context.session_id,
+                error = %error,
+                "ReasonAtom: proactive compaction attempt watermark write failed"
+            );
+        }
+        let _ = context
+            .event_emitter
+            .emit(EventRequest::new(
+                context.session_id,
+                context.event_context.clone(),
+                ContextCompactingData {
+                    reason: CompactionReason::ProactiveBudget,
+                    strategy: settings.strategy.to_string(),
+                    messages_before,
+                    tokens_before: Some(estimated_tokens_before),
+                    bytes_before: None,
+                },
+            ))
+            .await;
+
+        let applied = try_apply_native_compaction(
+            context.chat_driver,
+            context.policy,
+            context.checkpoint_store,
+            context.session_id,
+            context.message_source_sequence,
+            context.provider_type,
+            context.model,
+            context.system_prompt,
+            false,
+            messages,
+            config,
+        )
+        .await?;
+
+        if let Some(applied) = applied.as_ref() {
+            let steps = vec![CompactionStepData {
+                strategy: "native".to_string(),
+                messages_after: applied.output_items_after,
+                duration_ms: applied.duration_ms,
+            }];
+            let _ = context
+                .event_emitter
+                .emit(EventRequest::new(
+                    context.session_id,
+                    context.event_context.clone(),
+                    ContextCompactedData {
+                        checkpoint_id: applied.checkpoint_id.clone(),
+                        strategy_used: "native".to_string(),
+                        messages_before,
+                        messages_after: applied.output_items_after,
+                        tokens_before: applied.tokens_before,
+                        tokens_after: applied.tokens_after,
+                        bytes_before: applied.bytes_before,
+                        bytes_after: applied.bytes_after,
+                        duration_ms: applied.duration_ms,
+                        steps,
+                    },
+                ))
+                .await;
+        }
+        applied
+    } else {
+        None
+    };
+
+    if local_pressure && applied.is_none() {
+        if matches!(
+            settings.strategy,
+            CompactionStrategy::Auto | CompactionStrategy::ObservationMasking
+        ) {
+            let conversation = if context.system_prompt.is_some() {
+                &messages[1..]
+            } else {
+                &messages[..]
+            };
+            let masked = context.policy.apply_observation_masking(conversation);
+            if masked.masked_count > 0 {
+                let mut model_view = Vec::new();
+                if context.system_prompt.is_some() {
+                    model_view.push(messages[0].clone());
+                }
+                model_view.extend(masked.messages);
+                *messages = model_view;
+            }
+        }
+        let budget_tokens = (context_window as f32 * settings.budget_percent) as usize;
+        if context.policy.estimate_total_tokens(messages) > budget_tokens {
+            *messages = context.policy.aggressive_trim(
+                messages,
+                budget_tokens,
+                context.system_prompt.is_some(),
+            );
+        }
+    }
+
+    Ok(applied.map(|applied| {
+        LlmCompactionInfo::new(
+            Some(applied.input_items_before as u32),
+            applied
+                .tokens_after
+                .and_then(|value| u32::try_from(value).ok()),
+            Some(applied.duration_ms),
+            applied.cost_usd,
+        )
+    }))
+}
+
+pub(super) struct ReactiveCompactionContext<'a> {
+    pub(super) chat_driver: &'a dyn crate::ChatDriver,
+    pub(super) policy: &'a dyn crate::compaction_policy::CompactionPolicy,
+    pub(super) checkpoint_store: Option<&'a Arc<dyn crate::CompactionCheckpointStore>>,
+    pub(super) event_emitter: &'a dyn EventEmitter,
+    pub(super) event_context: &'a EventContext,
+    pub(super) session_id: SessionId,
+    pub(super) message_source_sequence: Option<i64>,
+    pub(super) provider_type: &'a str,
+    pub(super) model: &'a str,
+    pub(super) summarization_model_fallback: &'a str,
+    pub(super) system_prompt: Option<&'a str>,
+    pub(super) stateful_response_continuation: bool,
+}
+
+pub(super) struct ReactiveCompactionResult {
+    pub(super) generation_info: Option<LlmCompactionInfo>,
+}
+
+/// Apply the request-too-large recovery cascade as one state transition.
+///
+/// `Ok(None)` means the cascade could not materially reduce the request and
+/// the original provider error must remain authoritative.
+pub(super) async fn apply_reactive_compaction(
+    context: ReactiveCompactionContext<'_>,
+    messages: &mut Vec<LlmMessage>,
+    config: &mut crate::driver_registry::LlmCallConfig,
+) -> Result<Option<ReactiveCompactionResult>> {
+    use crate::compaction_policy::CompactionStrategy;
+
+    let settings = context.policy.settings();
+    let messages_before = messages.len();
+    tracing::info!(
+        session_id = %context.session_id,
+        strategy = %settings.strategy,
+        messages = messages_before,
+        "ReasonAtom: context too large, attempting compaction"
+    );
+
+    let tokens_before = Some(context.policy.estimate_total_tokens(messages) as u64);
+    let _ = context
+        .event_emitter
+        .emit(EventRequest::new(
+            context.session_id,
+            context.event_context.clone(),
+            ContextCompactingData {
+                reason: CompactionReason::RequestTooLarge,
+                strategy: settings.strategy.to_string(),
+                messages_before,
+                tokens_before,
+                bytes_before: None,
+            },
+        ))
+        .await;
+
+    let cascade_start = Instant::now();
+    let mut steps = Vec::new();
+    let mut strategies_used = Vec::new();
+    let mut checkpoint_id = None;
+    let mut generation_info = None;
+    let mut measured_tokens_before = tokens_before;
+    let mut tokens_after = None;
+    let mut bytes_before = None;
+    let mut bytes_after = None;
+    let has_system_prompt = context.system_prompt.is_some();
+
+    let run_masking = matches!(
+        settings.strategy,
+        CompactionStrategy::Auto | CompactionStrategy::ObservationMasking
+    );
+    let run_native = matches!(
+        settings.strategy,
+        CompactionStrategy::Auto | CompactionStrategy::Native
+    ) && context.chat_driver.supports_compact();
+    let run_summarization = matches!(
+        settings.strategy,
+        CompactionStrategy::Auto | CompactionStrategy::Summarization
+    );
+
+    if run_masking {
+        let step_start = Instant::now();
+        let conversation = if has_system_prompt {
+            &messages[1..]
+        } else {
+            &messages[..]
+        };
+        let masked = context.policy.apply_observation_masking(conversation);
+        if masked.masked_count > 0 {
+            let mut model_view = Vec::new();
+            if has_system_prompt {
+                model_view.push(messages[0].clone());
+            }
+            model_view.extend(masked.messages);
+            *messages = model_view;
+
+            let duration_ms = step_start.elapsed().as_millis() as u64;
+            strategies_used.push("observation_masking".to_string());
+            steps.push(CompactionStepData {
+                strategy: "observation_masking".to_string(),
+                messages_after: messages.len(),
+                duration_ms,
+            });
+            tracing::info!(
+                session_id = %context.session_id,
+                masked_count = masked.masked_count,
+                duration_ms,
+                "ReasonAtom: observation masking applied"
+            );
+        }
+    }
+
+    if run_native
+        && let Some(applied) = try_apply_native_compaction(
+            context.chat_driver,
+            context.policy,
+            context.checkpoint_store,
+            context.session_id,
+            context.message_source_sequence,
+            context.provider_type,
+            context.model,
+            context.system_prompt,
+            context.stateful_response_continuation,
+            messages,
+            config,
+        )
+        .await?
+    {
+        generation_info = Some(LlmCompactionInfo::new(
+            Some(applied.input_items_before as u32),
+            applied
+                .tokens_after
+                .and_then(|value| u32::try_from(value).ok()),
+            Some(applied.duration_ms),
+            applied.cost_usd,
+        ));
+        checkpoint_id = applied.checkpoint_id;
+        measured_tokens_before = applied.tokens_before;
+        tokens_after = applied.tokens_after;
+        bytes_before = applied.bytes_before;
+        bytes_after = applied.bytes_after;
+        strategies_used.push("native".to_string());
+        steps.push(CompactionStepData {
+            strategy: "native".to_string(),
+            messages_after: applied.output_items_after,
+            duration_ms: applied.duration_ms,
+        });
+    }
+
+    if run_summarization && !strategies_used.iter().any(|strategy| strategy == "native") {
+        let step_start = Instant::now();
+        let conversation = if has_system_prompt {
+            &messages[1..]
+        } else {
+            &messages[..]
+        };
+        let keep_recent = 10.min(conversation.len());
+        let to_summarize = &conversation[..conversation.len() - keep_recent];
+        let recent = &conversation[conversation.len() - keep_recent..];
+
+        if !to_summarize.is_empty() {
+            let summary_messages = vec![
+                LlmMessage {
+                    role: LlmMessageRole::System,
+                    content: LlmMessageContent::Text(context.policy.summarization_prompt()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    phase: None,
+                    thinking: None,
+                    thinking_signature: None,
+                },
+                LlmMessage {
+                    role: LlmMessageRole::User,
+                    content: LlmMessageContent::Text(
+                        context
+                            .policy
+                            .format_messages_for_summarization(to_summarize),
+                    ),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    phase: None,
+                    thinking: None,
+                    thinking_signature: None,
+                },
+            ];
+            let summary_config = crate::driver_registry::LlmCallConfig {
+                speed: None,
+                verbosity: None,
+                model: settings
+                    .summarization_model
+                    .clone()
+                    .unwrap_or_else(|| context.summarization_model_fallback.to_string()),
+                temperature: Some(0.0),
+                max_tokens: Some(2000),
+                tools: vec![],
+                reasoning_effort: None,
+                metadata: HashMap::new(),
+                previous_response_id: None,
+                provider_opaque_context: None,
+                tool_search: None,
+                prompt_cache: None,
+                openrouter_routing: None,
+                parallel_tool_calls: None,
+                volatile_suffix_len: 0,
+            };
+
+            match context
+                .chat_driver
+                .chat_completion(
+                    &crate::ProviderEndpoint::default(),
+                    summary_messages,
+                    &summary_config,
+                )
+                .await
+            {
+                Ok(response) => {
+                    let system_message = has_system_prompt.then(|| messages[0].clone());
+                    *messages = context.policy.compose_summary_with_recent(
+                        system_message,
+                        &response.text,
+                        recent,
+                    );
+                    let duration_ms = step_start.elapsed().as_millis() as u64;
+                    strategies_used.push("summarization".to_string());
+                    steps.push(CompactionStepData {
+                        strategy: "summarization".to_string(),
+                        messages_after: messages.len(),
+                        duration_ms,
+                    });
+                    tracing::info!(
+                        session_id = %context.session_id,
+                        duration_ms,
+                        messages_after = messages.len(),
+                        "ReasonAtom: summarization applied"
+                    );
+                }
+                Err(error) => tracing::warn!(
+                    session_id = %context.session_id,
+                    error = %error,
+                    "ReasonAtom: summarization failed, continuing"
+                ),
+            }
+        }
+    }
+
+    if strategies_used.is_empty() || messages.len() > messages_before / 2 {
+        let step_start = Instant::now();
+        let target = context.policy.estimate_total_tokens(messages) / 2;
+        let trimmed = context
+            .policy
+            .aggressive_trim(messages, target, has_system_prompt);
+        if trimmed.len() < messages.len() {
+            *messages = trimmed;
+            let duration_ms = step_start.elapsed().as_millis() as u64;
+            strategies_used.push("aggressive_trim".to_string());
+            steps.push(CompactionStepData {
+                strategy: "aggressive_trim".to_string(),
+                messages_after: messages.len(),
+                duration_ms,
+            });
+            tracing::info!(
+                session_id = %context.session_id,
+                messages_after = messages.len(),
+                "ReasonAtom: aggressive trim applied (last resort)"
+            );
+        }
+    }
+
+    let duration_ms = cascade_start.elapsed().as_millis() as u64;
+    let messages_after = messages.len();
+    if tokens_after.is_none() {
+        tokens_after = Some(context.policy.estimate_total_tokens(messages) as u64);
+    }
+    let effective = match (measured_tokens_before, tokens_after) {
+        (Some(before), Some(after)) => materially_reduced(before, after),
+        _ => match (bytes_before, bytes_after) {
+            (Some(before), Some(after)) => materially_reduced(before, after),
+            _ => false,
+        },
+    };
+    if !effective {
+        tracing::warn!(
+            session_id = %context.session_id,
+            ?measured_tokens_before,
+            ?tokens_after,
+            "ReasonAtom: compaction cascade made no material reduction"
+        );
+        return Ok(None);
+    }
+
+    let strategy_used = strategies_used.join("+");
+    if strategies_used
+        .iter()
+        .any(|strategy| strategy != "observation_masking")
+    {
+        let _ = context
+            .event_emitter
+            .emit(EventRequest::new(
+                context.session_id,
+                context.event_context.clone(),
+                ContextCompactedData {
+                    checkpoint_id,
+                    strategy_used: strategy_used.clone(),
+                    messages_before,
+                    messages_after,
+                    tokens_before: measured_tokens_before,
+                    tokens_after,
+                    bytes_before,
+                    bytes_after,
+                    duration_ms,
+                    steps,
+                },
+            ))
+            .await;
+    }
+
+    tracing::info!(
+        session_id = %context.session_id,
+        strategy = %strategy_used,
+        messages_before,
+        messages_after,
+        duration_ms,
+        "ReasonAtom: compaction cascade completed, retrying LLM call"
+    );
+    Ok(Some(ReactiveCompactionResult { generation_info }))
+}

--- a/crates/engine/src/execution/reason/error_policy.rs
+++ b/crates/engine/src/execution/reason/error_policy.rs
@@ -1,0 +1,103 @@
+use crate::capabilities::CapabilityRegistry;
+use crate::message::{Message, MessageRole};
+use crate::{ErrorDisclosure, user_facing_error_codes};
+
+const ERROR_PLACEHOLDER_MESSAGES: &[&str] = &[
+    "I encountered an error while processing your request. Please try again later.",
+    "The AI provider is experiencing issues. Please try again shortly.",
+    "Rate limited by the AI provider. Please wait a moment.",
+    "The conversation has become too long for the model to process. Please start a new session or reduce the context size.",
+    "There is a misconfiguration with the AI provider. Please contact support.",
+    "The AI provider account is out of credits or quota. Add credits or raise the provider account limits to continue.",
+];
+
+pub(super) fn is_error_placeholder_message(msg: &Message) -> bool {
+    if msg.role != MessageRole::Agent {
+        return false;
+    }
+    // Must have no tool calls (pure text-only error message)
+    if msg.has_tool_calls() {
+        return false;
+    }
+    if let Some(metadata) = &msg.metadata
+        && let Some(serde_json::Value::String(code)) = metadata.get("error_code")
+    {
+        return matches!(
+            code.as_str(),
+            user_facing_error_codes::BUDGET_EXHAUSTED
+                | user_facing_error_codes::BUDGET_PAUSED
+                | user_facing_error_codes::MODEL_UNAVAILABLE
+                | user_facing_error_codes::REQUEST_TOO_LARGE
+                | user_facing_error_codes::PROVIDER_RATE_LIMITED
+                | user_facing_error_codes::PROVIDER_USAGE_LIMIT_REACHED
+                | user_facing_error_codes::PROVIDER_MISCONFIGURED
+                | user_facing_error_codes::PROVIDER_QUOTA_EXHAUSTED
+                | user_facing_error_codes::PROVIDER_UNAVAILABLE
+                | user_facing_error_codes::DEPENDENCY_UNAVAILABLE
+                | user_facing_error_codes::PROCESSING_ERROR
+        );
+    }
+    let text = msg.text().unwrap_or("");
+    ERROR_PLACEHOLDER_MESSAGES.contains(&text) || is_dynamic_error_placeholder(text)
+}
+
+/// Per-message error-disclosure override from the most recent user message's
+/// controls (mirrors how reasoning effort is resolved). The value is clamped
+/// against the capability-configured ceiling in `resolve_error_disclosure`.
+pub(super) fn error_disclosure_override(messages: &[Message]) -> Option<String> {
+    messages
+        .iter()
+        .rev()
+        .find(|m| m.role == MessageRole::User)?
+        .controls
+        .as_ref()?
+        .error_disclosure
+        .clone()
+}
+
+/// Resolve the message-requested disclosure against the ceiling contributed
+/// by the active capability set. The engine consumes the contribution through
+/// the neutral `Capability` contract and does not know the implementation ID.
+pub(super) fn resolve_error_disclosure(
+    registry: &CapabilityRegistry,
+    configs: &[crate::CapabilityRef],
+    requested: Option<&str>,
+) -> ErrorDisclosure {
+    let ceiling = configs
+        .iter()
+        .find_map(|config| {
+            registry
+                .get(config.capability_id())?
+                .error_disclosure(config.config_value())
+        })
+        .unwrap_or_default();
+
+    // THREAT[TM-LLM-024]: client controls may narrow disclosure but never
+    // widen it beyond the operator-selected capability ceiling.
+    requested
+        .and_then(ErrorDisclosure::parse)
+        .map_or(ceiling, |requested| requested.min(ceiling))
+}
+
+pub(super) fn filter_response_text(
+    registry: &CapabilityRegistry,
+    configs: &[crate::CapabilityRef],
+    mut text: String,
+) -> String {
+    for config in configs {
+        if let Some(capability) = registry.get(config.capability_id()) {
+            text = capability.filter_response_text(text, config.config_value());
+        }
+    }
+    text
+}
+
+fn is_dynamic_error_placeholder(text: &str) -> bool {
+    (text.starts_with("Budget exhausted.") && text.ends_with("Increase the budget to continue."))
+        || (text.starts_with("Budget paused.")
+            && text.ends_with("Increase or resume the budget to continue."))
+        || (text.starts_with("Budget paused with ")
+            && text.ends_with("Increase or resume the budget to continue."))
+        || (text.starts_with("Soft limit reached.") && text.ends_with("soft limit."))
+        || (text.starts_with("The model `") && text.ends_with("Please select a different model."))
+}

--- a/crates/engine/src/execution/reason/observability.rs
+++ b/crates/engine/src/execution/reason/observability.rs
@@ -1,0 +1,131 @@
+use serde_json::json;
+use std::collections::{BTreeSet, HashMap};
+
+use crate::capabilities::CapabilityRegistry;
+use crate::events::{
+    CapabilityUsageKind, CapabilityUsageRecord, LlmPromptCacheInfo, LlmRequestOptions,
+    LlmToolSearchInfo,
+};
+use crate::tool_types::ToolDefinition;
+
+pub(super) fn build_request_options(
+    config: &crate::driver_registry::LlmCallConfig,
+    provider: &str,
+) -> Option<LlmRequestOptions> {
+    let prompt_cache = config
+        .prompt_cache
+        .as_ref()
+        .filter(|cfg| cfg.enabled)
+        .map(|cfg| LlmPromptCacheInfo {
+            enabled: true,
+            strategy: cfg.strategy,
+            provider_mode: match provider {
+                "openai" => Some("prompt_cache_key".to_string()),
+                "anthropic" => Some("cache_control".to_string()),
+                "gemini" => Some(
+                    if cfg.gemini_cached_content.is_some() {
+                        "cached_content"
+                    } else {
+                        "implicit"
+                    }
+                    .to_string(),
+                ),
+                _ => None,
+            },
+        });
+
+    let tool_search = config
+        .tool_search
+        .as_ref()
+        .filter(|cfg| cfg.enabled)
+        .map(|cfg| LlmToolSearchInfo {
+            enabled: true,
+            threshold: cfg.threshold,
+        });
+
+    let mut provider_options = HashMap::new();
+    if provider == "openai" && config.previous_response_id.is_some() {
+        provider_options.insert(
+            "openai".to_string(),
+            json!({ "previous_response_id": true }),
+        );
+    }
+    if provider == "gemini"
+        && config
+            .prompt_cache
+            .as_ref()
+            .filter(|cfg| cfg.enabled)
+            .and_then(|cfg| cfg.gemini_cached_content.as_ref())
+            .is_some()
+    {
+        provider_options.insert("gemini".to_string(), json!({ "cached_content": true }));
+    }
+
+    let request_options = LlmRequestOptions {
+        prompt_cache,
+        tool_search,
+        provider_options,
+        metadata: config.metadata.clone(),
+    };
+
+    (!request_options.is_empty()).then_some(request_options)
+}
+
+fn capability_name_snapshot(registry: &CapabilityRegistry, capability_id: &str) -> Option<String> {
+    registry
+        .get(capability_id)
+        .map(|capability| capability.name().to_string())
+}
+
+pub(super) fn capability_usage_snapshot_records(
+    registry: &CapabilityRegistry,
+    resolved_capability_configs: &[crate::CapabilityRef],
+    tool_definitions: &[ToolDefinition],
+) -> Vec<CapabilityUsageRecord> {
+    let mut records = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for config in resolved_capability_configs {
+        let capability_id = config.capability_id().to_string();
+        if seen.insert((
+            "resolved".to_string(),
+            capability_id.clone(),
+            None::<String>,
+        )) {
+            records.push(CapabilityUsageRecord {
+                capability_name: capability_name_snapshot(registry, &capability_id),
+                capability_id,
+                usage_kind: CapabilityUsageKind::Resolved,
+                tool_name: None,
+                usage_count: Some(1),
+                duration_ms: None,
+            });
+        }
+    }
+
+    for tool in tool_definitions {
+        let Some((capability_id, capability_name)) = tool.capability_attribution() else {
+            continue;
+        };
+        let capability_id = capability_id.to_string();
+        let tool_name = tool.name().to_string();
+        if seen.insert((
+            "exposed".to_string(),
+            capability_id.clone(),
+            Some(tool_name.clone()),
+        )) {
+            records.push(CapabilityUsageRecord {
+                capability_name: capability_name
+                    .map(str::to_string)
+                    .or_else(|| capability_name_snapshot(registry, &capability_id)),
+                capability_id,
+                usage_kind: CapabilityUsageKind::Exposed,
+                tool_name: Some(tool_name),
+                usage_count: Some(1),
+                duration_ms: None,
+            });
+        }
+    }
+
+    records
+}

--- a/crates/engine/src/execution/reason/output_hooks.rs
+++ b/crates/engine/src/execution/reason/output_hooks.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use crate::annotation_hook::{AnnotationProvider, VerifierProvider};
+use crate::capabilities::CapabilityRegistry;
+use crate::output_guardrail::{OutputGuardrail, PostGenerationProvider};
+
+pub(super) struct OutputHooks {
+    pub(super) streaming: Vec<(String, serde_json::Value, Arc<dyn OutputGuardrail>)>,
+    pub(super) post_generation: Vec<PostGenerationProvider>,
+    pub(super) annotations: Vec<AnnotationProvider>,
+    pub(super) citation_verifiers: Vec<VerifierProvider>,
+}
+
+pub(super) fn collect_output_hooks(
+    registry: &CapabilityRegistry,
+    configs: &[crate::CapabilityRef],
+) -> OutputHooks {
+    let streaming = configs
+        .iter()
+        .filter_map(|config| {
+            let capability_id = config.capability_id();
+            let capability = registry.get(capability_id)?;
+            let guardrails = capability.output_guardrails();
+            (!guardrails.is_empty()).then(|| {
+                guardrails
+                    .into_iter()
+                    .map(|guardrail| {
+                        (
+                            capability_id.to_string(),
+                            config.config_value().clone(),
+                            guardrail,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+        })
+        .flatten()
+        .collect();
+
+    let post_generation = configs
+        .iter()
+        .filter_map(|config| {
+            let capability_id = config.capability_id();
+            let capability = registry.get(capability_id)?;
+            let providers = capability.post_output_guardrails_with_config(config.config_value());
+            (!providers.is_empty()).then(|| {
+                providers
+                    .into_iter()
+                    .map(|provider| PostGenerationProvider {
+                        capability_id: capability_id.to_string(),
+                        provider,
+                    })
+                    .collect::<Vec<_>>()
+            })
+        })
+        .flatten()
+        .collect();
+
+    let annotations = configs
+        .iter()
+        .filter_map(|config| {
+            let capability_id = config.capability_id();
+            let capability = registry.get(capability_id)?;
+            let providers =
+                capability.post_output_annotation_hooks_with_config(config.config_value());
+            (!providers.is_empty()).then(|| {
+                providers
+                    .into_iter()
+                    .map(|provider| AnnotationProvider {
+                        capability_id: capability_id.to_string(),
+                        provider,
+                    })
+                    .collect::<Vec<_>>()
+            })
+        })
+        .flatten()
+        .collect();
+
+    let citation_verifiers = configs
+        .iter()
+        .filter_map(|config| {
+            let capability_id = config.capability_id();
+            let capability = registry.get(capability_id)?;
+            let provider = capability.citation_verifier_with_config(config.config_value())?;
+            Some(VerifierProvider {
+                capability_id: capability_id.to_string(),
+                provider,
+            })
+        })
+        .collect();
+
+    OutputHooks {
+        streaming,
+        post_generation,
+        annotations,
+        citation_verifiers,
+    }
+}

--- a/crates/engine/src/execution/reason/request_controls.rs
+++ b/crates/engine/src/execution/reason/request_controls.rs
@@ -1,0 +1,127 @@
+use crate::message::{Message, MessageRole};
+use crate::tool_context::ReasoningEffortHandle;
+use everruns_provider::DriverId;
+
+pub(super) struct RequestControls {
+    pub(super) reasoning_effort: Option<String>,
+    pub(super) speed: Option<String>,
+    pub(super) verbosity: Option<String>,
+}
+
+pub(super) fn resolve_request_controls(
+    messages: &[Message],
+    live_reasoning_effort: Option<&ReasoningEffortHandle>,
+    provider_type: &DriverId,
+    model: &str,
+) -> RequestControls {
+    let latest_user_controls = || {
+        messages
+            .iter()
+            .rev()
+            .find(|message| message.role == MessageRole::User)
+            .and_then(|message| message.controls.as_ref())
+    };
+
+    let reasoning_effort = live_reasoning_effort
+        .and_then(ReasoningEffortHandle::get)
+        .or_else(|| {
+            latest_user_controls()
+                .and_then(|controls| controls.reasoning.as_ref())
+                .and_then(|reasoning| reasoning.effort.clone())
+        })
+        .filter(|effort| {
+            if effort.eq_ignore_ascii_case("none") {
+                return false;
+            }
+            match crate::model_profiles::get_model_profile(provider_type, model) {
+                Some(profile) if !profile.reasoning => {
+                    tracing::warn!(
+                        model,
+                        effort,
+                        "Stripping reasoning_effort: model does not support reasoning"
+                    );
+                    false
+                }
+                _ => true,
+            }
+        });
+
+    let speed = latest_user_controls()
+        .and_then(|controls| controls.speed.clone())
+        .filter(|speed| {
+            let Some(profile) = crate::model_profiles::get_model_profile(provider_type, model)
+            else {
+                return true;
+            };
+            let Some(speed_config) = profile.speed else {
+                tracing::warn!(
+                    model,
+                    speed,
+                    "Stripping speed: model does not support service tiers"
+                );
+                return false;
+            };
+            let supported = speed_config.values.iter().any(|value| {
+                matches!(
+                    (&value.value, speed.as_str()),
+                    (crate::model::Speed::Flex, "flex")
+                        | (crate::model::Speed::Default, "default")
+                        | (crate::model::Speed::Priority, "priority")
+                )
+            });
+            if !supported {
+                tracing::warn!(
+                    model,
+                    speed,
+                    "Stripping speed: model does not support requested service tier"
+                );
+            }
+            supported
+        });
+
+    let verbosity = latest_user_controls()
+        .and_then(|controls| controls.verbosity.clone())
+        .filter(
+            |verbosity| match crate::model_profiles::get_model_profile(provider_type, model) {
+                Some(profile) if profile.verbosity.is_none() => {
+                    tracing::warn!(
+                        model,
+                        verbosity,
+                        "Stripping verbosity: model does not support verbosity control"
+                    );
+                    false
+                }
+                _ => true,
+            },
+        );
+
+    RequestControls {
+        reasoning_effort,
+        speed,
+        verbosity,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_reasoning_effort_is_not_sent() {
+        let mut message = Message::user("hello");
+        message.controls = Some(crate::message::Controls {
+            reasoning: Some(crate::message::ReasoningConfig {
+                effort: Some("none".to_string()),
+            }),
+            ..Default::default()
+        });
+
+        let controls = resolve_request_controls(
+            &[message],
+            None,
+            &DriverId::external("unknown"),
+            "unknown-model",
+        );
+        assert!(controls.reasoning_effort.is_none());
+    }
+}

--- a/crates/engine/src/execution/reason/stream_state.rs
+++ b/crates/engine/src/execution/reason/stream_state.rs
@@ -1,0 +1,179 @@
+use crate::driver_registry::{LlmCompletionMetadata, LlmStreamError, LlmStreamEvent};
+use crate::llm_retry::{RetryMetadata, is_transient_stream_error};
+use crate::output_guardrail::{ArmedGuardrail, TrippedGuardrail, evaluate_guardrails};
+
+/// Whether replaying the current provider attempt can duplicate externally
+/// visible output or tool side effects.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum StreamReplayState {
+    /// Only replay-safe reasoning or metadata has been observed.
+    #[default]
+    Replayable,
+    /// Final answer text or tool calls have crossed the replay boundary.
+    Committed,
+}
+
+impl StreamReplayState {
+    pub(super) fn observe(&mut self, event: &LlmStreamEvent) {
+        if matches!(self, Self::Committed) {
+            return;
+        }
+
+        if match event {
+            LlmStreamEvent::TextDelta(delta) => !delta.is_empty(),
+            LlmStreamEvent::ToolCalls(calls) => !calls.is_empty(),
+            LlmStreamEvent::ThinkingDelta(_)
+            | LlmStreamEvent::ThinkingSignature(_)
+            | LlmStreamEvent::ReasonItem { .. }
+            | LlmStreamEvent::MessagePhase(_)
+            | LlmStreamEvent::Done(_)
+            | LlmStreamEvent::Error(_) => false,
+        } {
+            *self = Self::Committed;
+        }
+    }
+
+    pub(super) fn should_retry(
+        self,
+        error: &LlmStreamError,
+        retry_attempts: u32,
+        max_retries: u32,
+    ) -> bool {
+        matches!(self, Self::Replayable)
+            && retry_attempts < max_retries
+            && is_transient_stream_error(error)
+    }
+}
+
+/// Terminal state of a single provider stream attempt.
+///
+/// Keeping this as one enum prevents completion, partial success, and
+/// guardrail blocking from being represented by contradictory independent
+/// flags.
+pub(super) enum StreamTermination {
+    Exhausted,
+    Completed(LlmCompletionMetadata),
+    PartialSuccess,
+    GuardrailBlocked(TrippedGuardrail),
+}
+
+impl StreamTermination {
+    pub(super) fn into_parts(self) -> (Option<LlmCompletionMetadata>, Option<TrippedGuardrail>) {
+        match self {
+            Self::Completed(metadata) => (Some(metadata), None),
+            Self::GuardrailBlocked(guardrail) => (None, Some(guardrail)),
+            Self::Exhausted | Self::PartialSuccess => (None, None),
+        }
+    }
+}
+
+pub(super) fn merge_retry_metadata(
+    existing: Option<RetryMetadata>,
+    additional: &RetryMetadata,
+) -> Option<RetryMetadata> {
+    if !additional.had_retries() {
+        return existing;
+    }
+
+    let mut merged = existing.unwrap_or_default();
+    merged.attempts += additional.attempts;
+    merged.total_retry_wait += additional.total_retry_wait;
+    if additional.last_rate_limit_info.is_some() {
+        merged.last_rate_limit_info = additional.last_rate_limit_info.clone();
+    }
+    Some(merged)
+}
+
+/// Returns true when a stream event carries assistant output progress.
+pub(super) fn advances_stall_deadline(event: &LlmStreamEvent) -> bool {
+    match event {
+        LlmStreamEvent::TextDelta(delta) | LlmStreamEvent::ThinkingDelta(delta) => {
+            !delta.is_empty()
+        }
+        LlmStreamEvent::ReasonItem {
+            encrypted_content,
+            summary,
+            token_count,
+            ..
+        } => {
+            encrypted_content
+                .as_ref()
+                .is_some_and(|content| !content.is_empty())
+                || summary.iter().any(|item| !item.is_empty())
+                || token_count.is_some_and(|count| count > 0)
+        }
+        LlmStreamEvent::ToolCalls(calls) => !calls.is_empty(),
+        LlmStreamEvent::MessagePhase(_)
+        | LlmStreamEvent::ThinkingSignature(_)
+        | LlmStreamEvent::Done(_)
+        | LlmStreamEvent::Error(_) => false,
+    }
+}
+
+pub(super) fn append_guarded_thinking_delta(
+    armed_guardrails: &mut [ArmedGuardrail],
+    thinking: &mut String,
+    pending_thinking_delta: &mut String,
+    delta: &str,
+) -> Option<TrippedGuardrail> {
+    thinking.push_str(delta);
+
+    if let Some(tripped) = evaluate_guardrails(armed_guardrails, thinking, delta) {
+        pending_thinking_delta.clear();
+        Some(tripped)
+    } else {
+        pending_thinking_delta.push_str(delta);
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_only_attempt_remains_replayable() {
+        let mut state = StreamReplayState::default();
+        state.observe(&LlmStreamEvent::ThinkingDelta("analysis".to_string()));
+        state.observe(&LlmStreamEvent::ThinkingSignature("signature".to_string()));
+        state.observe(&LlmStreamEvent::ReasonItem {
+            provider: "openai".to_string(),
+            model: None,
+            item_id: "item".to_string(),
+            encrypted_content: Some("opaque".to_string()),
+            summary: vec!["summary".to_string()],
+            token_count: Some(1),
+        });
+
+        let stall = LlmStreamError::new("provider stream stall: no tokens for 120s");
+        assert!(state.should_retry(&stall, 0, 2));
+    }
+
+    #[test]
+    fn final_output_commits_attempt_against_replay() {
+        let stall = LlmStreamError::new("provider stream stall: no tokens for 120s");
+
+        let mut text = StreamReplayState::default();
+        text.observe(&LlmStreamEvent::TextDelta("answer".to_string()));
+        assert_eq!(text, StreamReplayState::Committed);
+        assert!(!text.should_retry(&stall, 0, 2));
+
+        let mut tools = StreamReplayState::default();
+        tools.observe(&LlmStreamEvent::ToolCalls(vec![
+            crate::tool_types::ToolCall {
+                id: "call".to_string(),
+                name: "tool".to_string(),
+                arguments: serde_json::json!({}),
+            },
+        ]));
+        assert_eq!(tools, StreamReplayState::Committed);
+        assert!(!tools.should_retry(&stall, 0, 2));
+    }
+
+    #[test]
+    fn retry_budget_is_part_of_replay_decision() {
+        let stall = LlmStreamError::new("provider stream stall: no tokens for 120s");
+        assert!(StreamReplayState::Replayable.should_retry(&stall, 0, 2));
+        assert!(!StreamReplayState::Replayable.should_retry(&stall, 2, 2));
+    }
+}

--- a/crates/engine/src/execution/reason/tests.rs
+++ b/crates/engine/src/execution/reason/tests.rs
@@ -1,0 +1,776 @@
+use super::compaction::materially_reduced;
+use super::*;
+use crate::driver_registry::{LlmCallConfig, PromptCacheConfig, PromptCacheStrategy};
+use crate::events::CapabilityUsageKind;
+use serde_json::json;
+use std::collections::HashMap;
+
+#[test]
+fn material_reduction_requires_five_percent_at_normal_sizes() {
+    assert!(!materially_reduced(1_000, 951));
+    assert!(materially_reduced(1_000, 950));
+}
+
+#[test]
+fn material_reduction_uses_absolute_floor_for_small_sizes() {
+    assert!(!materially_reduced(0, 0));
+    assert!(!materially_reduced(100, 69));
+    assert!(materially_reduced(100, 68));
+}
+
+struct BlockWhenDeltaContains {
+    needle: &'static str,
+}
+
+impl crate::output_guardrail::OutputGuardrailRun for BlockWhenDeltaContains {
+    fn check(
+        &mut self,
+        _accumulated: &str,
+        delta: &str,
+    ) -> crate::output_guardrail::GuardrailDecision {
+        if delta.contains(self.needle) {
+            crate::output_guardrail::GuardrailDecision::block("test_leak", "[blocked]")
+        } else {
+            crate::output_guardrail::GuardrailDecision::Pass
+        }
+    }
+}
+
+fn test_armed_guardrail() -> ArmedGuardrail {
+    ArmedGuardrail {
+        capability_id: "test_capability".to_string(),
+        guardrail_id: "test_guardrail".to_string(),
+        run: Box::new(BlockWhenDeltaContains { needle: "secret" }),
+    }
+}
+
+#[test]
+fn test_append_guarded_thinking_delta_blocks_before_pending_emit() {
+    let mut guardrails = vec![test_armed_guardrail()];
+    let mut thinking = "safe ".to_string();
+    let mut pending = "safe ".to_string();
+
+    let tripped = append_guarded_thinking_delta(
+        &mut guardrails,
+        &mut thinking,
+        &mut pending,
+        "secret instructions",
+    )
+    .expect("thinking delta should trip guardrail");
+
+    assert_eq!(tripped.capability_id, "test_capability");
+    assert_eq!(tripped.guardrail_id, "test_guardrail");
+    assert_eq!(tripped.block.reason_code, "test_leak");
+    assert_eq!(tripped.block.replacement, "[blocked]");
+    assert_eq!(thinking, "safe secret instructions");
+    assert!(pending.is_empty());
+}
+
+#[test]
+fn test_append_guarded_thinking_delta_allows_safe_pending_emit() {
+    let mut guardrails = vec![test_armed_guardrail()];
+    let mut thinking = String::new();
+    let mut pending = String::new();
+
+    let tripped = append_guarded_thinking_delta(
+        &mut guardrails,
+        &mut thinking,
+        &mut pending,
+        "ordinary reasoning",
+    );
+
+    assert!(tripped.is_none());
+    assert_eq!(thinking, "ordinary reasoning");
+    assert_eq!(pending, "ordinary reasoning");
+}
+
+#[test]
+fn test_reason_result_default() {
+    let result = ReasonResult::default();
+    assert!(!result.success);
+    assert!(result.text.is_empty());
+    assert!(result.tool_calls.is_empty());
+    assert!(!result.has_tool_calls);
+    // Default derive gives 0, but serde deserialization gives 100 via default_max_iterations()
+    assert_eq!(result.max_iterations, 0);
+}
+
+#[test]
+fn test_reason_result_serde_default() {
+    // Test that serde uses the default_max_iterations function
+    let json = r#"{"success":true,"text":"","has_tool_calls":false}"#;
+    let result: ReasonResult = serde_json::from_str(json).unwrap();
+    assert_eq!(result.max_iterations, 500);
+}
+
+#[test]
+fn test_capability_usage_snapshot_keeps_resolved_and_exposed_separate() {
+    let registry = CapabilityRegistry::new();
+    let tool = ToolDefinition::Builtin(crate::tool_types::BuiltinTool {
+        name: "demo_tool".to_string(),
+        display_name: None,
+        description: "demo".to_string(),
+        parameters: json!({"type": "object"}),
+        policy: crate::tool_types::ToolPolicy::Auto,
+        category: None,
+        deferrable: crate::tool_types::DeferrablePolicy::default(),
+        hints: crate::tool_types::ToolHints::default(),
+        full_parameters: None,
+    })
+    .with_capability_attribution("cap:demo", Some("Demo Capability"));
+
+    let records = capability_usage_snapshot_records(
+        &registry,
+        &[crate::CapabilityRef::new("current_time")],
+        &[tool],
+    );
+
+    assert!(records.iter().any(|record| {
+        matches!(record.usage_kind, CapabilityUsageKind::Resolved)
+            && record.capability_id == "current_time"
+            && record.tool_name.is_none()
+    }));
+    assert!(records.iter().any(|record| {
+        matches!(record.usage_kind, CapabilityUsageKind::Exposed)
+            && record.capability_id == "cap:demo"
+            && record.tool_name.as_deref() == Some("demo_tool")
+    }));
+}
+
+#[test]
+fn stream_stall_deadline_ignores_empty_keepalive_events() {
+    assert!(!advances_stall_deadline(&LlmStreamEvent::TextDelta(
+        String::new()
+    )));
+    assert!(!advances_stall_deadline(&LlmStreamEvent::ThinkingDelta(
+        String::new()
+    )));
+    assert!(!advances_stall_deadline(
+        &LlmStreamEvent::ThinkingSignature("signature".to_string())
+    ));
+    assert!(!advances_stall_deadline(&LlmStreamEvent::ReasonItem {
+        provider: "openai".to_string(),
+        model: None,
+        item_id: "item_1".to_string(),
+        encrypted_content: None,
+        summary: vec![String::new()],
+        token_count: Some(0),
+    }));
+}
+
+#[test]
+fn stream_stall_deadline_advances_on_output_progress() {
+    assert!(advances_stall_deadline(&LlmStreamEvent::TextDelta(
+        "hello".to_string()
+    )));
+    assert!(advances_stall_deadline(&LlmStreamEvent::ThinkingDelta(
+        "thinking".to_string()
+    )));
+    assert!(advances_stall_deadline(&LlmStreamEvent::ReasonItem {
+        provider: "openai".to_string(),
+        model: Some("gpt-5.4".to_string()),
+        item_id: "item_1".to_string(),
+        encrypted_content: Some("encrypted".to_string()),
+        summary: vec![],
+        token_count: None,
+    }));
+    assert!(advances_stall_deadline(&LlmStreamEvent::ReasonItem {
+        provider: "openai".to_string(),
+        model: None,
+        item_id: "item_2".to_string(),
+        encrypted_content: None,
+        summary: vec!["summary".to_string()],
+        token_count: None,
+    }));
+    assert!(advances_stall_deadline(&LlmStreamEvent::ReasonItem {
+        provider: "openai".to_string(),
+        model: None,
+        item_id: "item_3".to_string(),
+        encrypted_content: None,
+        summary: vec![],
+        token_count: Some(1),
+    }));
+    assert!(advances_stall_deadline(&LlmStreamEvent::ToolCalls(vec![
+        ToolCall {
+            id: "call_1".to_string(),
+            name: "demo".to_string(),
+            arguments: json!({}),
+        }
+    ])));
+}
+
+#[tokio::test]
+async fn test_repair_dangling_tool_calls_no_tool_calls() {
+    use crate::events::EventContext;
+    use crate::typed_id::SessionId;
+    let messages = vec![Message::user("Hello"), Message::assistant("Hi there!")];
+    let emitter = crate::test_fixtures::NoopEventEmitter;
+    let session_id = SessionId::new();
+    let ctx = EventContext::empty();
+    let patched =
+        repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01").await;
+    assert_eq!(patched.len(), 2);
+}
+
+#[tokio::test]
+async fn test_repair_dangling_tool_calls_with_result() {
+    use crate::events::EventContext;
+    use crate::typed_id::SessionId;
+    let tool_call = ToolCall {
+        id: "call_123".to_string(),
+        name: "get_weather".to_string(),
+        arguments: serde_json::json!({"city": "NYC"}),
+    };
+
+    let messages = vec![
+        Message::user("What's the weather?"),
+        Message::assistant_with_tools("Let me check", vec![tool_call]),
+        Message::tool_result("call_123", Some(serde_json::json!({"temp": 72})), None),
+    ];
+
+    let emitter = crate::test_fixtures::NoopEventEmitter;
+    let session_id = SessionId::new();
+    let ctx = EventContext::empty();
+    let patched =
+        repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01").await;
+    assert_eq!(patched.len(), 3);
+}
+
+#[tokio::test]
+async fn test_repair_dangling_tool_calls_missing_result_no_store() {
+    use crate::events::EventContext;
+    use crate::typed_id::SessionId;
+    let tool_call = ToolCall {
+        id: "call_456".to_string(),
+        name: "search_web".to_string(),
+        arguments: serde_json::json!({"query": "rust"}),
+    };
+
+    let messages = vec![
+        Message::user("Search for rust"),
+        Message::assistant_with_tools("Searching...", vec![tool_call]),
+        Message::user("Actually, never mind"),
+    ];
+
+    let emitter = crate::test_fixtures::NoopEventEmitter;
+    let session_id = SessionId::new();
+    let ctx = EventContext::empty();
+    let patched =
+        repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01").await;
+    // Should have added a cancelled result
+    assert_eq!(patched.len(), 4);
+    assert_eq!(patched[2].role, MessageRole::ToolResult);
+    assert_eq!(patched[2].tool_call_id(), Some("call_456"));
+}
+
+#[tokio::test]
+async fn test_repair_dangling_tool_calls_settled_result_replayed() {
+    use crate::events::EventContext;
+    use crate::typed_id::SessionId;
+    use crate::{
+        durability::DurableToolCallStatus, durability::DurableToolResultStore,
+        durability::ToolCallClaimResult,
+    };
+
+    struct MockSettledStore;
+    #[async_trait::async_trait]
+    impl DurableToolResultStore for MockSettledStore {
+        async fn try_claim_tool_call(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::error::Result<ToolCallClaimResult> {
+            Ok(ToolCallClaimResult::Claimed {
+                claim_token: uuid::Uuid::new_v4(),
+            })
+        }
+        async fn settle_tool_call(
+            &self,
+            _: &str,
+            _: &str,
+            _: serde_json::Value,
+            _: &str,
+            _: uuid::Uuid,
+        ) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn get_tool_call_status(
+            &self,
+            _turn_id: &str,
+            _tool_call_id: &str,
+        ) -> crate::error::Result<Option<DurableToolCallStatus>> {
+            Ok(Some(DurableToolCallStatus::Settled {
+                result_json: serde_json::json!({
+                    "tool_call_id": "call_789",
+                    "result": {"answer": 42},
+                    "error": null,
+                    "images": null,
+                    "connection_required": null,
+                    "raw_output": null
+                }),
+            }))
+        }
+    }
+
+    let tool_call = ToolCall {
+        id: "call_789".to_string(),
+        name: "compute".to_string(),
+        arguments: serde_json::json!({"x": 21}),
+    };
+    let messages = vec![
+        Message::user("Compute"),
+        Message::assistant_with_tools("Computing...", vec![tool_call]),
+    ];
+
+    let store = MockSettledStore;
+    let emitter = crate::test_fixtures::NoopEventEmitter;
+    let session_id = SessionId::new();
+    let ctx = EventContext::empty();
+    let patched = repair_dangling_tool_calls(
+        &messages,
+        Some(&store as &dyn DurableToolResultStore),
+        &emitter,
+        session_id,
+        &ctx,
+        "turn_01",
+    )
+    .await;
+
+    // Settled result should be replayed (not cancelled message)
+    assert_eq!(patched.len(), 3);
+    assert_eq!(patched[2].role, MessageRole::ToolResult);
+    assert_eq!(patched[2].tool_call_id(), Some("call_789"));
+}
+
+#[tokio::test]
+async fn test_repair_dangling_tool_calls_interrupted_result_replayed() {
+    use crate::events::EventContext;
+    use crate::typed_id::SessionId;
+    use crate::{
+        durability::DurableToolCallStatus, durability::DurableToolResultStore,
+        durability::ToolCallClaimResult,
+    };
+
+    struct MockInterruptedStore;
+    #[async_trait::async_trait]
+    impl DurableToolResultStore for MockInterruptedStore {
+        async fn try_claim_tool_call(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::error::Result<ToolCallClaimResult> {
+            Ok(ToolCallClaimResult::Claimed {
+                claim_token: uuid::Uuid::new_v4(),
+            })
+        }
+        async fn settle_tool_call(
+            &self,
+            _: &str,
+            _: &str,
+            _: serde_json::Value,
+            _: &str,
+            _: uuid::Uuid,
+        ) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn get_tool_call_status(
+            &self,
+            _turn_id: &str,
+            _tool_call_id: &str,
+        ) -> crate::error::Result<Option<DurableToolCallStatus>> {
+            Ok(Some(DurableToolCallStatus::Interrupted {
+                result_json: None,
+            }))
+        }
+    }
+
+    let tool_call = ToolCall {
+        id: "call_int".to_string(),
+        name: "slow_op".to_string(),
+        arguments: serde_json::json!({}),
+    };
+    let messages = vec![
+        Message::user("Do it"),
+        Message::assistant_with_tools("Doing...", vec![tool_call]),
+    ];
+
+    let store = MockInterruptedStore;
+    let emitter = crate::test_fixtures::NoopEventEmitter;
+    let session_id = SessionId::new();
+    let ctx = EventContext::empty();
+    let patched = repair_dangling_tool_calls(
+        &messages,
+        Some(&store as &dyn DurableToolResultStore),
+        &emitter,
+        session_id,
+        &ctx,
+        "turn_01",
+    )
+    .await;
+
+    assert_eq!(patched.len(), 3);
+    let repair = &patched[2];
+    assert_eq!(repair.role, MessageRole::ToolResult);
+    assert_eq!(repair.tool_call_id(), Some("call_int"));
+    // Interrupted replay uses the stored error or fallback text; must contain "interrupted"
+    let content = format!("{:?}", repair);
+    assert!(
+        content.contains("interrupted") || content.contains("not complete"),
+        "expected interrupted message, got: {content}"
+    );
+}
+
+#[tokio::test]
+async fn test_repair_dangling_tool_calls_running_synthesized() {
+    use crate::events::EventContext;
+    use crate::typed_id::SessionId;
+    use crate::{
+        durability::DurableToolCallStatus, durability::DurableToolResultStore,
+        durability::ToolCallClaimResult,
+    };
+
+    struct MockRunningStore;
+    #[async_trait::async_trait]
+    impl DurableToolResultStore for MockRunningStore {
+        async fn try_claim_tool_call(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::error::Result<ToolCallClaimResult> {
+            Ok(ToolCallClaimResult::Claimed {
+                claim_token: uuid::Uuid::new_v4(),
+            })
+        }
+        async fn settle_tool_call(
+            &self,
+            _: &str,
+            _: &str,
+            _: serde_json::Value,
+            _: &str,
+            _: uuid::Uuid,
+        ) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn get_tool_call_status(
+            &self,
+            _turn_id: &str,
+            _tool_call_id: &str,
+        ) -> crate::error::Result<Option<DurableToolCallStatus>> {
+            Ok(Some(DurableToolCallStatus::Running))
+        }
+    }
+
+    let tool_call = ToolCall {
+        id: "call_run".to_string(),
+        name: "long_job".to_string(),
+        arguments: serde_json::json!({}),
+    };
+    let messages = vec![
+        Message::user("Start job"),
+        Message::assistant_with_tools("Starting...", vec![tool_call]),
+    ];
+
+    let store = MockRunningStore;
+    let emitter = crate::test_fixtures::NoopEventEmitter;
+    let session_id = SessionId::new();
+    let ctx = EventContext::empty();
+    let patched = repair_dangling_tool_calls(
+        &messages,
+        Some(&store as &dyn DurableToolResultStore),
+        &emitter,
+        session_id,
+        &ctx,
+        "turn_01",
+    )
+    .await;
+
+    assert_eq!(patched.len(), 3);
+    let repair = &patched[2];
+    assert_eq!(repair.role, MessageRole::ToolResult);
+    assert_eq!(repair.tool_call_id(), Some("call_run"));
+    // Running stale claim must warn "uncertain; do not retry automatically"
+    let content = format!("{:?}", repair);
+    assert!(
+        content.contains("uncertain") || content.contains("do not retry"),
+        "expected uncertain/do-not-retry message, got: {content}"
+    );
+}
+
+#[tokio::test]
+async fn test_repair_dangling_tool_calls_store_error_unknown() {
+    use crate::error::AgentLoopError;
+    use crate::events::EventContext;
+    use crate::typed_id::SessionId;
+    use crate::{durability::DurableToolResultStore, durability::ToolCallClaimResult};
+
+    struct MockErrorStore;
+    #[async_trait::async_trait]
+    impl DurableToolResultStore for MockErrorStore {
+        async fn try_claim_tool_call(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> crate::error::Result<ToolCallClaimResult> {
+            Ok(ToolCallClaimResult::Claimed {
+                claim_token: uuid::Uuid::new_v4(),
+            })
+        }
+        async fn settle_tool_call(
+            &self,
+            _: &str,
+            _: &str,
+            _: serde_json::Value,
+            _: &str,
+            _: uuid::Uuid,
+        ) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn get_tool_call_status(
+            &self,
+            _turn_id: &str,
+            _tool_call_id: &str,
+        ) -> crate::error::Result<Option<crate::durability::DurableToolCallStatus>> {
+            Err(AgentLoopError::tool("simulated store failure"))
+        }
+    }
+
+    let tool_call = ToolCall {
+        id: "call_err".to_string(),
+        name: "risky_op".to_string(),
+        arguments: serde_json::json!({}),
+    };
+    let messages = vec![
+        Message::user("Do risky op"),
+        Message::assistant_with_tools("On it...", vec![tool_call]),
+    ];
+
+    let store = MockErrorStore;
+    let emitter = crate::test_fixtures::NoopEventEmitter;
+    let session_id = SessionId::new();
+    let ctx = EventContext::empty();
+    let patched = repair_dangling_tool_calls(
+        &messages,
+        Some(&store as &dyn DurableToolResultStore),
+        &emitter,
+        session_id,
+        &ctx,
+        "turn_01",
+    )
+    .await;
+
+    assert_eq!(patched.len(), 3);
+    let repair = &patched[2];
+    assert_eq!(repair.role, MessageRole::ToolResult);
+    assert_eq!(repair.tool_call_id(), Some("call_err"));
+    // Store error must NOT say "safe to retry"
+    let content = format!("{:?}", repair);
+    assert!(
+        !content.contains("safe to retry"),
+        "store error must not say 'safe to retry', got: {content}"
+    );
+    assert!(
+        content.contains("do not retry") || content.contains("status unknown"),
+        "expected do-not-retry/status-unknown message, got: {content}"
+    );
+}
+
+#[test]
+fn test_build_request_options_for_openai_prompt_cache() {
+    let config = LlmCallConfig {
+        speed: None,
+        verbosity: None,
+        model: "gpt-5.4".to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: HashMap::new(),
+        previous_response_id: Some("resp_123".to_string()),
+        provider_opaque_context: None,
+        tool_search: None,
+        prompt_cache: Some(PromptCacheConfig {
+            enabled: true,
+            strategy: PromptCacheStrategy::Auto,
+            gemini_cached_content: None,
+        }),
+        openrouter_routing: None,
+        parallel_tool_calls: None,
+        volatile_suffix_len: 0,
+    };
+
+    let request_options = build_request_options(&config, "openai").unwrap();
+    assert_eq!(
+        request_options
+            .prompt_cache
+            .and_then(|info| info.provider_mode),
+        Some("prompt_cache_key".to_string())
+    );
+    assert_eq!(
+        request_options.provider_options.get("openai"),
+        Some(&json!({ "previous_response_id": true }))
+    );
+}
+
+#[test]
+fn test_build_request_options_for_gemini_explicit_cache() {
+    let config = LlmCallConfig {
+        speed: None,
+        verbosity: None,
+        model: "gemini-2.5-pro".to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: HashMap::new(),
+        previous_response_id: None,
+        provider_opaque_context: None,
+        tool_search: None,
+        prompt_cache: Some(PromptCacheConfig {
+            enabled: true,
+            strategy: PromptCacheStrategy::Auto,
+            gemini_cached_content: Some("cachedContents/demo-cache".to_string()),
+        }),
+        openrouter_routing: None,
+        parallel_tool_calls: None,
+        volatile_suffix_len: 0,
+    };
+
+    let request_options = build_request_options(&config, "gemini").unwrap();
+    assert_eq!(
+        request_options
+            .prompt_cache
+            .and_then(|info| info.provider_mode),
+        Some("cached_content".to_string())
+    );
+    assert_eq!(
+        request_options.provider_options.get("gemini"),
+        Some(&json!({ "cached_content": true }))
+    );
+}
+
+#[test]
+fn test_build_request_options_omits_gemini_cache_flag_when_disabled() {
+    let config = LlmCallConfig {
+        speed: None,
+        verbosity: None,
+        model: "gemini-2.5-pro".to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: HashMap::new(),
+        previous_response_id: None,
+        provider_opaque_context: None,
+        tool_search: None,
+        prompt_cache: Some(PromptCacheConfig {
+            enabled: false,
+            strategy: PromptCacheStrategy::Auto,
+            gemini_cached_content: Some("cachedContents/demo-cache".to_string()),
+        }),
+        openrouter_routing: None,
+        parallel_tool_calls: None,
+        volatile_suffix_len: 0,
+    };
+
+    assert!(build_request_options(&config, "gemini").is_none());
+}
+
+#[test]
+fn system_keys_override_embedder_keys_in_metadata() {
+    // Pins the injection order: embedder keys inserted first, then system
+    // keys overwrite any collision. A harness author cannot shadow session_id,
+    // turn_id, etc. by including them in embedder_metadata.
+    let embedder_metadata: HashMap<String, String> = [
+        ("session_id".to_string(), "attacker_value".to_string()),
+        ("custom_key".to_string(), "custom_value".to_string()),
+    ]
+    .into();
+
+    let mut metadata: HashMap<String, String> = HashMap::new();
+
+    // Inject embedder metadata first (mirrors execute_single_turn logic)
+    for (k, v) in &embedder_metadata {
+        metadata.insert(k.clone(), v.clone());
+    }
+
+    // System key injected second — must overwrite
+    metadata.insert("session_id".to_string(), "real_session_id".to_string());
+
+    assert_eq!(
+        metadata.get("session_id").map(String::as_str),
+        Some("real_session_id"),
+        "system key must overwrite embedder key with same name"
+    );
+    assert_eq!(
+        metadata.get("custom_key").map(String::as_str),
+        Some("custom_value"),
+        "non-colliding embedder key must be preserved"
+    );
+}
+
+// =========================================================================
+// ContinuePartial recovery tests (EVE-532)
+// =========================================================================
+
+use crate::test_fixtures::NoopPartialStreamStore;
+use crate::{durability::PartialStreamState, durability::PartialStreamStore};
+
+struct MockPartialStore(Option<PartialStreamState>);
+
+#[async_trait::async_trait]
+impl PartialStreamStore for MockPartialStore {
+    async fn get_partial_stream(
+        &self,
+        _session_id: crate::typed_id::SessionId,
+        _turn_id: &str,
+    ) -> crate::error::Result<Option<PartialStreamState>> {
+        Ok(self.0.clone())
+    }
+}
+
+#[tokio::test]
+async fn test_noop_partial_stream_store_returns_none() {
+    let store = NoopPartialStreamStore;
+    let result = store
+        .get_partial_stream(crate::typed_id::SessionId::new(), "turn_01")
+        .await
+        .unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn test_partial_stream_store_returns_accumulated_when_partial_exists() {
+    let message_id = MessageId::new();
+    let store = MockPartialStore(Some(PartialStreamState {
+        message_id,
+        accumulated: "partial text so far".to_string(),
+    }));
+    let result = store
+        .get_partial_stream(crate::typed_id::SessionId::new(), "turn_01")
+        .await
+        .unwrap();
+    let partial = result.unwrap();
+    assert_eq!(partial.message_id, message_id);
+    assert_eq!(partial.accumulated, "partial text so far");
+}
+
+#[tokio::test]
+async fn test_partial_stream_store_returns_empty_when_started_no_delta() {
+    let store = MockPartialStore(Some(PartialStreamState {
+        message_id: MessageId::new(),
+        accumulated: String::new(),
+    }));
+    let result = store
+        .get_partial_stream(crate::typed_id::SessionId::new(), "turn_01")
+        .await
+        .unwrap();
+    assert!(result.unwrap().accumulated.is_empty());
+}

--- a/crates/engine/src/execution/reason/transcript.rs
+++ b/crates/engine/src/execution/reason/transcript.rs
@@ -1,0 +1,150 @@
+use crate::durability::{DurableToolCallStatus, DurableToolResultStore};
+use crate::event_emitter::EventEmitter;
+use crate::events::{EventContext, EventRequest, TranscriptRepairAction, TranscriptRepairedData};
+use crate::message::{Message, MessageRole};
+use crate::typed_id::SessionId;
+
+/// Repair assistant tool calls without matching results before the next model
+/// request. Durable status determines whether replay is safe or the result is
+/// uncertain.
+pub(super) async fn repair_dangling_tool_calls(
+    messages: &[Message],
+    durable_store: Option<&dyn DurableToolResultStore>,
+    event_emitter: &dyn EventEmitter,
+    session_id: SessionId,
+    event_context: &EventContext,
+    turn_id: &str,
+) -> Vec<Message> {
+    let mut result = Vec::new();
+
+    for (index, message) in messages.iter().enumerate() {
+        result.push(message.clone());
+
+        if message.role != MessageRole::Agent || !message.has_tool_calls() {
+            continue;
+        }
+
+        for tool_call in message.tool_calls() {
+            let has_result = messages[(index + 1)..].iter().any(|candidate| {
+                candidate.role == MessageRole::ToolResult
+                    && candidate.tool_call_id() == Some(&tool_call.id)
+            });
+            if has_result {
+                continue;
+            }
+
+            let (repair_message, action) = if let Some(store) = durable_store {
+                match store.get_tool_call_status(turn_id, &tool_call.id).await {
+                    Ok(Some(DurableToolCallStatus::Settled { result_json })) => {
+                        let repair = match serde_json::from_value::<
+                            crate::tool_types::ToolResult,
+                        >(result_json.clone())
+                        {
+                            Ok(tool_result) => Message::tool_result(
+                                &tool_call.id,
+                                tool_result.result,
+                                tool_result.error,
+                            ),
+                            Err(_) => {
+                                Message::tool_result(&tool_call.id, Some(result_json), None)
+                            }
+                        };
+                        (repair, TranscriptRepairAction::Replay)
+                    }
+                    Ok(Some(DurableToolCallStatus::Interrupted { result_json })) => {
+                        let error = result_json
+                            .as_ref()
+                            .and_then(|value| {
+                                serde_json::from_value::<crate::tool_types::ToolResult>(
+                                    value.clone(),
+                                )
+                                .ok()
+                            })
+                            .and_then(|result| result.error)
+                            .unwrap_or_else(|| {
+                                "tool execution did not complete before recovery; result unknown"
+                                    .to_string()
+                            });
+                        (
+                            Message::tool_result(&tool_call.id, None, Some(error)),
+                            TranscriptRepairAction::Replay,
+                        )
+                    }
+                    Ok(Some(DurableToolCallStatus::Running)) => (
+                        Message::tool_result(
+                            &tool_call.id,
+                            None,
+                            Some(
+                                "interrupted - tool execution was interrupted by worker failure and the result is uncertain; do not retry automatically"
+                                    .to_string(),
+                            ),
+                        ),
+                        TranscriptRepairAction::Synthesize,
+                    ),
+                    Ok(None) => (
+                        Message::tool_result(
+                            &tool_call.id,
+                            None,
+                            Some(
+                                "interrupted - tool was not executed before recovery; safe to retry"
+                                    .to_string(),
+                            ),
+                        ),
+                        TranscriptRepairAction::Synthesize,
+                    ),
+                    Err(error) => {
+                        tracing::warn!(
+                            tool_call_id = %tool_call.id,
+                            error = %error,
+                            "transcript repair: durable store error; status unknown"
+                        );
+                        (
+                            Message::tool_result(
+                                &tool_call.id,
+                                None,
+                                Some(
+                                    "interrupted - tool execution status unknown due to store error; do not retry automatically"
+                                        .to_string(),
+                                ),
+                            ),
+                            TranscriptRepairAction::Synthesize,
+                        )
+                    }
+                }
+            } else {
+                (
+                    Message::tool_result(
+                        &tool_call.id,
+                        None,
+                        Some(
+                            "cancelled - another message came in before it could be completed"
+                                .to_string(),
+                        ),
+                    ),
+                    TranscriptRepairAction::Synthesize,
+                )
+            };
+
+            let repair_event = EventRequest::new(
+                session_id,
+                event_context.clone(),
+                TranscriptRepairedData {
+                    tool_call_id: tool_call.id.clone(),
+                    tool_name: Some(tool_call.name.clone()),
+                    action,
+                },
+            );
+            if let Err(error) = event_emitter.emit(repair_event).await {
+                tracing::warn!(
+                    tool_call_id = %tool_call.id,
+                    error = %error,
+                    "transcript repair: failed to emit transcript.repaired event"
+                );
+            }
+
+            result.push(repair_message);
+        }
+    }
+
+    result
+}


### PR DESCRIPTION
## What changed
Refactored the engine's reason execution into focused internal modules for stream state, compaction, transcript repair, request controls, output hooks, observability, error policy, and tests.

Replaced independent stream retry/completion flags with explicit replay and termination states. Reasoning-only output remains safe to retry, while answer text and tool calls commit the attempt against replay.

## Why
`reason.rs` had grown to 4,703 lines and its approximately 2,240-line LLM execution function mixed retry safety, stream termination, compaction, request shaping, hooks, and observability. The flag-driven control flow made retry invariants fragile and allowed contradictory terminal conditions to be represented.

## Before / After
This is an internal refactor with no intended observable API or runtime behavior change.

- `reason.rs`: 4,703 → 2,510 lines.
- `execute_llm_call`: approximately 2,240 → 1,535 lines.
- Retry safety is now represented by `StreamReplayState::{Replayable, Committed}`.
- Stream completion is now represented by one `StreamTermination` value rather than independent optional flags.
- `cargo test -p everruns-engine --all-features`: 74 unit tests plus engine integration and doctests passed.
- `cargo test -p everruns-engine --all-features --test resolved_execution_input_test`: the resolved-input `ReasonAtom` flow passed end to end.
- `just pre-push`: all 22 scoped checks passed.

## Risk
- Medium.
- The diff restructures central LLM streaming and compaction control flow. A regression could alter retry eligibility, partial-success handling, output guardrail termination, or request-too-large recovery.
- Focused state-transition tests, the engine suite, workspace-wide Clippy, architecture guards, and the resolved-input smoke test cover those seams.

## Security
- Threat categories reviewed: TM-LLM-005, TM-LLM-024, TM-LLM-031, and TM-DOS-032.
- Findings and resolutions: no new trust boundary, dependency, input surface, persistence format, or disclosure path was introduced. Bounded retry budgets and replay-safety classification remain centralized; the durable native-compaction install/apply boundary remains shared by proactive and reactive paths; error-disclosure clamping and its threat marker moved unchanged. No threat-model update is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
