### PR TITLE
feat(host): register capabilities on a running runtime

### DIFF
--- a/crates/host/src/composition.rs
+++ b/crates/host/src/composition.rs
@@ -28,7 +28,7 @@ use everruns_core::{
     tool_context::ToolContextExtensions,
 };
 use everruns_provider::driver_registry::DriverRegistry;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 /// The execution surface a deployment runs with.
 ///
@@ -50,9 +50,11 @@ use std::sync::Arc;
 ///     .capability(everruns_builtins::HumanIntentCapability)
 ///     .build();
 /// ```
-#[derive(Clone)]
 pub struct HostComposition {
-    capability_registry: CapabilityRegistry,
+    /// Copy-on-write so a capability can be registered through a shared handle
+    /// after composition (EVE-917). Readers take a snapshot and never observe a
+    /// half-built registry; writers clone, mutate, validate, then swap.
+    capability_registry: RwLock<Arc<CapabilityRegistry>>,
     driver_registry: DriverRegistry,
     egress_service: Arc<dyn EgressService>,
     utility_llm_service: Arc<dyn UtilityLlmService>,
@@ -64,7 +66,7 @@ impl HostComposition {
     /// Create a composition from explicit registries.
     pub fn new(capability_registry: CapabilityRegistry, driver_registry: DriverRegistry) -> Self {
         Self {
-            capability_registry,
+            capability_registry: RwLock::new(Arc::new(capability_registry)),
             driver_registry,
             egress_service: Arc::new(everruns_core::DisabledEgressService),
             utility_llm_service: Arc::new(everruns_core::DisabledUtilityLlmService),
@@ -78,14 +80,74 @@ impl HostComposition {
         HostCompositionBuilder::new()
     }
 
-    /// Immutable access to the capability registry.
-    pub fn capability_registry(&self) -> &CapabilityRegistry {
-        &self.capability_registry
+    /// A consistent snapshot of the capability registry.
+    ///
+    /// The snapshot is cheap to hold and never changes underneath its holder,
+    /// so a turn assembled from one either sees a dynamically registered
+    /// capability or does not — never a partially built registry.
+    pub fn capability_registry(&self) -> Arc<CapabilityRegistry> {
+        self.read_registry().clone()
     }
 
-    /// Mutable access to the capability registry.
-    pub fn capability_registry_mut(&mut self) -> &mut CapabilityRegistry {
-        &mut self.capability_registry
+    /// Register a capability on a live composition (EVE-917).
+    ///
+    /// Callable through a shared handle, so a host holding
+    /// `Arc<InProcessRuntime>` can make a capability discovered mid-session
+    /// known to the runtime. Registration is not activation: the id becomes
+    /// resolvable, and `activate_capability` still decides per-session
+    /// enablement.
+    ///
+    /// Duplicate canonical ids and alias collisions are rejected and leave the
+    /// existing registry untouched.
+    pub fn register_capability(
+        &self,
+        capability: Arc<dyn Capability>,
+    ) -> Result<(), everruns_capability::CapabilityError> {
+        self.update_registry(|registry| registry.try_register_arc(capability))
+    }
+
+    /// Register a capability with composition-time replace semantics.
+    ///
+    /// Re-registering a canonical id overrides the previous implementation,
+    /// matching [`CapabilityRegistry::register_arc`]. Use
+    /// [`HostComposition::register_capability`] for anything registered after
+    /// the deployment is assembled, where a silent override would hide a bug.
+    pub fn register_capability_overriding(&self, capability: Arc<dyn Capability>) {
+        let _ = self.update_registry(|registry| {
+            registry.register_arc(capability);
+            Ok::<(), everruns_capability::CapabilityError>(())
+        });
+    }
+
+    /// Whether a canonical id or alias already resolves in this composition.
+    ///
+    /// Lets a host skip registration for a capability that is already present
+    /// without matching on error strings.
+    pub fn is_capability_registered(&self, id: &str) -> bool {
+        self.read_registry().has(id)
+    }
+
+    fn read_registry(&self) -> std::sync::RwLockReadGuard<'_, Arc<CapabilityRegistry>> {
+        // A panic while a writer holds the lock would poison it. The registry
+        // is still coherent in that case — every write is a swap of a fully
+        // built value — so recovering beats taking the whole runtime down.
+        self.capability_registry
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn update_registry<E>(
+        &self,
+        mutate: impl FnOnce(&mut CapabilityRegistry) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let mut guard = self
+            .capability_registry
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut next = (**guard).clone();
+        mutate(&mut next)?;
+        *guard = Arc::new(next);
+        Ok(())
     }
 
     /// Immutable access to the driver registry.
@@ -119,6 +181,25 @@ impl HostComposition {
     }
 }
 
+/// Clones are independent compositions.
+///
+/// They start from the same registry snapshot — cheap, since the snapshot is
+/// shared until one side writes — but a capability registered on a clone is not
+/// visible to the original. That keeps the pre-EVE-917 behaviour of
+/// `#[derive(Clone)]`, where each clone owned its own registry.
+impl Clone for HostComposition {
+    fn clone(&self) -> Self {
+        Self {
+            capability_registry: RwLock::new(self.capability_registry()),
+            driver_registry: self.driver_registry.clone(),
+            egress_service: self.egress_service.clone(),
+            utility_llm_service: self.utility_llm_service.clone(),
+            session_file_system_factory: self.session_file_system_factory.clone(),
+            extensions: self.extensions.clone(),
+        }
+    }
+}
+
 impl Default for HostComposition {
     fn default() -> Self {
         Self::new(CapabilityRegistry::new(), DriverRegistry::new())
@@ -128,7 +209,7 @@ impl Default for HostComposition {
 impl std::fmt::Debug for HostComposition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HostComposition")
-            .field("capabilities", &self.capability_registry)
+            .field("capabilities", &self.capability_registry())
             .field("drivers", &self.driver_registry.registered_providers())
             .field("egress_service", &self.egress_service.name())
             .field("utility_llm_service", &self.utility_llm_service.name())
@@ -155,14 +236,19 @@ impl HostCompositionBuilder {
     }
 
     /// Replace the capability registry.
-    pub fn capability_registry(mut self, registry: CapabilityRegistry) -> Self {
-        self.composition.capability_registry = registry;
+    pub fn capability_registry(self, registry: CapabilityRegistry) -> Self {
+        *self
+            .composition
+            .capability_registry
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Arc::new(registry);
         self
     }
 
     /// Register a capability on the composition.
-    pub fn capability(mut self, capability: impl Capability + 'static) -> Self {
-        self.composition.capability_registry.register(capability);
+    pub fn capability(self, capability: impl Capability + 'static) -> Self {
+        self.composition
+            .register_capability_overriding(Arc::new(capability));
         self
     }
 
@@ -261,10 +347,8 @@ mod tests {
 
     #[test]
     fn composition_registries_stay_mutable_after_build() {
-        let mut composition = HostComposition::default();
-        composition
-            .capability_registry_mut()
-            .register(HumanIntentCapability);
+        let composition = HostComposition::default();
+        composition.register_capability_overriding(Arc::new(HumanIntentCapability));
 
         let info = everruns_core::CapabilityInfo::from_core(
             composition

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -408,10 +408,9 @@ impl InProcessRuntimeBuilder {
     }
 
     /// Register an additional capability on the runtime platform.
-    pub fn capability<C: Capability + 'static>(mut self, capability: C) -> Self {
+    pub fn capability<C: Capability + 'static>(self, capability: C) -> Self {
         self.host_composition
-            .capability_registry_mut()
-            .register(capability);
+            .register_capability_overriding(Arc::new(capability));
         self
     }
 
@@ -956,11 +955,11 @@ impl InProcessRuntime {
             &harness,
             agent,
             session,
-            self.host_composition.capability_registry(),
+            &self.host_composition.capability_registry(),
         );
         let contributed = collect_capability_mcp_servers(
             &resolved.resolved_capability_configs,
-            self.host_composition.capability_registry(),
+            &self.host_composition.capability_registry(),
         );
         let explicit = crate::mcp::merge_session_scoped_servers(&harness, agent, session);
         everruns_core::merge_scoped_mcp_servers(&contributed, &explicit)
@@ -982,6 +981,34 @@ impl InProcessRuntime {
     /// [`InProcessRuntimeBuilder::with_plugin_dir`] is called.
     pub fn plugin_warnings(&self) -> &[String] {
         &self.plugin_warnings
+    }
+
+    /// Register a capability on a running runtime (EVE-917).
+    ///
+    /// Takes `&self`, so a host holding `Arc<InProcessRuntime>` can make a
+    /// capability discovered after composition — an extension installed
+    /// mid-conversation, say — resolvable without rebuilding the runtime.
+    ///
+    /// Registration is not activation. Afterwards the id resolves and
+    /// [`InProcessRuntime::activate_capability`] behaves exactly as it does for
+    /// a capability present at startup, including per-session enablement and
+    /// the surface invalidation that follows it. Sessions that never activate
+    /// the id are unaffected.
+    ///
+    /// A duplicate canonical id or an alias that collides with a registered id
+    /// is rejected, and the existing capability is left untouched. Use
+    /// [`InProcessRuntime::is_capability_registered`] to skip registration for
+    /// something already present.
+    pub fn register_capability(&self, capability: Arc<dyn Capability>) -> Result<()> {
+        self.host_composition
+            .register_capability(capability)
+            .map_err(|error| AgentLoopError::config(format!("cannot register capability: {error}")))
+    }
+
+    /// Whether a canonical id or alias already resolves on this runtime.
+    pub fn is_capability_registered(&self, capability_id: &str) -> bool {
+        self.host_composition
+            .is_capability_registered(capability_id)
     }
 
     /// Activate a registered capability on a running session.
@@ -1032,7 +1059,7 @@ impl InProcessRuntime {
 
         let mut candidate = context.snapshot.capabilities;
         candidate.push(capability.clone());
-        resolve_capability_configs(&candidate, registry)
+        resolve_capability_configs(&candidate, &registry)
             .map_err(|error| AgentLoopError::config(error.to_string()))?;
 
         self.session_store
@@ -1558,7 +1585,7 @@ impl InProcessRuntime {
             self.session_store.clone(),
             self.event_history.clone(),
             self.provider_store.clone(),
-            registry.clone(),
+            (*registry).clone(),
             self.host_composition.driver_registry().clone(),
         )
         .with_file_store(self.file_store.clone())
@@ -1655,7 +1682,7 @@ impl InProcessRuntime {
             self.session_store.as_ref(),
             self.event_history.as_ref(),
             self.provider_store.as_ref(),
-            self.host_composition.capability_registry(),
+            &self.host_composition.capability_registry(),
             self.host_composition.driver_registry(),
             session_id,
             harness_id,
@@ -1749,7 +1776,9 @@ impl RuntimeHostAdapter for InProcessRuntime {
     }
 
     fn capability_registry(&self) -> CapabilityRegistry {
-        self.host_composition.capability_registry().clone()
+        // Snapshot per call, so a capability registered after composition
+        // (EVE-917) reaches the next caller rather than a stale copy.
+        (*self.host_composition.capability_registry()).clone()
     }
 
     fn driver_registry(&self) -> DriverRegistry {

--- a/crates/host/tests/mcp_runtime_test.rs
+++ b/crates/host/tests/mcp_runtime_test.rs
@@ -474,3 +474,444 @@ async fn live_capability_activation_and_deactivation_refresh_every_surface() {
         .expect_err("unknown capability must fail");
     assert!(unknown.to_string().contains("unknown capability"));
 }
+
+/// A different implementation claiming an id that is already registered.
+struct RivalCapability;
+
+impl Capability for RivalCapability {
+    fn id(&self) -> &str {
+        "live_test"
+    }
+
+    fn name(&self) -> &str {
+        "Rival"
+    }
+
+    fn description(&self) -> &str {
+        "Claims an id that is already taken."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some("RIVAL_CAPABILITY_PROMPT")
+    }
+}
+
+/// A distinct id whose alias collides with a registered capability.
+struct AliasCollisionCapability;
+
+impl Capability for AliasCollisionCapability {
+    fn id(&self) -> &str {
+        "alias_collision"
+    }
+
+    fn aliases(&self) -> Vec<&'static str> {
+        vec!["live_test"]
+    }
+
+    fn name(&self) -> &str {
+        "Alias Collision"
+    }
+
+    fn description(&self) -> &str {
+        "Aliases an id that is already taken."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+}
+
+/// A capability that did not exist when the runtime was composed becomes usable
+/// without a restart: register it on the live runtime, activate it, and every
+/// surface behaves exactly as it would have at startup (EVE-917).
+#[tokio::test]
+async fn capability_registered_after_startup_behaves_like_one_composed_at_startup() {
+    let traffic = Arc::new(Mutex::new(McpTraffic::default()));
+    let hooks = Arc::new(HookCounts::default());
+
+    // Composed with an empty capability registry — `live_test` arrives later.
+    let platform = HostComposition::builder()
+        .capability_registry(CapabilityRegistry::new())
+        .driver_registry(DriverRegistry::new())
+        .egress_service(Arc::new(FakeMcpEgress {
+            traffic: traffic.clone(),
+        }))
+        .build();
+
+    let harness_id = everruns_provider::typed_id::HarnessId::from_seed(917);
+    let agent_id = everruns_provider::typed_id::AgentId::from_seed(917);
+    let active_session_id = everruns_provider::typed_id::SessionId::from_seed(917);
+    let bystander_session_id = everruns_provider::typed_id::SessionId::from_seed(918);
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .host_composition(platform)
+        .llm_sim_as_default(LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![
+                SimToolCall {
+                    name: "live_echo".to_string(),
+                    arguments: json!({ "value": "hello" }),
+                    id: None,
+                },
+                SimToolCall {
+                    name: "mcp_docs__echo".to_string(),
+                    arguments: json!({ "message": "hi" }),
+                    id: None,
+                },
+            ]),
+            SimTurn::Assistant("used the late-registered tools".to_string()),
+        ]))
+        .harness(
+            HarnessBuilder::new("live", "Base prompt")
+                .id(harness_id)
+                .build(),
+        )
+        .agent(
+            AgentBuilder::new("live-agent", "Base agent prompt")
+                .id(agent_id)
+                .max_iterations(8)
+                .build(),
+        )
+        .session(
+            SessionBuilder::new(harness_id)
+                .id(active_session_id)
+                .agent(agent_id)
+                .build(),
+        )
+        .session(
+            SessionBuilder::new(harness_id)
+                .id(bystander_session_id)
+                .agent(agent_id)
+                .build(),
+        )
+        .build()
+        .await
+        .expect("runtime builds");
+
+    // Before registration the id does not resolve at all.
+    assert!(!runtime.is_capability_registered("live_test"));
+    let unknown = runtime
+        .activate_capability(
+            active_session_id,
+            everruns_capability::CapabilityRef::with_config(
+                "live_test",
+                json!({ "enabled": true }),
+            ),
+        )
+        .await
+        .expect_err("an unregistered capability cannot be activated");
+    assert!(unknown.to_string().contains("unknown capability"));
+
+    // Register on the running runtime through a shared handle.
+    runtime
+        .register_capability(Arc::new(LiveCapability {
+            hooks: hooks.clone(),
+        }))
+        .expect("registration succeeds on a running runtime");
+    assert!(runtime.is_capability_registered("live_test"));
+
+    // Registration is not activation: nothing has reached the session yet.
+    let registered_only = runtime.load_context(active_session_id).await.unwrap();
+    assert!(
+        !registered_only
+            .runtime_agent
+            .system_prompt
+            .contains("LIVE_CAPABILITY_PROMPT"),
+        "registering must not change a session that has not activated the capability"
+    );
+    assert!(
+        !registered_only
+            .runtime_agent
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "live_echo")
+    );
+
+    // Config validation runs against the freshly registered instance.
+    let invalid = runtime
+        .activate_capability(
+            active_session_id,
+            everruns_capability::CapabilityRef::new("live_test"),
+        )
+        .await
+        .expect_err("invalid config must fail before mutation");
+    assert!(invalid.to_string().contains("enabled must be true"));
+
+    let delta = runtime
+        .activate_capability(
+            active_session_id,
+            everruns_capability::CapabilityRef::with_config(
+                "live_test",
+                json!({ "enabled": true }),
+            ),
+        )
+        .await
+        .expect("activation succeeds for a late-registered capability");
+    assert!(delta.changed && delta.active && delta.surfaces_dirty);
+
+    // Every surface is assembled: prompt, tools, commands.
+    let active = runtime.load_context(active_session_id).await.unwrap();
+    assert!(
+        active
+            .runtime_agent
+            .system_prompt
+            .contains("LIVE_CAPABILITY_PROMPT")
+    );
+    assert!(
+        active
+            .runtime_agent
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "live_echo")
+    );
+    assert_eq!(
+        runtime
+            .list_commands(active_session_id)
+            .await
+            .unwrap()
+            .first()
+            .map(|command| command.name.clone()),
+        Some("live".to_string())
+    );
+
+    // The contributed MCP server is discovered and its tool routes out; hooks fire.
+    let turn = runtime
+        .run_text_turn(active_session_id, "Use the late-registered tools")
+        .await
+        .expect("turn runs");
+    assert!(turn.success);
+    assert_eq!(traffic.lock().unwrap().tools_call_names, vec!["echo"]);
+    assert_eq!(hooks.pre.load(Ordering::SeqCst), 2);
+    assert_eq!(hooks.post.load(Ordering::SeqCst), 2);
+
+    // A session on the same runtime that never activated it sees nothing.
+    let bystander = runtime.load_context(bystander_session_id).await.unwrap();
+    assert!(
+        !bystander
+            .runtime_agent
+            .system_prompt
+            .contains("LIVE_CAPABILITY_PROMPT")
+    );
+    assert!(
+        !bystander
+            .runtime_agent
+            .tools
+            .iter()
+            .any(|tool| tool.name() == "live_echo")
+    );
+    assert!(
+        runtime
+            .list_commands(bystander_session_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    // Deactivate / re-activate behaves as it does for a composed capability.
+    let off = runtime
+        .deactivate_capability(active_session_id, "live_test")
+        .await
+        .expect("deactivation succeeds");
+    assert!(off.changed && !off.active && off.surfaces_dirty);
+    let inactive = runtime.load_context(active_session_id).await.unwrap();
+    assert!(
+        !inactive
+            .runtime_agent
+            .system_prompt
+            .contains("LIVE_CAPABILITY_PROMPT")
+    );
+
+    let back_on = runtime
+        .activate_capability(
+            active_session_id,
+            everruns_capability::CapabilityRef::with_config(
+                "live_test",
+                json!({ "enabled": true }),
+            ),
+        )
+        .await
+        .expect("re-activation succeeds");
+    assert!(back_on.changed && back_on.active && back_on.surfaces_dirty);
+    assert!(
+        runtime
+            .load_context(active_session_id)
+            .await
+            .unwrap()
+            .runtime_agent
+            .system_prompt
+            .contains("LIVE_CAPABILITY_PROMPT")
+    );
+}
+
+/// Live registration validates exactly as composition-time registration does:
+/// a duplicate id or a colliding alias is rejected and the incumbent survives
+/// untouched (EVE-917).
+#[tokio::test]
+async fn live_registration_rejects_duplicate_ids_and_alias_collisions() {
+    let hooks = Arc::new(HookCounts::default());
+    let runtime = InProcessRuntimeBuilder::new()
+        .host_composition(
+            HostComposition::builder()
+                .capability_registry(CapabilityRegistry::new())
+                .driver_registry(DriverRegistry::new())
+                .build(),
+        )
+        .llm_sim_as_default(LlmSimConfig::fixed("ok"))
+        .single_session(|session| {
+            session
+                .harness("live", "Base prompt")
+                .agent("live-agent", "Base agent prompt")
+        })
+        .build()
+        .await
+        .expect("runtime builds");
+    let session_id = runtime.default_session_id().expect("session id");
+
+    runtime
+        .register_capability(Arc::new(LiveCapability {
+            hooks: hooks.clone(),
+        }))
+        .expect("first registration succeeds");
+
+    let duplicate = runtime
+        .register_capability(Arc::new(RivalCapability))
+        .expect_err("a duplicate canonical id is rejected");
+    assert!(
+        duplicate.to_string().contains("live_test"),
+        "the error names the conflicting id, got: {duplicate}"
+    );
+
+    let collision = runtime
+        .register_capability(Arc::new(AliasCollisionCapability))
+        .expect_err("an alias colliding with a registered id is rejected");
+    assert!(
+        collision.to_string().contains("live_test"),
+        "the error names the conflicting id, got: {collision}"
+    );
+    assert!(!runtime.is_capability_registered("alias_collision"));
+
+    // The incumbent is untouched: activating still yields the original surfaces.
+    runtime
+        .activate_capability(
+            session_id,
+            everruns_capability::CapabilityRef::with_config(
+                "live_test",
+                json!({ "enabled": true }),
+            ),
+        )
+        .await
+        .expect("the originally registered capability still activates");
+    let prompt = runtime
+        .load_context(session_id)
+        .await
+        .unwrap()
+        .runtime_agent
+        .system_prompt;
+    assert!(prompt.contains("LIVE_CAPABILITY_PROMPT"));
+    assert!(
+        !prompt.contains("RIVAL_CAPABILITY_PROMPT"),
+        "a rejected registration must not replace the incumbent"
+    );
+}
+
+/// A capability registered under an id derived from an index, so a test can
+/// register many distinct ones concurrently.
+struct NumberedCapability {
+    id: String,
+}
+
+impl Capability for NumberedCapability {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn name(&self) -> &str {
+        "Numbered"
+    }
+
+    fn description(&self) -> &str {
+        "Registered concurrently with a running turn."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+}
+
+/// Registration races with turn assembly and with reads from background tasks.
+/// Concurrent registrations must not panic, deadlock, or let a reader observe a
+/// half-built registry — every id registered is present, and a turn running
+/// through the same registry still completes (EVE-917).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_registration_during_a_turn_is_safe() {
+    const REGISTRATIONS: usize = 32;
+
+    let runtime = Arc::new(
+        InProcessRuntimeBuilder::new()
+            .host_composition(
+                HostComposition::builder()
+                    .capability_registry(CapabilityRegistry::new())
+                    .driver_registry(DriverRegistry::new())
+                    .build(),
+            )
+            .llm_sim_as_default(LlmSimConfig::fixed("done"))
+            .single_session(|session| {
+                session
+                    .harness("live", "Base prompt")
+                    .agent("live-agent", "Base agent prompt")
+            })
+            .build()
+            .await
+            .expect("runtime builds"),
+    );
+    let session_id = runtime.default_session_id().expect("session id");
+
+    // A turn assembling its surfaces from the registry, while writers swap it.
+    let turn_runtime = runtime.clone();
+    let turn = tokio::spawn(async move {
+        turn_runtime
+            .run_text_turn(session_id, "Run while capabilities are registered")
+            .await
+    });
+
+    let writers: Vec<_> = (0..REGISTRATIONS)
+        .map(|index| {
+            let runtime = runtime.clone();
+            tokio::spawn(async move {
+                runtime.register_capability(Arc::new(NumberedCapability {
+                    id: format!("numbered_{index}"),
+                }))
+            })
+        })
+        .collect();
+
+    // Readers racing the writers must always see a coherent registry.
+    let reader_runtime = runtime.clone();
+    let reader = tokio::spawn(async move {
+        for _ in 0..200 {
+            let _ = reader_runtime.is_capability_registered("numbered_0");
+            let _ = reader_runtime.load_context(session_id).await;
+            tokio::task::yield_now().await;
+        }
+    });
+
+    for writer in writers {
+        writer
+            .await
+            .expect("no writer panicked")
+            .expect("each distinct id registers");
+    }
+    reader.await.expect("no reader panicked");
+    let result = turn.await.expect("the turn task did not panic");
+    assert!(result.expect("the turn completed").success);
+
+    for index in 0..REGISTRATIONS {
+        assert!(
+            runtime.is_capability_registered(&format!("numbered_{index}")),
+            "every concurrently registered id survives the copy-on-write swaps"
+        );
+    }
+}

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -355,7 +355,7 @@ impl AppState {
         Self {
             session_service: Arc::new(SessionService::with_registry(
                 db.clone(),
-                host_composition.capability_registry().clone(),
+                (*host_composition.capability_registry()).clone(),
             )),
             message_service: Arc::new(MessageService::new(
                 db.clone(),

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -460,7 +460,7 @@ impl AppState {
         Self {
             session_service: Arc::new(SessionService::with_registry(
                 db.clone(),
-                host_composition.capability_registry().clone(),
+                (*host_composition.capability_registry()).clone(),
             )),
             event_service: EventService::new(db.clone(), event_delivery.clone()),
             db,

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -104,7 +104,7 @@ impl AppState {
         Self {
             session_service: Arc::new(SessionService::with_registry(
                 db.clone(),
-                host_composition.capability_registry().clone(),
+                (*host_composition.capability_registry()).clone(),
             )),
             message_service: dependencies.message_service,
             event_service: EventService::new(db.clone(), dependencies.event_delivery),

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -961,7 +961,7 @@ impl ServerAppBuilder {
         );
         let mut session_service = crate::domains::sessions::SessionService::with_registry(
             db.clone(),
-            host_composition.capability_registry().clone(),
+            (*host_composition.capability_registry()).clone(),
         )
         .with_virtual_registry(virtual_registry.clone());
         if let Some(service) = &session_sandbox_service {
@@ -1013,7 +1013,7 @@ impl ServerAppBuilder {
             session_service: Arc::new(
                 crate::domains::sessions::SessionService::with_registry(
                     db.clone(),
-                    host_composition.capability_registry().clone(),
+                    (*host_composition.capability_registry()).clone(),
                 )
                 .with_virtual_registry(virtual_registry.clone()),
             ),
@@ -1089,7 +1089,7 @@ impl ServerAppBuilder {
             services::CapabilityService::with_registry(
                 db.clone(),
                 encryption.clone(),
-                host_composition.capability_registry().clone(),
+                (*host_composition.capability_registry()).clone(),
             )
             .with_mcp_egress_service(host_composition.egress_service()),
         );
@@ -1106,7 +1106,7 @@ impl ServerAppBuilder {
                 event_service.clone(),
                 provider_resolver.clone(),
                 mcp_server_service.clone(),
-                host_composition.capability_registry().clone(),
+                (*host_composition.capability_registry()).clone(),
                 driver_registry.as_ref().clone(),
                 sqldb_store.clone(),
             )
@@ -2258,7 +2258,7 @@ impl ServerAppBuilder {
                     event_service.clone(),
                     provider_resolver.clone(),
                     mcp_server_service,
-                    host_composition.capability_registry().clone(),
+                    (*host_composition.capability_registry()).clone(),
                     host_composition.driver_registry().clone(),
                     sqldb_store.clone(),
                 )

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -569,7 +569,7 @@ impl WorkerServiceImpl {
         >,
         provider_resolver_service: Option<Arc<ProviderResolverService>>,
     ) -> Self {
-        let capability_registry = host_composition.capability_registry().clone();
+        let capability_registry = (*host_composition.capability_registry()).clone();
         let session_service = {
             let svc = SessionService::with_registry(db.clone(), capability_registry.clone());
             if let Some(ref reg) = virtual_registry {

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -343,7 +343,7 @@ impl TestServer {
             session_service: Arc::new(
                 everruns_server::domains::sessions::SessionService::with_registry(
                     db.clone(),
-                    host_composition.capability_registry().clone(),
+                    (*host_composition.capability_registry()).clone(),
                 ),
             ),
             event_service: event_service.clone(),
@@ -383,7 +383,7 @@ impl TestServer {
         let capability_service = Arc::new(services::CapabilityService::with_registry(
             db.clone(),
             encryption.clone(),
-            host_composition.capability_registry().clone(),
+            (*host_composition.capability_registry()).clone(),
         ));
         let mcp_service = Arc::new(
             everruns_server::domains::mcp_servers::McpServerService::new(
@@ -417,7 +417,7 @@ impl TestServer {
                     event_service.clone(),
                     provider_resolver,
                     mcp_service.clone(),
-                    host_composition.capability_registry().clone(),
+                    (*host_composition.capability_registry()).clone(),
                     driver_registry.as_ref().clone(),
                     sqldb_store.clone(),
                 )

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -401,7 +401,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
     // =========================================================================
 
     fn capability_registry(&self) -> CapabilityRegistry {
-        self.host_composition.capability_registry().clone()
+        (*self.host_composition.capability_registry()).clone()
     }
 
     fn driver_registry(&self) -> DriverRegistry {

--- a/knowledge/execution/capabilities.md
+++ b/knowledge/execution/capabilities.md
@@ -227,6 +227,32 @@ without rebuilding the runtime or replacing the session:
 host-storage boundary. Its default implementation fails closed, while the bundled
 in-memory runtime store implements both mutations atomically.
 
+### Live registration
+
+Activation can only reach a capability the registry already knows. A host that
+discovers one after composition — an extension installed mid-conversation, say —
+registers it on the running runtime rather than rebuilding it:
+
+- `InProcessRuntime::register_capability(capability)` takes `&self`, so a host
+  holding `Arc<InProcessRuntime>` can call it. `is_capability_registered(id)`
+  answers whether a registration is needed without matching on error strings.
+- Registration is not activation. It makes the id resolvable; the session
+  overlay above still decides per-session enablement, so sessions that never
+  activate the id are unaffected and no surface is invalidated by registering
+  alone.
+- Validation matches composition time: a duplicate canonical id or an alias
+  colliding with a registered id is rejected and the incumbent capability is
+  left untouched. Composition-time registration keeps its override semantics,
+  where re-registering an id deliberately replaces the previous implementation.
+- `HostComposition` holds its registry copy-on-write behind a lock. A reader
+  takes a snapshot, so a turn assembled while a registration lands either sees
+  the capability or does not, never a partially built registry. Clones of a
+  composition stay independent registries, as they were before.
+
+Unregistering is deliberately absent: removal raises lifetime questions —
+in-flight tool calls, spawned processes — that the motivating case does not
+need.
+
 ### Automatic session titles
 
 The built-in `session` capability may opt into automatic title maintenance.


### PR DESCRIPTION
## What changed

A host can now make a capability usable in a live session without restarting:

```rust
runtime.register_capability(Arc::new(capability))?;   // &self, not &mut self
runtime.is_capability_registered("ext:name");
```

Registration stays separate from activation. `register_capability` makes an id resolvable; `activate_capability` still decides per-session enablement, so a session that never activates the id sees no change to its prompt, tools, hooks, commands, or MCP servers. Once activated, every surface assembles exactly as it would have for a capability present at composition.

Validation matches composition time: a duplicate canonical id or an alias colliding with a registered id is rejected and the incumbent is left untouched. `is_capability_registered` lets a host skip a redundant registration without matching on error strings.

`HostComposition` holds its registry copy-on-write behind an `RwLock<Arc<CapabilityRegistry>>`. Readers take a snapshot, so a turn assembled while a registration lands either sees the capability or does not, never a partially built registry. Writers clone, mutate, validate, then swap — a rejected registration never becomes visible. Clones of a composition remain independent registries, as `#[derive(Clone)]` gave before.

Unregistering is deliberately not added: removal raises lifetime questions (in-flight tool calls, spawned processes) that the motivating case does not need.

## Why

EVE-917. `activate_capability` resolves ids through the composed registry and answered `unknown capability` for anything that arrived later. The registry was owned by value with only a `&mut` accessor, and hosts hold the runtime as a shared `Arc<InProcessRuntime>`, so no mutation path existed at all.

The motivating case is yolop installing an extension mid-conversation: the user watches the install succeed, watches the enable succeed, and gets nothing until a full restart. yolop currently ships an honest "needs a restart" message as a placeholder for this API.

## Before / After

Before — the id never resolves, so activation cannot be reached:

```
runtime.activate_capability(session, "live_test")
  → Err("unknown capability: live_test")
```

After — the same runtime, after one `register_capability` call:

```
test capability_registered_after_startup_behaves_like_one_composed_at_startup ... ok
test live_registration_rejects_duplicate_ids_and_alias_collisions ... ok
test concurrent_registration_during_a_turn_is_safe ... ok
test live_capability_activation_and_deactivation_refresh_every_surface ... ok
test runtime_discovers_and_executes_scoped_mcp_tool ... ok

test result: ok. 5 passed; 0 failed
```

The three new tests map onto the issue's acceptance criteria:

| Criterion | Covered by |
|---|---|
| 1. Register then activate returns `changed/active/surfaces_dirty` instead of `unknown capability` | `capability_registered_after_startup_…` |
| 2. Next turn exposes tools + prompt; hooks fire; MCP servers and commands present | same — runs a real turn, asserts `tools_call_names == ["echo"]` and both hook counters at 2 |
| 3. Duplicate id and alias collision rejected, incumbent untouched | `live_registration_rejects_duplicate_ids_and_alias_collisions` — asserts the rival's prompt never appears |
| 4. A second session that never activates sees no change | `capability_registered_after_startup_…` — a bystander session on the same runtime |
| 5. Registration during an in-flight turn does not panic, deadlock, or expose a partial registry | `concurrent_registration_during_a_turn_is_safe` — 32 concurrent registrations and a reader loop against a running turn |
| 6. Deactivate/re-activate behaves as for a composed capability | `capability_registered_after_startup_…` |

The two pre-existing tests in that file are unchanged and still pass, which is the evidence that composition-time behaviour did not move.

## Risk

- **Medium** — the risk is API surface, not behaviour.
- Every read of the capability registry now goes through a lock acquisition plus an `Arc` clone rather than a borrow. Turn assembly reads it a handful of times per turn, so this is not a hot path, and the snapshot is held for the duration of the work rather than re-acquired.
- Lock poisoning is recovered from rather than propagated (`unwrap_or_else(|p| p.into_inner())`): every write is a swap of a fully built value, so a poisoned lock still guards a coherent registry, and taking the runtime down would be the worse failure.
- `register_capability_overriding` keeps the old replace semantics for composition-time registration, so `HostCompositionBuilder::capability` and `InProcessRuntimeBuilder::capability` behave exactly as before — including deliberate overrides of a built-in.
- Verified with `cargo check --workspace --all-targets --all-features` (clean) and `cargo clippy -p everruns-host -p everruns-server -p everruns-worker --all-targets --all-features -- -D warnings` (clean). The concurrency test was run 12 times consecutively without a failure.

### Breaking change to a published crate

`everruns-host` is published at 0.19.0 and this changes its public API:

- `HostComposition::capability_registry` returns `Arc<CapabilityRegistry>` instead of `&CapabilityRegistry`. Interior mutability makes returning a plain reference impossible; the issue anticipates this ("implies interior mutability on the registry (e.g. `RwLock`) or an equivalent design").
- `HostComposition::capability_registry_mut` is removed, replaced by `register_capability` and `register_capability_overriding`.

Per `knowledge/project/release-process.md` this makes `everruns-host` a **minor** bump (`0.19.0 → 0.20.0`) at its next release, and the dependant cone has to be closed — the same cone that was just closed for the 0.19 bump in #3214. Nothing to do in this PR; flagging it so release prep classifies it correctly rather than running `cargo semver-checks` and being surprised. In-repo callers in `everruns-server` and `everruns-worker` are updated here.

## Security

- Threat categories reviewed: **TM-TOOL**, **TM-TENANT**, **TM-DOS**.
  - *TM-TOOL*: registration widens what a host can make available mid-session, so the validation boundary matters. It reuses `CapabilityRegistry::try_register_arc` — the same duplicate-id and alias-collision rules composition uses — so a late registration cannot silently shadow or replace an existing capability, which would be the way to hijack a tool name. The replace-semantics variant is confined to builder-time paths that already had `&mut`. `activate_capability` still runs its own availability check, config validation, and dependency resolution before anything reaches a session.
  - *TM-TENANT*: registration is runtime-scoped and activation stays session-scoped, unchanged. A registered-but-not-activated capability reaches no session, which the bystander-session assertion pins. There is no path by which registering affects another tenant's session without that session activating the id itself.
  - *TM-DOS*: writes are copy-on-write, so each registration clones the registry — O(capabilities) per call. Registration is a host-initiated control-plane action, not something a model or a request can drive in a loop, and reads never block on each other.
  - No new deserialization, no new network or filesystem surface, no change to credential handling.
- Findings and resolutions: none.

## Follow-ups

- Unregistering a capability is out of scope, per the issue — it needs a decision about in-flight tool calls and spawned processes first.
- The issue's open question about evaluating `CapabilityStatus` at registration time is answered by keeping the current split: registration stores the capability, `activate_capability` checks `status() == Available` at activation, so a capability whose availability changes is re-checked each time rather than pinned at registration.
- `register_capability` takes `Arc<dyn Capability>` rather than `impl Capability + 'static`, per the issue's third open question — hosts registering something they also hold elsewhere (as yolop does) already have the `Arc`, and the builder path keeps the `impl Capability` ergonomics.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — breaking for `everruns-host`, documented above and in the commit message
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WsdJnttojKUGCSwrSuGZg)_