### PR TITLE
ci(release): auto-tag and publish library crates on merge

### DIFF
--- a/.agents/commands/prepare-crate-release.md
+++ b/.agents/commands/prepare-crate-release.md
@@ -43,16 +43,22 @@ Run `just pre-push`, commit with
 `chore(<package>): prepare vX.Y.Z`, and merge the normal PR after its checks are
 green. Do not create the package tag from an unreviewed branch.
 
-## 4. Tag and publish
+## 4. Let CI tag and publish
 
-At the reviewed main commit, create and push:
+Tags are created by CI, not by hand — the same schema as the product release.
+On merge to `main`, the **Crate Release** workflow (`.github/workflows/crate-release.yml`)
+compares every published crate's manifest version against crates.io, creates the
+`crate/<package>/vX.Y.Z` tag for any version not yet published, and dispatches
+**Publish Crate** for it. When several crates are released together it walks them
+in dependency order, waiting for each publish to finish before the dependant that
+pins it. Detection is idempotent: a version already on crates.io is skipped.
 
-```bash
-git tag "crate/<package>/vX.Y.Z" <40-character-main-sha>
-git push origin "crate/<package>/vX.Y.Z"
-```
+Watch the Crate Release run to a green finish and confirm the new version appears
+on crates.io. `workflow_dispatch` with `dry_run: true` lists what would be
+released without tagging or publishing.
 
-Run **Publish Crate** with the exact package name, tag, and commit SHA. The
-workflow verifies the tag, manifest version, dependency pins, packaged
-artifact, and main reachability before using the crates.io token. For multiple
-packages, publish dependencies first and dispatch each package separately.
+Manual tagging is a fallback only if the workflow is unavailable — at the
+reviewed main commit, `git tag "crate/<package>/vX.Y.Z" <sha>` and push it, then
+run **Publish Crate** with the package, tag, and SHA; publish dependencies before
+dependants. Publishing to crates.io is not possible from a sandbox whose egress
+policy blocks tag pushes; rely on the CI workflow there.

--- a/.agents/commands/prepare-release.md
+++ b/.agents/commands/prepare-release.md
@@ -49,9 +49,12 @@ crates.io package silently drifts behind its source.
    not an eyeballed diff), then bump the **patch** component for a non-breaking (additive-only) change
    (`0.18.0 → 0.18.1`) and the **minor** component only for a breaking change (`0.18.0 → 0.19.0`; the
    minor is the breaking slot for `0.x` crates). Do not round crates up to the product version for
-   tidiness. Then run `/prepare-crate-release` (bump the package, run
-   `python3 scripts/sync-publish-pin-versions.py --write`, tag `crate/<pkg>/v<ver>`, Publish Crate).
-   Release dependencies before dependants. For an absorbed/deleted crate, record where its API moved.
+   tidiness. Then run `/prepare-crate-release` to bump the package and run
+   `python3 scripts/sync-publish-pin-versions.py --write`. Tagging and publishing are automated: on
+   merge to `main` the **Crate Release** workflow (`.github/workflows/crate-release.yml`) creates
+   `crate/<pkg>/v<ver>` and dispatches Publish Crate for any version not yet on crates.io, in
+   dependency order — you never push crate tags by hand. For an absorbed/deleted crate, record where
+   its API moved.
 4. **Record the audit in the release PR**: either the list of crate releases cut this cycle, or an
    explicit "no published crate contracts changed" line. A reviewer must be able to see the decision
    was made, not assumed.

--- a/.github/workflows/crate-release.yml
+++ b/.github/workflows/crate-release.yml
@@ -1,0 +1,185 @@
+name: Crate Release
+
+# Independent library-crate releases, automated the same way as the product
+# release (release.yml): tags are created by CI on merge to main, never pushed
+# by hand. On every push to main this workflow compares each published crate's
+# manifest version against what is already on crates.io; for any crate whose
+# version is not yet published it creates the crate/<package>/v<version> tag and
+# dispatches Publish Crate. Crates are released in dependency order so a
+# dependant never publishes before the dependency it pins is on crates.io.
+#
+# Detection is by crates.io presence, not by diffing the push, so a version bump
+# that merged before this workflow existed is still picked up, and re-runs are
+# idempotent (a version already on crates.io is skipped). The product release and
+# its version bump are unaffected: this only ever touches independently versioned
+# library crates (packages without `publish = false`).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '.github/workflows/crate-release.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List crates that would be released without tagging or publishing'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crate-release
+  cancel-in-progress: false
+
+jobs:
+  release-crates:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create crate/<package>/v<version> tags
+      actions: write # dispatch the Publish Crate workflow
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve crates that need a release
+        id: plan
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' > release-plan.json
+          import json, subprocess, sys, urllib.request, urllib.error
+
+          def index_path(name: str) -> str:
+              n = name.lower()
+              if len(n) == 1:
+                  return f"1/{n}"
+              if len(n) == 2:
+                  return f"2/{n}"
+              if len(n) == 3:
+                  return f"3/{n[0]}/{n}"
+              return f"{n[0:2]}/{n[2:4]}/{n}"
+
+          def published_versions(name: str) -> set[str]:
+              url = f"https://index.crates.io/{index_path(name)}"
+              try:
+                  with urllib.request.urlopen(url, timeout=30) as resp:
+                      body = resp.read().decode()
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 404:
+                      return set()  # never published
+                  raise
+              return {json.loads(line)["vers"] for line in body.splitlines() if line.strip()}
+
+          meta = json.loads(subprocess.check_output(
+              ["cargo", "metadata", "--no-deps", "--format-version", "1"], text=True))
+          # Published packages are those whose manifest does not set publish = false
+          # (cargo reports publish = [] for those).
+          published = {p["name"]: p for p in meta["packages"] if p.get("publish") != []}
+
+          to_release = {
+              name: pkg["version"]
+              for name, pkg in published.items()
+              if pkg["version"] not in published_versions(name)
+          }
+
+          # Topologically sort the release set so dependencies publish first.
+          deps = {
+              name: {
+                  d["name"]
+                  for d in published[name]["dependencies"]
+                  if d["name"] in to_release and (d.get("kind") in (None, "normal", "build"))
+              }
+              for name in to_release
+          }
+          ordered: list[str] = []
+          done: set[str] = set()
+          while len(ordered) < len(to_release):
+              ready = sorted(n for n in to_release if n not in done and deps[n] <= done)
+              if not ready:
+                  print("::error::dependency cycle among crates to release", file=sys.stderr)
+                  sys.exit(1)
+              ordered.extend(ready)
+              done.update(ready)
+
+          print(json.dumps([
+              {"package": n, "version": to_release[n], "tag": f"crate/{n}/v{to_release[n]}"}
+              for n in ordered
+          ]))
+          PY
+
+          COUNT=$(jq 'length' release-plan.json)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Release plan ($COUNT crate(s), dependency order):"
+          jq -r '.[] | "  \(.package) \(.version)  (\(.tag))"' release-plan.json
+
+      - name: Tag and publish in dependency order
+        if: steps.plan.outputs.count != '0' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          count=$(jq 'length' release-plan.json)
+          for i in $(seq 0 $((count - 1))); do
+            PKG=$(jq -r ".[$i].package" release-plan.json)
+            VER=$(jq -r ".[$i].version" release-plan.json)
+            TAG=$(jq -r ".[$i].tag" release-plan.json)
+            echo "::group::Release $PKG $VER ($TAG)"
+
+            # Create the tag on GitHub's infrastructure (the Actions token can push
+            # tags; a hand push cannot). Idempotent if a prior run already tagged.
+            if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+              echo "Tag $TAG already exists locally"
+            elif git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "Tag $TAG already exists on origin"
+            else
+              git tag "$TAG" "$SHA"
+              git push origin "refs/tags/$TAG:refs/tags/$TAG"
+              echo "Created and pushed $TAG"
+            fi
+
+            # Record the newest existing Publish Crate run so we can detect the one
+            # this dispatch creates (gh workflow run does not return a run id).
+            BEFORE=$(gh run list --workflow=publish-crates.yml --limit=1 \
+              --json databaseId --jq '.[0].databaseId // 0')
+            gh workflow run publish-crates.yml \
+              -f package="$PKG" -f tag="$TAG" -f sha="$SHA"
+
+            # Wait for the new run to appear, then follow it to a terminal state.
+            RUN_ID=""
+            for _ in $(seq 1 30); do
+              sleep 6
+              CAND=$(gh run list --workflow=publish-crates.yml --limit=1 \
+                --json databaseId --jq '.[0].databaseId // 0')
+              if [ "$CAND" != "$BEFORE" ] && [ "$CAND" != "0" ]; then RUN_ID="$CAND"; break; fi
+            done
+            if [ -z "$RUN_ID" ]; then
+              echo "::error::Publish Crate run for $PKG did not start"; exit 1
+            fi
+            echo "Watching Publish Crate run $RUN_ID for $PKG..."
+            gh run watch "$RUN_ID" --exit-status --interval 15
+
+            # Let the crates.io sparse index publish the new version before a
+            # dependant crate that pins it is published next.
+            sleep 25
+            echo "::endgroup::"
+          done
+          echo "All crate releases dispatched and confirmed."
+
+      - name: Dry-run summary
+        if: steps.plan.outputs.count != '0' && github.event_name == 'workflow_dispatch' && inputs.dry_run
+        run: |
+          echo "Dry run — the following crates would be released:"
+          jq -r '.[] | "  \(.package) \(.version)  (\(.tag))"' release-plan.json
+
+      - name: Nothing to release
+        if: steps.plan.outputs.count == '0'
+        run: echo "No published crate has a version missing from crates.io; nothing to release."

--- a/knowledge/project/release-process.md
+++ b/knowledge/project/release-process.md
@@ -89,13 +89,25 @@ To release a changed crate:
 2. Run `python3 scripts/sync-publish-pin-versions.py --write` so published
    dependants reference the dependency package's current version.
 3. Validate and merge the release change to `main`.
-4. Create `crate/<package>/v<version>` at the reviewed commit.
-5. Run **Publish Crate** with the package, tag, and exact commit SHA.
 
-The workflow validates the selected manifest version, derives internal path
-dependency pins from Cargo metadata, and publishes only that package. If a set
-of related crates needs releases, publish dependencies first and then their
-dependants; do not recreate a lockstep workspace release.
+Tagging and publishing are then automated — the same schema as the product
+release, where tags are created by CI rather than pushed by hand. On merge to
+`main` the **Crate Release** workflow (`.github/workflows/crate-release.yml`)
+compares each published crate's manifest version against crates.io, creates the
+`crate/<package>/v<version>` tag for any version not yet published, and
+dispatches **Publish Crate** for it. When several crates release together it
+orders them by dependency so a dependant never publishes before the dependency it
+pins is on crates.io. Detection is by crates.io presence, so a bump that merged
+before the tag existed is still picked up and re-runs are idempotent (a version
+already published is skipped). `workflow_dispatch` with `dry_run: true` previews
+the set.
+
+**Publish Crate** validates the selected manifest version, derives internal path
+dependency pins from Cargo metadata, and publishes only that package. Manual
+tagging remains a fallback when the workflow is unavailable, publishing
+dependencies before dependants; do not recreate a lockstep workspace release.
+Publishing cannot be completed from a sandbox whose egress policy blocks tag
+pushes — the CI workflow is the supported path.
 
 ### Migration Handling
 

--- a/scripts/test-release-workflow-security.sh
+++ b/scripts/test-release-workflow-security.sh
@@ -13,6 +13,7 @@ workflows = [
     Path(".github/workflows/server-worker-binaries.yml"),
     Path(".github/workflows/publish-crates.yml"),
     Path(".github/workflows/release.yml"),
+    Path(".github/workflows/crate-release.yml"),
 ]
 untrusted = re.compile(r"\$\{\{[^\n]*(?:inputs\.|client_payload\.tag|ref_name)")
 sha_ref = re.compile(r"uses:\s+([^./\s][^@\s]*)@([0-9a-f]{40})(?:\s+#\s+\S+)?$")


### PR DESCRIPTION
## What changed
Adds a **Crate Release** workflow (`.github/workflows/crate-release.yml`) that automates independent library-crate publishing the same way `release.yml` automates the product tag — **tags are created by CI on merge, never pushed by hand.**

On every push to `main` it:
1. Reads each published crate's manifest version (`cargo metadata`; published = no `publish = false`).
2. Compares against crates.io via the **sparse index** (`index.crates.io`).
3. For any version not yet published, creates the `crate/<package>/v<version>` tag at the merge SHA and dispatches **Publish Crate** for it.
4. Walks the release set in **dependency order**, waiting for each publish to finish before the dependant that pins it.

Detection by crates.io presence (not by diffing the push) means a version bump that merged *before* the workflow existed is still picked up, and re-runs are idempotent — a version already published is skipped. `workflow_dispatch` with `dry_run: true` previews the set without tagging or publishing.

Also updates the release spec and both skills (`prepare-release`, `prepare-crate-release`) to the CI-tags-and-publishes schema, and brings the new workflow under `test-release-workflow-security.sh` (SHA-pinned actions, no untrusted inputs in run blocks).

## Why
Independent crate versioning previously relied on a human pushing `crate/*` tags and dispatching Publish Crate per package. That is manual, easy to skip, order-sensitive, and — as this cycle showed — impossible from an environment whose egress policy blocks tag pushes. Creating the tags in CI (which pushes with the Actions token on GitHub's own infra) mirrors the proven product-release schema and removes the manual step entirely.

## Before / After
- **Before:** crate releases needed a manual `git tag` + push and per-package Publish Crate dispatch, in the right order. The 0.19.0 crate bumps (`host`/`mcp` → 0.19.0, `everruns`/`builtins`/`platform` → 0.18.1, merged in #3211) were left unpublished because tag pushes are blocked in the sandbox.
- **After:** merging this PR triggers the workflow, which detects exactly those five versions as missing from crates.io, tags them, and publishes them in dependency order (`mcp`, `builtins` → `host` → `platform` → `everruns`). Future cycles publish automatically on the version-bump merge.

## Risk
- Medium (touches crates.io publishing automation)
- Scoped to independently versioned library crates (never the product). Publishing reuses the existing hardened **Publish Crate** workflow (trusted-tag/SHA/pin/artifact validation + crates.io token). Detection is idempotent and skips already-published versions, so it cannot double-publish or mass-publish the unchanged 0.18.0 crates. `dry_run` allows a safe preview.

## Security
- Threat categories reviewed: TM-CI / supply-chain (release automation). Actions are SHA-pinned; no `${{ inputs.* }}` or tag refs are interpolated into run blocks (guarded by `test-release-workflow-security.sh`, now covering this workflow). The crates.io token stays inside the existing Publish Crate workflow; this workflow only dispatches it with validated package/tag/sha.
- Findings and resolutions: None.

## Follow-ups
On merge, watch the Crate Release run publish the five 0.19.0-cycle crates, then refresh the v0.19.0 GitHub Release body with the Crate Releases list. Retired crates (`everruns-observability`, `everruns-session-services`, `everruns-http`, `everruns-local`, `everruns-openui`, `everruns-a2ui`) stay at their last-published version.

## Checklist
- [x] Tests added or updated — brought under `test-release-workflow-security.sh`; `test-publish-crates-order.sh` still green
- [x] Backward compatibility considered — manual tag+Publish Crate remains a documented fallback
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed

Guard tests pass locally (`test-release-workflow-security.sh`, `test-publish-crates-order.sh`); `just check-okf` conformant; workflow YAML validated.

---
_Generated by [Claude Code](https://claude.ai/code/session_011qBw2DMiz9KHVGA4FHooP2)_