### PR TITLE
chore(release): republish everruns-host as 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Independently versioned crates published this cycle (smallest compatible bump, breaking classification from the public-API diff):
 
-- `everruns-host` 0.19.0 → 0.20.0 (breaking: `capability_registry()` now returns `Arc<CapabilityRegistry>` and `capability_registry_mut()` was removed; adds `register_capability`/`is_capability_registered`)
+- `everruns-host` 0.19.0 → 0.20.1 (breaking: `capability_registry()` now returns `Arc<CapabilityRegistry>` and `capability_registry_mut()` was removed; adds `register_capability`/`is_capability_registered`. Published as 0.20.1: the 0.20.0 crate publish was blocked by a dev-dependency publish-order deadlock, fixed in the same cycle, and 0.20.1 is the identical code republished under a fresh tag.)
 - `everruns` 0.18.1 → 0.18.2 (additive: new opt-in `a2a` feature; host dependency baseline cascade)
 - `everruns-platform` 0.18.1 → 0.18.2 (host dependency baseline cascade)
 - `everruns-test-support` 0.18.1 → 0.18.2 (host dependency baseline cascade)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11201,9 +11201,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ everruns-capability = { path = "crates/capability", version = "0.18.0", default-
 everruns-builtins = { path = "crates/builtins", version = "0.18.1" }
 everruns-core = { path = "crates/core", version = "0.18.0" }
 everruns-engine = { path = "crates/engine", version = "0.18.0" }
-everruns-host = { path = "crates/host", version = "0.20.0" }
+everruns-host = { path = "crates/host", version = "0.20.1" }
 everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.2", default-features = false }
 everruns-test-support = { path = "crates/test-support", version = "0.18.2", default-features = false }
 everruns-platform = { path = "crates/platform", version = "0.18.2" }

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "everruns-host"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2960,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",


### PR DESCRIPTION
## What changed
Bumps the independently versioned `everruns-host` crate `0.20.0 → 0.20.1` (identical code) plus the lockfiles and the CHANGELOG note. Product version stays **v0.20.0**.

## Why
The 0.20.0 crate release deadlocked: publishing `everruns-host` 0.20.0 failed because its dev-dependency pins on `everruns-llmsim`/`everruns-test-support` (0.18.2, not yet on crates.io) could not resolve while host publishes first. That deadlock is fixed on `main` (#3228, dev-deps made version-less). But the `crate/everruns-host/v0.20.0` tag was already created against the pre-fix commit, and tags cannot be moved/deleted from this environment (only the Actions token can push tags). Publish Crate checks out the tag's commit, so the `v0.20.0` tag is permanently pinned to the broken manifest.

Republishing under a fresh `0.20.1` patch is the clean recovery: a new `crate/everruns-host/v0.20.1` tag at the fixed commit publishes correctly, and the 0.18.2 cone (`everruns`, `everruns-platform`, `everruns-test-support`, `everruns-llmsim`) publishes after it.

## Before / After
- `cargo publish -p everruns-host --dry-run` → `Packaged 64 files` (no llmsim/test-support resolution).
- `cargo metadata --locked` → OK. `sync-publish-pin-versions.py --check` → verified for 40 packages.
- Root + external-consumer fixture lockfiles updated to host `0.20.1`.

After merge, the Crate Release workflow tags `crate/everruns-host/v0.20.1` at this commit and publishes host + the 0.18.2 cone in dependency order; `strand-check` goes green once they land.

## Crate-release audit
- `everruns-host` 0.20.0 → **0.20.1** (patch: republish only; no source/API change from 0.20.0).
- Cone dependants (`everruns`, `everruns-platform`, `everruns-test-support`, `everruns-llmsim` 0.18.2) re-pin host `^0.20.1` via the workspace dependency; they publish this cycle with fresh tags.
- The stale `crate/everruns-host/v0.20.0` tag remains but 0.20.0 is never published to crates.io.

## Risk
- Low. Version/lock/changelog metadata only; host code is byte-identical to 0.20.0.

## Security
- Threat categories reviewed: No security-relevant code changes (release metadata only).
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — release metadata; dry-run proof above)
- [x] Backward compatibility considered (patch republish; consumers pin `^0.20`)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvxtyWwp3P8vURMULX7gh1)_