### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-08-16
+
+### Highlights
+
+- **The 0.18 neutral-kernel boundary** - `everruns-core` is now a neutral execution kernel. Hosted platform records — sessions, agents and agent versions, harnesses, evals and observers, connectors, system email, feature flags, and OAuth/credential infrastructure — moved out to `everruns-platform` (and sibling crates), and the logic-free `everruns-runtime` compatibility crate was removed. REST/gRPC shapes and stored schema are unchanged; see the [0.18 migration guide](https://github.com/everruns/everruns/pull/3148) and the **Breaking** notes below ([#3160](https://github.com/everruns/everruns/pull/3160), [#3101](https://github.com/everruns/everruns/pull/3101)).
+- **Engine-owned sessions and unified execution** - Engines now own the session lifecycle, and a single execution path serves both in-process and durable runs ([#3179](https://github.com/everruns/everruns/pull/3179), [#3173](https://github.com/everruns/everruns/pull/3173), [#3167](https://github.com/everruns/everruns/pull/3167)).
+- **Multi-head workspaces** - Framework workspaces now support multiple heads ([#3166](https://github.com/everruns/everruns/pull/3166)).
+- **Metered embedding spend** - Retrieval and knowledge-index embedding spend is now metered and ledgered against the organization ([#3149](https://github.com/everruns/everruns/pull/3149), [#3163](https://github.com/everruns/everruns/pull/3163)).
+- **Chats as core functionality** - Chats is always present in navigation and search for every organization with no feature opt-in, and now supports chat pinning.
+
 ### Breaking
 
 - **Moved concrete in-memory backends out of `everruns-core`.** Embedded-host
@@ -154,6 +164,95 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   envelopes into a fixture session's event log. It is the supported way to
   give an in-memory loop a prior conversation now that history projects from
   canonical events and `EventHistory` is read-only.
+
+### What's Changed
+
+- refactor(llmsim): extract publishable simulator crate by [@chaliy](https://github.com/chaliy)
+- fix(framework): close provider adoption gaps ([#3189](https://github.com/everruns/everruns/pull/3189)) by [@chaliy](https://github.com/chaliy)
+- docs(framework): publish execution architecture ([#3188](https://github.com/everruns/everruns/pull/3188)) by [@chaliy](https://github.com/chaliy)
+- fix: resolve deep smoke test regressions ([#3187](https://github.com/everruns/everruns/pull/3187)) by [@chaliy](https://github.com/chaliy)
+- refactor(framework): simplify coding agent setup ([#3186](https://github.com/everruns/everruns/pull/3186)) by [@chaliy](https://github.com/chaliy)
+- ci(actions): move every action off the deprecated Node 20 runtime ([#3184](https://github.com/everruns/everruns/pull/3184)) by [@chaliy](https://github.com/chaliy)
+- refactor(engine): split reason execution states ([#3185](https://github.com/everruns/everruns/pull/3185)) by [@chaliy](https://github.com/chaliy)
+- refactor(framework): complete library boundary cleanup ([#3182](https://github.com/everruns/everruns/pull/3182)) by [@chaliy](https://github.com/chaliy)
+- fix(docs): bump the nanoid override to the actual GHSA-2v37-7h3g-55p8 fix ([#3183](https://github.com/everruns/everruns/pull/3183)) by [@chaliy](https://github.com/chaliy)
+- chore(knowledge): move active proposals into knowledge ([#3181](https://github.com/everruns/everruns/pull/3181)) by [@chaliy](https://github.com/chaliy)
+- chore(agents): document PR evidence publishing ([#3180](https://github.com/everruns/everruns/pull/3180)) by [@chaliy](https://github.com/chaliy)
+- fix(engine): retry stalls after reasoning output ([#3177](https://github.com/everruns/everruns/pull/3177)) by [@chaliy](https://github.com/chaliy)
+- refactor(framework)!: make engines own session lifecycle ([#3179](https://github.com/everruns/everruns/pull/3179)) by [@chaliy](https://github.com/chaliy)
+- refactor(engine): finish unified execution migration ([#3175](https://github.com/everruns/everruns/pull/3175)) by [@chaliy](https://github.com/chaliy)
+- perf(build): speed up worktree validation ([#3176](https://github.com/everruns/everruns/pull/3176)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): prevent shell injection in release workflow ([#3174](https://github.com/everruns/everruns/pull/3174)) by [@chaliy](https://github.com/chaliy)
+- refactor(engine): unify in-process and durable execution ([#3173](https://github.com/everruns/everruns/pull/3173)) by [@chaliy](https://github.com/chaliy)
+- revert(scale): remove portable distributed engine ([#3172](https://github.com/everruns/everruns/pull/3172)) by [@chaliy](https://github.com/chaliy)
+- feat(scale): add portable distributed engine by [@chaliy](https://github.com/chaliy)
+- refactor(engine)!: own shared execution kernel ([#3170](https://github.com/everruns/everruns/pull/3170)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): add engine-owned sessions ([#3167](https://github.com/everruns/everruns/pull/3167)) by [@chaliy](https://github.com/chaliy)
+- refactor(example): use Framework workspace heads ([#3168](https://github.com/everruns/everruns/pull/3168)) by [@chaliy](https://github.com/chaliy)
+- feat(framework): add multi-head workspaces ([#3166](https://github.com/everruns/everruns/pull/3166)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): bump the nanoid override to the actual GHSA-2v37-7h3g-55p8 fix ([#3165](https://github.com/everruns/everruns/pull/3165)) by [@chaliy](https://github.com/chaliy)
+- feat(embeddings): ledger index-sync embedding spend against the org ([#3163](https://github.com/everruns/everruns/pull/3163)) by [@chaliy](https://github.com/chaliy)
+- fix(research): migrate lua eval from core exports ([#3164](https://github.com/everruns/everruns/pull/3164)) by [@chaliy](https://github.com/chaliy)
+- fix(server): preserve credentialless gRPC provider type ([#3162](https://github.com/everruns/everruns/pull/3162)) by [@chaliy](https://github.com/chaliy)
+- fix(research): replay seeded conversation events into the session log ([#3161](https://github.com/everruns/everruns/pull/3161)) by [@chaliy](https://github.com/chaliy)
+- refactor(core)!: freeze the 0.18 neutral-kernel boundary ([#3160](https://github.com/everruns/everruns/pull/3160)) by [@chaliy](https://github.com/chaliy)
+- refactor(host): move store-backed execution resolution ([#3159](https://github.com/everruns/everruns/pull/3159)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): split execution service contracts ([#3158](https://github.com/everruns/everruns/pull/3158)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): isolate TLS and transport dependencies ([#3157](https://github.com/everruns/everruns/pull/3157)) by [@chaliy](https://github.com/chaliy)
+- refactor(storage): move in-memory backends to owners by [@chaliy](https://github.com/chaliy)
+- refactor(core): move concrete capabilities out of kernel by [@chaliy](https://github.com/chaliy)
+- chore(knowledge): close EVE-897 and record why the context bag stays ([#3154](https://github.com/everruns/everruns/pull/3154)) by [@chaliy](https://github.com/chaliy)
+- chore(ui): retire the Dashboard as a top-level page ([#3153](https://github.com/everruns/everruns/pull/3153)) by [@chaliy](https://github.com/chaliy)
+- fix(research): finish the HostComposition rename in lua-vs-bash ([#3152](https://github.com/everruns/everruns/pull/3152)) by [@chaliy](https://github.com/chaliy)
+- feat(openresponses): report per-call cost for compaction requests ([#3150](https://github.com/everruns/everruns/pull/3150)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): breadcrumbs name their navigation group ([#3151](https://github.com/everruns/everruns/pull/3151)) by [@chaliy](https://github.com/chaliy)
+- feat(embeddings): meter retrieval embedding spend ([#3149](https://github.com/everruns/everruns/pull/3149)) by [@chaliy](https://github.com/chaliy)
+- docs(how-to): add the 0.18 migration guide for direct core consumers ([#3148](https://github.com/everruns/everruns/pull/3148)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): drop the dead embedded-platform-docs feature from the kernel ([#3146](https://github.com/everruns/everruns/pull/3146)) by [@chaliy](https://github.com/chaliy)
+- refactor(context): resolve the session mutator as a typed extension ([#3147](https://github.com/everruns/everruns/pull/3147)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): drop the vestigial sqlx feature from the kernel ([#3145](https://github.com/everruns/everruns/pull/3145)) by [@chaliy](https://github.com/chaliy)
+- chore(knowledge): close EVE-880 — three session families stay in the kernel ([#3143](https://github.com/everruns/everruns/pull/3143)) by [@chaliy](https://github.com/chaliy)
+- test(llm): skip explicit OpenRouter credit ceilings ([#3144](https://github.com/everruns/everruns/pull/3144)) by [@chaliy](https://github.com/chaliy)
+- test(llm): separate sampling misses from contract failures ([#3142](https://github.com/everruns/everruns/pull/3142)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): move background tool runs out of the kernel ([#3140](https://github.com/everruns/everruns/pull/3140)) by [@chaliy](https://github.com/chaliy)
+- fix(scripts): stop export-openapi truncating the committed spec ([#3139](https://github.com/everruns/everruns/pull/3139)) by [@chaliy](https://github.com/chaliy)
+- refactor(context): resolve the session SQL store as a typed extension ([#3138](https://github.com/everruns/everruns/pull/3138)) by [@chaliy](https://github.com/chaliy)
+- refactor(composition): move the composition root out of the kernel ([#3137](https://github.com/everruns/everruns/pull/3137)) by [@chaliy](https://github.com/chaliy)
+- refactor(platform): move the Workspace and managed session sandbox records out of the kernel ([#3133](https://github.com/everruns/everruns/pull/3133)) by [@chaliy](https://github.com/chaliy)
+- feat(agents): protect built-in agents at the command layer ([#3136](https://github.com/everruns/everruns/pull/3136)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump @astrojs/markdown-satteri from 0.3.4 to 0.3.5 in /apps/docs ([#3125](https://github.com/everruns/everruns/pull/3125)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump distroless/cc-debian12 from `fccdbb0` to `adcd20c` in /docker ([#3124](https://github.com/everruns/everruns/pull/3124)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump distroless/cc-debian12 from `fccdbb0` to `adcd20c` in /crates/server ([#3122](https://github.com/everruns/everruns/pull/3122)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): take syn 3, hold buffa and js-yaml majors ([#3135](https://github.com/everruns/everruns/pull/3135)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump distroless/cc-debian12 from `fccdbb0` to `adcd20c` in /crates/worker ([#3123](https://github.com/everruns/everruns/pull/3123)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump marked from 18.0.6 to 18.0.9 in /apps/docs ([#3127](https://github.com/everruns/everruns/pull/3127)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump @astrojs/check from 0.9.9 to 0.9.10 in /apps/docs ([#3128](https://github.com/everruns/everruns/pull/3128)) by [@dependabot](https://github.com/dependabot)
+- ci: stop third-party apt repo failures from reddening main ([#3134](https://github.com/everruns/everruns/pull/3134)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): move session-service capabilities out of the kernel ([#3132](https://github.com/everruns/everruns/pull/3132)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): move portable policy builtins out of core ([#3131](https://github.com/everruns/everruns/pull/3131)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): move hosted knowledge, delegation and platform capabilities out of core ([#3111](https://github.com/everruns/everruns/pull/3111)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): move environment implementations out of core ([#3119](https://github.com/everruns/everruns/pull/3119)) by [@chaliy](https://github.com/chaliy)
+- refactor(platform): move connector, OAuth, credential and system-email infrastructure out of core ([#3120](https://github.com/everruns/everruns/pull/3120)) by [@chaliy](https://github.com/chaliy)
+- fix(core): fail closed on unknown capability registration gates ([#3121](https://github.com/everruns/everruns/pull/3121)) by [@chaliy](https://github.com/chaliy)
+- feat(models): use platform default fallback ([#3114](https://github.com/everruns/everruns/pull/3114)) by [@chaliy](https://github.com/chaliy)
+- refactor(platform): move eval, observer and feature-management records out of core ([#3118](https://github.com/everruns/everruns/pull/3118)) by [@chaliy](https://github.com/chaliy)
+- refactor(platform): move the persisted Session aggregate out of core ([#3117](https://github.com/everruns/everruns/pull/3117)) by [@chaliy](https://github.com/chaliy)
+- refactor(platform): move Harness records and built-in provisioning out of core ([#3116](https://github.com/everruns/everruns/pull/3116)) by [@chaliy](https://github.com/chaliy)
+- fix(llm-tests): skip subagent live test on provider quota exhaustion ([#3115](https://github.com/everruns/everruns/pull/3115)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): separate session recording projections ([#3113](https://github.com/everruns/everruns/pull/3113)) by [@chaliy](https://github.com/chaliy)
+- feat(chats): add chat pinning by [@chaliy](https://github.com/chaliy)
+- refactor(providers): remove provider crates' direct dependency on core ([#3110](https://github.com/everruns/everruns/pull/3110)) by [@chaliy](https://github.com/chaliy)
+- refactor(platform): move Agent and AgentVersion persistence records out of core ([#3109](https://github.com/everruns/everruns/pull/3109)) by [@chaliy](https://github.com/chaliy)
+- refactor(observability): move telemetry and event-listener implementations out of core ([#3108](https://github.com/everruns/everruns/pull/3108)) by [@chaliy](https://github.com/chaliy)
+- refactor(test-support): move llmsim, in-memory loop and fake capabilities out of core ([#3107](https://github.com/everruns/everruns/pull/3107)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): establish one neutral capability contract for Framework and product ([#3106](https://github.com/everruns/everruns/pull/3106)) by [@chaliy](https://github.com/chaliy)
+- fix(examples): repair standalone crates after session-events and DriverId API drift ([#3105](https://github.com/everruns/everruns/pull/3105)) by [@chaliy](https://github.com/chaliy)
+- refactor(host): replace stored record inputs with resolved execution snapshot ([#3103](https://github.com/everruns/everruns/pull/3103)) by [@chaliy](https://github.com/chaliy)
+- fix(host): make the canonical EventLog SPI externally implementable ([#3102](https://github.com/everruns/everruns/pull/3102)) by [@chaliy](https://github.com/chaliy)
+- refactor(0.18)!: delete the everruns-runtime compatibility crate ([#3101](https://github.com/everruns/everruns/pull/3101)) by [@chaliy](https://github.com/chaliy)
+- fix(chat): make Chats unconditional ([#3100](https://github.com/everruns/everruns/pull/3100)) by [@chaliy](https://github.com/chaliy)
+- test: use obvious credential fixtures ([#3099](https://github.com/everruns/everruns/pull/3099)) by [@chaliy](https://github.com/chaliy)
+- fix(release): correct everruns-local publish dependency map ([#3098](https://github.com/everruns/everruns/pull/3098)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.17.26] - 2026-08-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1275,7 +1275,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "inout 0.1.4",
 ]
 
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -2121,7 +2121,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2591,11 +2591,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.17.26"
+version = "0.18.0"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "schemars",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "everruns-provider",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-http"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-bashkit"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "buffa",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-lua"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openrouter-workspace"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-web-fetch"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "everruns-capability",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-local"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-observability"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3452,11 +3452,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.17.26"
+version = "0.18.0"
 
 [[package]]
 name = "everruns-platform"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-services"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-test-support"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4230,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -5062,9 +5062,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.1",
  "inotify-sys",
@@ -5219,9 +5219,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
+checksum = "7941c8de9c591052050550f228c62ef80d3ecbd84c330f5c454bc8ebb7a04089"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -5561,9 +5561,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -6869,9 +6869,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -6879,9 +6879,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6889,9 +6889,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -6902,9 +6902,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.26"
+version = "0.18.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -179,30 +179,30 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-capability = { path = "crates/capability", version = "0.17.26", default-features = false }
-everruns-builtins = { path = "crates/builtins", version = "0.17.26" }
-everruns-core = { path = "crates/core", version = "0.17.26" }
-everruns-engine = { path = "crates/engine", version = "0.17.26" }
-everruns-host = { path = "crates/host", version = "0.17.26" }
-everruns-session-services = { path = "crates/session-services", version = "0.17.26" }
-everruns-http = { path = "crates/http", version = "0.17.26" }
-everruns-llmsim = { path = "crates/llmsim", version = "0.17.26", default-features = false }
-everruns-test-support = { path = "crates/test-support", version = "0.17.26", default-features = false }
-everruns-platform = { path = "crates/platform", version = "0.17.26" }
-everruns-provider = { path = "crates/provider", version = "0.17.26", default-features = false }
-everruns-observability = { path = "crates/observability", version = "0.17.1" }
-everruns-mcp = { path = "crates/mcp", version = "0.17.26" }
-everruns-ard = { path = "crates/ard", version = "0.17.26" }
-everruns-openai = { path = "crates/openai", version = "0.17.0" }
-everruns-local = { path = "crates/local", version = "0.17.26" }
-everruns = { path = "crates/everruns", version = "0.17.26" }
-everruns-macros = { path = "crates/macros", version = "0.17.26" }
-everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.17.26" }
-everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.17.26" }
-everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.17.26" }
-everruns-integrations-duckduckgo = { path = "integrations/duckduckgo", version = "0.17.26" }
-everruns-integrations-lua = { path = "integrations/lua", version = "0.17.26" }
-everruns-integrations-openrouter-workspace = { path = "integrations/openrouter-workspace", version = "0.17.26" }
+everruns-capability = { path = "crates/capability", version = "0.18.0", default-features = false }
+everruns-builtins = { path = "crates/builtins", version = "0.18.0" }
+everruns-core = { path = "crates/core", version = "0.18.0" }
+everruns-engine = { path = "crates/engine", version = "0.18.0" }
+everruns-host = { path = "crates/host", version = "0.18.0" }
+everruns-session-services = { path = "crates/session-services", version = "0.18.0" }
+everruns-http = { path = "crates/http", version = "0.18.0" }
+everruns-llmsim = { path = "crates/llmsim", version = "0.18.0", default-features = false }
+everruns-test-support = { path = "crates/test-support", version = "0.18.0", default-features = false }
+everruns-platform = { path = "crates/platform", version = "0.18.0" }
+everruns-provider = { path = "crates/provider", version = "0.18.0", default-features = false }
+everruns-observability = { path = "crates/observability", version = "0.18.0" }
+everruns-mcp = { path = "crates/mcp", version = "0.18.0" }
+everruns-ard = { path = "crates/ard", version = "0.18.0" }
+everruns-openai = { path = "crates/openai", version = "0.18.0" }
+everruns-local = { path = "crates/local", version = "0.18.0" }
+everruns = { path = "crates/everruns", version = "0.18.0" }
+everruns-macros = { path = "crates/macros", version = "0.18.0" }
+everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.0" }
+everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.18.0" }
+everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.18.0" }
+everruns-integrations-duckduckgo = { path = "integrations/duckduckgo", version = "0.18.0" }
+everruns-integrations-lua = { path = "integrations/lua", version = "0.18.0" }
+everruns-integrations-openrouter-workspace = { path = "integrations/openrouter-workspace", version = "0.18.0" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.17.26",
+  "version": "0.18.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -43,7 +43,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../provider", version = "0.17.26" }
+everruns-provider = { path = "../provider", version = "0.18.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -39,7 +39,7 @@ base64.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../provider", version = "0.17.26" }
+everruns-provider = { path = "../provider", version = "0.18.0" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -18,10 +18,10 @@ categories = ["development-tools", "asynchronous"]
 # execution values. It owns no host, platform, database, network, process, or
 # interpreter implementation edge.
 everruns-capability.workspace = true
-everruns-core = { path = "../core", version = "0.17.26", default-features = false }
+everruns-core = { path = "../core", version = "0.18.0", default-features = false }
 everruns-provider.workspace = true
-everruns-openui = { path = "../openui", version = "0.17.26", optional = true }
-everruns-a2ui = { path = "../a2ui", version = "0.17.26", optional = true }
+everruns-openui = { path = "../openui", version = "0.18.0", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.18.0", optional = true }
 
 async-trait.workspace = true
 chrono.workspace = true

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -39,7 +39,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../provider", version = "0.17.26" }
+everruns-provider = { path = "../provider", version = "0.18.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -24,7 +24,7 @@ serde.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../provider", version = "0.17.26" }
+everruns-provider = { path = "../provider", version = "0.18.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -57,10 +57,10 @@ tracing-subscriber.workspace = true
 # default-features = false sheds core's heavy optional subtrees (a2a,
 # web-fetch) that the exporters do not need — they only use the always-on
 # event/trait/telemetry-conventions surface.
-everruns-core = { path = "../core", version = "0.17.0", default-features = false }
+everruns-core = { path = "../core", version = "0.18.0", default-features = false }
 # Server/worker startup selects ring before observability or HTTP clients can
 # initialize rustls. This keeps the concrete TLS choice outside core.
-everruns-provider = { path = "../provider", version = "0.17.0", default-features = false, features = ["tls-ring"] }
+everruns-provider = { path = "../provider", version = "0.18.0", default-features = false, features = ["tls-ring"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../provider", version = "0.17.26" }
+everruns-provider = { path = "../provider", version = "0.18.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -34,7 +34,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../provider", version = "0.17.26" }
+everruns-provider = { path = "../provider", version = "0.18.0" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -44,7 +44,7 @@ fixtures = ["dep:everruns-platform"]
 host = ["dep:everruns-host", "sim", "everruns-llmsim/host"]
 
 [dependencies]
-everruns-core = { path = "../core", version = "0.17.26", default-features = false }
+everruns-core = { path = "../core", version = "0.18.0", default-features = false }
 everruns-engine.workspace = true
 everruns-capability.workspace = true
 everruns-provider.workspace = true

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -421,9 +421,10 @@ dependencies = [
  "everruns-capability",
  "everruns-core",
  "everruns-host",
+ "everruns-integrations-filesystem",
+ "everruns-llmsim",
  "everruns-macros",
  "everruns-provider",
- "everruns-test-support",
  "schemars",
  "serde",
  "serde_json",
@@ -434,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -450,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -467,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "schemars",
@@ -477,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -507,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -542,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -551,8 +552,8 @@ dependencies = [
  "everruns-core",
  "everruns-engine",
  "everruns-integrations-filesystem",
- "everruns-platform",
  "everruns-provider",
+ "everruns-session-services",
  "futures",
  "ignore",
  "regex",
@@ -567,11 +568,12 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.23.1",
+ "everruns-capability",
  "everruns-core",
  "everruns-provider",
  "hex",
@@ -581,8 +583,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-llmsim"
+version = "0.18.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "everruns-provider",
+ "futures",
+ "llmsim",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "everruns-macros"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -591,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -605,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -613,32 +628,11 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "everruns-platform"
-version = "0.17.26"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "everruns-capability",
- "everruns-core",
- "everruns-provider",
- "inventory",
- "jsonschema",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "uuid",
 ]
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -664,23 +658,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "everruns-test-support"
-version = "0.17.26"
+name = "everruns-session-services"
+version = "0.18.0"
 dependencies = [
- "anyhow",
  "async-trait",
- "chrono",
  "everruns-capability",
  "everruns-core",
- "everruns-engine",
  "everruns-provider",
- "futures",
- "inventory",
- "llmsim",
  "serde",
  "serde_json",
- "tokio",
- "uuid",
 ]
 
 [[package]]

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "schemars",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-services"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "everruns-capability",

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "schemars",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-services"
-version = "0.17.26"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fluent-uri"
@@ -1581,9 +1581,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "potential_utf"
@@ -2550,9 +2550,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",


### PR DESCRIPTION
## What changed
Cuts the **v0.18.0** release. Bumps the workspace version (`Cargo.toml`), UI (`apps/ui/package.json`), and all internal path-dependency pins to `0.18.0`; regenerates `Cargo.lock`; and adds the `0.18.0` CHANGELOG section (Highlights + the existing Breaking/Changed notes + What's Changed for the 86 commits since v0.17.26).

The headline of this release is the **0.18 neutral-kernel boundary**: `everruns-core` is now a neutral execution kernel, hosted platform records moved out to `everruns-platform` and sibling crates, and the logic-free `everruns-runtime` compatibility crate was removed. REST/gRPC shapes and stored schema are unchanged.

This is a minor bump (`0.17.26` → `0.18.0`), not a major release.

## Why
Release the 86 commits merged to `main` since `v0.17.26`. Merging this commit (`chore(release): prepare v0.18.0`) triggers the auto-tagging workflow, which creates the `v0.18.0` tag + GitHub Release and dispatches Docker, CLI binaries, and crates.io publishing.

## Before / After
- **Before:** workspace at `0.17.26`; `CHANGELOG.md` had an `[Unreleased]` section accumulating the 0.18 work.
- **After:** workspace at `0.18.0`; `[Unreleased]` is empty and a dated `## [0.18.0] - 2026-08-16` section captures the release notes.

Version bump verified end-to-end — `cargo generate-lockfile` resolves cleanly, all internal path-dep pins report `0.18.0`, and migrations remain sequential (`001..120`). Note: this being the first minor bump in a while, several loose caret path-dep pins (`everruns-observability`, `everruns-openai`, `everruns-openui`, `everruns-a2ui`, `everruns-integrations-duckduckgo`, and observability's core/provider pins) that had matched within `0.17.x` needed bumping to `0.18.0` alongside the sync-script–covered pins. The out-of-workspace consumer lockfiles (`tests/fixtures/external-consumer`, `examples/weekend-concierge-host`, `evals/generic`) were refreshed to 0.18.0 as well.

## Risk
- Low
- Mechanical release change: version strings, lockfiles, and CHANGELOG only. No functional code changes.

## Security
- Threat categories reviewed: No security-relevant code changes — release metadata only.
- Findings and resolutions: None.

## Follow-ups
No follow-ups. After merge: verify auto-tag + Release + Docker/crates.io/CLI publishes, then bump the SaaS repo to `v0.18.0`.

## Checklist
- [ ] Tests added or updated — n/a (release metadata only)
- [x] Backward compatibility considered — breaking changes documented in CHANGELOG Breaking section + 0.18 migration guide
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR (45 checks: 30 success, 15 skipped by path filtering)
- [x] All review comments addressed (code change or written reasoning)