### PR TITLE
fix(release): move openui/a2ui publish pins from core to builtins

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -132,8 +132,6 @@ jobs:
 
           dependency_versions = {
               "crates/core/Cargo.toml": [
-                  "everruns-openui",
-                  "everruns-a2ui",
                   "everruns-provider",
                   "everruns-capability",
               ],
@@ -141,6 +139,8 @@ jobs:
                   "everruns-core",
               ],
               "crates/builtins/Cargo.toml": [
+                  "everruns-openui",
+                  "everruns-a2ui",
                   "everruns-capability",
                   "everruns-core",
               ],

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -27,12 +27,12 @@ REPO = Path(__file__).resolve().parent.parent
 # Path-pin versions kept in sub-crate manifests. Keep in sync with
 # .github/workflows/publish-crates.yml `dependency_versions`.
 INNER_PINS: dict[str, list[str]] = {
-    "crates/core/Cargo.toml": [
+    "crates/engine/Cargo.toml": ["everruns-core"],
+    "crates/builtins/Cargo.toml": [
         "everruns-openui",
         "everruns-a2ui",
+        "everruns-core",
     ],
-    "crates/engine/Cargo.toml": ["everruns-core"],
-    "crates/builtins/Cargo.toml": ["everruns-core"],
     "crates/platform/Cargo.toml": [
         "everruns-builtins",
         "everruns-core",


### PR DESCRIPTION
## What changed
Moves `everruns-openui` and `everruns-a2ui` from the `crates/core` entry to the `crates/builtins` entry in the `dependency_versions` map of `.github/workflows/publish-crates.yml`, and mirrors the same move in `scripts/sync-publish-pin-versions.py`'s `INNER_PINS`.

## Why
The 0.18 neutral-kernel refactor moved `everruns-openui`/`everruns-a2ui` out of `everruns-core` into `everruns-builtins`, but both publish-pin maps still listed them under `crates/core`. The **v0.18.0 crates.io publish failed** with `KeyError: 'everruns-openui'` — the verification script did `crates/core[dependencies]['everruns-openui']` while core no longer declares those deps (they now live in `crates/builtins`, pinned `version = "0.18.0"`).

## Before / After
**Before** — publish-crates verification, run `31925882444`, failed with `KeyError: 'everruns-openui'` at the manifest-dependency lookup.

**After** — simulated verification against the v0.18.0 tag manifests:
```
crates/core/Cargo.toml everruns-provider: OK
crates/core/Cargo.toml everruns-capability: OK
crates/builtins/Cargo.toml everruns-openui: OK
crates/builtins/Cargo.toml everruns-a2ui: OK
crates/builtins/Cargo.toml everruns-capability: OK
crates/builtins/Cargo.toml everruns-core: OK
ERRORS: 0
```
`python3 scripts/sync-publish-pin-versions.py --check` → `all path-dep pins at 0.18.0`.

The publish workflow verifies manifests from the detached release-tag commit but uses the `dependency_versions` map from the workflow file on `main`, so once this lands on `main` the v0.18.0 crates.io publish can be re-dispatched (`workflow_dispatch`, tag `v0.18.0`) and will pass — no new tag required.

## Risk
- Low
- Release-tooling map only. No crate/source changes; the pinned versions in the manifests are unchanged and already correct.

## Security
- Threat categories reviewed: No security-relevant code changes — CI release-tooling map only.
- Findings and resolutions: None.

## Follow-ups
No follow-ups. After merge: re-dispatch the crates.io publish for v0.18.0 and confirm success.

## Checklist
- [ ] Tests added or updated — n/a (CI map fix; verified by local simulation + `--check`)
- [x] Backward compatibility considered — no behavior change beyond fixing the publish gate
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)