### PR TITLE
test(release): catch stale entries in the publish-crates version map

### DIFF
--- a/scripts/test-publish-crates-order.sh
+++ b/scripts/test-publish-crates-order.sh
@@ -157,6 +157,28 @@ for manifest_rel, dependency in (
             f"{manifest_rel} dependency {dependency}"
         )
 
+# The reverse direction: every entry in the workflow's dependency_versions map
+# must name a dependency the manifest actually declares. The workflow indexes
+# that map with `dependencies[dependency_name]`, so a stale entry left behind by
+# a refactor raises KeyError and fails the release *after* the tag exists —
+# which is how v0.18.0 broke on `everruns-integrations-duckduckgo` (#3194), and
+# v0.17.x before it. The coverage checks above only assert the map is a superset
+# of the required edges, so they cannot catch drift in this direction.
+for manifest_rel, entry_body in re.findall(
+    r'"([^"]+Cargo\.toml)":\s*\[(.*?)\]', workflow_text, re.DOTALL
+):
+    manifest_path = REPO / manifest_rel
+    if not manifest_path.is_file():
+        fail(f"publish-crates.yml version verification names missing manifest {manifest_rel}")
+        continue
+    declared = load(manifest_path).get("dependencies", {})
+    for dependency in re.findall(r'"([^"]+)"', entry_body):
+        if dependency not in declared:
+            fail(
+                f"publish-crates.yml version verification lists {dependency} for "
+                f"{manifest_rel}, but that manifest does not depend on it"
+            )
+
 # The sync script keeps those pins at the workspace version between releases.
 sync_text = (REPO / "scripts/sync-publish-pin-versions.py").read_text()
 workspace_pins = re.search(r"WORKSPACE_PIN_DEPS:\s*list\[str\]\s*=\s*\[(.*?)\]", sync_text, re.DOTALL)


### PR DESCRIPTION
## What changed

`scripts/test-publish-crates-order.sh` now also checks the publish workflow's
`dependency_versions` map in the reverse direction: every entry must name a
manifest that exists and a dependency that manifest actually declares.

## Why

The publish workflow verifies pinned dependency versions by indexing each
manifest's `[dependencies]` table with a hand-maintained map:

```python
dependency = dependencies[dependency_name]
```

When a refactor removes a dependency from a manifest but leaves it in the map,
that lookup raises `KeyError`. Because the map is only read during the release
job, the failure lands **after the tag already exists**:

| Release | Failure |
|---|---|
| v0.18.0 (2026-08-16) | `KeyError: 'everruns-integrations-duckduckgo'` — fixed by #3194, then manually re-dispatched |
| v0.17.x (2026-08-09/10) | same shape, same manual recovery |

The existing guard only asserts the map is a *superset* of a required-edge list,
so it is structurally unable to see drift in this direction — it checks that
needed entries are present, never that present entries are real.

Note this is not a new failure mode being guarded speculatively: it has broken
the release pipeline three times, and each recovery was a human noticing a red
`Publish Crates` run and re-dispatching by hand.

## Before / After

**Before** — drift is invisible until release time, after tagging:

```
Run VERSION="0.18.0"
KeyError: 'everruns-integrations-duckduckgo'
##[error]Process completed with exit code 1.
```

**After** — the same drift fails on the PR that introduces it, naming both sides:

```
$ bash scripts/test-publish-crates-order.sh
FAIL: publish-crates.yml version verification lists everruns-integrations-duckduckgo
      for crates/platform/Cargo.toml, but that manifest does not depend on it
```

Verified by reintroducing the exact v0.18.0 stale entry, confirming the guard
fails, then restoring it and confirming it passes:

```
=== 1. passes on current main ===
publish order verified for 39 crate(s)

=== 2. would it have caught the v0.18.0 failure? ===
FAIL: publish-crates.yml version verification lists everruns-integrations-duckduckgo for crates/platform/Cargo.toml, but that manifest does not depend on it
^^ guard caught the regression

=== 3. restored, passes again ===
publish order verified for 39 crate(s)
```

The script already runs in CI: `run-shell-tests.sh` globs `scripts/test-*.sh`,
and the `shell` path filter covers both `scripts/test-*.sh` and
`.github/workflows/publish-crates.yml`, so edits to either side trigger it.

## Risk

- **Low**
- Test-only. No runtime, workflow, or manifest change; the publish workflow
  itself is untouched.
- The check is a strict addition to an existing guard, so the worst case is a
  false positive that blocks a PR rather than anything reaching a release.
- Parsing is the same regex shape the surrounding checks already use against the
  workflow text.

## Security

- **Threat categories reviewed:** none applicable — no security-relevant code
  changes. This is a build-time consistency check over two files already in the
  repo. It adds no runtime surface, reads no credentials, and touches no
  network, filesystem, or database path. `scripts/test-release-workflow-security.sh`
  continues to own the release workflow's security invariants and is unmodified.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated — the change *is* the test, and it was verified to
      fail on the real historical regression
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR — pending; Shell Tests (Repo Scripts)
      is the affected job and is not gated by the `slow_ci_enabled` switch
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8m3wok2HsjedTjosHgwny)_