### PR TITLE
fix(release): break the crate-publish dev-dependency deadlock for 0.20.0

### DIFF
--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -150,8 +150,11 @@ thiserror = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
-everruns-llmsim = { workspace = true, features = ["host"] }
-everruns-test-support = { workspace = true, features = ["fixtures"] }
+# Version-less path dev-dependencies: stripped on publish, so these test-only
+# edges do not force the facade to package before same-cycle sibling releases
+# (e.g. everruns-test-support) reach crates.io.
+everruns-llmsim = { path = "../drivers/llmsim", features = ["host"] }
+everruns-test-support = { path = "../test-support", features = ["fixtures"] }
 tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread", "time"] }
 serde = { workspace = true }
 trybuild = { workspace = true }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -96,7 +96,7 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 # Deterministic simulator for host tests/examples. Version-less path
 # dependency: stripped on publish, so the optional llmsim -> host edge does
 # not create a published cycle.
-everruns-llmsim = { version = "0.18.2", path = "../drivers/llmsim", features = ["host"] }
+everruns-llmsim = { path = "../drivers/llmsim", features = ["host"] }
 # Test doubles and demo fixtures.
-everruns-test-support = { version = "0.18.2", path = "../test-support" }
+everruns-test-support = { path = "../test-support" }
 wiremock = "0.6"

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -38,15 +38,24 @@ def metadata() -> dict[str, Any]:
     return json.loads(output)
 
 
+# Dev-dependencies are deliberately excluded. They never reach downstream
+# consumers (`cargo publish` drops a version-less path dev-dependency entirely),
+# and crate-release.yml already ignores dev edges in both its publish ordering
+# and its strand check. Pinning a dev-dependency to a workspace version that is
+# not yet on crates.io only creates a publish-order deadlock: a crate that
+# dev-depends on a sibling bumped in the same cycle cannot package before that
+# sibling publishes, while the sibling may in turn depend on it (host <-> llmsim).
+# Leaving such dev edges version-less keeps them stripped on publish and the
+# cycle unbroken.
 def dependency_tables(manifest: dict[str, Any]) -> Iterator[dict[str, Any]]:
-    for name in ("dependencies", "build-dependencies", "dev-dependencies"):
+    for name in ("dependencies", "build-dependencies"):
         table = manifest.get(name)
         if isinstance(table, dict):
             yield table
     for target in manifest.get("target", {}).values():
         if not isinstance(target, dict):
             continue
-        for name in ("dependencies", "build-dependencies", "dev-dependencies"):
+        for name in ("dependencies", "build-dependencies"):
             table = target.get(name)
             if isinstance(table, dict):
                 yield table


### PR DESCRIPTION
## What changed
The 0.20.0 crate release (Crate Release + Publish Crate workflows) failed at the first crate. Publishing `everruns-host` 0.20.0 aborted while packaging:

```
error: failed to prepare local package for uploading
  failed to select a version for the requirement `everruns-llmsim = "^0.18.2"`
  location searched: crates.io index
```

This makes the cross-crate **dev**-dependencies that form publish cycles version-less path deps (stripped on publish) and stops `sync-publish-pin-versions.py` from managing dev-dependencies:

- `crates/host/Cargo.toml` — drop `version=` from the `everruns-llmsim` / `everruns-test-support` dev-deps (matching the file's own "Version-less path dependency: stripped on publish" comment).
- `crates/everruns/Cargo.toml` — same for its `everruns-llmsim` / `everruns-test-support` dev-deps.
- `scripts/sync-publish-pin-versions.py` — exclude `dev-dependencies` from pin enforcement.

## Why
`crate-release.yml` orders publishes by **normal**/build deps only (and its `strand-check` ignores dev edges too), so `everruns-host` publishes first. But `sync-publish-pin-versions.py` had pinned host's **dev**-deps on `everruns-llmsim`/`everruns-test-support` to the same-cycle `0.18.2` bump — versions not on crates.io yet — so host's packaging couldn't resolve them. `everruns` hit the same wall via its `test-support` dev-dep (test-support is ordered last). host 0.19.0 only published cleanly last cycle because its dev-deps happened to pin the already-published `^0.18.0`.

`cargo` strips a version-less path dev-dependency on publish, and the release machinery already ignores dev edges everywhere, so a dev-dep version pin buys nothing and only deadlocks the order.

## Before / After
- **Before**: `cargo publish -p everruns-host` → `failed to select a version for the requirement everruns-llmsim = "^0.18.2"`.
- **After**: `cargo publish -p everruns-host --dry-run` → `Packaged 64 files` (no llmsim/test-support resolution). `cargo publish -p everruns --dry-run` now only awaits `everruns-host ^0.20.0` (a normal dep that publishes first), not the test-support dev-dep.
- `scripts/sync-publish-pin-versions.py --check` → verified for 40 packages. `scripts/test-publish-crates-order.sh` → pass. `cargo metadata --locked` → OK (lockfile unchanged).

After merge: delete the stale `crate/everruns-host/v0.20.0` tag (created against the pre-fix commit, never published) and re-run **Crate Release** so it re-tags at the fixed commit and publishes host 0.20.0 + the 0.18.2 cone (llmsim, platform, everruns, test-support) in order; `strand-check` goes green once they land.

## Risk
- Low. Dev-only dependency metadata + a release-script scope narrowing. No product source or public API changes; workspace builds/tests use the path deps unchanged.

## Security
- Threat categories reviewed: No security-relevant code changes (release tooling + dev-dep metadata only).
- Findings and resolutions: None.

## Follow-ups
- `scripts/test-publish-crates-order.sh` verifies pin consistency but did not catch this dev-dep publish-order deadlock; a follow-up could add a `cargo publish --dry-run` ordering simulation to catch it pre-merge.

## Checklist
- [x] Tests added or updated (existing `test-publish-crates-order.sh` re-run; dry-run proof in description)
- [x] Backward compatibility considered (dev-only metadata; no consumer-visible change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvxtyWwp3P8vURMULX7gh1)_