### PR TITLE
chore(security): drop the stale quick-xml advisory ignores

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -13,17 +13,8 @@ unmaintained = "none"
 # affected crate over ignoring; only ignore when no upstream fix path exists and
 # the advisory is not reachable in our usage.
 ignore = [
-    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml <0.41 DoS (quadratic attr
-    # duplicate check / unbounded namespace-declaration allocation) via NsReader
-    # on UNTRUSTED XML. Reaches us only transitively through object_store 0.14
-    # (its S3 XML response parser). object_store 0.14.0 is the latest release and
-    # pins quick-xml ^0.40, so there is no upstream upgrade path yet (a [patch] to
-    # 0.41 cannot satisfy ^0.40). Our sole object_store use is the blob store
-    # against an operator-configured S3 endpoint (blob_store_from_env), i.e. a
-    # trusted backend — not attacker-controlled XML — so neither DoS is reachable.
-    # Remove once object_store ships a release depending on quick-xml >=0.41.
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
+    # Empty: every advisory in the tree must be fixed by upgrading, not ignored.
+    # Entries here need a justification comment and a removal condition.
 ]
 
 [licenses]


### PR DESCRIPTION
## What changed

Empties the `[advisories] ignore` list in `deny.toml`, removing `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195`. `cargo deny check advisories` now enforces both again. No dependency versions change.

## Why

Both entries were added because `object_store` 0.14.0 pinned `quick-xml ^0.40`, leaving no upgrade path off the vulnerable line. Their comment set the removal condition explicitly: *"Remove once object_store ships a release depending on quick-xml >=0.41."*

That condition is now met, and the tree moved on without anyone revisiting the ignores:

- `Cargo.lock` resolves exactly one `object_store`, at **0.14.1**.
- `Cargo.lock` resolves exactly one `quick-xml`, at **0.41.0**.
- Both advisories declare `patched = [">= 0.41.0"]` in the RustSec DB.

So neither advisory applies to the current tree, and the suppressions are dead weight.

Leaving them is not neutral. `cargo deny` suppresses an advisory ID for whatever version resolves in future, not just the version that prompted the ignore. A later change that pulled `quick-xml` back under 0.41 (a transitive downgrade, a new dependency with an older pin) would sail through the supply-chain gate with no signal. Removing the entries restores the gate to something that actually fails when it should.

## Before / After

No behavior or dependency change. The gate's coverage changes:

```
Before: RUSTSEC-2026-0194, RUSTSEC-2026-0195 suppressed for any resolved quick-xml
After:  both enforced; current tree (quick-xml 0.41.0) is already clean
```

Resolved versions, unchanged by this PR:

```
$ grep -A2 '^name = "object_store"' Cargo.lock | head -3
name = "object_store"
version = "0.14.1"

$ awk '/^name = "quick-xml"/{n=1} /^version = /{if(n){print;n=""}}' Cargo.lock
version = "0.41.0"
```

Advisory metadata, fetched from the RustSec DB:

```
RUSTSEC-2026-0194  quick-xml  patched = [">= 0.41.0"]
RUSTSEC-2026-0195  quick-xml  patched = [">= 0.41.0"]
```

The `Check Dependency Licenses` / advisories job on this PR is the real proof: it runs `cargo deny check advisories` against the live database with the ignores gone.

## Risk

- Low
- What can break: only CI, and only informatively. If the advisory database or the resolved tree disagrees with the analysis above, the advisories job fails on this PR rather than letting a suppression persist. Nothing ships differently; `deny.toml` is a CI gate, not a build input.

## Security

- Threat categories reviewed: supply chain / dependency advisories (the `cargo deny check advisories` gate added under EVE-624).
- Findings and resolutions: the finding *is* the change. Two advisory suppressions outlived the condition that justified them, silently widening the gate. Verified the underlying vulnerability is genuinely gone (single `quick-xml` 0.41.0, at or above both advisories' patched floor) rather than merely unreachable, then removed the suppressions. No new dependency, code, or configuration surface.
- Note on the original reachability argument: the old comment also argued the DoS was unreachable because `object_store` is only used against an operator-configured S3 endpoint. That argument is no longer load-bearing; the dependency is patched outright.

## Follow-ups

No follow-ups.

## Checklist

- [ ] Tests added or updated (n/a; CI gate configuration, verified by the advisories job itself)
- [x] Backward compatibility considered (no API, behavior, or dependency change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cijF68iMm1XMnoqKbpfJw)_