### PR TITLE
fix(release): drop stale publish-map entries (duckduckgo/platform, builtins/local)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -151,7 +151,6 @@ jobs:
                   "everruns-integrations-filesystem",
                   "everruns-integrations-bashkit",
                   "everruns-integrations-web-fetch",
-                  "everruns-integrations-duckduckgo",
                   "everruns-integrations-lua",
                   "everruns-integrations-openrouter-workspace",
               ],
@@ -194,7 +193,6 @@ jobs:
                   "everruns-llmsim",
               ],
               "crates/local/Cargo.toml": [
-                  "everruns-builtins",
                   "everruns-core",
                   "everruns-host",
                   "everruns-platform",

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -69,7 +69,6 @@ INNER_PINS: dict[str, list[str]] = {
     "crates/llmsim/Cargo.toml": ["everruns-provider", "everruns-host"],
     "crates/test-support/Cargo.toml": ["everruns-core", "everruns-llmsim"],
     "crates/local/Cargo.toml": [
-        "everruns-builtins",
         "everruns-core",
         "everruns-host",
         "everruns-platform",


### PR DESCRIPTION
## What changed
Removes two dependency entries from the `dependency_versions` map in `.github/workflows/publish-crates.yml` (and mirrors the `builtins`/`local` removal in `scripts/sync-publish-pin-versions.py`) that name deps the manifests do not declare:
- `crates/platform/Cargo.toml` → `everruns-integrations-duckduckgo` (platform does not depend on it)
- `crates/local/Cargo.toml` → `everruns-builtins` (local does not depend on it)

## Why
Follow-up to #3193. With the `openui`/`a2ui` move fixed, the v0.18.0 crates.io publish verification advanced past `core` and then KeyErrored on `everruns-integrations-duckduckgo` (`crates/platform[dependencies]['everruns-integrations-duckduckgo']`). The map carried two more entries for deps that don't exist in the 0.18 manifests.

## Before / After
**Before** — publish-crates verification, run `31926806373`, failed with `KeyError: 'everruns-integrations-duckduckgo'`.

**After** — a local re-implementation of the exact CI verification (iterating the current map against the v0.18.0 tag manifests) reports every one of the map's declared deps present and pinned at `0.18.0`:
```
MAP CLEAN ✓
all path-dep pins at 0.18.0
```

## Risk
- Low
- CI release-tooling map only; no crate/source changes.

## Security
- Threat categories reviewed: No security-relevant code changes — CI release-tooling map only.
- Findings and resolutions: None.

## Follow-ups
No follow-ups. After merge: re-dispatch the crates.io publish for v0.18.0 and confirm success.

## Checklist
- [ ] Tests added or updated — n/a (CI map fix; verified by exhaustive local simulation against the tag manifests)
- [x] Backward compatibility considered — no behavior change beyond fixing the publish gate
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)