### PR TITLE
feat(everruns): gate a2a delegation behind an opt-in feature

### DIFF
--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -89,6 +89,11 @@ local = [
     "tokio/process",
     "tokio/time",
 ]
+# Outbound A2A delegation. Off by default: `a2a-client` drags a full second
+# HTTP/TLS stack (its own reqwest major) into any consumer that only wants the
+# local runtime, so hosts that delegate to remote A2A agents opt in explicitly.
+# Requires `local`, since the delegation capability ships in `everruns-platform`.
+a2a = ["local", "everruns-platform/a2a"]
 # Configure real OpenAI-backed models via `everruns::providers::openai`. Off by
 # default so the standard facade build pulls in no provider or Reqwest edge; the
 # `OpenAI` config type and its driver wiring compile only with this feature.
@@ -107,7 +112,7 @@ everruns-host.workspace = true
 # Production-safe deterministic in-process simulator backing
 # `Model::simulated`; no dependency on testing/demo helpers.
 everruns-llmsim.workspace = true
-everruns-platform = { workspace = true, optional = true, features = ["a2a", "portable-builtins"] }
+everruns-platform = { workspace = true, optional = true, features = ["portable-builtins"] }
 everruns-integrations-filesystem = { workspace = true, optional = true }
 everruns-integrations-bashkit = { workspace = true, optional = true }
 everruns-integrations-web-fetch = { workspace = true, optional = true }

--- a/crates/platform/src/capabilities/mod.rs
+++ b/crates/platform/src/capabilities/mod.rs
@@ -215,6 +215,26 @@ mod tests {
         assert!(registry.has(PLATFORM_MANAGEMENT_CAPABILITY_ID));
     }
 
+    // The `a2a` Cargo feature is the only thing that puts outbound A2A delegation
+    // in the registry; without it the build carries no A2A client at all.
+    #[test]
+    fn a2a_delegation_registration_follows_the_a2a_feature() {
+        if std::env::var("FEATURE_AGENT_DELEGATION").is_ok() {
+            // A deployment override decides delegation registration here, not the
+            // Cargo feature under test.
+            return;
+        }
+        let registry = hosted_capability_registry_for_grade(everruns_core::DeploymentGrade::Dev);
+        assert!(
+            registry.has(AGENT_HANDOFF_CAPABILITY_ID),
+            "dev grade should register agent delegation, otherwise this test is vacuous"
+        );
+        assert_eq!(
+            registry.has(everruns_core::capabilities::A2A_AGENT_DELEGATION_CAPABILITY_ID),
+            cfg!(feature = "a2a"),
+        );
+    }
+
     #[cfg(feature = "portable-builtins")]
     #[test]
     fn hosted_registry_contains_full_portable_policy_catalog() {

--- a/knowledge/integrations/a2a-capability.md
+++ b/knowledge/integrations/a2a-capability.md
@@ -44,6 +44,17 @@ V1 does not support:
 - Durable push webhook callbacks from remote A2A agents.
 - Encrypted org-level external-agent credentials.
 
+## Packaging
+
+The capability is opt-in at build time. `everruns-platform`'s `a2a` feature gates the
+[`a2a_delegation`](../../crates/platform/src/capabilities/a2a_delegation.rs) module and the
+`A2aAgentDelegationCapability` registration; the `everruns` facade re-exposes it as its own `a2a`
+feature. Both stay off by default because the A2A client crate carries an independent HTTP/TLS
+stack, which an embedder that only runs local agents would otherwise duplicate against its own.
+The product build (`everruns-server`, `everruns-worker`) enables the platform feature directly, so
+hosted behavior is unchanged; embedders that delegate to external agents opt in with
+`everruns/a2a`.
+
 ## Model
 
 ### Configured External Agents


### PR DESCRIPTION
## What changed

Outbound A2A delegation is now opt-in for embedders. The `everruns` facade no longer
forces `everruns-platform/a2a` on through its `local` feature; it exposes its own
`a2a = ["local", "everruns-platform/a2a"]` feature that is off by default.

For a consumer of `everruns` with `local`, the A2A client and the whole HTTP/TLS/gRPC
subtree behind it disappear from the build, and `a2a_agent_delegation` is no longer
registered in the hosted capability registry. Hosts that delegate to external A2A agents
turn it back on with `everruns/a2a`; nothing about the capability's behavior changes when
enabled.

The product build is unaffected: `everruns-server` and `everruns-worker` already enable
`everruns-platform/a2a` directly.

## Why

`everruns-platform` gates A2A correctly, but the facade re-enabled it unconditionally, so
any consumer of the local runtime compiled `a2a-client-lf` plus its own `reqwest` major.
A downstream host on a newer `reqwest` ended up linking two complete HTTP/TLS stacks
(tens of MB of rlib) purely to satisfy a capability it never used, with no way to trim it
locally because the edge was not gateable from outside.

## Before / After

Dependency graph of `everruns` with `local` (`cargo tree -e normal`, unique packages):

| | packages |
|---|---|
| before | 251 |
| after | 195 |

56 packages drop out, including `a2a-client-lf`, `a2a-lf`, `a2a-pb`, `reqwest 0.12`,
`hyper`, `hyper-rustls`, `rustls`, `aws-lc-rs`/`aws-lc-sys`, `tonic`, `prost`, `axum`,
`tower`/`tower-http`, `h2`, `webpki-roots`.

```
$ cargo tree -p everruns --features local -e normal | grep -c a2a-client
0
$ cargo tree -p everruns --features a2a -e normal | grep -c a2a-client
1
```

Server build is byte-identical in feature terms — `cargo tree -p everruns-server -e normal`
(697 packages) diffs clean between `origin/main` and this branch.

## Risk

- Low
- Behavior change is scoped to embedders of the `everruns` facade: a default `local` build
  no longer registers the `a2a_agent_delegation` capability (local `agent_handoff`
  delegation is unaffected). Recovering it is a one-line feature opt-in. The hosted
  server/worker path is unchanged.

## Security

- Threat categories reviewed: TM-AGENT (delegation/egress), TM-TOOL, TM-A2A.
- Findings and resolutions: no mitigation code was touched. The egress ACL gate
  (`enforce_network_access`, TM-AGENT-024) and the schema-bound artifact validation
  (TM-AGENT-027) live in `crates/platform/src/capabilities/a2a_delegation.rs` and are
  unchanged; the platform `a2a` tests, including the live A2A server integration tests,
  pass with the feature enabled. The change strictly reduces default surface: a high-risk
  capability and a duplicated TLS/HTTP supply-chain subtree leave the default embedder
  build. No threat-model update needed — no new threat and no changed mitigation.

## Follow-ups

No follow-ups.

Noted but out of scope: `examples/weekend-concierge-host/Cargo.lock` and
`evals/generic/Cargo.lock` are stale on `main` (`cargo metadata --locked` fails there
before and after this branch). Unrelated to this diff.

## Checklist

- [x] Tests added or updated — `a2a_delegation_registration_follows_the_a2a_feature` asserts
      registry membership tracks `cfg!(feature = "a2a")` in both directions
- [x] Backward compatibility considered — facade consumers relying on A2A add `features = ["a2a"]`
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ua12rGX96jThrSM5YG8ye)_