### PR TITLE
ci(security): run the advisory gate on a schedule

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -25,6 +25,14 @@ on:
       - '.github/workflows/licenses.yml'
       - '**/Cargo.lock'
       - 'scripts/lib/check-nonworkspace-advisories.sh'
+  schedule:
+    # Advisories are published against a dependency tree that is not changing,
+    # so the path filters above answer "were there advisories the last time Rust
+    # code moved" rather than "are there advisories today" (EVE-920). Weekly,
+    # Mondays 16:00 UTC — after examples-check at 15:00 so the scheduled sweeps
+    # do not pile onto the same runners.
+    - cron: '0 16 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What changed

The RustSec advisory gate now runs weekly against an unchanged dependency tree, and can be triggered on demand.

`licenses.yml` owns `cargo deny check licenses`, `cargo deny check advisories`, and `scripts/lib/check-nonworkspace-advisories.sh`. It fired only on pushes and PRs whose paths touch Rust sources, a lockfile, `deny.toml`, or the guard script. Adds `schedule: '0 16 * * 1'` and `workflow_dispatch`.

16:00 UTC Mondays sits an hour after `examples-check` (15:00) and two after `integration-live-sweep` (14:00), so the three scheduled sweeps do not land on the runners together.

## Why

EVE-920, found during the 2026-08-19 maintenance sweep.

Advisories are published continuously against a dependency tree that is not changing. Path filters make the gate answer "were there advisories the last time Rust code moved", not "are there advisories today". The most recent run on `main` before this sweep was 2026-07-19 — a month in which a newly published RustSec advisory against a pinned dependency would have been reported by nothing.

In practice this repo commits Rust often enough that the window is usually short, so this is a latent gap rather than an active exposure. It becomes real during a quiet period or on a frozen release branch.

## Before / After

Before — the workflow's triggers, and what `main` had actually run:

```
on:
  push:        [paths: Cargo.toml, Cargo.lock, crates/**, integrations/**, deny.toml, **/Cargo.lock, ...]
  pull_request: [same paths]

$ most recent License Check run on main
2026-07-19T21:46:31Z  completed/success  3cfe4e1
```

After — a fourth and fifth trigger, so a run happens whether or not anything changed:

```
$ python3 -c "import yaml; print(list(yaml.safe_load(open('.github/workflows/licenses.yml'))[True].keys()))"
['push', 'pull_request', 'schedule', 'workflow_dispatch']
```

No behaviour changes inside the job — same steps, same `deny.toml`, same pinned `cargo-deny`. The gate's current verdict is unchanged and green: the `Check Dependency Licenses` job on the current head passes every step, including both advisory scans.

## Risk

- **Low**
- What can break: a scheduled run has no PR to fail against, so a genuine advisory shows up as a red workflow on `main` rather than blocking a merge. That is the intent, but it means someone has to be watching the workflow list. The alternative — a gate that stays quiet until an unrelated commit lands — is worse.
- One extra short job per week. No secrets, no `permissions` change (`contents: read` already), no effect on required status checks for PRs.

## Security

- Threat categories reviewed: **supply chain / dependency risk** (the subject of the change).
  - The diff adds two workflow triggers and nothing else — no new steps, no new permissions, no secrets, no third-party actions. `permissions: contents: read` is unchanged, so the scheduled run has the same minimal token as the existing push/PR runs.
  - `workflow_dispatch` on a `contents: read` workflow with no inputs gives a maintainer a manual run and no additional capability.
  - Net effect on posture is positive: advisory coverage goes from event-driven to time-driven.
- Findings and resolutions: none.

## Follow-ups

- The npm side (`apps/ui`, `apps/docs`, `.deepsec`) still has no audit gate in CI — advisories there surface only as Dependabot PRs. All three are clean today (`pnpm audit` and `pnpm audit --prod`: no known vulnerabilities), and whether that deserves a failing check is a separate decision, noted on EVE-920 rather than decided here.
- The Dependabot alerts API is unreadable from scheduled cloud-agent sessions (`403 Resource not accessible by integration` for both the session token and the Doppler PAT). Tracked on EVE-913; it needs a permissions grant, not a code change.

## Checklist

- [x] Tests added or updated — n/a, CI configuration; validated by parsing the workflow and confirming the trigger set
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WsdJnttojKUGCSwrSuGZg)_