### PR TITLE
docs(framework): publish execution architecture

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -167,6 +167,7 @@ export default defineConfig({
                   items: [
                     { label: "Overview", slug: "framework" },
                     { label: "Quickstart", slug: "framework/quickstart" },
+                    { label: "Architecture", slug: "framework/architecture" },
                   ],
                 },
                 {

--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -16,9 +16,9 @@ ecosystem. Normal Rust applications should start here; focused core, engine,
 host, provider, and platform crates support the implementation and advanced
 execution hosts.
 
-The public `Engine` SPI owns sessions. `InMemoryEngine` is the explicit
-process-local implementation; `everruns-engine` is the shared execution kernel
-for Input/Reason/Act and turn planning.
+The concrete `Engine` owns process-local sessions. It uses `everruns-engine`,
+the shared execution kernel for Input/Reason/Act and turn planning. The same
+kernel also drives the Everruns Platform's durable server/worker path.
 
 ## Installation
 
@@ -44,7 +44,7 @@ for feature boundaries and advanced-host composition.
 ## Offline Quickstart
 
 ```rust
-use everruns::{Agent, InMemoryEngine, Model};
+use everruns::{Agent, Engine, Model};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .model(Model::simulated("Hello from Everruns."))
         .build()?;
 
-    let engine = InMemoryEngine::new();
+    let engine = Engine::new();
     let session = engine.create(agent);
     let session_id = session.session_id();
     let turn = session.send_and_wait("Say hello.").await?;
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 `Model::simulated` uses the normal provider/execution path and returns a fixed
 response locally. It needs no credential or network connection.
 
-`InMemoryEngine` owns Agent snapshots, the process-local session catalog, and
+`Engine` owns Agent snapshots, the process-local session catalog, and
 runtime state. `engine.create(agent)` and `engine.resume(session_id)` return the
 same first-class `Session` abstraction. Agents never own hidden execution
 engines or session catalogs.
@@ -177,9 +177,9 @@ before sending to observe live events, or pass a cancellation token through
 `RunOptions`.
 
 ```rust
-use everruns::{CancellationToken, InMemoryEngine, RunOptions};
+use everruns::{CancellationToken, Engine, RunOptions};
 
-let engine = InMemoryEngine::new();
+let engine = Engine::new();
 let session = engine.create(agent);
 let mut events = session.events();
 let first = session.send("Remember this turn.").await?;
@@ -204,7 +204,7 @@ next model call without exposing backend records.
 
 ## Workspace Heads and Environments
 
-Simple applications retain an `InMemoryEngine` and may use
+Simple applications retain an `Engine` and may use
 `AgentBuilder::workspace(path)` as shorthand for one shared local directory.
 Applications that need isolated mutable project views use the open
 `WorkspaceProvider` SPI, create a `WorkspaceHead`, and permanently bind it
@@ -212,7 +212,7 @@ before execution:
 
 ```rust
 use std::sync::Arc;
-use everruns::{Environment, InMemoryEngine, LocalGitWorkspaceProvider, Workspace};
+use everruns::{Environment, Engine, LocalGitWorkspaceProvider, Workspace};
 
 # async fn bind(agent: &everruns::Agent, repository: &std::path::Path, state: &std::path::Path)
 # -> Result<(), Box<dyn std::error::Error>> {
@@ -220,7 +220,7 @@ let provider = Arc::new(LocalGitWorkspaceProvider::new(state)?);
 let workspace = Workspace::open(provider, repository.to_string_lossy()).await?;
 let head = workspace.head("feature").from_revision("main").create().await?;
 let environment = Environment::builder().workspace(head).build()?;
-let engine = InMemoryEngine::new();
+let engine = Engine::new();
 let session = engine.create(agent.clone()).environment(environment).start().await?;
 assert!(session.workspace_head().is_some());
 # Ok(())
@@ -308,6 +308,7 @@ Examples are compiled in CI and import only `everruns`.
 ## Documentation
 
 - [Everruns Framework](https://docs.everruns.com/framework/)
+- [Framework architecture](https://docs.everruns.com/framework/architecture/)
 - [Framework quickstart](https://docs.everruns.com/framework/quickstart/)
 - [Workspace security](https://docs.everruns.com/framework/workspace-security/)
 - [Workspaces and environments](https://docs.everruns.com/framework/workspaces-and-environments/)

--- a/crates/everruns/examples/advanced_capability.rs
+++ b/crates/everruns/examples/advanced_capability.rs
@@ -5,7 +5,7 @@
 //! OPENAI_API_KEY=sk-... cargo run -p everruns --features openai --example advanced_capability
 //! ```
 
-use everruns::{Agent, InMemoryEngine, OpenAI, SessionEventKind, capability};
+use everruns::{Agent, Engine, OpenAI, SessionEventKind, capability};
 
 #[derive(capability::Deserialize, capability::JsonSchema)]
 #[serde(crate = "everruns::capability::serde")]
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .capability(catalog)
         .build()?;
 
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
     let mut events = session.events();
     let pending = session.send("What is product EVR-42?").await?;
     while let Some(event) = events.recv().await? {

--- a/crates/everruns/examples/canonical_events.rs
+++ b/crates/everruns/examples/canonical_events.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .instructions("Answer concisely.")
         .model(Model::simulated("Hello from Everruns."))
         .build()?;
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
     let mut events = session.events();
 
     let observer = tokio::spawn(async move {

--- a/crates/everruns/examples/capability_configuration.rs
+++ b/crates/everruns/examples/capability_configuration.rs
@@ -3,9 +3,7 @@
 //! Run offline with:
 //! `cargo run -p everruns --example capability_configuration`
 
-use everruns::{
-    Agent, CapabilityRef, CompactionConfig, InMemoryEngine, Model, ToolSearch, capability,
-};
+use everruns::{Agent, CapabilityRef, CompactionConfig, Engine, Model, ToolSearch, capability};
 
 #[derive(capability::Deserialize, capability::JsonSchema)]
 #[serde(crate = "everruns::capability::serde")]
@@ -69,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .build()?;
 
-    let turn = InMemoryEngine::new()
+    let turn = Engine::new()
         .create(agent)
         .run("Confirm the agent is configured.")
         .await?;

--- a/crates/everruns/examples/engine_sessions.rs
+++ b/crates/everruns/examples/engine_sessions.rs
@@ -1,8 +1,8 @@
-use everruns::{Agent, InMemoryEngine, Model};
+use everruns::{Agent, Engine, Model};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let engine = InMemoryEngine::new();
+    let engine = Engine::new();
     let agent = Agent::builder()
         .instructions("Be concise.")
         .model(Model::simulated("Hello."))

--- a/crates/everruns/examples/github_monitor.rs
+++ b/crates/everruns/examples/github_monitor.rs
@@ -17,7 +17,7 @@
 use std::process::Stdio;
 use std::time::Duration;
 
-use everruns::{Agent, FunctionTool, InMemoryEngine, OpenAI, ToolResponse};
+use everruns::{Agent, Engine, FunctionTool, OpenAI, ToolResponse};
 use serde_json::json;
 use tokio::process::Command;
 use tokio::sync::mpsc;
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     println!("monitoring {}", mode.target());
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
     let started = session
         .send_and_wait("Monitor this pull request until its checks finish.")
         .await?;

--- a/crates/everruns/examples/hello.rs
+++ b/crates/everruns/examples/hello.rs
@@ -7,7 +7,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use everruns::{Agent, InMemoryEngine, OpenAI};
+use everruns::{Agent, Engine, OpenAI};
 
 /// Return the current Unix time in seconds.
 #[everruns::tool]
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .tool(current_time())
         .build()?;
 
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
     let mut events = session.events();
     let pending = session.send("what time is it?").await?;
     let mut event_types = Vec::new();

--- a/crates/everruns/examples/lifecycle_hooks.rs
+++ b/crates/everruns/examples/lifecycle_hooks.rs
@@ -9,7 +9,7 @@
 //! Lifecycle hooks are awaited extension points. Use `Session::events()`
 //! instead when code only needs a non-blocking observation stream.
 
-use everruns::{Agent, InMemoryEngine, OpenAI};
+use everruns::{Agent, Engine, OpenAI};
 
 /// Return a deterministic service status so the model has a tool to call.
 #[everruns::tool]
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .build()?;
 
-    let turn = InMemoryEngine::new()
+    let turn = Engine::new()
         .create(agent)
         .send_and_wait("Is the payments service healthy?")
         .await?;

--- a/crates/everruns/examples/live_session.rs
+++ b/crates/everruns/examples/live_session.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use everruns::{Agent, InMemoryEngine, LlmSimConfig, Model, SendDisposition};
+use everruns::{Agent, Engine, LlmSimConfig, Model, SendDisposition};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .instructions("Plan trips and incorporate every user message.")
         .model(model)
         .build()?;
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
 
     let initial = session.send("Plan my trip.").await?;
     let latest = session.send("Prefer trains.").await?;

--- a/crates/everruns/examples/observe_and_cancel.rs
+++ b/crates/everruns/examples/observe_and_cancel.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     // --- Observe a turn's events -----------------------------------------
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
     let mut events = session.events();
 
     let pending = session.send("hi").await?;
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(rendered, turn.response);
 
     // --- Cancel a turn ---------------------------------------------------
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
     let token = CancellationToken::new();
     token.cancel(); // cancel up front for a deterministic example
 

--- a/crates/everruns/examples/production_agent.rs
+++ b/crates/everruns/examples/production_agent.rs
@@ -6,7 +6,7 @@
 //! cargo run -p everruns --features openai --example production_agent
 //! ```
 
-use everruns::{Agent, InMemoryEngine, OpenAI};
+use everruns::{Agent, Engine, OpenAI};
 
 /// Look up an order in the read-only public order namespace.
 #[everruns::tool]
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .tool(lookup_order())
         .build()?;
 
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
     let first = session
         .send_and_wait("What is the status of order A-42?")
         .await?;

--- a/crates/everruns/examples/session_history.rs
+++ b/crates/everruns/examples/session_history.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use everruns::{Agent, InMemoryEngine, LocalConfig, Model};
+use everruns::{Agent, Engine, LocalConfig, Model};
 
 fn agent(data_dir: &Path) -> Result<Agent, everruns::BuildError> {
     Agent::builder()
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|| PathBuf::from("target/framework-session-history-example"));
 
     let session_id = {
-        let engine = InMemoryEngine::new();
+        let engine = Engine::new();
         let first_agent = agent(&data_dir)?;
         let session = engine.create(first_agent);
         session.send_and_wait("My project is Atlas.").await?;
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // configuration; the engine attaches it to identity/history from the same
     // local profile. Application code never opens an event log or database.
     let second_agent = agent(&data_dir)?;
-    let engine = InMemoryEngine::new();
+    let engine = Engine::new();
     engine.attach(session_id, second_agent).await?;
     let resumed = engine.resume(session_id).await?;
     let mut pages = resumed.history().limit(2)?.pages();

--- a/crates/everruns/examples/session_work.rs
+++ b/crates/everruns/examples/session_work.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use everruns::work::{TaskOutcome, TaskRequest, WakePolicy, WakeReason, WorkQueue};
-use everruns::{Agent, InMemoryEngine, Model};
+use everruns::{Agent, Engine, Model};
 use serde_json::json;
 
 #[tokio::main]
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .instructions("You summarize completed background work.")
         .model(Model::simulated("Background work handled."))
         .build()?;
-    let session = InMemoryEngine::new().create(agent.clone());
+    let session = Engine::new().create(agent.clone());
 
     let queue = WorkQueue::in_memory();
     let session_work = session.work(&queue);

--- a/crates/everruns/examples/subagents.rs
+++ b/crates/everruns/examples/subagents.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use everruns::{Agent, FunctionTool, InMemoryEngine, OpenAI, ToolResponse};
+use everruns::{Agent, Engine, FunctionTool, OpenAI, ToolResponse};
 use serde_json::json;
 use tokio::task::JoinHandle;
 
@@ -80,7 +80,7 @@ fn spawn_tool(tasks: Arc<ChildTasks>) -> FunctionTool {
                             .model(MODEL_ID)
                             .build()
                             .map_err(|error| error.to_string())?;
-                        let result = InMemoryEngine::new()
+                        let result = Engine::new()
                             .create(child)
                             .run(instruction)
                             .await
@@ -212,7 +212,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Delegate each of these five independent reviews, then wait for every task ID:\n- {}",
         task_descriptions.join("\n- ")
     );
-    let result = InMemoryEngine::new()
+    let result = Engine::new()
         .create(parent.clone())
         .send_and_wait(prompt)
         .await?;

--- a/crates/everruns/examples/workspace_heads.rs
+++ b/crates/everruns/examples/workspace_heads.rs
@@ -4,8 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use everruns::{
-    Agent, InMemoryEngine, LocalConfig, LocalGitWorkspaceProvider, Model, Workspace,
-    WorkspacePolicy,
+    Agent, Engine, LocalConfig, LocalGitWorkspaceProvider, Model, Workspace, WorkspacePolicy,
 };
 
 #[tokio::main]
@@ -31,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .workspace_provider(provider)
         .workspace_policy(WorkspacePolicy::read_write())
         .build()?;
-    let session = InMemoryEngine::new()
+    let session = Engine::new()
         .create(agent.clone())
         .workspace(head.clone())
         .start()

--- a/crates/everruns/examples/workspace_policy.rs
+++ b/crates/everruns/examples/workspace_policy.rs
@@ -1,6 +1,6 @@
 //! Configure portable workspace access without importing runtime backends.
 
-use everruns::{Agent, InMemoryEngine, Model, WorkspacePolicy};
+use everruns::{Agent, Engine, Model, WorkspacePolicy};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .readonly_file("input/brief.md", "Summarize the workspace policy.")
         .build()?;
 
-    let turn = InMemoryEngine::new()
+    let turn = Engine::new()
         .create(agent)
         .send_and_wait("Confirm the policy is active.")
         .await?;

--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -210,11 +210,20 @@ pub enum BuildError {
     /// A live model was selected without a provider.
     MissingProvider,
     /// More than one provider was attached to the agent.
-    MultipleProviders { registered: Vec<String> },
+    MultipleProviders {
+        /// Stable keys of the providers attached to the agent.
+        registered: Vec<String>,
+    },
     /// MCP server configuration was invalid or duplicated.
-    InvalidMcpServer { reason: String },
+    InvalidMcpServer {
+        /// Why the MCP server configuration was rejected.
+        reason: String,
+    },
     /// Two workspace providers registered the same stable SPI id.
-    DuplicateWorkspaceProvider { id: String },
+    DuplicateWorkspaceProvider {
+        /// The colliding workspace provider id.
+        id: String,
+    },
 }
 
 impl fmt::Display for BuildError {

--- a/crates/everruns/src/lib.rs
+++ b/crates/everruns/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 //! The application-facing crate for the [Everruns Framework](https://docs.everruns.com/framework/).
 //!
 //! Build agents, attach provider configuration, select model ids, add typed
@@ -22,14 +24,14 @@
 //! ```
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use everruns::{Agent, InMemoryEngine, Model};
+//! use everruns::{Agent, Engine, Model};
 //!
 //! let agent = Agent::builder()
 //!     .instructions("You are a helpful assistant.")
 //!     .model(Model::simulated("4"))
 //!     .build()
 //!     .expect("valid agent");
-//! let engine = InMemoryEngine::new();
+//! let engine = Engine::new();
 //! let result = engine.create(agent).send_and_wait("What is 2 + 2?").await?;
 //! assert!(result.success);
 //! assert_eq!(result.response, "4");

--- a/crates/everruns/src/session.rs
+++ b/crates/everruns/src/session.rs
@@ -704,10 +704,15 @@ impl EnvironmentSessionBuilder {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SessionEnvironmentError {
+    /// The Session already started and its Environment can no longer change.
     AlreadyStarted,
+    /// The Session is already bound to a different Environment.
     AlreadyBound,
+    /// The Environment's workspace provider conflicts with the Agent configuration.
     ProviderConflict,
+    /// The recorded Environment or workspace head cannot be reopened.
     Unavailable,
+    /// The workspace provider rejected the requested operation.
     Workspace(everruns_host::WorkspaceError),
 }
 
@@ -846,7 +851,9 @@ impl TurnHandle {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CancelError {
+    /// The Session closed before the cancellation request could be delivered.
     SessionClosed,
+    /// The turn had already reached a terminal state.
     TurnFinished,
 }
 

--- a/docs/framework/agents.md
+++ b/docs/framework/agents.md
@@ -55,8 +55,8 @@ the application-facing session context.
 Inspect the next model call before or after a turn:
 
 ```rust
-# use everruns::InMemoryEngine;
-let engine = InMemoryEngine::new();
+# use everruns::Engine;
+let engine = Engine::new();
 let session = engine.create(agent);
 let context = session.inspect().await?;
 println!("messages: {}", context.messages.len());

--- a/docs/framework/architecture.md
+++ b/docs/framework/architecture.md
@@ -1,0 +1,90 @@
+---
+title: Framework Architecture
+description: Understand Agent, Engine, Session, and how immediate and durable execution share one kernel.
+---
+
+Everruns has one turn model and two ways to execute it. A library application
+uses the concrete `everruns::Engine` in its own process. The Everruns Platform
+uses server and worker services with durable checkpoints. Both paths converge
+on the same `everruns-engine` Input/Reason/Act state machine.
+
+![Framework execution architecture](./architecture.svg)
+
+## Public Framework objects
+
+| Object | Responsibility |
+| --- | --- |
+| `Agent` | Immutable behavior: instructions, model and provider, tools, capabilities, files, and lifecycle hooks |
+| `Engine` | Concrete process-local owner of Agent snapshots, session identity, backends, history, and resume authority |
+| `Session` | First-class, engine-bound conversation used for turns, steering, events, cancellation, inspection, and history |
+| `Environment` | Session resources, including one exact provider-owned workspace head and typed extensions |
+
+New Framework code creates and resumes sessions through an Engine:
+
+```rust
+use everruns::{Agent, Engine, Model};
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let agent = Agent::builder()
+    .instructions("Answer concisely.")
+    .model(Model::simulated("Ready."))
+    .build()?;
+
+let engine = Engine::new();
+let session = engine.create(agent);
+let session_id = session.session_id();
+let turn = session.send_and_wait("Begin.").await?;
+assert!(turn.success);
+
+drop(session);
+let resumed = engine.resume(session_id).await?;
+assert_eq!(resumed.session_id(), session_id);
+# Ok(())
+# }
+```
+
+`InMemoryEngine` remains a compatibility alias. It is not a second engine
+implementation; use `Engine` in new 0.18 code.
+
+## Two execution paths, one kernel
+
+The library path is immediate. `everruns::Engine` uses `everruns-host` to run
+`InProcessExecution` in the caller's process. It can be entirely volatile or
+use the local profile for crash-durable canonical events.
+
+The Platform path is distributed and checkpointed. The server schedules work,
+workers resolve host services and effects, and `everruns-durable` advances a
+`DurableExecution` across persisted phase boundaries. PostgreSQL remains the
+source of recovery state.
+
+Neither path owns a private copy of the turn algorithm. `everruns-engine` owns
+the `Execution` contract, `TurnExecution` state, Input/Reason/Act atoms, phase
+ordering, and effect production. Immediate and durable adapters select where
+state lives and how work is scheduled.
+
+## Choose a recovery boundary
+
+- **Volatile Framework:** `Engine::new()` is offline and database-free. The
+  creating Engine can resume a dropped Session, but process exit loses it.
+- **Local crash-durable Framework:** `LocalConfig` stores canonical events and
+  session identity locally. Rebuild the trusted Agent configuration, attach it
+  to a new Engine, and resume by typed `SessionId`.
+- **Distributed durable Platform:** server and workers checkpoint workflow state
+  in PostgreSQL and recover across process or worker loss. Applications call it
+  through the remote API or SDKs rather than configuring the facade Engine.
+
+See [Persistence](/framework/persistence/) and [Session History and
+Resume](/framework/session-history/) for the exact application lifecycle.
+
+## Extension boundaries
+
+Normal applications depend on `everruns`. `everruns::Engine` is concrete and is
+not implemented by applications. Provider integrations implement the open
+`ChatDriver` boundary, while canonical storage hosts can implement
+`EventLog`/`EventReader` through `everruns-host`.
+
+An application that is itself an execution host may compose
+`everruns-engine::Execution` with `everruns-host` or `everruns-durable`. That is
+an advanced deployment boundary: preserve event ordering, workspace isolation,
+credential separation, cancellation, and committed effect semantics. Start
+with [Custom Backends](/framework/custom-backends/) before crossing it.

--- a/docs/framework/architecture.mmd
+++ b/docs/framework/architecture.mmd
@@ -1,0 +1,20 @@
+flowchart TB
+    F["Everruns Framework<br/>Agent • Engine • Session"]
+    P["Everruns Platform<br/>Server • Worker"]
+    H["everruns-host<br/>InProcessExecution"]
+    D["everruns-durable<br/>DurableExecution"]
+    K["everruns-engine<br/>Execution • TurnExecution • Input / Reason / Act"]
+
+    F -->|"create / resume / run"| H
+    P -->|"schedule / checkpoint / retry"| D
+    H -->|"implements Execution"| K
+    D -->|"implements Execution"| K
+
+    classDef application fill:#F5F5F5,stroke:#0A0A0A,color:#0A0A0A
+    classDef immediate fill:#F5F5F5,stroke:#1B7F4B,color:#0A0A0A
+    classDef durable fill:#F5F5F5,stroke:#B45309,color:#0A0A0A
+    classDef kernel fill:#F5F5F5,stroke:#0A1636,color:#0A0A0A
+    class F,P application
+    class H immediate
+    class D durable
+    class K kernel

--- a/docs/framework/architecture.svg
+++ b/docs/framework/architecture.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 490" fill="none">
+  <style>
+    text { font-family: 'Geist', 'Inter', system-ui, sans-serif; }
+    .label { font-size: 13px; fill: #0A0A0A; font-weight: 600; }
+    .sublabel { font-size: 11px; fill: #404040; font-weight: 400; }
+    .header-text { font-size: 11px; fill: #707070; font-weight: 500; letter-spacing: 0.08em; }
+    .mono { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 10px; fill: #404040; }
+    .arrow-label { font-size: 10px; fill: #0A1636; font-weight: 500; }
+  </style>
+  <rect width="800" height="490" fill="#FFFFFF"/>
+
+  <text x="190" y="30" text-anchor="middle" class="header-text">LIBRARY APPLICATION</text>
+  <rect x="40" y="45" width="300" height="100" fill="#F5F5F5" stroke="#0A0A0A"/>
+  <text x="190" y="82" text-anchor="middle" class="label">Everruns Framework</text>
+  <text x="190" y="105" text-anchor="middle" class="sublabel">Agent • Engine • Session</text>
+  <text x="190" y="124" text-anchor="middle" class="mono">application-owned, process-local</text>
+
+  <text x="610" y="30" text-anchor="middle" class="header-text">DISTRIBUTED PRODUCT</text>
+  <rect x="460" y="45" width="300" height="100" fill="#F5F5F5" stroke="#0A0A0A"/>
+  <text x="610" y="82" text-anchor="middle" class="label">Everruns Platform</text>
+  <text x="610" y="105" text-anchor="middle" class="sublabel">Server • Worker</text>
+  <text x="610" y="124" text-anchor="middle" class="mono">PostgreSQL-backed orchestration</text>
+
+  <line x1="190" y1="145" x2="190" y2="219" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="185,219 190,229 195,219" fill="#0A1636"/>
+  <text x="202" y="188" class="arrow-label">create / resume / run</text>
+
+  <line x1="610" y1="145" x2="610" y2="219" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="605,219 610,229 615,219" fill="#0A1636"/>
+  <text x="622" y="181" class="arrow-label">schedule / checkpoint</text>
+  <text x="622" y="195" class="arrow-label">/ retry</text>
+
+  <text x="70" y="219" class="header-text" fill="#1B7F4B">IMMEDIATE</text>
+  <rect x="70" y="230" width="240" height="90" fill="#F5F5F5" stroke="#0A0A0A"/>
+  <rect x="70" y="230" width="5" height="90" fill="#1B7F4B"/>
+  <text x="190" y="266" text-anchor="middle" class="label">everruns-host</text>
+  <text x="190" y="290" text-anchor="middle" class="mono">InProcessExecution</text>
+  <text x="190" y="307" text-anchor="middle" class="sublabel">immediate adapter</text>
+
+  <text x="490" y="219" class="header-text" fill="#B45309">DURABLE</text>
+  <rect x="490" y="230" width="240" height="90" fill="#F5F5F5" stroke="#0A0A0A"/>
+  <rect x="490" y="230" width="5" height="90" fill="#B45309"/>
+  <text x="610" y="266" text-anchor="middle" class="label">everruns-durable</text>
+  <text x="610" y="290" text-anchor="middle" class="mono">DurableExecution</text>
+  <text x="610" y="307" text-anchor="middle" class="sublabel">checkpointed adapter</text>
+
+  <line x1="190" y1="320" x2="190" y2="384" stroke="#0A1636" stroke-width="1.5"/>
+  <line x1="610" y1="320" x2="610" y2="384" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="185,384 190,394 195,384" fill="#0A1636"/>
+  <polygon points="605,384 610,394 615,384" fill="#0A1636"/>
+  <text x="202" y="356" class="arrow-label">implements Execution</text>
+  <text x="622" y="356" class="arrow-label">implements Execution</text>
+
+  <text x="400" y="384" text-anchor="middle" class="header-text">SHARED EXECUTION KERNEL</text>
+  <rect x="130" y="395" width="540" height="80" fill="#F5F5F5" stroke="#0A0A0A"/>
+  <rect x="130" y="395" width="540" height="4" fill="#0A1636"/>
+  <text x="400" y="426" text-anchor="middle" class="label">everruns-engine</text>
+  <text x="400" y="449" text-anchor="middle" class="sublabel">Execution • TurnExecution • Input / Reason / Act</text>
+  <text x="400" y="466" text-anchor="middle" class="mono">one turn state machine and event order</text>
+</svg>

--- a/docs/framework/canonical-events.md
+++ b/docs/framework/canonical-events.md
@@ -16,7 +16,7 @@ let agent = Agent::builder()
     .instructions("Answer concisely.")
     .model(Model::simulated("Hello!"))
     .build()?;
-let engine = InMemoryEngine::new();
+let engine = Engine::new();
 let mut session = engine.create(agent);
 let mut events = session.events();
 

--- a/docs/framework/custom-backends.md
+++ b/docs/framework/custom-backends.md
@@ -29,17 +29,21 @@ one facade.
 
 ## Two engine boundaries
 
-`everruns::Engine` is the application SPI that owns Agent snapshots, sessions,
-history, and resume authority. Implement it when replacing session ownership.
+`everruns::Engine` is a concrete application object that owns Agent snapshots,
+sessions, history, and resume authority. It is the normal Framework entrypoint,
+not an extension trait. Applications do not implement it.
 
-`everruns-engine` is the lower-level shared execution kernel. It owns the
-`Execution` contract, serializable `TurnExecution` state machine,
+`everruns-engine` is the lower-level shared execution kernel. Advanced hosts
+compose its `Execution` contract and serializable `TurnExecution` state machine,
 `InputAtom`/`ReasonAtom`/`ActAtom`, and phase values. The immediate implementation
 lives in `everruns-host`; the checkpointed implementation lives in
 `everruns-durable`. Both use narrow contracts from `everruns-core`. The kernel
 has no dependency on host, platform, server, worker, or durable crates. Do not
 copy state advancement or the phase loop into a custom backend; implement the
 execution boundary and keep deployment-specific service selection in the host.
+
+See [Framework Architecture](/framework/architecture/) for the complete layer
+map and the distinction between immediate and durable execution.
 
 Conversation persistence is the one backend with a single write path. Replace it
 by implementing the canonical `EventLog`/`EventReader` SPI and passing it to

--- a/docs/framework/events-and-cancellation.md
+++ b/docs/framework/events-and-cancellation.md
@@ -6,7 +6,7 @@ description: Subscribe to live Framework session events and cancel a turn cooper
 Subscribe before sending a message to observe its live event projection:
 
 ```rust
-use everruns::{Agent, InMemoryEngine, Model};
+use everruns::{Agent, Engine, Model};
 
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,7 +14,7 @@ let agent = Agent::builder()
     .instructions("Be concise.")
     .model(Model::simulated("Done."))
     .build()?;
-let session = InMemoryEngine::new().create(agent);
+let session = Engine::new().create(agent);
 let mut events = session.events();
 
 let pending = session.send("Start.").await?;
@@ -50,13 +50,13 @@ A message receipt exposes the specific accepting turn, so live applications
 can cancel without racing against whichever turn is active later:
 
 ```rust
-# use everruns::{Agent, InMemoryEngine, LlmSimConfig, Model};
+# use everruns::{Agent, Engine, LlmSimConfig, Model};
 # use std::time::Duration;
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # let model = Model::simulated_with_config(LlmSimConfig::fixed("Done.").with_response_delay(Duration::from_millis(100)));
 # let agent = Agent::builder().instructions("Be concise.").model(model).build()?;
-# let session = InMemoryEngine::new().create(agent);
+# let session = Engine::new().create(agent);
 let pending = session.send("Start.").await?;
 pending.turn().cancel().await?;
 let cancelled = pending.wait().await?;

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -8,14 +8,14 @@ crate. Use it to describe agents, attach models and tools, run multi-turn sessio
 observe events, and embed agent execution directly in a Rust process.
 
 ```rust
-use everruns::{Agent, InMemoryEngine, Model};
+use everruns::{Agent, Engine, Model};
 
 let agent = Agent::builder()
     .instructions("Answer in one short sentence.")
     .model(Model::simulated("Hello from Everruns."))
     .build()?;
 
-let engine = InMemoryEngine::new();
+let engine = Engine::new();
 let turn = engine.create(agent).send_and_wait("Say hello.").await?;
 assert_eq!(turn.response, "Hello from Everruns.");
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -39,6 +39,7 @@ storage or orchestration cross into [custom backends](/framework/custom-backends
 ## Start here
 
 - [Quickstart](/framework/quickstart/) — install the crate and run an offline agent.
+- [Architecture](/framework/architecture/) — understand Agent, Engine, Session, and the shared immediate/durable execution kernel.
 - [Agents](/framework/agents/) — instructions, files, workspaces, MCP, plugins, and context inspection.
 - [Workspace security](/framework/workspace-security/) — configure portable read and write scopes with secure defaults.
 - [Workspaces and Environments](/framework/workspaces-and-environments/) — bind sessions to isolated or explicitly shared provider-owned heads.

--- a/docs/framework/persistence.md
+++ b/docs/framework/persistence.md
@@ -1,11 +1,17 @@
 ---
 title: Persistence
-description: Choose volatile or crash-durable Framework session and local application state.
+description: Choose volatile memory, crash-durable local state, or the distributed durable Platform.
 ---
 
 Framework history is a read-only projection of canonical events. Normal
 execution has one write path—the engine's event log—so a resumed session and a
 running session cannot disagree about the conversation.
+
+| Deployment | Conversation state | Recovery boundary | Use when |
+| --- | --- | --- | --- |
+| `Engine::new()` | Volatile memory | One Engine in one process | Embedding, tests, and short-lived tools |
+| `Engine` with `LocalConfig` | Crash-durable local canonical events and catalog | One trusted application process | Desktop apps, CLIs, and single-node services |
+| Everruns Platform | PostgreSQL-backed durable workflow state and canonical events | Distributed server and workers | Restarts, retries, horizontal workers, and remote clients |
 
 ## Default: engine-lifetime memory
 
@@ -28,7 +34,7 @@ event log under the configured application data directory. It also supplies a
 trusted real-disk workspace plus SQLite-backed task and schedule state:
 
 ```rust
-use everruns::{Agent, InMemoryEngine, LocalConfig, Model};
+use everruns::{Agent, Engine, LocalConfig, Model};
 
 let local = LocalConfig::new(".everruns-data").workspace("./workspace");
 let agent = Agent::builder()
@@ -36,7 +42,7 @@ let agent = Agent::builder()
     .model(Model::simulated("Ready."))
     .local(local)
     .build()?;
-let engine = InMemoryEngine::new();
+let engine = Engine::new();
 let session = engine.create(agent);
 # Ok::<(), everruns::BuildError>(())
 ```
@@ -84,3 +90,16 @@ typed recovery-limit error instead of allocating or scanning without bound.
 
 Do not design new application persistence around a legacy storage
 representation.
+
+## Platform: distributed durable execution
+
+The Everruns Platform uses the same `everruns-engine` turn state machine as the
+Framework, but adapts it through `everruns-durable`. The server schedules work,
+workers execute phases and apply effects, and PostgreSQL stores workflow
+checkpoints and canonical events. A worker can disappear between phases and a
+later worker can continue from the committed checkpoint.
+
+This is a deployment boundary, not another configuration mode on
+`everruns::Engine`. Remote applications use the Platform API or an SDK; product
+hosts compose the lower-level durable crates. See [Framework
+Architecture](/framework/architecture/) for the layer map.

--- a/docs/framework/quickstart.md
+++ b/docs/framework/quickstart.md
@@ -17,7 +17,7 @@ do not select a network provider.
 ## Run one turn
 
 ```rust
-use everruns::{Agent, InMemoryEngine, Model};
+use everruns::{Agent, Engine, Model};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .model(Model::simulated("Everruns is ready."))
         .build()?;
 
-    let engine = InMemoryEngine::new();
+    let engine = Engine::new();
     let session = engine.create(agent);
     let turn = session.send_and_wait("Are you ready?").await?;
     println!("{}", turn.response);
@@ -65,5 +65,6 @@ let agent = Agent::builder()
 The model id stays credential-free. `OpenAI::from_env` configures the separate
 provider at the application boundary and redacts the key from debug output.
 
-Continue with [Agents](/framework/agents/), [Tools and macros](/framework/tools-and-macros/),
+Continue with [Framework Architecture](/framework/architecture/),
+[Agents](/framework/agents/), [Tools and macros](/framework/tools-and-macros/),
 and [Sessions](/framework/sessions/).

--- a/docs/framework/session-history.md
+++ b/docs/framework/session-history.md
@@ -7,7 +7,7 @@ Every Framework session has a typed `SessionId`. Keep that value when an
 application may need to reopen the conversation:
 
 ```rust
-use everruns::{Agent, InMemoryEngine, Model, SessionId};
+use everruns::{Agent, Engine, Model, SessionId};
 
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,7 +16,7 @@ let agent = Agent::builder()
     .model(Model::simulated("Acknowledged."))
     .build()?;
 
-let engine = InMemoryEngine::new();
+let engine = Engine::new();
 let session = engine.create(agent);
 let session_id: SessionId = session.session_id();
 session.send_and_wait("My project is Atlas.").await?;
@@ -40,14 +40,14 @@ snapshot attached to that engine; it never reconstructs behavior from events.
 messages by default in canonical event-sequence order, oldest first:
 
 ```rust
-# use everruns::{Agent, InMemoryEngine, Model};
+# use everruns::{Agent, Engine, Model};
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # let agent = Agent::builder()
 #     .instructions("Be concise.")
 #     .model(Model::simulated("Done."))
 #     .build()?;
-# let session = InMemoryEngine::new().create(agent);
+# let session = Engine::new().create(agent);
 let page = session.history().page().await?;
 for message in &page.messages {
     println!("{:?}: {}", message.role, message.text());
@@ -62,14 +62,14 @@ maximum. A page never claims to contain the entire transcript. Continue from
 its opaque cursor:
 
 ```rust
-# use everruns::{Agent, InMemoryEngine, Model};
+# use everruns::{Agent, Engine, Model};
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # let agent = Agent::builder()
 #     .instructions("Be concise.")
 #     .model(Model::simulated("Done."))
 #     .build()?;
-# let session = InMemoryEngine::new().create(agent);
+# let session = Engine::new().create(agent);
 let first = session.history().limit(25)?.page().await?;
 if let Some(cursor) = first.next_cursor {
     let second = session.history().limit(25)?.after(cursor)?.page().await?;
@@ -92,14 +92,14 @@ For callers that intentionally walk the whole snapshot, `pages` is a lazy
 convenience that still reads one bounded page at a time:
 
 ```rust
-# use everruns::{Agent, InMemoryEngine, Model};
+# use everruns::{Agent, Engine, Model};
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # let agent = Agent::builder()
 #     .instructions("Be concise.")
 #     .model(Model::simulated("Done."))
 #     .build()?;
-# let session = InMemoryEngine::new().create(agent);
+# let session = Engine::new().create(agent);
 let mut pages = session.history().limit(50)?.pages();
 while let Some(page) = pages.next_page().await? {
     for message in page.messages {
@@ -124,7 +124,7 @@ Enable `local` and configure a trusted application data directory when sessions
 must survive a new Agent or process:
 
 ```rust
-use everruns::{Agent, InMemoryEngine, LocalConfig, Model};
+use everruns::{Agent, Engine, LocalConfig, Model};
 
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -134,13 +134,13 @@ let build_agent = || Agent::builder()
     .local(LocalConfig::new(".everruns-data"))
     .build();
 
-let first_engine = InMemoryEngine::new();
+let first_engine = Engine::new();
 let session = first_engine.create(build_agent()?);
 session.start().await?;
 let session_id = session.session_id();
 
 // In a later process, rebuild trusted behavior before resuming persisted state.
-let restarted_engine = InMemoryEngine::new();
+let restarted_engine = Engine::new();
 restarted_engine.attach(session_id, build_agent()?).await?;
 let resumed = restarted_engine.resume(session_id).await?;
 # Ok::<(), Box<dyn std::error::Error>>(())

--- a/docs/framework/sessions.md
+++ b/docs/framework/sessions.md
@@ -7,7 +7,7 @@ An `Agent` is immutable reusable behavior. An `Engine` owns session identity,
 history, and runtime state. A `Session` is an engine-bound live conversation.
 
 ```rust
-use everruns::{Agent, InMemoryEngine, Model};
+use everruns::{Agent, Engine, Model};
 
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,7 +16,7 @@ let agent = Agent::builder()
     .model(Model::simulated("Acknowledged."))
     .build()?;
 
-let engine = InMemoryEngine::new();
+let engine = Engine::new();
 let session = engine.create(agent);
 let first = session.send_and_wait("My project is Atlas.").await?;
 let second = session.send_and_wait("Continue with that project.").await?;
@@ -34,11 +34,11 @@ reports which case occurred, so applications do not need to race on session
 state themselves:
 
 ```rust
-# use everruns::{Agent, InMemoryEngine, Model, SendDisposition};
+# use everruns::{Agent, Engine, Model, SendDisposition};
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # let agent = Agent::builder().instructions("Remember input.").model(Model::simulated("Done.")).build()?;
-# let engine = InMemoryEngine::new();
+# let engine = Engine::new();
 let session = engine.create(agent);
 let initial = session.send("Plan my trip.").await?;
 let latest = session.send("Prefer trains.").await?;

--- a/docs/framework/testing-and-simulation.md
+++ b/docs/framework/testing-and-simulation.md
@@ -7,7 +7,7 @@ description: Test Framework applications deterministically without network acces
 resolution and execution path while returning a fixed response locally.
 
 ```rust
-use everruns::{Agent, InMemoryEngine, Model};
+use everruns::{Agent, Engine, Model};
 
 # #[tokio::test]
 # async fn agent_follows_the_application_flow() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,7 +16,7 @@ let agent = Agent::builder()
     .model(Model::simulated("approved"))
     .build()?;
 
-let session = InMemoryEngine::new().create(agent);
+let session = Engine::new().create(agent);
 let turn = session.send_and_wait("Review this.").await?;
 assert!(turn.success);
 assert_eq!(turn.response, "approved");

--- a/docs/framework/workspaces-and-environments.md
+++ b/docs/framework/workspaces-and-environments.md
@@ -19,7 +19,7 @@ Enable the `local` feature to use the public Git-worktree provider:
 ```rust
 use std::sync::Arc;
 use everruns::{
-    Agent, InMemoryEngine, LocalGitWorkspaceProvider, Model, Workspace, WorkspacePolicy,
+    Agent, Engine, LocalGitWorkspaceProvider, Model, Workspace, WorkspacePolicy,
 };
 
 # async fn example(repository: &std::path::Path, state: &std::path::Path)
@@ -36,7 +36,7 @@ let agent = Agent::builder()
     .model(Model::simulated("ready"))
     .workspace_policy(WorkspacePolicy::read_write())
     .build()?;
-let engine = InMemoryEngine::new();
+let engine = Engine::new();
 let session = engine.create(agent).workspace(head).start().await?;
 
 assert!(session.workspace_head().is_some());

--- a/knowledge/docs/diagrams.md
+++ b/knowledge/docs/diagrams.md
@@ -4,13 +4,13 @@ title: "Diagram Specification"
 description: "Diagram specification."
 tags:
   - everruns
-  - ui
+  - documentation
 ---
 # Diagram Specification
 
 Style guide for technical diagrams in documentation. All diagrams follow the Everruns brand system (see `knowledge/ui/brand.md`) and are hand-authored SVGs.
 
-Adopted from [`everruns/landing/knowledge/ui/diagrams.md`](https://github.com/everruns/landing/blob/main/knowledge/ui/diagrams.md).
+Adopted from the current [`everruns/landing` diagram specification](https://github.com/everruns/landing/blob/main/specs/diagrams.md), with the restrained semantic-color rule aligned to the Chaliy web diagram system.
 
 ## Placement
 
@@ -37,7 +37,13 @@ This separation means:
 
 ## Colors
 
-Grayscale palette with Navy as the only accent. No gradients. No other colors.
+Black and white first. Grayscale with Navy remains the default, and most
+diagrams should stay in it. A diagram may use restrained semantic color when it
+materially clarifies an important boundary, execution path, status, or state
+distinction. Color is informational, never decorative: use no more than two
+hues beyond the base palette, keep each meaning consistent within the diagram,
+label the distinction in text, and never rely on color alone. Prefer a narrow
+rail, label, or status marker over a full colored box. No gradients.
 
 | Element                      | Hex       | Brand name |
 | ---------------------------- | --------- | ---------- |
@@ -52,6 +58,14 @@ Grayscale palette with Navy as the only accent. No gradients. No other colors.
 | Step badge text              | `#FFFFFF` | White      |
 | Secondary connectors         | `#A0A0A0` | Silver     |
 | Annotation box stroke        | `#404040` | Slate      |
+
+Suggested semantic highlights, used only when needed:
+
+| Meaning | Accent |
+| --- | --- |
+| Success or immediate/local path | `#1B7F4B` |
+| Warning or durable/checkpointed path | `#B45309` |
+| Danger or failure | `#B42318` |
 
 ## Typography
 

--- a/knowledge/docs/index.md
+++ b/knowledge/docs/index.md
@@ -1,0 +1,3 @@
+# Documentation
+
+* [Diagram Specification](diagrams.md) - Placement, source-of-truth, brand, color, and visual-review rules for technical diagrams.

--- a/knowledge/framework/documentation-and-examples.md
+++ b/knowledge/framework/documentation-and-examples.md
@@ -18,6 +18,12 @@ application lifecycle, and marks `everruns-host` as advanced host material.
 The `everruns` README and rustdoc are concise entrances
 to that same path rather than independent architecture narratives.
 
+The public architecture guide names the concrete `everruns::Engine` as the
+application session owner and separately explains the lower-level
+`everruns-engine::Execution` host contract. It shows both immediate and durable
+execution converging on one turn kernel and distinguishes volatile, local
+crash-durable, and distributed Platform persistence.
+
 Exact API shapes belong in source/rustdoc. Public guides link there instead of
 freezing exhaustive fields or variants in durable knowledge.
 

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -13,6 +13,7 @@ okf_version: "0.2"
 * [foundations/](foundations/) - Core entities, architecture, runtime, providers, and developer conventions.
 * [execution/](execution/) - API contracts, capability behavior, tool execution, and streaming.
 * [runtime-resources/](runtime-resources/) - Agents, sessions, workspaces, knowledge, memory, and runtime-owned resources.
+* [docs/](docs/) - Public documentation structure, diagrams, and visual artifact contracts.
 * [ui/](ui/) - User interface, message rendering, generative UI, and product presentation.
 * [integrations/](integrations/) - MCP, external integrations, apps, plugins, and messaging channels.
 * [operations/](operations/) - Deployment, persistence, scheduling, observability, networking, and operations.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,15 @@
 
 ## 2026-08-15
 
+* **Framework architecture is public and unambiguous.** The Framework guide
+  now presents concrete `everruns::Engine` as the canonical application API,
+  separates it from the low-level `everruns-engine::Execution` host contract,
+  and maps immediate and durable execution onto their shared turn kernel. The
+  persistence guide distinguishes volatile, local crash-durable, and
+  distributed Platform recovery boundaries. The diagram contract now lives in
+  the documentation knowledge domain and permits at most two restrained,
+  labeled semantic accents when color clarifies an important boundary.
+
 * Moved the remaining active design work out of the temporary `proposals/`
   area and into its owning knowledge domains: secret-leak guardrails under
   security, external evaluation publishing under evaluation, and the portable

--- a/knowledge/ui/documentation.md
+++ b/knowledge/ui/documentation.md
@@ -296,7 +296,7 @@ hero: ./my-feature-screenshot.png
 
 (The legacy form `hero: ../images/features/my-feature-screenshot.png` still resolves for grandfathered assets under `docs/images/{section}/`, but new pages should follow the co-located form above.)
 
-Place new hero images (and any other diagrams or screenshots used by a single page) in the **same directory as the page that embeds them**, and reference them with relative paths (`hero: ./my-feature-screenshot.png`). Existing assets under `docs/images/{section}/` continue to work and are not migrated en masse. See `knowledge/ui/diagrams.md` for the colocation rule applied to diagrams.
+Place new hero images (and any other diagrams or screenshots used by a single page) in the **same directory as the page that embeds them**, and reference them with relative paths (`hero: ./my-feature-screenshot.png`). Existing assets under `docs/images/{section}/` continue to work and are not migrated en masse. See `knowledge/docs/diagrams.md` for the colocation rule applied to diagrams.
 
 **Generated files are gitignored** — `public/og/` and `public/og-image.png` are rebuilt on every `pnpm run build` (via the `prebuild` script). Only the generation script and source images are committed.
 
@@ -321,9 +321,9 @@ The docs site must ship a single `sitemap.xml` file at the site root.
 
 ### Diagram Rendering
 
-Diagrams are hand-authored SVGs following `knowledge/ui/diagrams.md`. Each SVG has a co-located `.mmd` (Mermaid) source-of-truth file.
+Diagrams are hand-authored SVGs following `knowledge/docs/diagrams.md`. Each SVG has a co-located `.mmd` (Mermaid) source-of-truth file.
 
-1. New SVGs (and their `.mmd` siblings) **must** live in the same directory as the markdown page that embeds them, and are referenced via `![alt](./<name>.svg)`. See `knowledge/ui/diagrams.md` for the full placement rule.
+1. New SVGs (and their `.mmd` siblings) **must** live in the same directory as the markdown page that embeds them, and are referenced via `![alt](./<name>.svg)`. See `knowledge/docs/diagrams.md` for the full placement rule.
 2. Legacy diagrams under `docs/images/<category>/` remain in place and continue to work; they are not migrated en masse.
 3. No client-side rendering library is needed — SVGs are static assets processed by Astro's image pipeline
 4. The Mermaid `.mmd` files are source-of-truth for diagram content but are not rendered at build time

--- a/knowledge/ui/index.md
+++ b/knowledge/ui/index.md
@@ -7,6 +7,5 @@
 * [MCP Entity Cards](mcp-cards.md) - MCP Apps entity cards and sandboxed HTML resources.
 * [Navigation Information Architecture](information-architecture.md) - How navigation is grouped by what you do with a thing, and the dismissed alternatives.
 * [Brand Specification](brand.md) - Brand identity, colors, typography.
-* [Diagram Specification](diagrams.md) - Diagram specification.
 * [Documentation Site Specification](documentation.md) - Documentation site.
 * [Sign-up Experience Redesign — Analysis & Design Brief](signup-experience-redesign-brief.md) - Design brief for on-brand sign-up / onboarding screens.

--- a/scripts/test-published-crate-docs.sh
+++ b/scripts/test-published-crate-docs.sh
@@ -113,7 +113,11 @@ for package in published:
     require(re.search(r"^## License\s*$", readme_text, re.M | re.I) is not None, readme, "add a License section")
     require("github.com/everruns/everruns/blob/main/LICENSE" in readme_text, readme, "link the repository MIT license")
 
-    require(rustdoc.startswith("//!"), lib, "start with crate-level rustdoc")
+    # Crate-level lint attributes may precede the inner rustdoc. Strip only
+    # single-line inner attributes; executable items or ordinary comments must
+    # still fail the structural contract.
+    rustdoc_start = re.sub(r"\A(?:#!\[[^\n]*\]\s*)*", "", rustdoc)
+    require(rustdoc_start.startswith("//!"), lib, "start with crate-level rustdoc")
     require("https://everruns.com" in crate_docs, lib, "mirror the Everruns ecosystem link in rustdoc")
     require(
         re.search(r"^//! ```(?:rust|no_run)?\s*$", crate_docs, re.M) is not None,


### PR DESCRIPTION
## Summary

- publish a Framework architecture guide and semantic-color diagram showing the concrete application Engine, immediate host adapter, durable Platform adapter, and their shared execution kernel
- make `Engine` the canonical name across Framework docs and runnable examples while retaining `InMemoryEngine` as a documented compatibility alias
- distinguish volatile, local crash-durable, and distributed PostgreSQL recovery boundaries and correct the false claim that `everruns::Engine` is an implementable SPI
- enforce crate-wide public API documentation and teach the published-doc guard to accept crate attributes before inner rustdoc
- update Framework navigation, knowledge, and the diagram standard

## Validation

- `just pre-push` (22/22, after rebase onto latest main)
- `cargo check -p everruns --all-features`
- `cargo check -p everruns --examples --all-features`
- `cargo test -p everruns --doc --all-features` (11/11)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p everruns --all-features --no-deps`
- `CI=true pnpm run check` in `apps/docs`
- `CI=true pnpm run build` in `apps/docs` (493 pages, all links valid)
- `bash scripts/test-published-crate-docs.sh` (38 packages)
- `just check-okf`
- SVG XML validation plus 800px rasterized visual review

## Security review

Documentation/API-lint-only change. No new ingress, credential handling, persistence format, authorization path, dependency, or executable runtime behavior. The guide explicitly preserves credential separation, workspace isolation, canonical event ordering, cancellation, and committed-effect semantics at custom-host boundaries.

Slow PR jobs remain in their intentionally disabled state.