### PR TITLE
fix(sessions): let session deletion pass the append-only guards

### DIFF
--- a/crates/server/migrations/122_session_delete_append_only_guards.sql
+++ b/crates/server/migrations/122_session_delete_append_only_guards.sql
@@ -1,0 +1,110 @@
+-- Let `DELETE /v1/sessions/{session_id}` succeed on PostgreSQL (EVE-919).
+--
+-- Deleting a session fans out through foreign keys into tables that carry
+-- append-only guards, and every one of those guards aborted the delete:
+--
+--   * events            — FK ON DELETE CASCADE fires the BEFORE DELETE guard
+--   * usage_journal     — FK ON DELETE SET NULL fires the BEFORE UPDATE guard
+--   * usage_ledger      — same as usage_journal
+--   * eval_case_results — FK declares no ON DELETE action, so it restricts
+--
+-- Any session that has taken a single turn has both events and usage rows, so
+-- the DELETE always aborted and the API answered 500. The in-memory backend
+-- cascades in Rust and has no triggers, which is why tests never caught it.
+--
+-- The guards themselves stay. What changes is that each one now recognises the
+-- one legitimate way its rows are allowed to move: a session being purged.
+
+-- ---------------------------------------------------------------------------
+-- events: purging a session removes its history wholesale
+-- ---------------------------------------------------------------------------
+-- `app.archival_bypass` already exists for the retention archiver
+-- (crates/server/src/event_retention.rs). Session deletion is the second
+-- legitimate remover of events, and it is not archival, so it gets its own
+-- flag rather than borrowing a name that would misdescribe it. Both bypasses
+-- are scoped to `events`; budget_ledger shares this function and must keep
+-- strict append-only semantics.
+CREATE OR REPLACE FUNCTION prevent_event_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'DELETE'
+       AND TG_TABLE_NAME = 'events'
+       AND (current_setting('app.archival_bypass', true) = 'true'
+            OR current_setting('app.session_purge', true) = 'true') THEN
+        RETURN OLD;
+    END IF;
+    RAISE EXCEPTION 'events are append-only: % operations are not allowed', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION prevent_event_mutation() IS
+    'Enforces append-only semantics. On events, DELETE is permitted under app.archival_bypass (retention archival) or app.session_purge (session deletion); every other table using this function is strictly append-only.';
+
+-- ---------------------------------------------------------------------------
+-- usage_journal / usage_ledger: the financial record outlives the session
+-- ---------------------------------------------------------------------------
+-- Both already declare their references as ON DELETE SET NULL, which is
+-- exactly the intended behaviour: keep the row, forget what produced it. The
+-- shared events guard rejected those cascades because they arrive as UPDATEs.
+-- This guard permits precisely that detachment — a reference column going from
+-- a value to NULL — and rejects any other write, including no-op updates.
+CREATE OR REPLACE FUNCTION prevent_usage_record_mutation()
+RETURNS TRIGGER AS $$
+DECLARE
+    reference_columns CONSTANT text[] := ARRAY[
+        'budget_id', 'event_id', 'session_id',
+        'user_id', 'principal_id', 'agent_id', 'harness_id'
+    ];
+    detached integer;
+    rewritten integer;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        SELECT
+            count(*) FILTER (
+                WHERE new_field.value = 'null'::jsonb
+                  AND old_field.key = ANY (reference_columns)
+            ),
+            count(*) FILTER (
+                WHERE new_field.value <> 'null'::jsonb
+                   OR NOT old_field.key = ANY (reference_columns)
+            )
+        INTO detached, rewritten
+        FROM jsonb_each(to_jsonb(OLD)) AS old_field
+        JOIN jsonb_each(to_jsonb(NEW)) AS new_field ON new_field.key = old_field.key
+        WHERE old_field.value IS DISTINCT FROM new_field.value;
+
+        IF detached > 0 AND rewritten = 0 THEN
+            RETURN NEW;
+        END IF;
+    END IF;
+
+    RAISE EXCEPTION 'usage records are append-only: % operations are not allowed', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION prevent_usage_record_mutation() IS
+    'Enforces append-only semantics on usage_journal and usage_ledger, except for ON DELETE SET NULL cascades that detach a deleted session, event, or other referenced row.';
+
+DROP TRIGGER prevent_usage_journal_mutation ON usage_journal;
+CREATE TRIGGER prevent_usage_journal_mutation
+    BEFORE UPDATE OR DELETE ON usage_journal
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_usage_record_mutation();
+
+DROP TRIGGER prevent_usage_ledger_mutation ON usage_ledger;
+CREATE TRIGGER prevent_usage_ledger_mutation
+    BEFORE UPDATE OR DELETE ON usage_ledger
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_usage_record_mutation();
+
+-- ---------------------------------------------------------------------------
+-- eval_case_results: eval history outlives the session it ran in
+-- ---------------------------------------------------------------------------
+-- The column is already nullable; the FK simply never declared an ON DELETE
+-- action, so it restricted instead. Detaching matches the usage tables.
+ALTER TABLE eval_case_results
+    DROP CONSTRAINT eval_case_results_session_id_fk;
+
+ALTER TABLE eval_case_results
+    ADD CONSTRAINT eval_case_results_session_id_fk
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE SET NULL;

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -1063,7 +1063,19 @@ impl Database {
     }
 
     /// Delete session by org and session id
+    ///
+    /// Runs in a transaction that sets `app.session_purge`, the flag the
+    /// append-only guard on `events` recognises (migration 122). Without it the
+    /// FK cascade into `events` trips the guard and the whole delete aborts —
+    /// which is what made this endpoint answer 500 for any session that had
+    /// taken a turn (EVE-919).
     pub async fn delete_session(&self, org_id: i64, id: SessionId) -> Result<bool> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("SET LOCAL app.session_purge = 'true'")
+            .execute(&mut *tx)
+            .await?;
+
         let result = sqlx::query(
             r#"
             DELETE FROM sessions
@@ -1072,8 +1084,10 @@ impl Database {
         )
         .bind(org_id)
         .bind(id)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
+
+        tx.commit().await?;
 
         Ok(result.rows_affected() > 0)
     }

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -3857,3 +3857,312 @@ async fn test_llm_generation_without_session_is_org_attributed() {
     assert_eq!(output_tokens, 0, "embeddings produce vectors, not tokens");
     assert_eq!(actual_cost_usd, Some(0.000_82));
 }
+
+/// A session that has taken a turn fans out into append-only tables when it is
+/// deleted: its `events` cascade away, and its `usage_journal` / `usage_ledger`
+/// rows are detached by `ON DELETE SET NULL`. Before migration 122 every one of
+/// those guards aborted the delete, so `DELETE /v1/sessions/{id}` answered 500
+/// for any real session (EVE-919).
+#[tokio::test]
+async fn delete_session_purges_events_and_detaches_usage_records() {
+    let backend = create_test_backend().await;
+    let pool = create_test_pool().await;
+
+    let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
+    let session = backend
+        .create_session(CreateSessionRow {
+            source: everruns_platform::SessionSource::Api,
+            workspace_id: None,
+            org_id: TEST_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_version_id: None,
+            agent_config_hash: None,
+            agent_identity_id: None,
+            owner_principal_id,
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+            budget_root_session_id: None,
+        })
+        .await
+        .expect("Failed to create session");
+
+    let event = backend
+        .create_event(CreateEventRow {
+            session_id: session.id,
+            event_type: "input.message".to_string(),
+            ts: Utc::now(),
+            context: json!({"turn_id": Uuid::now_v7().to_string(), "role": "user"}),
+            data: json!({"message": {"role": "user", "content": []}}),
+            metadata: None,
+            tags: None,
+        })
+        .await
+        .expect("Failed to create event");
+
+    let journal_id = Uuid::now_v7();
+    sqlx::query(
+        r#"
+        INSERT INTO usage_journal (id, org_id, kind, session_id, event_id)
+        VALUES ($1, $2, 'llm.generation', $3, $4)
+        "#,
+    )
+    .bind(journal_id)
+    .bind(TEST_ORG_ID)
+    .bind(session.id.uuid())
+    .bind(event.id)
+    .execute(&pool)
+    .await
+    .expect("Failed to record usage journal entry");
+
+    let ledger_id = Uuid::now_v7();
+    sqlx::query(
+        r#"
+        INSERT INTO usage_ledger (id, journal_id, org_id, session_id, currency, amount, meter_source)
+        VALUES ($1, $2, $3, $4, 'usd', 1.25, 'llm')
+        "#,
+    )
+    .bind(ledger_id)
+    .bind(journal_id)
+    .bind(TEST_ORG_ID)
+    .bind(session.id.uuid())
+    .execute(&pool)
+    .await
+    .expect("Failed to record usage ledger entry");
+
+    let deleted = backend
+        .delete_session(TEST_ORG_ID, session.id)
+        .await
+        .expect("Deleting a session that has taken a turn must not error");
+    assert!(deleted, "the session row was removed");
+
+    let sessions_left: i64 = sqlx::query_scalar("SELECT count(*) FROM sessions WHERE id = $1")
+        .bind(session.id.uuid())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(sessions_left, 0, "session is gone");
+
+    let events_left: i64 = sqlx::query_scalar("SELECT count(*) FROM events WHERE session_id = $1")
+        .bind(session.id.uuid())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(events_left, 0, "the session's events went with it");
+
+    // The financial record outlives the session it came from — detached, not deleted.
+    let (journal_session, journal_event): (Option<Uuid>, Option<Uuid>) =
+        sqlx::query_as("SELECT session_id, event_id FROM usage_journal WHERE id = $1")
+            .bind(journal_id)
+            .fetch_one(&pool)
+            .await
+            .expect("usage journal entry survives session deletion");
+    assert_eq!(journal_session, None, "journal detached from the session");
+    assert_eq!(journal_event, None, "journal detached from the event");
+
+    let (ledger_session, amount): (Option<Uuid>, f64) =
+        sqlx::query_as("SELECT session_id, amount FROM usage_ledger WHERE id = $1")
+            .bind(ledger_id)
+            .fetch_one(&pool)
+            .await
+            .expect("usage ledger entry survives session deletion");
+    assert_eq!(ledger_session, None, "ledger detached from the session");
+    assert_eq!(amount, 1.25, "the amount charged is untouched");
+}
+
+/// The purge path is the *only* way rows leave these tables. Nothing about
+/// migration 122 may weaken the append-only guarantees themselves.
+#[tokio::test]
+async fn append_only_guards_still_reject_ordinary_mutations() {
+    let backend = create_test_backend().await;
+    let pool = create_test_pool().await;
+
+    let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
+    let session = backend
+        .create_session(CreateSessionRow {
+            source: everruns_platform::SessionSource::Api,
+            workspace_id: None,
+            org_id: TEST_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_version_id: None,
+            agent_config_hash: None,
+            agent_identity_id: None,
+            owner_principal_id,
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+            budget_root_session_id: None,
+        })
+        .await
+        .expect("Failed to create session");
+
+    let event = backend
+        .create_event(CreateEventRow {
+            session_id: session.id,
+            event_type: "input.message".to_string(),
+            ts: Utc::now(),
+            context: json!({"turn_id": Uuid::now_v7().to_string(), "role": "user"}),
+            data: json!({"message": {"role": "user", "content": []}}),
+            metadata: None,
+            tags: None,
+        })
+        .await
+        .expect("Failed to create event");
+
+    let journal_id = Uuid::now_v7();
+    sqlx::query(
+        r#"
+        INSERT INTO usage_journal (id, org_id, kind, session_id)
+        VALUES ($1, $2, 'llm.generation', $3)
+        "#,
+    )
+    .bind(journal_id)
+    .bind(TEST_ORG_ID)
+    .bind(session.id.uuid())
+    .execute(&pool)
+    .await
+    .expect("Failed to record usage journal entry");
+
+    // Events: no rewriting, and no removing one outside a purge or archival run.
+    let rewrite = sqlx::query("UPDATE events SET event_type = 'tampered' WHERE id = $1")
+        .bind(event.id)
+        .execute(&pool)
+        .await;
+    assert!(rewrite.is_err(), "events cannot be rewritten");
+
+    let remove = sqlx::query("DELETE FROM events WHERE id = $1")
+        .bind(event.id)
+        .execute(&pool)
+        .await;
+    assert!(remove.is_err(), "events cannot be deleted one by one");
+
+    // Usage records: only the FK-driven detachment is allowed, nothing else.
+    let rewrite_journal = sqlx::query("UPDATE usage_journal SET kind = 'tampered' WHERE id = $1")
+        .bind(journal_id)
+        .execute(&pool)
+        .await;
+    assert!(
+        rewrite_journal.is_err(),
+        "usage records cannot be rewritten"
+    );
+
+    let hand_detach =
+        sqlx::query("UPDATE usage_journal SET kind = 'tampered', session_id = NULL WHERE id = $1")
+            .bind(journal_id)
+            .execute(&pool)
+            .await;
+    assert!(
+        hand_detach.is_err(),
+        "detaching is not a licence to edit the rest of the row"
+    );
+
+    let remove_journal = sqlx::query("DELETE FROM usage_journal WHERE id = $1")
+        .bind(journal_id)
+        .execute(&pool)
+        .await;
+    assert!(remove_journal.is_err(), "usage records cannot be deleted");
+
+    // budget_ledger shares the events guard and stays strictly append-only:
+    // the purge bypass is scoped to `events`, so setting the flag buys nothing.
+    let budget_id = Uuid::now_v7();
+    sqlx::query(
+        r#"
+        INSERT INTO budgets (id, org_id, subject_type, subject_id, currency, "limit", balance)
+        VALUES ($1, $2, 'org', $3, 'usd', 100.0, 0.0)
+        "#,
+    )
+    .bind(budget_id)
+    .bind(TEST_ORG_ID)
+    .bind(TEST_ORG_ID.to_string())
+    .execute(&pool)
+    .await
+    .expect("Failed to create budget");
+
+    let budget_entry_id = Uuid::now_v7();
+    sqlx::query(
+        r#"
+        INSERT INTO budget_ledger (id, budget_id, amount, meter_source)
+        VALUES ($1, $2, 1.0, 'llm')
+        "#,
+    )
+    .bind(budget_entry_id)
+    .bind(budget_id)
+    .execute(&pool)
+    .await
+    .expect("Failed to record budget ledger entry");
+
+    let mut purge_tx = pool.begin().await.expect("begin purge transaction");
+    sqlx::query("SET LOCAL app.session_purge = 'true'")
+        .execute(&mut *purge_tx)
+        .await
+        .expect("set purge flag");
+    let budget_ledger_delete = sqlx::query("DELETE FROM budget_ledger WHERE id = $1")
+        .bind(budget_entry_id)
+        .execute(&mut *purge_tx)
+        .await;
+    assert!(
+        budget_ledger_delete.is_err(),
+        "the session-purge bypass must not reach budget_ledger"
+    );
+    let _ = purge_tx.rollback().await;
+
+    backend
+        .delete_session(TEST_ORG_ID, session.id)
+        .await
+        .expect("cleanup");
+}
+
+/// Eval results outlive the session they ran in: the FK detaches rather than
+/// blocking the delete (EVE-919).
+#[tokio::test]
+async fn eval_case_results_detach_from_deleted_sessions() {
+    let pool = create_test_pool().await;
+
+    let delete_action: String = sqlx::query_scalar(
+        r#"
+        SELECT confdeltype::text
+          FROM pg_constraint
+         WHERE conname = 'eval_case_results_session_id_fk'
+        "#,
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("the eval_case_results session FK exists");
+
+    assert_eq!(
+        delete_action, "n",
+        "eval_case_results.session_id must be ON DELETE SET NULL, not restricting"
+    );
+}

--- a/knowledge/security/budgeting.md
+++ b/knowledge/security/budgeting.md
@@ -97,6 +97,19 @@ The journal stores scope (`org_id`, `user_id`, `principal_id`, `session_id`, `ag
 
 Immutable, append-only rated posting derived from a journal row. Positive = debit, negative = credit (top-up/refund). Each ledger row links back to `journal_id`; budget-scoped postings also carry `budget_id`. Protected by append-only triggers in Postgres.
 
+### Detachment is the one permitted write
+
+Spend outlives whatever produced it. When a session, event, or other referenced
+row is deleted, the journal and ledger rows stay and their reference column is
+nulled by `ON DELETE SET NULL` — the amount, currency, org, and measures are
+never touched. The append-only trigger permits exactly that shape of update and
+rejects everything else, including a hand-written update that nulls a reference
+while editing another column. Deleting a journal or ledger row is never allowed.
+
+This is why deleting a session no longer fails: before migration 122 the trigger
+rejected the cascade itself, so `DELETE /v1/sessions/{id}` returned 500 for any
+session that had spent anything.
+
 ## Evaluation Pipeline
 
 On every `llm.generation` event:


### PR DESCRIPTION
## What changed

`DELETE /v1/sessions/{session_id}` works. Before this, it returned 500 for any session that had taken a turn — which is every real session — so the `rel: delete` action the API advertises on every session was dead on PostgreSQL.

Deleting a session fans out through foreign keys into tables that carry append-only guards, and every one of those guards aborted the delete:

| Table | How the cascade arrives | Guard that rejected it |
|---|---|---|
| `events` | FK `ON DELETE CASCADE` | `BEFORE DELETE` append-only trigger |
| `usage_journal` | FK `ON DELETE SET NULL` | `BEFORE UPDATE` append-only trigger |
| `usage_ledger` | FK `ON DELETE SET NULL` | same |
| `eval_case_results` | FK declares no `ON DELETE` action | restricts outright |

Migration 122 teaches each guard the one legitimate way its rows are allowed to move — a session being purged — without loosening anything else:

- **`events`** are removable under a new `app.session_purge` flag, alongside the existing `app.archival_bypass` used by the retention archiver. Both bypasses are now scoped to `TG_TABLE_NAME = 'events'`, so `budget_ledger`, which shares the same trigger function, is strictly append-only where it previously would have inherited the archival bypass.
- **`usage_journal` / `usage_ledger`** move to their own guard that accepts exactly the FK-driven detachment — a reference column going from a value to `NULL` with every other column byte-identical — and rejects everything else, including a hand-written update that nulls a reference while editing another column. Deletes stay rejected.
- **`eval_case_results.session_id`** becomes `ON DELETE SET NULL`. The column was already nullable; the FK simply never declared an action.

The repository runs the delete in a transaction that sets `app.session_purge`.

Spend and eval history survive the session that produced them, detached rather than deleted.

## Why

EVE-919. Found by the 2026-08-19 scheduled smoke test on `dev.everruns.com`: create a session, send a message, wait for `idle`/`completed`, `DELETE` it → HTTP 500, reproducible.

The in-memory backend cascades in Rust and has no triggers, which is why the existing tests never caught this — the only HTTP-level `DELETE /v1/sessions/{id}` in the suite is unasserted teardown.

## Before / After

Against a local PostgreSQL with the schema at `main` (migrations 001–121):

```
=== case 1: delete a session that has one event ===
ERROR:  events are append-only: DELETE operations are not allowed
CONTEXT:  PL/pgSQL function prevent_event_mutation() line 7 at RAISE
SQL statement "DELETE FROM ONLY "public"."events" WHERE $1 OPERATOR(pg_catalog.=) "session_id""

=== case 3: session with only a usage_journal row (no events) ===
ERROR:  events are append-only: UPDATE operations are not allowed
CONTEXT:  PL/pgSQL function prevent_event_mutation() line 7 at RAISE
SQL statement "UPDATE ONLY "public"."usage_journal" SET "session_id" = NULL WHERE $1 OPERATOR(pg_catalog.=) "session_id""

=== case 4: plain session, nothing referencing it ===
DELETE 1
```

The three new tests, run against that same pre-122 database:

```
test append_only_guards_still_reject_ordinary_mutations ... FAILED
test delete_session_purges_events_and_detaches_usage_records ... FAILED
test eval_case_results_detach_from_deleted_sessions ... FAILED

panicked at crates/server/tests/repository_integration_test.rs:3952:
  Deleting a session that has taken a turn must not error:
  error returned from database: events are append-only: DELETE operations are not allowed
panicked at crates/server/tests/repository_integration_test.rs:4161:
  assertion `left == right` failed: eval_case_results.session_id must be ON DELETE SET NULL, not restricting

test result: FAILED. 0 passed; 3 failed
```

With migration 122 applied:

```
test append_only_guards_still_reject_ordinary_mutations ... ok
test delete_session_purges_events_and_detaches_usage_records ... ok
test eval_case_results_detach_from_deleted_sessions ... ok

test result: ok. 3 passed; 0 failed
```

And the guards still hold — every one of these is rejected after the change: rewriting an event, deleting a single event outside a purge, rewriting a usage record, deleting a usage record, nulling a usage record's `session_id` by hand while editing another column, and deleting from `budget_ledger` even with `app.session_purge` set.

## Risk

- **Medium**
- The change is a schema migration touching integrity triggers on the tables that hold spend and conversation history. What could break: a guard written too loosely would let something rewrite a ledger row. The new usage guard compares `to_jsonb(NEW)` against `to_jsonb(OLD)` column by column and admits a change only when the column is one of the known reference columns *and* the new value is `NULL`, so any substantive edit — including one bundled with a legitimate detachment — is rejected; `append_only_guards_still_reject_ordinary_mutations` pins that.
- Session deletion now genuinely destroys the session's events. That is what deleting a session means, and it is what the endpoint always claimed to do, but it is irreversible where previously the operation simply failed.
- Migration 122 rewrites two trigger definitions and one FK constraint; it takes brief locks on `usage_journal`, `usage_ledger`, and `eval_case_results`. No table rewrite, no data migration.

## Security

- Threat categories reviewed: **TM-SQL**, **TM-TENANT**, **TM-API**, **TM-DOS**.
  - *TM-SQL*: no new string-built SQL. The delete stays a bound-parameter statement; `SET LOCAL app.session_purge = 'true'` is a constant with no interpolation. The flag is transaction-scoped (`SET LOCAL`), so it cannot leak to another statement on a pooled connection after commit or rollback.
  - *TM-TENANT*: org scoping is unchanged — the delete is still `WHERE org_id = $1 AND id = $2`, so a caller cannot reach another tenant's session. Wrapping it in a transaction does not widen the predicate.
  - *TM-API*: the endpoint's contract does not change; a call that used to 500 now returns its documented 204.
  - *TM-DOS*: a delete now cascades across the session's events instead of aborting on the first one, so the statement does more work than before. It is bounded by one session's history and gated by the existing `SESSION_MANAGE` policy.
  - Audit-integrity review is the substance of this change and is covered under Risk above: the guards narrow in one place (`budget_ledger` loses an inherited archival bypass) and widen only for FK-driven detachment.
- Findings and resolutions: the first draft of the events bypass was not scoped by table, which would have let `app.session_purge` authorise deletes from `budget_ledger`. Fixed by the `TG_TABLE_NAME = 'events'` condition, with a test that sets the flag and asserts a `budget_ledger` delete still fails.
- `knowledge/security/budgeting.md` gains a short section stating that detachment is the one permitted write to the journal and ledger, since the previous text asserted an unqualified append-only rule.

## Follow-ups

- `delete_session` discards the `bool` the command returns, so deleting a nonexistent or cross-org session answers 204 even though the OpenAPI annotation documents a 404. Real, but a separate contract bug from the 500 this PR fixes — filed as a follow-up rather than widened into here.
- Session deletion still leaves the session's `workspaces` row and `workspace_files` behind (the file FK cascades from `workspaces`, not `sessions`), and does not tear down the physical sandbox or cancel durable workflow instances keyed to the session. Out of scope: none of it blocks the delete, and each needs its own decision about what "delete a session" should reclaim.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WsdJnttojKUGCSwrSuGZg)_