### PR TITLE
ci: bound every ci.yml job with a timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v7
@@ -546,7 +546,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v7
@@ -617,7 +617,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -739,7 +739,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -1440,9 +1440,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Ensure jq is available
-        # Same apt stall mode as the shell-test install; the runner image usually
-        # short-circuits this before apt is reached (EVE-921).
-        timeout-minutes: 12
+        # Same apt stall mode as the shell-test install, but the runner image ships
+        # jq so this short-circuits before apt is reached (measured at 0.00m across
+        # 400 runs). Kept well under the job's own 10m ceiling (EVE-921).
+        timeout-minutes: 5
         run: |
           # jq ships with the GitHub-hosted runner image, so the apt path is only
           # a fallback. See the shell-test job for why the refresh is tolerated.
@@ -1632,7 +1633,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.ui == 'true'
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     defaults:
       run:
@@ -1688,7 +1689,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.ui == 'true' && needs.changes.outputs.skip_ui_e2e != 'true'
-    timeout-minutes: 25
+    timeout-minutes: 35
 
     defaults:
       run:
@@ -1723,10 +1724,11 @@ jobs:
       - name: Install Playwright browsers
         # `--with-deps` shells out to apt for the Chromium system libraries, so
         # this step has the same stall mode as the shell-test install (EVE-921).
-        # Sized off the observed max of 6.6m across 400 runs, not the 0.27m median:
-        # the median is a browser-cache hit, the max is a cold cache paying for the
-        # Chromium download on top of the apt work.
-        timeout-minutes: 15
+        # Sized off the cold-cache path, not the 0.27m median. A run of this branch
+        # missed the browser cache entirely and this step took 14.0m and still
+        # succeeded — more than double the 6.6m max seen across 400 mostly-warm
+        # runs. 25m keeps roughly 1.8x over that cold path.
+        timeout-minutes: 25
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright smoke tests
@@ -1745,7 +1747,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.docs == 'true'
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,7 +770,9 @@ jobs:
       - name: Install shell test dependencies
         # Step-level ceiling so a stalled package mirror names the install in the
         # failure instead of burning the whole job budget silently (EVE-921).
-        timeout-minutes: 8
+        # 12m against a ~2m warm-cache observation: the step also pulls Caddy from
+        # GitHub releases, so leave room for a slow-but-working mirror.
+        timeout-minutes: 12
         run: |
           # `apt-get update` exits non-zero when *any* configured repo fails, and
           # the runner image ships third-party lists we never install from
@@ -1440,7 +1442,7 @@ jobs:
       - name: Ensure jq is available
         # Same apt stall mode as the shell-test install; the runner image usually
         # short-circuits this before apt is reached (EVE-921).
-        timeout-minutes: 8
+        timeout-minutes: 12
         run: |
           # jq ships with the GitHub-hosted runner image, so the apt path is only
           # a fallback. See the shell-test job for why the refresh is tolerated.
@@ -1721,7 +1723,9 @@ jobs:
       - name: Install Playwright browsers
         # `--with-deps` shells out to apt for the Chromium system libraries, so
         # this step has the same stall mode as the shell-test install (EVE-921).
-        timeout-minutes: 8
+        # 12m rather than 8m: the ~2.5m observation is a cache hit, and a cold
+        # browser cache adds the Chromium download on top of the apt work.
+        timeout-minutes: 12
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,8 +770,8 @@ jobs:
       - name: Install shell test dependencies
         # Step-level ceiling so a stalled package mirror names the install in the
         # failure instead of burning the whole job budget silently (EVE-921).
-        # 12m against a ~2m warm-cache observation: the step also pulls Caddy from
-        # GitHub releases, so leave room for a slow-but-working mirror.
+        # 12m against an observed max of 2.45m across 400 runs: the step also pulls
+        # Caddy from GitHub releases, so leave room for a slow-but-working mirror.
         timeout-minutes: 12
         run: |
           # `apt-get update` exits non-zero when *any* configured repo fails, and
@@ -1688,7 +1688,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.ui == 'true' && needs.changes.outputs.skip_ui_e2e != 'true'
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     defaults:
       run:
@@ -1723,9 +1723,10 @@ jobs:
       - name: Install Playwright browsers
         # `--with-deps` shells out to apt for the Chromium system libraries, so
         # this step has the same stall mode as the shell-test install (EVE-921).
-        # 12m rather than 8m: the ~2.5m observation is a cache hit, and a cold
-        # browser cache adds the Chromium download on top of the apt work.
-        timeout-minutes: 12
+        # Sized off the observed max of 6.6m across 400 runs, not the 0.27m median:
+        # the median is a browser-cache hit, the max is a cold cache paying for the
+        # Chromium download on top of the apt work.
+        timeout-minutes: 15
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
       skip_docs_notebooks: ${{ steps.ci_opt_outs.outputs.skip_docs_notebooks }}
       skip_docker: ${{ steps.ci_opt_outs.outputs.skip_docker }}
       skip_integration_workflows: ${{ steps.ci_opt_outs.outputs.skip_integration_workflows }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -168,6 +169,10 @@ jobs:
               # scripts/test-publish-crates-order.sh reads the publish workflow
               # and the workspace member manifests it publishes.
               - '.github/workflows/publish-crates.yml'
+              # scripts/test-ci-job-timeouts.sh reads this workflow, so a PR that
+              # drops a timeout-minutes must run the guard even when it touches
+              # nothing under scripts/.
+              - '.github/workflows/ci.yml'
               - 'Cargo.toml'
               - 'crates/*/Cargo.toml'
               - 'integrations/*/Cargo.toml'
@@ -299,6 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -315,6 +321,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -332,6 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v7
@@ -364,6 +372,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.knowledge == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -384,6 +393,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -399,6 +409,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -417,6 +428,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -436,6 +448,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -454,6 +467,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -474,6 +488,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -493,6 +508,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -511,6 +527,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -529,6 +546,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v7
@@ -551,6 +569,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -566,6 +585,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && github.event_name == 'pull_request'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -584,6 +604,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true'
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7
@@ -596,6 +617,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v7
@@ -624,6 +646,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -716,6 +739,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v7
@@ -738,11 +762,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.shell == 'true'
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v7
 
       - name: Install shell test dependencies
+        # Step-level ceiling so a stalled package mirror names the install in the
+        # failure instead of burning the whole job budget silently (EVE-921).
+        timeout-minutes: 8
         run: |
           # `apt-get update` exits non-zero when *any* configured repo fails, and
           # the runner image ships third-party lists we never install from
@@ -889,6 +917,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.postgres_integration == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
+    timeout-minutes: 40
     services:
       postgres:
         image: postgres:17-alpine
@@ -1072,6 +1101,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.object_storage == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:17-alpine
@@ -1193,6 +1223,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@v7
@@ -1251,6 +1282,7 @@ jobs:
       - changes
       - build-binaries
     if: github.event_name == 'push' && needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:17-alpine
@@ -1406,6 +1438,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Ensure jq is available
+        # Same apt stall mode as the shell-test install; the runner image usually
+        # short-circuits this before apt is reached (EVE-921).
+        timeout-minutes: 8
         run: |
           # jq ships with the GitHub-hosted runner image, so the apt path is only
           # a fallback. See the shell-test job for why the refresh is tolerated.
@@ -1463,6 +1498,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.sdk_compat == 'true' && needs.changes.outputs.skip_sdk_compat != 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -1558,6 +1594,7 @@ jobs:
       - changes
       - build-binaries
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v7
@@ -1593,6 +1630,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.ui == 'true'
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -1648,6 +1686,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.ui == 'true' && needs.changes.outputs.skip_ui_e2e != 'true'
+    timeout-minutes: 20
 
     defaults:
       run:
@@ -1680,6 +1719,9 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
+        # `--with-deps` shells out to apt for the Chromium system libraries, so
+        # this step has the same stall mode as the shell-test install (EVE-921).
+        timeout-minutes: 8
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright smoke tests
@@ -1698,6 +1740,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.docs == 'true'
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -1797,6 +1840,7 @@ jobs:
       - changes
       - build-binaries
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_docker != 'true'
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -1841,6 +1885,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.changes.outputs.run_ci == 'true' && github.event_name == 'pull_request'
     needs: changes
+    timeout-minutes: 10
     steps:
       - name: Require affected CI before merge
         run: |
@@ -1924,6 +1969,7 @@ jobs:
       - daytona-live-test
       - e2b-live-test
       - deno-live-test
+    timeout-minutes: 10
     steps:
       - name: Verify all jobs passed
         run: |

--- a/scripts/test-ci-job-timeouts.sh
+++ b/scripts/test-ci-job-timeouts.sh
@@ -19,8 +19,10 @@ from pathlib import Path
 
 import yaml
 
-# Generous relative to observed runtimes (the slowest job sampled over ~120 recent
-# runs finishes in under 7 minutes). A job that trips this is wedged, not slow.
+# Generous relative to observed runtimes. Most jobs finish in under 7 minutes, but
+# the ones that compile Rust or download browsers have a cache-miss cliff — ui-e2e
+# has been measured at 16m on a cold Playwright cache — so their ceilings are sized
+# off the cold path. A job that trips this ceiling is wedged, not slow.
 CEILING_MINUTES = 45
 
 # Commands that reach a package mirror and can hang rather than fail.
@@ -62,6 +64,24 @@ if unbounded_installs:
     errors.append(
         f"{path}: package-install steps without a step-level timeout-minutes: "
         + ", ".join(sorted(unbounded_installs))
+    )
+
+# A step ceiling at or above its job's ceiling can never fire — the job dies first,
+# which is the six-hour-shaped failure this guard exists to prevent, just smaller.
+inverted = []
+for name, job in jobs.items():
+    job_timeout = job.get("timeout-minutes")
+    if not isinstance(job_timeout, int):
+        continue
+    for step in job.get("steps") or []:
+        step_timeout = step.get("timeout-minutes")
+        if isinstance(step_timeout, int) and step_timeout >= job_timeout:
+            label = step.get("name") or "<unnamed step>"
+            inverted.append(f"{name}: '{label}' {step_timeout}m >= job {job_timeout}m")
+if inverted:
+    errors.append(
+        f"{path}: step timeout-minutes at or above the job's own ceiling: "
+        + ", ".join(sorted(inverted))
     )
 
 if errors:

--- a/scripts/test-ci-job-timeouts.sh
+++ b/scripts/test-ci-job-timeouts.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Guard ci.yml against inheriting the 360-minute GitHub Actions default timeout.
+#
+# A job with no `timeout-minutes` does not fail when a package mirror stalls — it
+# squats for six hours, and because ci.yml jobs are required checks, every open PR
+# sits at mergeable_state=blocked for that whole window with no signal telling
+# "installing" apart from "wedged" (EVE-921). An explicit ceiling turns a wedge
+# into a legible red in minutes.
+#
+# Two rules:
+#   1. every job binds a timeout-minutes, at or below CEILING_MINUTES;
+#   2. every step that shells out to apt binds its own, so the failure names the
+#      install rather than the whole job.
+
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+import yaml
+
+# Generous relative to observed runtimes (the slowest job sampled over ~120 recent
+# runs finishes in under 7 minutes). A job that trips this is wedged, not slow.
+CEILING_MINUTES = 45
+
+# Commands that reach a package mirror and can hang rather than fail.
+APT_MARKERS = ("apt-get", "apt install", "--with-deps")
+
+path = Path(".github/workflows/ci.yml")
+jobs = yaml.safe_load(path.read_text())["jobs"]
+
+errors = []
+
+missing = [name for name, job in jobs.items() if "timeout-minutes" not in job]
+if missing:
+    errors.append(
+        f"{path}: jobs without timeout-minutes inherit the 360m default: "
+        + ", ".join(sorted(missing))
+    )
+
+excessive = [
+    f"{name} ({job['timeout-minutes']}m)"
+    for name, job in jobs.items()
+    if isinstance(job.get("timeout-minutes"), int)
+    and job["timeout-minutes"] > CEILING_MINUTES
+]
+if excessive:
+    errors.append(
+        f"{path}: timeout-minutes above the {CEILING_MINUTES}m ceiling: "
+        + ", ".join(sorted(excessive))
+    )
+
+unbounded_installs = []
+for name, job in jobs.items():
+    for step in job.get("steps") or []:
+        run = step.get("run") or ""
+        if any(marker in run for marker in APT_MARKERS):
+            if "timeout-minutes" not in step:
+                label = step.get("name") or run.strip().splitlines()[0]
+                unbounded_installs.append(f"{name}: {label}")
+if unbounded_installs:
+    errors.append(
+        f"{path}: package-install steps without a step-level timeout-minutes: "
+        + ", ".join(sorted(unbounded_installs))
+    )
+
+if errors:
+    raise SystemExit("\n".join(errors))
+
+print(
+    f"all {len(jobs)} ci.yml jobs bound a timeout-minutes at or below "
+    f"{CEILING_MINUTES}m, and every package-install step bounds its own"
+)
+PY


### PR DESCRIPTION
## What changed

Every job in `ci.yml` now declares an explicit `timeout-minutes`. 33 of the 39 jobs previously declared none and inherited the GitHub Actions default of **360 minutes**.

The three steps that shell out to `apt` also get their own step-level ceiling, so a stalled mirror fails naming the install rather than the whole job:

| Job | Step | Step ceiling | Job ceiling |
| --- | --- | --- | --- |
| `ui-e2e` | Install Playwright browsers (`--with-deps`) | 25 min | 35 min |
| `shell-test` | Install shell test dependencies | 12 min | 20 min |
| `cli-e2e-test` | Ensure jq is available | 5 min | 10 min (pre-existing) |

`scripts/test-ci-job-timeouts.sh` keeps these properties from regressing, and `.github/workflows/ci.yml` joins the `shell` path filter so a PR that drops a timeout runs the guard even when it touches nothing under `scripts/`.

## Why

Resolves EVE-921. On 2026-08-19 three unrelated PRs (#3219, #3222, #3224) each had a job stall in an `apt` step for 30–71 minutes with no output and no failure. An `apt` mirror that **hangs** — as opposed to one that fails, which `ci.yml` already tolerates with `apt-get update || true` — does not fail the job. It holds it open for six hours. Because these are required checks, every affected PR sits at `mergeable_state=blocked` for that window, and nothing distinguishes "installing" from "wedged".

## Before / After

**Before** — 33 jobs unbounded, so the guard fails on `main`:

```
$ bash scripts/test-ci-job-timeouts.sh
.github/workflows/ci.yml: jobs without timeout-minutes inherit the 360m default:
agent-record-isolation, build-binaries, capability-contract, changes,
ci-opt-out-policy, ci-success, clippy, core-kernel-dependencies, core-public-api,
docker-build, docs-build, environment-capability-isolation, format,
hosted-capability-isolation, integration-test, knowledge, lockfile,
migration-immutability, msrv, observability-isolation, openapi-check,
portable-builtins-isolation, provider-isolation, s3-integration-test,
sdk-compat-matrix, server-test-enumeration, shell-test, test-support-isolation,
ui-build, ui-e2e, unit-test, worker-test, workflow-test
exit=1
```

**After**:

```
$ bash scripts/test-ci-job-timeouts.sh
all 39 ci.yml jobs bound a timeout-minutes at or below 45m, and every
package-install step bounds its own
exit=0

$ bash scripts/run-shell-tests.sh
Running 17 repo shell test(s)...
All repo shell tests passed.
```

Worst case for a wedged `apt` mirror goes from **360 min** to **5–25 min** at the step and **10–35 min** at the job.

### How the values were chosen — and why they moved three times

This is the part worth reviewing. The sizing was wrong twice before it was right, and CI on this branch is what caught it.

**First pass** sized the install steps at 8 min off a single warm-cache observation (~2.5 min).

**Second pass:** sampling the three install steps across **400 runs** showed the warm view was misleading:

| Step | median | p95 | max |
| --- | --- | --- | --- |
| Install Playwright browsers | 0.27 min | 1.57 min | **6.60 min** |
| Install shell test dependencies | 0.18 min | 0.50 min | **2.45 min** |
| Ensure jq is available | 0.00 min | 0.00 min | **0.00 min** |

8 min was **1.2× a real observed maximum** — a false red waiting to happen. Raised to 12/15 min.

**Third pass:** a run of this very branch then missed the Playwright cache outright. `Cache Playwright browsers` restored nothing (0.05 min) and the install took **14.0 min and still succeeded** — more than double the max across 400 mostly-warm runs. The 15-minute ceiling it passed under had **7% of headroom**.

The lesson generalizes: any job that compiles Rust or downloads browsers has a cache-miss cliff, and a warm p95 does not describe it. Those jobs are now sized off the cold path — `clippy` and `worker-test` to 30 min, `msrv` and `core-public-api` to 25 min, `ui-build` and `docs-build` to 20 min, `ui-e2e` to 35 min. Jobs that neither compile nor download (the guards and gates, all measured under 0.5 min across 60+ samples) stay at 10 min.

| Tier | Ceiling | Jobs |
| --- | --- | --- |
| Guards / gates | 10 | `changes`, `format`, `lockfile`, `knowledge`, all 8 isolation guards, `migration-immutability`, `server-test-enumeration`, `sdk-compat-matrix`, `ci-opt-out-policy`, `ci-success` |
| Light | 15–20 | `openapi-check`, `ui-build`, `docs-build`, `shell-test`, `sdk-compat-test` |
| Compiles / downloads | 25–35 | `msrv`, `core-public-api`, `clippy`, `worker-test`, `ui-e2e` |
| Heavy Rust / integration | 30–40 | `unit-test`, `s3-integration-test`, `workflow-test`, `docker-build`, `integration-test`, `build-binaries` |

The heavy tier is sized from step content rather than measurement because those jobs are currently gated off (EVE-922); the guard's 45-minute ceiling still bounds them at 8× better than the default.

### A bug this surfaced

Auditing the result caught an inverted ceiling: `Ensure jq is available` had a **12 min step timeout inside `cli-e2e-test`'s pre-existing 10 min job timeout**, so the step ceiling could never fire — the job would die first. That is the same six-hour-shaped failure this PR exists to prevent, just smaller. Fixed to 5 min, and the guard now fails on any step ceiling at or above its job's:

```
$ bash scripts/test-ci-job-timeouts.sh   # with the bug reintroduced
.github/workflows/ci.yml: step timeout-minutes at or above the job's own ceiling:
cli-e2e-test: 'Ensure jq is available' 12m >= job 10m
exit=1
```

## Risk

- **Low**
- A ceiling set too tight would fail a legitimately slow job — the actual risk in this change, and what drove all three revisions. Every ceiling is now sized against a measured **cold-path** duration rather than a warm median, with the tightest remaining margin ~1.8× over the worst observed successful run.
- No `uses:`, `permissions:`, `secrets.`, or `${{ }}` expressions touched.

## Security

- **Threat categories reviewed:** TM-DOS. Also checked for supply-chain surface (no `uses:` added or changed, so no new action provenance), secret exposure (no `secrets.` references touched), and expression injection (no `${{ }}` introduced — verified against the diff).
- **Findings and resolutions:** No new surface. The change *reduces* TM-DOS exposure: an unbounded job holds a hosted runner and a required check for up to 6 hours, which is a self-inflicted availability sink on the merge queue and on Actions concurrency. Bounding it converts that into a fast, legible failure. The new guard script reads a repository file and runs local Python — no network, no untrusted input, no privileged operation. No `THREAT[...]` markers are near the diff, and no threat-model update is warranted.

## Follow-ups

- **EVE-922** (filed): `slow_ci_enabled` is hardcoded `false`, so `unit-test`, `integration-test`, `s3-integration-test` and `build-binaries` have been skipped on every run since #3173 on 2026-08-14 (and `cli-e2e-test` with them, as it consumes `build-binaries` artifacts). Deliberate and documented in a source comment, but untracked and unexpiring. Deferred because flipping it means triaging whatever the restored matrix reports — a different change with a different risk profile from CI configuration.
- The `ui-e2e` Playwright cache missed on this branch despite `restore-keys`, turning a 2-minute job into a 16-minute one. That is a cache-effectiveness question, not a timeout one, so it is not fixed here — but it is why `ui-e2e` now carries the loosest ceiling of any non-heavy job, and tightening the cache would let that come back down.
- The same 360-minute default applies to jobs in other workflows (`docker-publish.yml`, `release.yml`, and the integration sweeps). Deferred because those are not required checks, so a stall there does not block PRs — the impact that made EVE-921 worth fixing.
- Not doing the issue's optional suggestion #3 (retry `apt` with backoff). A timeout already converts a stall into a fast red; retries would trade legibility for a slower, sometimes-green run. Worth revisiting only if these stalls prove frequent rather than one-off.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)