### PR TITLE
chore(release): make library-crate release audit a mandatory release step

### DIFF
--- a/.agents/commands/prepare-release.md
+++ b/.agents/commands/prepare-release.md
@@ -29,15 +29,37 @@ have one highlight or none, in which case recommend dropping the section.
 Present the commit list and your proposed highlights, and let the user confirm or replace them
 before editing files.
 
-## 3. Update versions
+## 3. Audit published library crates for independent releases
+
+Mandatory every release — never skip it, and never leave the outcome implicit. Published library
+crates are versioned independently of the product, so a product bump does **not** carry their
+changes to crates.io. If a crate's public contract changed and you don't cut its own release, the
+crates.io package silently drifts behind its source.
+
+1. Diff each published crate's source and manifest since its last release, e.g.
+   `git diff "$PREV"..HEAD -- <crate-dir>/src <crate-dir>/Cargo.toml`. Published crates are the
+   workspace packages **without** `publish = false`.
+2. Judge *public contract*, not churn. "Touched" over-counts wildly: a transitive dependency
+   bump, an internal refactor, or a pure directory move (like grouping the drivers under
+   `crates/drivers/`) is **not** a contract change. A release candidate is a crate whose exported
+   API, behavior, feature flags, or MSRV changed — or a crate that was **deleted/absorbed**, whose
+   crates.io package is now orphaned and whose consumers must migrate.
+3. For each crate whose contract changed, run `/prepare-crate-release` (bump that package, run
+   `python3 scripts/sync-publish-pin-versions.py --write`, tag `crate/<pkg>/v<ver>`, Publish Crate).
+   Release dependencies before dependants. For an absorbed/deleted crate, record where its API moved.
+4. **Record the audit in the release PR**: either the list of crate releases cut this cycle, or an
+   explicit "no published crate contracts changed" line. A reviewer must be able to see the decision
+   was made, not assumed.
+
+## 4. Update versions
 
 - `Cargo.toml` → `workspace.package.version`
 - `apps/ui/package.json` → `version`
 
-Do not bump published library crate versions. They are released independently
-with `/prepare-crate-release` when their own public contracts change.
+Do not bump published library crate versions here. They are released independently with
+`/prepare-crate-release` when their own public contracts change — that call is step 3, not this one.
 
-## 4. Add the CHANGELOG entry
+## 5. Add the CHANGELOG entry
 
 Insert after `## [Unreleased]`, preserving the file header and versioning policy:
 
@@ -57,13 +79,13 @@ Link PRs and usernames. Add a **Migration Notes** section only when operators ne
 engineering-only migration detail belongs in `crates/server/migrations/` and `knowledge/operations/migrations.md`.
 Include screenshot links for UI changes.
 
-## 5. Verify migrations without rewriting them
+## 6. Verify migrations without rewriting them
 
 Never squash, rename, or delete existing migrations for a release. Confirm the sorted basenames in
 `crates/server/migrations/` still start at `001_` and stay strictly sequential
 (`bash scripts/lib/check-migration-ordering.sh`).
 
-## 6. Refresh lockfiles
+## 7. Refresh lockfiles
 
 ```bash
 cargo generate-lockfile
@@ -71,7 +93,7 @@ cargo generate-lockfile
 (cd apps/docs && pnpm install --lockfile-only)
 ```
 
-## 7. Commit and open the PR
+## 8. Commit and open the PR
 
 Stage the files you touched by name, then:
 
@@ -82,4 +104,6 @@ git push -u origin <current-branch>
 
 Open the PR with `.github/pull_request_template.md`, and tell the user to review CHANGELOG.md, add
 any highlights or screenshots, and merge once CI is green — the tag, GitHub Release, Docker images,
-and product binaries follow automatically. Crates.io publishing is independent.
+and product binaries follow automatically. Crates.io publishing is independent: include the step 3
+crate-release audit outcome in the PR body (the crate releases cut, or "no published crate contracts
+changed"), so the decision is on the record rather than assumed.

--- a/knowledge/project/release-process.md
+++ b/knowledge/project/release-process.md
@@ -25,6 +25,8 @@ This specification defines the release process for Everruns. The process is desi
 
 Release readiness also includes the integration backstops that are intentionally kept off the `pull_request` hot path. Before cutting a release PR or merging it, review the latest push-only live integration workflow runs on `main` and the latest `.github/workflows/integration-live-sweep.yml` result. Do not release through unresolved failures there unless the failure is understood, documented, and explicitly accepted.
 
+Release preparation also **audits the independently versioned library crates** (see [Library Crate Releases](#library-crate-releases)). This audit is a mandatory step of every product release, not an occasional side task: a product bump never carries a library crate's changes to crates.io, so any published crate whose public contract changed since its last release must get its own `/prepare-crate-release` — or the release PR must explicitly record that no published crate contracts changed. The decision must be visible in the PR, never silently skipped.
+
 ### CHANGELOG.md as Source of Truth
 
 1. CHANGELOG.md is the canonical source for release notes
@@ -49,7 +51,24 @@ effect of a product release.
 
 ### Library Crate Releases
 
-Each crates.io package is versioned and released independently:
+Each crates.io package is versioned and released independently.
+
+**Audit obligation (every product release).** Independent versioning does not mean "ignore the
+crates until someone complains." As part of preparing each product release, audit whether any
+published crate's public contract changed since its last crates.io release and release the changed
+ones. Guidance:
+
+- Published crates are the workspace packages **without** `publish = false`. Diff each one's
+  `src/` and manifest since its previous release.
+- Judge *public contract*, not churn. Being git-touched over-counts massively — transitive
+  dependency bumps, internal refactors, and pure directory moves (e.g. grouping providers under
+  `crates/drivers/`) are not contract changes. A release candidate is a crate whose exported API,
+  behavior, feature set, or MSRV changed, or a crate that was **deleted/absorbed** (its crates.io
+  package is now orphaned and consumers must migrate to the new location).
+- Record the outcome in the release PR — the crate releases cut, or an explicit "no published
+  crate contracts changed" — so the decision is reviewable rather than assumed.
+
+To release a changed crate:
 
 1. Bump only the package whose public contract changed.
 2. Run `python3 scripts/sync-publish-pin-versions.py --write` so published


### PR DESCRIPTION
## What changed
Makes the **independent library-crate release audit** an explicit, mandatory step of every product release, in both the `/prepare-release` skill and the release-process spec.

Previously the skill said "do not bump published library crate versions — they release independently" but never told the release engineer to **check** whether any crate's public contract had changed and therefore warranted its own crates.io release. The decision was silently skipped, so published crate versions can drift behind their source (e.g. at `v0.19.0` every library pin still read `0.18.0`, despite `everruns-host`/`everruns-platform`/`everruns-builtins` gaining real public surface).

- `.agents/commands/prepare-release.md`: new step 3 "Audit published library crates for independent releases" (diff each published crate's public contract since its last release; judge contract change, not churn — transitive bumps, refactors, and pure directory moves like the `crates/drivers/` grouping don't count; `/prepare-crate-release` the changed ones; record the outcome in the PR). Remaining steps renumbered.
- `knowledge/project/release-process.md`: audit obligation added to the Workflow section and the Library Crate Releases section, with the same "record the decision in the PR" requirement.

## Why
A product version bump never carries a library crate's changes to crates.io. Without a required audit, contract-changing crates go unreleased and the decision is invisible to reviewers.

## Before / After
- **Before:** crate-release analysis was implicit; a release could skip it with no trace.
- **After:** the audit is a numbered, mandatory step; the release PR must state the crate releases cut or an explicit "no published crate contracts changed."

## Risk
- Low
- Documentation/process only (skill + knowledge spec). No code or runtime change.

## Security
- Threat categories reviewed: No security-relevant code changes — process docs only.
- Findings and resolutions: None.

## Follow-ups
The v0.19.0 crate-release audit itself (candidates: `everruns-host`, `everruns-platform`, `everruns-builtins`, `everruns-core`; `everruns-observability` now absorbed into `everruns-host`) is pending a maintainer decision on whether to publish to crates.io now or keep it on-demand. Tracked separately from this process change.

## Checklist
- [x] Tests added or updated — N/A (docs/process)
- [x] Backward compatibility considered — N/A
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

`just check-okf` passes (OKF v0.2 conformant).

---
_Generated by [Claude Code](https://claude.ai/code/session_011qBw2DMiz9KHVGA4FHooP2)_