### PR TITLE
fix: resolve deep smoke test regressions

### DIFF
--- a/apps/ui/e2e/navigation-prefetch.spec.ts
+++ b/apps/ui/e2e/navigation-prefetch.spec.ts
@@ -48,6 +48,17 @@ async function mockAppApi(page: Page) {
       json = { success: true, org_id: DEFAULT_ORG_ID };
     } else if (pathname.endsWith("/config")) {
       json = { policies: {} };
+    } else if (pathname === "/api/v1/sessions/facets") {
+      json = {
+        active_now: 0,
+        by_activity: [],
+        by_agent: [],
+        by_source: [],
+        failed_today: 0,
+        p95_duration_ms: 0,
+        tokens_today: 0,
+        total: 0,
+      };
     } else {
       json = { data: [], has_more: false, total: 0 };
     }
@@ -108,7 +119,9 @@ test.describe("Sidebar navigation prefetch", () => {
     await mockAppApi(page);
   });
 
-  test("Landing-surface startup does not prefetch unrelated sidebar routes or APIs", async ({ page }) => {
+  test("Landing-surface startup does not prefetch unrelated sidebar routes or APIs", async ({
+    page,
+  }) => {
     const requests: Request[] = [];
     page.on("request", (request) => requests.push(request));
 
@@ -150,6 +163,7 @@ test.describe("Sidebar navigation prefetch", () => {
     await expect(page.getByRole("link", { name: "Sessions" })).toBeVisible();
     await page.getByRole("link", { name: "Sessions" }).click();
     await expect(page).toHaveURL(/\/sessions$/);
+    await expect(page.getByText("Tokens today 0")).toBeVisible();
   });
 
   test("Settings navigation avoids child route fan-out", async ({ page }) => {

--- a/apps/ui/e2e/webmcp.spec.ts
+++ b/apps/ui/e2e/webmcp.spec.ts
@@ -74,6 +74,17 @@ async function mockAppApi(page: Page) {
       json = { success: true, org_id: DEFAULT_ORG_ID };
     } else if (pathname.endsWith("/config")) {
       json = { policies: {} };
+    } else if (pathname === "/api/v1/sessions/facets") {
+      json = {
+        active_now: 0,
+        by_activity: [],
+        by_agent: [],
+        by_source: [],
+        failed_today: 0,
+        p95_duration_ms: 0,
+        tokens_today: 0,
+        total: 0,
+      };
     } else {
       json = { data: [], has_more: false, total: 0 };
     }
@@ -132,4 +143,5 @@ test("registers and executes WebMCP shell tools", async ({
     await modelContext.executeTool(tool, JSON.stringify({ target_type: "page", page: "sessions" }));
   });
   await expect(page).toHaveURL(/\/sessions$/);
+  await expect(page.getByText("Tokens today 0")).toBeVisible();
 });

--- a/apps/ui/src/__tests__/mcp-servers-page.test.tsx
+++ b/apps/ui/src/__tests__/mcp-servers-page.test.tsx
@@ -171,6 +171,34 @@ describe("McpServersPage", () => {
     expect(mockMutateAsync).not.toHaveBeenCalled();
   });
 
+  it("surfaces a server-side create failure without closing the dialog", async () => {
+    const mockMutateAsync = jest
+      .fn()
+      .mockRejectedValue(
+        new Error("Invalid MCP server URL: Blocked host: 127.0.0.1 (private/internal address)"),
+      );
+    mockUseCreateMcpServer.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    });
+
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Server" }));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.change(within(dialog).getByLabelText("Name"), { target: { value: "local-mcp" } });
+    fireEvent.change(within(dialog).getByLabelText("URL"), {
+      target: { value: "http://127.0.0.1:9/mcp" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Create Server" }));
+
+    expect(
+      await within(dialog).findByText(/Blocked host: 127\.0\.0\.1 \(private\/internal address\)/),
+    ).toBeInTheDocument();
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
   it("opens the edit dialog prefilled with the server's current values", () => {
     render(<McpServersPage />);
 

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -193,6 +193,7 @@ function AddMcpServerDialog({
   const [protocolMode, setProtocolMode] = useState<McpProtocolMode>("auto");
   const [headers, setHeaders] = useState<Array<{ key: string; value: string }>>([]);
   const [headerErrors, setHeaderErrors] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const createServer = useCreateMcpServer();
@@ -207,11 +208,13 @@ function AddMcpServerDialog({
     setProtocolMode("auto");
     setHeaders([]);
     setHeaderErrors(null);
+    setFormError(null);
     setFieldErrors({});
   }, [open]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setFormError(null);
     const parsed = mcpServerFormSchema.safeParse({
       name,
       description,
@@ -246,7 +249,12 @@ function AddMcpServerDialog({
       api_key: parsed.data.auth_mode === "api_key" ? parsed.data.api_key : undefined,
       headers: headersRecord,
     };
-    await createServer.mutateAsync(data);
+    try {
+      await createServer.mutateAsync(data);
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : "MCP server could not be created");
+      return;
+    }
     onOpenChange(false);
     setName("");
     setDescription("");
@@ -431,6 +439,11 @@ function AddMcpServerDialog({
             )}
             {headerErrors && <p className="text-xs text-destructive">{headerErrors}</p>}
           </div>
+          {formError && (
+            <p role="alert" className="text-sm text-destructive">
+              {formError}
+            </p>
+          )}
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel

--- a/crates/server/src/storage/repositories/evals.rs
+++ b/crates/server/src/storage/repositories/evals.rs
@@ -18,7 +18,7 @@ impl Database {
             INSERT INTO evals (org_id, public_id, name, description, target, model_override, tags)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             RETURNING id, org_id, public_id, name, description, target,
-                      model_override, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at
+                      model_override, tags, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
@@ -52,7 +52,7 @@ impl Database {
         let row = sqlx::query_as::<_, EvalRow>(
             r#"
             SELECT id, org_id, public_id, name, description, target,
-                   model_override, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at
+                   model_override, tags, status, created_at, updated_at, archived_at, deleted_at
             FROM evals
             WHERE org_id = $1 AND public_id = $2
             "#,
@@ -79,7 +79,7 @@ impl Database {
         };
         let sql = format!(
             r#"SELECT id, org_id, public_id, name, description, target,
-                      model_override, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at
+                      model_override, tags, status, created_at, updated_at, archived_at, deleted_at
                FROM evals
                WHERE org_id = $1{status_sql}{search_sql}
                ORDER BY created_at DESC"#
@@ -111,7 +111,7 @@ impl Database {
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, public_id, name, description, target,
-                      model_override, tags, status, is_built_in, created_at, updated_at, archived_at, deleted_at
+                      model_override, tags, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -22,12 +22,12 @@ use everruns_server::api::common::Pagination;
 use everruns_server::org_init;
 use everruns_server::storage::{
     CreateAgentCapabilityRow, CreateAgentHealthCheckRunRow, CreateAgentRow, CreateAppRow,
-    CreateDeclarativeCapabilityRow, CreateEventRow, CreateHarnessRow, CreateImageRow,
-    CreateMcpServerRow, CreateModelRow, CreateOrganizationRow, CreatePrincipalRow,
+    CreateDeclarativeCapabilityRow, CreateEvalRow, CreateEventRow, CreateHarnessRow,
+    CreateImageRow, CreateMcpServerRow, CreateModelRow, CreateOrganizationRow, CreatePrincipalRow,
     CreateProviderRow, CreateSessionFileRow, CreateSessionRow, CreateSessionScheduleRow,
     CreateUserConnectionRow, CreateUserRow, Database, SessionListFilters, StorageBackend,
-    UpdateAgent, UpdateAgentHealthCheckRunRow, UpdateDeclarativeCapability, UpdateModel,
-    UpdateOrganization, UpdateOrganizationSettings, UpdateProvider, UpdateSession,
+    UpdateAgent, UpdateAgentHealthCheckRunRow, UpdateDeclarativeCapability, UpdateEvalRow,
+    UpdateModel, UpdateOrganization, UpdateOrganizationSettings, UpdateProvider, UpdateSession,
     UpdateSessionFile, UpdateSessionScheduleRow,
 };
 use test_harness::get_database_url;
@@ -58,6 +58,54 @@ async fn ensure_test_harness_id(
     org_init::generic_harness_id(backend, TEST_ORG_ID)
         .await
         .expect("generic harness id")
+}
+
+#[tokio::test]
+async fn test_eval_crud_matches_postgres_schema() {
+    let backend = create_test_backend().await;
+    let public_id = format!("eval_{}", Uuid::now_v7().simple());
+
+    let created = backend
+        .create_eval(
+            TEST_ORG_ID,
+            CreateEvalRow {
+                public_id: public_id.clone(),
+                name: "Postgres schema regression".to_string(),
+                description: Some("Exercises every EvalRow projection".to_string()),
+                target: None,
+                model_override: None,
+                tags: vec!["schema".to_string()],
+            },
+        )
+        .await
+        .expect("create eval using migrated schema");
+
+    let fetched = backend
+        .get_eval_by_public_id(TEST_ORG_ID, &public_id)
+        .await
+        .expect("fetch eval using migrated schema")
+        .expect("created eval exists");
+    assert_eq!(fetched.id, created.id);
+
+    let listed = backend
+        .list_evals(TEST_ORG_ID, Some("schema regression"), false)
+        .await
+        .expect("list evals using migrated schema");
+    assert!(listed.iter().any(|eval| eval.id == created.id));
+
+    let updated = backend
+        .update_eval(
+            TEST_ORG_ID,
+            created.id,
+            UpdateEvalRow {
+                name: Some("Updated Postgres schema regression".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("update eval using migrated schema")
+        .expect("updated eval exists");
+    assert_eq!(updated.name, "Updated Postgres schema regression");
 }
 
 async fn create_test_principal(


### PR DESCRIPTION
## What changed

- Restored PostgreSQL-backed Eval create, lookup, list, and update projections so the Evals UI loads normally.
- Kept rejected MCP server creation inside the dialog and rendered the API's actionable validation detail.
- Completed Sessions facet mocks in the navigation and WebMCP browser tests so green Playwright runs no longer hide render exceptions.
- Added regression coverage for the fresh PostgreSQL schema and the MCP rejection path.

## Why

A deep smoke test found three current-main failures: Evals returned HTTP 500 because its queries selected a nonexistent `is_built_in` column, rejected private MCP URLs escaped as unhandled client errors, and two browser mocks returned list-shaped data for the Sessions facets endpoint while the Playwright suite stayed green.

## Before / After

Before:

- `GET /api/v1/evals` returned HTTP 500 with `column "is_built_in" does not exist`; `/evals` remained on skeleton cards.
- Submitting `http://127.0.0.1:9/mcp` returned the correct server-side SSRF rejection, but the dialog showed no feedback and Next.js reported an unhandled `ApiError`.
- Playwright reported 49/49 passed while logging `Cannot read properties of undefined (reading 'toString')` from the Sessions masthead.

After:

- The same freshly migrated PostgreSQL database returns HTTP 200 and renders the persisted Eval record.
- The MCP dialog remains open and displays `Invalid MCP server URL: Blocked host: 127.0.0.1 (private/internal address)` with no browser error.
- Playwright reports 49/49 passed with no application error output; both navigation paths assert `Tokens today 0` from contract-complete facet responses.

Final local evidence:

- `just pre-push`: 22/22 checks passed after rebasing onto latest `origin/main`.
- Jest: 1,453/1,453 passed.
- Eval integration: 21/21 passed.
- Fresh-PostgreSQL Eval CRUD regression: passed.
- UI lint, typecheck, and generated API types: passed.
- Canonical DB-backed stack smoke: Evals HTTP 200 and rendered record; MCP SSRF rejection rendered inline; stack stopped cleanly.
- Visual evidence:

  Evals page rendering the persisted smoke-test record:

  ![Evals page rendering the persisted smoke-test record](https://github.com/user-attachments/assets/3cce1f5f-8c2a-4611-9a2d-42c19bab8d7e)

  MCP server dialog surfacing the backend SSRF rejection inline:

  ![MCP server dialog surfacing the backend SSRF rejection inline](https://github.com/user-attachments/assets/505f0d2b-6da0-48ae-a79d-b62e88c61c64)

## Risk

- Medium.
- Eval SQL projection changes cover every `EvalRow` query and are pinned against a freshly migrated PostgreSQL schema.
- MCP error handling changes only the rejected mutation path; successful creation still closes and resets the dialog.
- No schema migration, dependency, API contract, or OpenAPI change.

## Security

- Threat categories reviewed: TM-SQL, TM-TENANT, TM-API, TM-MCP, TM-WEB.
- Findings and resolutions: Eval queries remain parameterized and organization-scoped. The backend SSRF policy remains authoritative; the client only renders the existing API detail as escaped React text. No new trust boundary, secret exposure, or threat-model mitigation change was introduced.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
