### PR TITLE
docs(knowledge): align current architecture decisions

### DIFF
--- a/knowledge/foundations/architecture.md
+++ b/knowledge/foundations/architecture.md
@@ -101,7 +101,7 @@ Production event routing therefore prefers:
 2. **Crate Separation** (folder → package name):
    - `server/` → `everruns-server` - **Control plane**: HTTP API (axum) + gRPC server (tonic), SSE streaming, database layer
    - `worker/` → `everruns-worker` - TaskWorker, WorkerAdapters, activities, gRPC adapters, durable task execution
-   - `core/` → `everruns-core` - Transport- and persistence-neutral execution contracts, tools, events, portable projections, and current atom interfaces. Depends privately on the contract-only provider surface and does not re-export it.
+   - `core/` → `everruns-core` - Transport- and persistence-neutral execution contracts, tools, events, and portable projections. Depends privately on the contract-only provider surface and does not re-export it.
    - `provider/` → `everruns-provider` - LLM/provider abstraction that the provider crates depend on instead of core: `ChatDriver`, the shared OpenAI/OpenResponses protocol drivers, model profiles, retry/stream helpers, typed IDs, credential form schema, and the LLM error taxonomy
    - `engine/` → `everruns-engine` - Pure turn state machine plus shared Input/Reason/Act execution
    - `platform/` → `everruns-platform` - Hosted product records, services, and capability implementations
@@ -110,8 +110,7 @@ Production event routing therefore prefers:
    - `macros/` → `everruns-macros` - Framework tool-macro implementation re-exported through `everruns::tool`
    - `internal-protocol/` → `everruns-internal-protocol` - gRPC protocol for worker ↔ server
    - `durable/` → `everruns-durable` - PostgreSQL-backed durable execution engine
-   - `openai/` → `everruns-openai` - OpenAI LLM provider implementation
-   - `anthropic/` → `everruns-anthropic` - Anthropic LLM provider implementation
+   - `drivers/*` - independently versioned official LLM driver packages over `everruns-provider`
    - `integrations/docker/` → `everruns-integrations-docker` - Docker container integration (auto-registered via `inventory` plugin system)
    - `integrations/daytona/` → `everruns-integrations-daytona` - Daytona cloud sandbox integration (auto-registered via `inventory` plugin system)
    - `integrations/e2b/` → `everruns-integrations-e2b` - E2B cloud sandbox integration (auto-registered via `inventory` plugin system)
@@ -134,15 +133,13 @@ everruns/
 │   ├── core/             # Neutral execution contracts and portable projections
 │   ├── provider/         # LLM/provider abstraction (ChatDriver, protocol drivers, model profiles)
 │   ├── engine/           # Shared turn planning and execution coordination
-│   ├── session-services/ # Neutral session host contracts/capabilities
 │   ├── platform/         # Hosted product records and services
 │   ├── everruns/         # Application-facing Framework crate
 │   ├── host/             # Low-level in-process host and reusable host phases
 │   ├── macros/           # everruns-macros implementation crate
 │   ├── internal-protocol/# gRPC protocol definitions
 │   ├── durable/          # Durable execution engine
-│   ├── openai/           # OpenAI provider
-│   └── anthropic/        # Anthropic provider
+│   └── drivers/          # Independently versioned official LLM drivers
 ├── integrations/
 │   ├── docker/           # Docker container (inventory plugin)
 │   ├── daytona/          # Daytona cloud sandbox (inventory plugin)
@@ -155,19 +152,17 @@ everruns/
 └── scripts/              # Dev scripts
 ```
 
-### Crate Dependency Graph
+### Major Crate Dependency Direction
 
 ```mermaid
 graph TD
     provider[provider]
     core[core]
     engine[engine]
-    session_services[session-services]
     platform[platform]
     host[host]
     framework[everruns]
-    openai[openai]
-    anthropic[anthropic]
+    drivers[drivers/*]
     protocol[internal-protocol]
     durable[durable]
     worker[worker]
@@ -176,25 +171,26 @@ graph TD
     core --> provider
     engine --> core
     engine --> provider
-    session_services --> core
-    session_services --> provider
     host --> engine
     host --> core
     host --> provider
-    host --> session_services
     platform -->|host extension ports| host
-    platform --> session_services
+    platform --> core
     framework --> host
     framework --> core
     framework --> provider
-    openai --> provider
-    anthropic --> provider
+    framework -.->|opt-in hosted composition| platform
+    drivers --> provider
+    durable --> engine
+    durable --> provider
     worker --> host
     worker --> durable
     worker --> protocol
+    worker --> platform
     server --> host
     server --> durable
     server --> protocol
+    server --> platform
     worker -.->|gRPC| server
 ```
 
@@ -229,7 +225,7 @@ process should use `everruns-host`.
 `everruns-host` provides:
 
 - `InProcessRuntimeBuilder`
-- in-memory session/filesystem/storage/message backends
+- in-memory session/filesystem/storage/event backends
 - turn execution via `everruns-engine::TurnExecution` and
   `everruns-host::InProcessExecution`
 - direct seeding of harnesses, agents, sessions, and files

--- a/knowledge/foundations/code-organization.md
+++ b/knowledge/foundations/code-organization.md
@@ -59,6 +59,18 @@ badge-free header and omit docs.rs links.
 
 ### Crate dependency conventions
 
+A crate boundary exists for ownership, not for source-file count. Retain or
+introduce a crate when it provides at least one independently useful boundary:
+an application/public contract, a kernel dependency firewall, a deployment or
+process boundary, or a selectable integration/driver. A leaf package that only
+forwards or re-exports another owner's implementation adds release overhead and
+should be folded into that owner. Conversely, mechanical consolidation must not
+erase one of those boundaries merely to reduce the workspace package count.
+
+Repository folders may group related packages without merging their package
+identity. `crates/drivers/` is such a grouping: its children remain separate,
+independently versioned integrations over the common provider SPI.
+
 Thin LLM provider crates (`openai`, `anthropic`, `gemini`, `bedrock`, `mai`,
 `fireworks`, `openrouter`) depend on `everruns-provider`, **not**
 `everruns-core`. `everruns-provider` is the lean provider/LLM abstraction crate
@@ -163,7 +175,8 @@ on full `everruns-core`.
 Two pin conventions follow from package publishability:
 
 - **Unpublished** crates reference path deps without a version
-  (`{ path = "../provider" }` for provider crates; `{ path = "../core", default-features = false }` for crates that do depend on core), matching `server`/`worker`.
+  (`{ path = "../../provider" }` for crates nested under `crates/drivers/`;
+  top-level workspace crates use their corresponding sibling path).
 - **Published** crates own explicit package versions rather than inheriting the
   product workspace version. Their internal path dependencies carry the target
   package's current version, including dependencies inherited from

--- a/knowledge/framework/application-api.md
+++ b/knowledge/framework/application-api.md
@@ -200,8 +200,9 @@ and multi-host lifecycle management remain host concerns.
   backend stores, or host lifecycle entities.
 - Resume authority is engine-scoped. An in-memory engine must reject an id from
   another engine, retain the exact Agent snapshot chosen at creation, and reopen
-  the exact persisted WorkspaceHead and typed Environment extensions. Scale
-  portability and Agent serialization are intentionally outside this slice.
+  the exact persisted WorkspaceHead and typed Environment extensions. Agent
+  serialization is not part of the Framework contract; distributed Platform
+  composition reconstructs trusted behavior at its host boundary.
 - Capability values converge through one builder entrypoint. New built-ins do
   not add builder methods, and third-party values must not require a core or
   host dependency. Dynamic references validate their open ID and JSON object
@@ -223,11 +224,11 @@ Every application surface promoted in an atomic unit has a downstream-style
 compile/run fixture that imports only `everruns`, uses offline simulation and
 temporary files, and does not require credentials or network access. The same
 bar applies when the event/history, hooks, task/wake, workspace-policy, and
-capability-SPI units land. Compatibility tests continue to exercise the old
-runtime path. Product worker/server and local host behavior must remain
-unchanged. Facade-only dependency guards apply to ordinary application
-fixtures; advanced host fixtures instead forbid the transitional runtime
-dependency while allowing focused host and sibling crates.
+capability-SPI units land. Product worker/server and local host behavior must
+remain aligned through the shared engine kernel. Facade-only dependency guards
+apply to ordinary application fixtures; advanced host fixtures may depend on
+focused host and sibling crates without turning those crates into Framework
+entrypoints.
 
 ## Source index
 

--- a/knowledge/framework/library-experience.md
+++ b/knowledge/framework/library-experience.md
@@ -47,7 +47,11 @@ they protect.
 
 ## Compatibility posture
 
-Improving the Framework must not break the supported 0.17.x runtime path or
-silently fork turn/provider semantics. Compatibility duration, host-only
-allowances, and removal exclusions are specified in [Application API
+The Framework follows the semantic version of the `everruns` package rather
+than a workspace-wide product version. Within a compatible release line,
+improving the Framework must preserve its public application contract and must
+never fork turn or provider semantics from the shared execution path. Removed
+pre-0.18 runtime entrypoints are not a parallel compatibility target.
+
+Application versus host ownership is specified in [Application API
 Boundaries](application-api.md).

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,12 @@
 
 ## 2026-08-17
 
+* **Crate boundaries follow ownership rather than package count.** Public,
+  kernel, deployment, and selectable integration boundaries remain focused
+  crates; forwarding-only leaves should fold into their owner. Official model
+  drivers are grouped physically under `crates/drivers/` while retaining
+  independent package identities and versions over `everruns-provider`.
+
 * **Session services are host-owned.** `SessionMutator` and the portable
   session/session-storage capabilities are collocated in `everruns-host`;
   platform re-exports the same types. The former leaf package added release


### PR DESCRIPTION
## What changed
Aligned the canonical knowledge bundle with the current 0.18 architecture. Current specifications now describe the shared execution kernel, immediate and durable hosts, the removed runtime boundary, the consolidated session-services ownership, and the grouped independently versioned driver packages consistently. Added the durable crate-boundary decision: ownership and dependency boundaries matter; package count alone does not.

## Why
Recent architecture and crate-layout work was captured in focused concepts, but older architecture and Framework pages still presented deleted crates and transitional runtime compatibility as current requirements. The Framework spec also named a reverted experiment instead of stating the positive distributed-host boundary.

## Before / After
Before: the knowledge bundle listed `session-services`, root-level OpenAI/Anthropic crates, core atom ownership, an old runtime compatibility path, and a future portability placeholder.

After: current concepts describe only the shipped architecture and physical layout. `just check-okf` reports 147 conformant concepts, and changed-surface `just pre-push` passes 22/22.

No runtime behavior changes; this is a knowledge-only correction.

## Risk
- Low
- Incorrect architectural guidance is the only affected surface. The revised dependency direction was checked against Cargo metadata and the current workspace layout.

## Security
- Threat categories reviewed: No security-relevant code changes; only Markdown knowledge specifications changed.
- Findings and resolutions: None. No trust boundary, credential handling, API, persistence, or executable configuration changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (not applicable; OKF and changed-surface guards passed)
- [x] Backward compatibility considered (documentation only)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review comments were filed)
