### PR TITLE
chore(release): prepare v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-18
+
+### Highlights
+
+- **First-class sandbox and checkpoint records** - Sandboxes and checkpoints are now first-class records, giving durable runs an explicit, addressable execution substrate ([#3197](https://github.com/everruns/everruns/pull/3197)).
+
+### What's Changed
+
+- docs(knowledge): align current architecture decisions ([#3208](https://github.com/everruns/everruns/pull/3208)) by [@chaliy](https://github.com/chaliy)
+- refactor(drivers): group provider crates ([#3207](https://github.com/everruns/everruns/pull/3207)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): quote container sandbox test filter ([#3206](https://github.com/everruns/everruns/pull/3206)) by [@chaliy](https://github.com/chaliy)
+- refactor(architecture): consolidate runtime implementation crates ([#3205](https://github.com/everruns/everruns/pull/3205)) by [@chaliy](https://github.com/chaliy)
+- refactor(server): absorb session SQLite backend ([#3204](https://github.com/everruns/everruns/pull/3204)) by [@chaliy](https://github.com/chaliy)
+- refactor(host): absorb session services ([#3203](https://github.com/everruns/everruns/pull/3203)) by [@chaliy](https://github.com/chaliy)
+- refactor(builtins): absorb UI prompt catalogs ([#3202](https://github.com/everruns/everruns/pull/3202)) by [@chaliy](https://github.com/chaliy)
+- refactor(host): absorb direct HTTP egress ([#3201](https://github.com/everruns/everruns/pull/3201)) by [@chaliy](https://github.com/chaliy)
+- build(release): version crates independently ([#3200](https://github.com/everruns/everruns/pull/3200)) by [@chaliy](https://github.com/chaliy)
+- refactor(host): invert platform extension dependency ([#3199](https://github.com/everruns/everruns/pull/3199)) by [@chaliy](https://github.com/chaliy)
+- test(release): catch stale entries in the publish-crates version map ([#3198](https://github.com/everruns/everruns/pull/3198)) by [@chaliy](https://github.com/chaliy)
+- feat(sandbox): add first-class sandbox and checkpoint records ([#3197](https://github.com/everruns/everruns/pull/3197)) by [@chaliy](https://github.com/chaliy)
+- chore(security): drop the stale quick-xml advisory ignores ([#3196](https://github.com/everruns/everruns/pull/3196)) by [@chaliy](https://github.com/chaliy)
+- chore(knowledge): record the coding CLI MCP trust boundary as TM-TOOL-031 ([#3195](https://github.com/everruns/everruns/pull/3195)) by [@chaliy](https://github.com/chaliy)
+- chore(docs): remove em-dashes and AI-tell wording from prose ([#3191](https://github.com/everruns/everruns/pull/3191)) by [@chaliy](https://github.com/chaliy)
+- fix(release): drop stale publish-map entries (duckduckgo/platform, builtins/local) ([#3194](https://github.com/everruns/everruns/pull/3194)) by [@chaliy](https://github.com/chaliy)
+- fix(release): move openui/a2ui publish pins from core to builtins ([#3193](https://github.com/everruns/everruns/pull/3193)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.18.0] - 2026-08-16
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.139.0"
+version = "1.140.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dffe4bd3da45048fa0d30b50febaedf093e93a25d832cc21f2845a6e0c72616"
+checksum = "5bca4d762965c0b7f5fb88ec0a4b48cfa1a22502e1a0283e5fd5d9498dae52b6"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -2721,7 +2721,7 @@ dependencies = [
  "ratatui",
  "ratatui-textarea",
  "serde_json",
- "similar 3.1.2",
+ "similar 3.2.0",
  "tempfile",
  "textwrap",
  "tokio",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3081,7 +3081,7 @@ dependencies = [
  "regex",
  "serde_json",
  "sha2 0.11.0",
- "similar 3.1.2",
+ "similar 3.2.0",
  "tokio",
  "uuid 1.24.1",
 ]
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "everruns-capability",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4271,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -7363,9 +7363,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -8766,9 +8766,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
 dependencies = [
  "bstr",
 ]
@@ -11212,9 +11212,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {


### PR DESCRIPTION
## What changed
Cuts the **v0.19.0** product release. Bumps the workspace product version (`Cargo.toml` `workspace.package.version` and `apps/ui/package.json`) from `0.18.0` to `0.19.0`, adds the `[0.19.0]` CHANGELOG section, and refreshes `Cargo.lock`. Independent library-crate versions are intentionally left untouched (they release via `/prepare-crate-release`).

The 17 commits since v0.18.0 are predominantly internal restructuring — consolidating runtime/host/server crates, inverting the platform extension dependency, and moving to independent crate versioning — plus one user-facing feature: first-class sandbox and checkpoint records ([#3197](https://github.com/everruns/everruns/pull/3197)).

On merge, the `chore(release): prepare v0.19.0` commit triggers auto-tagging (`v0.19.0`), the GitHub Release from CHANGELOG.md, and the dispatched Docker/CLI-binary publish.

## Why
Release the accumulated changes on `main` since v0.18.0.

## Before / After
- Product version `0.18.0` → `0.19.0` across `Cargo.toml`, `apps/ui/package.json`, `Cargo.lock`.
- New `## [0.19.0] - 2026-08-18` CHANGELOG section with Highlights + What's Changed.
- No behavior change beyond the already-merged commits this release packages.

## Risk
- Low
- Release-metadata-only change. `Cargo.lock` also picked up incidental patch-level dependency bumps (aws-sdk-bedrockruntime, h2, quinn-proto, similar, zerovec-derive) from `cargo generate-lockfile`; no major bumps.

## Security
- Threat categories reviewed: No security-relevant code changes — version/changelog/lockfile only.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A (release metadata only)
- [x] Backward compatibility considered — no runtime change
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Migration ordering verified sequential (001..121). Latest `main` CI and `integration-live-sweep` are green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011qBw2DMiz9KHVGA4FHooP2)_