### PR TITLE
perf: shrink shipped binaries by ~22% (strip + CLI dispatch boxing)

### DIFF
--- a/.agents/skills/maintenance/references/surfaces.md
+++ b/.agents/skills/maintenance/references/surfaces.md
@@ -68,6 +68,43 @@ rather than an arbitrary full matrix.
 Recent changes introduce no obvious scale or latency regression: query shape, pagination, indexes,
 batching, and background job cost reviewed where relevant; no unbounded list paths or easy N+1s.
 
+## Binary and artifact size
+
+Shipped artifacts stay proportionate to what they do: release binaries and container images do not
+grow silently across releases, and growth that did happen has a named cause.
+
+Check this when the pass covers release readiness, a dependency change that pulls a new transitive
+tree, or a suspicion that a binary jumped. Compare against the previous release's published tarball
+before calling growth acceptable.
+
+```bash
+cargo build --release -p everruns-cli   # or -p everruns-server -p everruns-worker
+ls -l target/release/everruns
+```
+
+For attribution, [`cargo-bsize`](https://github.com/Boshen/cargo-bsize) ranks a binary by crate,
+generic family, duplicate dependency version, and duplicated constant:
+
+```bash
+cargo install cargo-bsize --locked
+cargo bsize --bin everruns      # add --baseline <path> to diff against an earlier build
+```
+
+Know its limits before trusting the report:
+
+- it builds `release` plus debuginfo into its own `target/bsize` rather than reusing
+  `target/release`, costing several minutes and ~2 GB of disk
+- `--mono`, `--macros`, and `--remarks` need nightly `-Z` flags, which the pinned stable toolchain in
+  `rust-toolchain.toml` cannot provide
+- its "reached by no reference the graph can see" figure covers most of the binary and is a limit of
+  its call-graph analysis, not dead code — do not report it as recoverable
+- it is pre-1.0 and used ad hoc, deliberately not wired into `just` or CI, and its report asks the
+  reader for source-level changes only, so profile and link-level wins are its blind spot
+
+Findings that repay the run: duplicate crate versions shipping two copies of a tree, two backends
+linked for one job, and generic families instantiated per caller where one concrete function would
+do. Anything too large to fix in the pass becomes a Linear issue.
+
 ## Technical debt
 
 Structural debt is named and tracked before it compounds: god objects, duplicated logic, and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,10 +259,13 @@ opt-level = 3
 # Drop the symbol table from shipped artifacts: ~19% off every binary (CLI
 # 18.1MB -> 14.6MB, server 200.5MB -> 163.9MB, worker 94.9MB -> 76.9MB), which
 # is user-visible in the CLI release tarballs and the distroless image layers.
-# Nothing consumes symbolized backtraces from a release build: production sets
-# no RUST_BACKTRACE, and the server's only panic boundary (supervised_task.rs)
+# No deployment consumes symbolized backtraces: production sets no
+# RUST_BACKTRACE, and the server's only panic boundary (supervised_task.rs)
 # discards the payload and reports a metric. CI keeps its symbols because
 # release-ci overrides this back to false for RUST_BACKTRACE=1 jobs.
+# Accepted cost: a user running the CLI with RUST_BACKTRACE=1 now gets
+# `<unknown>` frames. Bug reports should quote the anyhow error message, which
+# is unaffected; reproduce with a release-ci build when frames are needed.
 strip = true
 # Use thin LTO for faster builds while retaining most optimization benefits
 # Full LTO (`lto = true`) provides ~5-10% smaller binaries but 2-5x slower link times

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,14 @@ debug = 0
 
 [profile.release]
 opt-level = 3
+# Drop the symbol table from shipped artifacts: ~19% off every binary (CLI
+# 18.1MB -> 14.6MB, server 200.5MB -> 163.9MB, worker 94.9MB -> 76.9MB), which
+# is user-visible in the CLI release tarballs and the distroless image layers.
+# Nothing consumes symbolized backtraces from a release build: production sets
+# no RUST_BACKTRACE, and the server's only panic boundary (supervised_task.rs)
+# discards the payload and reports a metric. CI keeps its symbols because
+# release-ci overrides this back to false for RUST_BACKTRACE=1 jobs.
+strip = true
 # Use thin LTO for faster builds while retaining most optimization benefits
 # Full LTO (`lto = true`) provides ~5-10% smaller binaries but 2-5x slower link times
 lto = "thin"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -177,7 +177,12 @@ async fn main() -> anyhow::Result<()> {
     // Commands that don't need authentication
     match &cli.command {
         Commands::Login { token } => {
-            return commands::login::run(cli.api_url.as_deref(), *token, &cli.profile).await;
+            return Box::pin(commands::login::run(
+                cli.api_url.as_deref(),
+                *token,
+                &cli.profile,
+            ))
+            .await;
         }
         Commands::Logout => {
             return commands::logout::run(&cli.profile);
@@ -187,8 +192,10 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Orgs { command } => {
             return match command {
-                Some(OrgsCommand::Select) => commands::orgs::run_select(&cli.profile).await,
-                None => commands::orgs::run_list(output_format, &cli.profile).await,
+                Some(OrgsCommand::Select) => {
+                    Box::pin(commands::orgs::run_select(&cli.profile)).await
+                }
+                None => Box::pin(commands::orgs::run_list(output_format, &cli.profile)).await,
             };
         }
         _ => {}
@@ -211,9 +218,14 @@ async fn main() -> anyhow::Result<()> {
         Everruns::with_base_url(&api_key, &api_url)?
     };
 
+    // Each arm's future is boxed rather than awaited inline. Without it every
+    // command's state machine is inlined into main's, which the optimizer then
+    // duplicates across codegen units — main::{{closure}} and its drop glue cost
+    // ~200 KiB of the release binary. One allocation per process is free here:
+    // the CLI runs exactly one command and exits.
     match cli.command {
         Commands::Agents { command } => {
-            commands::agents::run(
+            Box::pin(commands::agents::run(
                 command,
                 &client,
                 &api_url,
@@ -221,18 +233,18 @@ async fn main() -> anyhow::Result<()> {
                 org_id.as_deref(),
                 output_format,
                 cli.quiet,
-            )
+            ))
             .await
         }
         Commands::Connections { command } => {
-            commands::connections::run(
+            Box::pin(commands::connections::run(
                 command,
                 &client,
                 &api_url,
                 &api_key,
                 output_format,
                 cli.quiet,
-            )
+            ))
             .await
         }
         Commands::Capabilities { status, command } => {
@@ -240,40 +252,40 @@ async fn main() -> anyhow::Result<()> {
                 Some(CapabilitiesCommand::List { status }) => status.clone(),
                 None => status,
             };
-            commands::capabilities::run(&client, output_format, &status).await
+            Box::pin(commands::capabilities::run(&client, output_format, &status)).await
         }
         Commands::Plugins { command } => {
-            commands::plugins::run(
+            Box::pin(commands::plugins::run(
                 command,
                 &api_url,
                 &api_key,
                 org_id.as_deref(),
                 output_format,
-            )
+            ))
             .await
         }
         Commands::Skills { command } => {
-            commands::skills::run(
+            Box::pin(commands::skills::run(
                 command,
                 &api_url,
                 &api_key,
                 org_id.as_deref(),
                 output_format,
-            )
+            ))
             .await
         }
         Commands::KnowledgeBases { command } => {
-            commands::knowledge_bases::run(
+            Box::pin(commands::knowledge_bases::run(
                 command,
                 &api_url,
                 &api_key,
                 org_id.as_deref(),
                 output_format,
-            )
+            ))
             .await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(
+            Box::pin(commands::sessions::run(
                 command,
                 &client,
                 &api_url,
@@ -281,11 +293,11 @@ async fn main() -> anyhow::Result<()> {
                 org_id.as_deref(),
                 output_format,
                 cli.quiet,
-            )
+            ))
             .await
         }
         Commands::Triggers { agent, command } => {
-            commands::triggers::run(
+            Box::pin(commands::triggers::run(
                 command,
                 agent,
                 &api_url,
@@ -293,11 +305,11 @@ async fn main() -> anyhow::Result<()> {
                 org_id.as_deref(),
                 output_format,
                 cli.quiet,
-            )
+            ))
             .await
         }
         Commands::Participants { session, command } => {
-            commands::participants::run(
+            Box::pin(commands::participants::run(
                 command,
                 session,
                 &api_url,
@@ -305,18 +317,18 @@ async fn main() -> anyhow::Result<()> {
                 org_id.as_deref(),
                 output_format,
                 cli.quiet,
-            )
+            ))
             .await
         }
         Commands::Files { command } => {
-            commands::files::run(
+            Box::pin(commands::files::run(
                 command,
                 &api_url,
                 &api_key,
                 org_id.as_deref(),
                 output_format,
                 cli.quiet,
-            )
+            ))
             .await
         }
         Commands::Chat {
@@ -325,7 +337,7 @@ async fn main() -> anyhow::Result<()> {
             timeout,
             no_stream,
         } => {
-            commands::chat::run(
+            Box::pin(commands::chat::run(
                 &client,
                 output_format,
                 cli.quiet,
@@ -333,7 +345,7 @@ async fn main() -> anyhow::Result<()> {
                 session,
                 timeout,
                 no_stream,
-            )
+            ))
             .await
         }
         // Already handled above

--- a/knowledge/project/maintenance.md
+++ b/knowledge/project/maintenance.md
@@ -24,6 +24,7 @@ Maintenance work should optimize for these outcomes:
 4. Keep release claims honest: do not call the repo ready unless the relevant surfaces were checked.
 5. Detect half-built features whose visible surfaces do not match their implementation status, especially gaps between UI, backend APIs, MCP, CLI, docs, and tests.
 6. Keep shipped plugin surfaces current, mutually consistent, and aligned with upstream platform behavior.
+7. Keep the size of shipped artifacts a maintained property rather than an accident, so release binaries and container images do not grow silently.
 
 ## Ownership Boundary
 
@@ -94,6 +95,7 @@ Before a release, maintenance should cover:
   - pnpm-managed packages enforce the seven-day release-age floor with `minimumReleaseAge: 10080`; do not bypass that gate for routine dependency maintenance
   - major pnpm upgrades (TypeScript, lucide-react, marked, openui packages) ship as separate PRs per framework family so each can be validated by the matching UI or docs build
   - bump pnpm packages that have transitive runtime dependencies (e.g. `@ag-ui/core`) together with the packages that pin them (e.g. `@openuidev/*`), otherwise pnpm installs duplicate copies in the lockfile
+- shipped artifact size for the release binaries and container images, compared against the previous release. Growth without a named cause is a finding, not a rounding error; attribution tooling and its caveats live in [`.agents/skills/maintenance/references/surfaces.md`](../../.agents/skills/maintenance/references/surfaces.md)
 - feature completeness across product surfaces: changed or recently shipped features should have their intended UI, backend, MCP, CLI, docs, tests, and manual-test coverage checked for disconnected, stubbed, or contradictory behavior
 - crate documentation for every crate whose public surface changed: its `README.md` and crate-level rustdoc must still meet the crate documentation standard in `knowledge/foundations/code-organization.md` (abstract, ecosystem line, example, docs links, license; no publishing mechanics or internal `knowledge/` links; badges only on published crates)
 - the Codex and Claude Code plugin surfaces reviewed against recent upstream plugin-platform changes: inspect the latest relevant platform references, then compare them to `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `plugins/everruns-dev/.codex-plugin/plugin.json`, `plugins/everruns-dev/.claude-plugin/plugin.json`, shipped plugin behavior, skills, docs, and marketplace entries; run `scripts/test-everruns-dev-plugin.sh` or equivalent metadata validation to prove registration, version parity, compatibility, and non-contradiction before claiming release readiness


### PR DESCRIPTION
## What changed

Shipped binaries get smaller, with no behavior change.

- `[profile.release]` now sets `strip = true`, dropping the symbol table from every release artifact. Release builds carry no DWARF to begin with, so this removes only `.symtab`/`.strtab`.
- The `everruns` CLI boxes each subcommand's future in its dispatch match instead of awaiting it inline, so command state machines stop being inlined into `main`'s and duplicated across codegen units.
- `knowledge/project/maintenance.md` and the maintenance skill's `references/surfaces.md` gain binary size as a maintained property, with the commands and the caveats of the tool used here.

Combined effect on the CLI tarball: **18,079,480 → 14,036,600 bytes, 22.4% smaller.**

## Why

Nothing tracked artifact size, so nothing objected as it grew. `cargo bsize` against the release CLI showed two costs worth taking: 3.4 MB of symbol table shipped to every user for no consumer, and `main::{{closure}}` plus its drop glue as the two largest symbols in the binary that are our own code (130 KiB across 3 instances, 73 KiB across 5).

The CLI ships as three release tarballs and the server/worker as distroless layers, so both are user-visible.

## Before / After

Sizes measured on `x86_64-unknown-linux-gnu`, release profile:

| Binary | Before | After | Saved |
|---|---:|---:|---:|
| `everruns` (CLI) | 18,079,480 | 14,036,600 | 4,042,880 (22.4%) |
| `everruns-server` | 200,504,392 | 163,851,568 | 36,652,824 (18.3%) |
| `everruns-worker` | 94,854,256 | 76,863,504 | 17,990,752 (19.0%) |

Server and worker numbers are the strip contribution alone, measured by stripping the built artifact; the boxing change touches only the CLI, where it accounts for 538,768 bytes (3.7%).

Symbol tables land where intended — `release` stripped, `release-ci` untouched so `RUST_BACKTRACE=1` CI jobs keep actionable frames:

```
$ nm target/release/everruns
nm: target/release/everruns: no symbols
$ nm target/release-ci/everruns | wc -l
49658
```

CLI behavior is unchanged across the boxed dispatch paths:

```
$ target/release/everruns status
Not logged in. Run `everruns login` to authenticate. (looked in ~/.config/everruns/credentials.json)
$ target/release/everruns agents list
Error: Not logged in. Run `everruns login` or set EVERRUNS_API_KEY environment variable.
```

Evidence gathered: `cargo fmt --check` (workspace) clean, `cargo clippy -p everruns-cli --all-targets -- -D warnings` clean, `cargo test -p everruns-cli` 11 passed, `python3 scripts/check_okf.py knowledge` conformant, plus the smoke run above. Workspace-wide clippy and tests were left to CI — the profile change affects only release linking and the source change is confined to the CLI.

## Risk

- Low
- The one real cost: a user running the CLI with `RUST_BACKTRACE=1` now gets `<unknown>` frames instead of named ones. Bug reports should quote the anyhow error message, which is unaffected; a `release-ci` build reproduces named frames when they are needed. This is recorded next to the profile in `Cargo.toml`.
- Deployments are unaffected: no `RUST_BACKTRACE` is set anywhere in `infra/` or `docker/`, and the server's only panic boundary (`crates/server/src/supervised_task.rs`) discards the payload in favor of a counter and a log line.
- The boxing adds one heap allocation per process, on a binary that parses one command, runs it, and exits.

## Security

- Threat categories reviewed: none apply. No auth, authorization, API surface, tool/MCP, tenancy, filesystem, SQL, sandbox, or frontend code is touched — the diff is a build profile flag, a dispatch-shape change in the CLI's `main`, and documentation. No `THREAT[...]` markers exist in `crates/cli/src/`, and none elsewhere are near the diff.
- Findings and resolutions: none. Stripping marginally *reduces* information disclosure in shipped artifacts by removing symbol names. No dependency or lockfile change (`Cargo.lock` untouched).

## Follow-ups

- EVE-924 — `ring` and `aws-lc-rs` are both linked (~800 KiB, ~5.8% of the shipped CLI). Deferred because it is not fixable from this repository: `bashkit` and `ureq` (via `rakers`) pin `ring` with hard-coded feature lists, while `a2a-client-lf`, `connectrpc`, and `object_store` pin `aws-lc-rs`, and Cargo unifies features across the graph. The issue carries the verified analysis and the upstream sequence.
- `panic = "abort"` would reclaim the 1.5 MiB (10.8%) of unwind and exception tables, but is not viable: `supervised_task.rs` relies on `catch_unwind` to restart panicked background tasks, and profiles cannot vary per package.
- 154 KiB of byte-identical constants would collapse under linker `--icf`, deferred as a link-flag change with cross-platform behavior to verify across the three release targets.

## Checklist
- [x] Tests added or updated — existing CLI suite covers the dispatch paths; the change is size-only, and the size claims are verified by measurement rather than by a test
- [x] Backward compatibility considered — no API, CLI, or wire surface changes
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZ634FSbKKdt6o9MbGReFH)_