### PR TITLE
chore(release): prepare v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-19
+
+### Highlights
+
+- **Register capabilities on a running runtime** - A host holding `Arc<InProcessRuntime>` can now make a capability discovered after composition resolvable without rebuilding the runtime, via `register_capability`/`is_capability_registered`. Registration stays separate from activation, and readers always see a consistent registry snapshot ([#3224](https://github.com/everruns/everruns/pull/3224)).
+- **A2A delegation is now opt-in** - Outbound A2A delegation moved behind a new `a2a` Cargo feature, off by default, so the standard build no longer drags a second HTTP/TLS stack into consumers that only run the local runtime. Hosts that delegate to remote A2A agents enable the `a2a` feature explicitly ([#3221](https://github.com/everruns/everruns/pull/3221)).
+
+### What's Changed
+
+- feat(host): register capabilities on a running runtime ([#3224](https://github.com/everruns/everruns/pull/3224)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): let session deletion pass the append-only guards ([#3222](https://github.com/everruns/everruns/pull/3222)) by [@chaliy](https://github.com/chaliy)
+- feat(everruns): gate a2a delegation behind an opt-in feature ([#3221](https://github.com/everruns/everruns/pull/3221)) by [@chaliy](https://github.com/chaliy)
+- ci(security): run the advisory gate on a schedule ([#3223](https://github.com/everruns/everruns/pull/3223)) by [@chaliy](https://github.com/chaliy)
+- ci(security): advisory-scan non-workspace lockfiles ([#3213](https://github.com/everruns/everruns/pull/3213)) by [@chaliy](https://github.com/chaliy)
+- ci(release): auto-tag and publish library crates on merge ([#3212](https://github.com/everruns/everruns/pull/3212)) by [@chaliy](https://github.com/chaliy)
+- fix(release): close the crate-release cone after the host 0.19 breaking bump ([#3214](https://github.com/everruns/everruns/pull/3214)) by [@chaliy](https://github.com/chaliy)
+- chore(release): release library crates for the 0.19.0 cycle ([#3211](https://github.com/everruns/everruns/pull/3211)) by [@chaliy](https://github.com/chaliy)
+- chore(release): make library-crate release audit a mandatory release step ([#3210](https://github.com/everruns/everruns/pull/3210)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump react, react-dom and @types/react in /apps/ui ([#3219](https://github.com/everruns/everruns/pull/3219)) by [@dependabot](https://github.com/dependabot)
+- chore(deps-dev): bump @typescript/native-preview to 7.0.0-dev.20260707.2 in /apps/ui ([#3220](https://github.com/everruns/everruns/pull/3220)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump @tanstack/react-query from 5.101.2 to 5.101.4 in /apps/ui ([#3218](https://github.com/everruns/everruns/pull/3218)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump @astrojs/starlight from 0.41.3 to 0.41.7 in /apps/docs ([#3217](https://github.com/everruns/everruns/pull/3217)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump shiki from 4.3.1 to 4.4.3 in /apps/docs ([#3216](https://github.com/everruns/everruns/pull/3216)) by [@dependabot](https://github.com/dependabot)
+
+### Crate Releases
+
+Independently versioned crates published this cycle (smallest compatible bump, breaking classification from the public-API diff):
+
+- `everruns-host` 0.19.0 → 0.20.0 (breaking: `capability_registry()` now returns `Arc<CapabilityRegistry>` and `capability_registry_mut()` was removed; adds `register_capability`/`is_capability_registered`)
+- `everruns` 0.18.1 → 0.18.2 (additive: new opt-in `a2a` feature; host dependency baseline cascade)
+- `everruns-platform` 0.18.1 → 0.18.2 (host dependency baseline cascade)
+- `everruns-test-support` 0.18.1 → 0.18.2 (host dependency baseline cascade)
+- `everruns-llmsim` 0.18.1 → 0.18.2 (host dependency baseline cascade)
+
+No crates were deleted or absorbed this cycle. `everruns-mcp` and the remaining published crates had no public-contract change and are not re-released.
+
+### Migration Notes
+
+- Embedders that use outbound A2A delegation must enable the `everruns` crate's new `a2a` feature; it is off by default and the standard build no longer includes the A2A client.
+- Consumers of `everruns-host` that called `HostComposition::capability_registry()` now receive an `Arc<CapabilityRegistry>` snapshot instead of a `&CapabilityRegistry`, and `capability_registry_mut()` is gone — register capabilities through `register_capability`/`register_capability_overriding` instead.
+
 ## [0.19.0] - 2026-08-18
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "everruns-capability",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-test-support"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4271,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -7732,18 +7732,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2 1.0.107",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -177,10 +177,10 @@ everruns-capability = { path = "crates/capability", version = "0.18.0", default-
 everruns-builtins = { path = "crates/builtins", version = "0.18.1" }
 everruns-core = { path = "crates/core", version = "0.18.0" }
 everruns-engine = { path = "crates/engine", version = "0.18.0" }
-everruns-host = { path = "crates/host", version = "0.19.0" }
-everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.1", default-features = false }
-everruns-test-support = { path = "crates/test-support", version = "0.18.1", default-features = false }
-everruns-platform = { path = "crates/platform", version = "0.18.1" }
+everruns-host = { path = "crates/host", version = "0.20.0" }
+everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.2", default-features = false }
+everruns-test-support = { path = "crates/test-support", version = "0.18.2", default-features = false }
+everruns-platform = { path = "crates/platform", version = "0.18.2" }
 everruns-provider = { path = "crates/provider", version = "0.18.0", default-features = false }
 everruns-mcp = { path = "crates/mcp", version = "0.19.0" }
 everruns-ard = { path = "crates/ard", version = "0.18.0" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/ard/Cargo.toml
+++ b/crates/ard/Cargo.toml
@@ -49,6 +49,6 @@ url = "2"
 ard-live-tests = []
 
 [dev-dependencies]
-everruns-host = { version = "0.19.0", path = "../host", features = ["direct-egress"] }
+everruns-host = { version = "0.20.0", path = "../host", features = ["direct-egress"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 wiremock = "0.6"

--- a/crates/drivers/llmsim/Cargo.toml
+++ b/crates/drivers/llmsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-llmsim"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "everruns-host"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -96,7 +96,7 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 # Deterministic simulator for host tests/examples. Version-less path
 # dependency: stripped on publish, so the optional llmsim -> host edge does
 # not create a published cycle.
-everruns-llmsim = { version = "0.18.1", path = "../drivers/llmsim", features = ["host"] }
+everruns-llmsim = { version = "0.18.2", path = "../drivers/llmsim", features = ["host"] }
 # Test doubles and demo fixtures.
-everruns-test-support = { version = "0.18.1", path = "../test-support" }
+everruns-test-support = { version = "0.18.2", path = "../test-support" }
 wiremock = "0.6"

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "everruns-platform"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "everruns-test-support"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -1719,18 +1719,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2159,9 +2159,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
 dependencies = [
  "bstr",
 ]
@@ -2971,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## What changed
Cuts the **v0.20.0** product release. Bumps the workspace/product version (`Cargo.toml`, `apps/ui/package.json`) to `0.20.0`, adds the CHANGELOG entry, and cuts the library-crate releases whose public contracts changed since v0.19.0.

Since v0.19.0 (14 commits), the two user-facing changes are:
- Hosts can register a capability on a **running** `InProcessRuntime` (`register_capability` / `is_capability_registered`) without rebuilding it.
- Outbound **A2A delegation is now opt-in** behind a new `a2a` Cargo feature; the default build no longer pulls a second HTTP/TLS stack.

## Why
Regular release of the accumulated changes on `main` since v0.19.0.

## Before / After
- **Product version**: `0.19.0` → `0.20.0` (`Cargo.toml` workspace, `apps/ui/package.json`).
- `python3 scripts/sync-publish-pin-versions.py --check` → *independent crate versions and pins verified for 40 package(s)*.
- `cargo metadata --locked` → OK (lockfile consistent; only everruns crate versions changed).
- `bash scripts/lib/check-migration-ordering.sh` → *migrations sequential (001..122)*.

On merge, the release commit `chore(release): prepare v0.20.0` auto-tags `v0.20.0` and the Crate Release workflow tags/publishes the crate versions below in dependency order.

## Crate-release audit (mandatory)
Audited every published crate (packages without `publish = false`) for public-contract changes since its last crates.io release. Releasing this cycle:

- `everruns-host` **0.19.0 → 0.20.0** — breaking: `HostComposition::capability_registry()` now returns `Arc<CapabilityRegistry>` (was `&CapabilityRegistry`), `capability_registry_mut()` removed; adds `register_capability`/`is_capability_registered`. Minor is the breaking slot for 0.x.
- `everruns` **0.18.1 → 0.18.2** — additive: new opt-in `a2a` feature; plus host-baseline cascade.
- `everruns-platform` **0.18.1 → 0.18.2** — host-baseline cascade (only a test was added to its source).
- `everruns-test-support` **0.18.1 → 0.18.2** — host-baseline cascade (optional `host` dep).
- `everruns-llmsim` **0.18.1 → 0.18.2** — host-baseline cascade (optional `host` dep).

Cone closed for the host breaking bump: every published crate pinning `everruns-host` gets a patch bump + re-pin to `0.20.0` so no consumer compiles two host copies (`strand-check` should stay green). `everruns-mcp` (0.19.0) and all other published crates had no public-contract change and are not re-released. No crates were deleted or absorbed.

## Risk
- Low
- Version/manifest/changelog-only change; no product source modified. The crate bumps are the standard release mechanic. The one behavioral shift for embedders is A2A delegation becoming opt-in (already merged in #3221, documented in Migration Notes).

## Security
- Threat categories reviewed: No security-relevant code changes in this PR (release metadata only). Advisory-gate CI changes from this cycle (#3213, #3223) are already on `main`.
- Findings and resolutions: None.

## Follow-ups
No follow-ups. Adopting v0.20.0 into the SaaS wrapper is tracked separately.

## Checklist
- [x] Tests added or updated (n/a — release metadata only)
- [x] Backward compatibility considered (breaking host bump handled via minor bump + cone closure; Migration Notes added)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvxtyWwp3P8vURMULX7gh1)_