### PR TITLE
chore(build): add just prune and settle why the library crates are large

### DIFF
--- a/justfile
+++ b/justfile
@@ -163,6 +163,10 @@ pre-pr:
 clean:
     cargo clean
 
+# Reclaim disk by dropping incremental caches, keeping compiled artifacts
+prune:
+    ./scripts/lib/prune-build-cache.sh
+
 # === Services ===
 
 # Start in DEV MODE (in-memory storage, no PostgreSQL required)

--- a/knowledge/project/build-artifact-size.md
+++ b/knowledge/project/build-artifact-size.md
@@ -1,0 +1,73 @@
+---
+type: Specification
+title: "Build Artifact Size"
+description: "Why the Everruns library crates compile large, and which levers actually move the number."
+tags:
+  - everruns
+  - project
+  - build
+---
+# Build Artifact Size
+
+## Abstract
+
+The three largest workspace library crates produce debug rlibs an order of magnitude
+larger than their sources, which repeatedly prompts "what is bloating these crates?".
+This concept records the measured breakdown so the question does not have to be
+re-investigated, and separates the levers that work from the ones that look plausible
+and do not.
+
+## Measured Baseline
+
+Dev profile, default features, `rustc` 1.96.0:
+
+| Crate | rlib | `lib.rmeta` | objects | `.text` |
+|---|---|---|---|---|
+| `everruns-core` | 32.9 MB | 14 MB | 18 MB | 3.8 MB |
+| `everruns-platform` | 23.6 MB | 10 MB | 13 MB | ~2.5 MB |
+| `everruns-provider` | 20.7 MB | 8 MB | 12 MB | ~2.5 MB |
+
+Enabling `openapi` adds ~3 MB to `everruns-core`.
+
+Section totals across core's 256 object files: `.strtab` 5.2 MB, `.text` 3.8 MB,
+`.rela*` 2.6 MB, `.symtab` 1.6 MB, plus ~3 MB of section headers for 48,443 sections.
+
+Two facts follow, and they are the whole answer:
+
+1. **Executable code is ~10% of the file.** The bulk is crate metadata plus ELF
+   symbol/relocation bookkeeping for mangled names of monomorphized generics.
+2. **Size tracks API surface, not waste.** Nothing oversized is embedded: `include_str!`
+   covers three small schema files, the workspace `docs/` embed is behind a non-default
+   feature, and published `.crate` tarballs carry 145/68/34 files.
+
+Serde derives account for 41% of core's `.text` (1.57 MB of 3.83 MB), from 232
+`Serialize` plus 230 `Deserialize` derives. All 282 `ToSchema` sites are already
+`cfg_attr`-gated behind `openapi`.
+
+## Constraints
+
+- Profile knobs are already at their useful settings: `debug = 0` on both `dev` and
+  `test`, `openapi` off by default, CI and pre-push building with `CARGO_INCREMENTAL=0`.
+  Treat the profile block as tuned and do not re-litigate it without new measurements.
+- Incremental state, not artifacts, dominates local disk. Building core, platform, and
+  provider alone produced 2.6 GB of `target/debug/incremental` against 2.0 GB of
+  `target/debug/deps`. Reclaim it with `just prune`, which keeps compiled artifacts.
+- Incremental compilation stays on for local development: a warm edit rebuild of
+  `everruns-core` measured ~4 s against ~10 s with `CARGO_INCREMENTAL=0`. The 2.5x
+  inner-loop cost is not worth the disk outside CI and pre-push.
+- The remaining real lever is public API surface. Core's 14 MB of `lib.rmeta` is
+  serialized type information and MIR for everything reachable from outside the crate,
+  and it is re-read by every downstream crate. Narrowing visibility to `pub(crate)` and
+  dropping serde derives from types that never cross a wire shrinks metadata, object
+  bookkeeping, and downstream compile time together.
+
+## Success Bar
+
+- A claim that a crate is "too big" cites a measured breakdown, not the rlib size alone.
+- Changes made for size report before/after numbers from the same profile and features.
+
+Relevant references:
+- [`knowledge/project/maintenance.md`](maintenance.md) - artifact size as a maintained property.
+- [`knowledge/project/dismissed-options.md`](dismissed-options.md) - `codegen-units` tuning.
+- [`scripts/lib/prune-build-cache.sh`](../../scripts/lib/prune-build-cache.sh) - reclaims incremental caches.
+- [`crates/core/public-api.txt`](../../crates/core/public-api.txt) - core's tracked public surface.

--- a/knowledge/project/build-artifact-size.md
+++ b/knowledge/project/build-artifact-size.md
@@ -55,16 +55,22 @@ Serde derives account for 41% of core's `.text` (1.57 MB of 3.83 MB), from 232
 - Incremental compilation stays on for local development: a warm edit rebuild of
   `everruns-core` measured ~4 s against ~10 s with `CARGO_INCREMENTAL=0`. The 2.5x
   inner-loop cost is not worth the disk outside CI and pre-push.
-- The remaining real lever is public API surface. Core's 14 MB of `lib.rmeta` is
-  serialized type information and MIR for everything reachable from outside the crate,
-  and it is re-read by every downstream crate. Narrowing visibility to `pub(crate)` and
-  dropping serde derives from types that never cross a wire shrinks metadata, object
-  bookkeeping, and downstream compile time together.
+- Narrowing public API surface does not shrink artifacts, and was measured rather than
+  assumed. 222 of core's 989 named public items are referenced nowhere outside the crate;
+  demoting the 158 of them that are not root re-exports moved the rlib from 32.9 MB to
+  32.7 MB and `lib.rmeta` from 13.74 MB to 13.71 MB. Metadata is encoded for the crate's
+  own use regardless of visibility, so `pub(crate)` buys API hygiene, not bytes. Do not
+  fund a visibility audit as a size measure.
+- Demotion does expose dead code that `pub` masks: the same experiment produced 95
+  `never used` warnings inside core. Deleting genuinely dead code is the one lever that
+  removes both metadata and object bytes, and it is worth doing on its own merits.
 
 ## Success Bar
 
 - A claim that a crate is "too big" cites a measured breakdown, not the rlib size alone.
-- Changes made for size report before/after numbers from the same profile and features.
+- Changes made for size report before/after numbers from the same profile and features,
+  built the same way: incremental and non-incremental builds of identical sources produce
+  rlibs that differ by enough (32.9 MB against 33.5 MB for core) to invent a result.
 
 Relevant references:
 - [`knowledge/project/maintenance.md`](maintenance.md) - artifact size as a maintained property.

--- a/knowledge/project/build-artifact-size.md
+++ b/knowledge/project/build-artifact-size.md
@@ -61,9 +61,17 @@ Serde derives account for 41% of core's `.text` (1.57 MB of 3.83 MB), from 232
   32.7 MB and `lib.rmeta` from 13.74 MB to 13.71 MB. Metadata is encoded for the crate's
   own use regardless of visibility, so `pub(crate)` buys API hygiene, not bytes. Do not
   fund a visibility audit as a size measure.
-- Demotion does expose dead code that `pub` masks: the same experiment produced 95
-  `never used` warnings inside core. Deleting genuinely dead code is the one lever that
-  removes both metadata and object bytes, and it is worth doing on its own merits.
+- The 95 `never used` warnings that demotion exposes are not a cleanup backlog, and were
+  triaged item by item before being dismissed. They fall into four groups, none of them
+  deletable: the OTel GenAI semantic-convention vocabulary in `telemetry.rs` (51, a
+  deliberately complete constant table that `everruns-host` uses selectively); in-flight
+  feature scaffolding whose design intent is already specified
+  ([model router](../integrations/model-router.md), 14, and turn-completion gating, 10);
+  embedder-facing convenience and extension surface that core exists to publish, such as
+  the locale-aware `narrate_*` phrasing helpers capabilities call and the `Collected*`
+  result types; and warnings the experiment manufactured, where demoting a producer makes
+  its product look unused. In a crate published for out-of-tree embedders, "unreferenced
+  in this workspace" is not evidence of dead code. Do not delete on that signal alone.
 
 ## Success Bar
 

--- a/knowledge/project/dismissed-options.md
+++ b/knowledge/project/dismissed-options.md
@@ -156,3 +156,24 @@ execution keys.
 - Worker affinity routing is implemented for other reasons
 - WebSocket transport supports multiple concurrent responses
 - Benchmarks show HTTP connection overhead is a meaningful bottleneck
+
+## Lowering `codegen-units` for smaller rlibs
+
+**Status**: Dismissed
+
+**What it was**: Reducing `codegen-units` on `[profile.dev]` from the default 256 to
+shrink the workspace's large debug rlibs, on the theory that fewer codegen units means
+less duplicated monomorphization and fewer ELF sections.
+
+**Why considered**: `everruns-core`, `everruns-platform`, and `everruns-provider` produce
+debug rlibs of 20-33 MB, and per-CGU symbol and relocation tables are a measured majority
+of the object bytes (see [Build Artifact Size](build-artifact-size.md)).
+
+**Why dismissed**: Measured on `everruns-core` at default features, the effect is small
+and the cost is not: 33.6 MB at 256 units, 33.0 MB at 32, 32.8 MB at 16, 30.7 MB at 1.
+A 9% reduction at the extreme setting serializes codegen for every crate in the
+workspace. The dominant term is crate metadata and API surface, which `codegen-units`
+does not touch.
+
+**Revisit if**: the public API surface shrinks enough that per-CGU bookkeeping becomes
+the dominant term, or a profile is added whose builds are not latency-sensitive.

--- a/knowledge/project/index.md
+++ b/knowledge/project/index.md
@@ -7,4 +7,5 @@
 * [Skills Registry Specification](skills-registry.md) - Agent Skills registry.
 * [Commands System](commands.md) - Slash commands system.
 * [XML Prompt Formatting](xml-prompt-formatting.md) - XML tags for system prompt structure.
+* [Build Artifact Size](build-artifact-size.md) - Why the library crates compile large, and which levers move it.
 * [Dismissed Options](dismissed-options.md) - Technical options considered but dismissed.

--- a/scripts/lib/prune-build-cache.sh
+++ b/scripts/lib/prune-build-cache.sh
@@ -41,6 +41,15 @@ prune_target() {
 
   [ -d "$target_dir" ] || return 0
 
+  # Only recurse into a directory cargo owns. CARGO_TARGET_DIR is inherited from
+  # the caller's environment, and this function deletes what it finds, so a
+  # stray or misspelled value must not turn into `rm -rf` against an unrelated
+  # tree. Cargo writes CACHEDIR.TAG into every target dir it creates.
+  if [ ! -f "$target_dir/CACHEDIR.TAG" ]; then
+    echo "   skipped $label $target_dir (not a cargo target directory)"
+    return 0
+  fi
+
   # Incremental state lives at <target>/<profile>/incremental.
   while IFS= read -r incremental; do
     before="$(dir_size "$incremental")"

--- a/scripts/lib/prune-build-cache.sh
+++ b/scripts/lib/prune-build-cache.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Reclaim Rust build-cache disk without discarding compiled artifacts.
+#
+# Only incremental-compilation state is removed. Incremental caches are the
+# largest single consumer of `target/` (measured: 2.6 GB against 2.0 GB of
+# actual artifacts after building core/platform/provider alone) because they
+# store per-CGU dependency graphs for crates whose metadata is already large.
+# Dropping them costs one non-incremental rebuild (~2.5x a warm edit rebuild
+# of `everruns-core`) and keeps every .rlib, binary, and build-script output.
+#
+# Prunes the workspace target dir and the shared pre-push target dir
+# (scripts/lib/pre-push-context.sh), which already builds with
+# CARGO_INCREMENTAL=0 but may hold state from other entry points.
+#
+# Usage: bash scripts/lib/prune-build-cache.sh
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/lib/pre-push-context.sh
+source "$PROJECT_ROOT/scripts/lib/pre-push-context.sh"
+
+dir_size() {
+  [ -d "$1" ] || { echo 0; return; }
+  du -sk "$1" 2>/dev/null | awk '{print $1}'
+}
+
+human() {
+  awk -v kb="$1" 'BEGIN {
+    split("KB MB GB TB", unit, " ")
+    i = 1
+    while (kb >= 1024 && i < 4) { kb /= 1024; i++ }
+    printf "%.1f %s\n", kb, unit[i]
+  }'
+}
+
+freed_kb=0
+
+prune_target() {
+  local target_dir="$1" label="$2" incremental before
+
+  [ -d "$target_dir" ] || return 0
+
+  # Incremental state lives at <target>/<profile>/incremental.
+  while IFS= read -r incremental; do
+    before="$(dir_size "$incremental")"
+    [ "$before" -gt 0 ] || continue
+    rm -rf "$incremental"
+    freed_kb=$((freed_kb + before))
+    echo "   removed $label ${incremental#"$target_dir"/} ($(human "$before"))"
+  done < <(find "$target_dir" -maxdepth 2 -type d -name incremental)
+}
+
+echo "Pruning Rust incremental caches..."
+prune_target "${CARGO_TARGET_DIR:-$PROJECT_ROOT/target}" "workspace"
+prune_target "$(pre_push_shared_target_dir)" "pre-push"
+
+if [ "$freed_kb" -eq 0 ]; then
+  echo "   nothing to prune"
+else
+  echo "Freed $(human "$freed_kb"). Next build is non-incremental."
+fi

--- a/scripts/test-prune-build-cache.sh
+++ b/scripts/test-prune-build-cache.sh
@@ -25,6 +25,7 @@ echo incremental-state >"$target/release/incremental/everruns_core-def/dep-graph
 echo artifact >"$target/debug/deps/libeverruns_core-abc.rlib"
 echo artifact >"$target/debug/deps/libeverruns_core-abc.rmeta"
 echo artifact >"$target/debug/build/everruns-core-123/output"
+printf 'Signature: 8a477f597d28d172789f06886806bc55\n' >"$target/CACHEDIR.TAG"
 
 output="$(TMPDIR="$workdir" CARGO_TARGET_DIR="$target" bash "$PROJECT_ROOT/scripts/lib/prune-build-cache.sh")"
 
@@ -52,6 +53,19 @@ output="$(TMPDIR="$workdir" CARGO_TARGET_DIR="$target" bash "$PROJECT_ROOT/scrip
 case "$output" in
 *"nothing to prune"*) ;;
 *) fail "re-running prune on a clean target did not report 'nothing to prune'" ;;
+esac
+
+# CARGO_TARGET_DIR comes from the caller's environment, so a directory cargo
+# does not own must be left alone rather than walked and deleted from.
+foreign="$workdir/not-a-target"
+mkdir -p "$foreign/debug/incremental/everruns_core-abc"
+echo state >"$foreign/debug/incremental/everruns_core-abc/dep-graph.bin"
+output="$(TMPDIR="$workdir" CARGO_TARGET_DIR="$foreign" bash "$PROJECT_ROOT/scripts/lib/prune-build-cache.sh")"
+[ -d "$foreign/debug/incremental" ] ||
+  fail "prune walked a directory without CACHEDIR.TAG"
+case "$output" in
+*"not a cargo target directory"*) ;;
+*) fail "prune did not say why it skipped a non-target directory" ;;
 esac
 
 echo "PASS: prune-build-cache removes incremental state and keeps artifacts"

--- a/scripts/test-prune-build-cache.sh
+++ b/scripts/test-prune-build-cache.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Guard scripts/lib/prune-build-cache.sh against the one way it could hurt:
+# reclaiming disk by deleting artifacts instead of incremental state.
+#
+# `just prune` exists so a developer can free several GB without paying for a
+# cold rebuild. If it ever removed .rlib/.rmeta/binaries it would still "work"
+# — the disk number improves either way — so the distinction is asserted here
+# rather than left to whoever notices the next rebuild took ten minutes.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+target="$workdir/target"
+mkdir -p "$target/debug/incremental/everruns_core-abc" \
+  "$target/debug/deps" \
+  "$target/release/incremental/everruns_core-def" \
+  "$target/debug/build/everruns-core-123"
+
+echo incremental-state >"$target/debug/incremental/everruns_core-abc/dep-graph.bin"
+echo incremental-state >"$target/release/incremental/everruns_core-def/dep-graph.bin"
+echo artifact >"$target/debug/deps/libeverruns_core-abc.rlib"
+echo artifact >"$target/debug/deps/libeverruns_core-abc.rmeta"
+echo artifact >"$target/debug/build/everruns-core-123/output"
+
+output="$(TMPDIR="$workdir" CARGO_TARGET_DIR="$target" bash "$PROJECT_ROOT/scripts/lib/prune-build-cache.sh")"
+
+fail() {
+  echo "FAIL: $1" >&2
+  echo "--- prune output ---" >&2
+  echo "$output" >&2
+  exit 1
+}
+
+for profile in debug release; do
+  [ ! -d "$target/$profile/incremental" ] ||
+    fail "$profile/incremental survived the prune"
+done
+
+for kept in \
+  "$target/debug/deps/libeverruns_core-abc.rlib" \
+  "$target/debug/deps/libeverruns_core-abc.rmeta" \
+  "$target/debug/build/everruns-core-123/output"; do
+  [ -f "$kept" ] || fail "prune deleted a compiled artifact: ${kept#"$target"/}"
+done
+
+# A second run must stay quiet and exit clean: the recipe is safe to re-run.
+output="$(TMPDIR="$workdir" CARGO_TARGET_DIR="$target" bash "$PROJECT_ROOT/scripts/lib/prune-build-cache.sh")"
+case "$output" in
+*"nothing to prune"*) ;;
+*) fail "re-running prune on a clean target did not report 'nothing to prune'" ;;
+esac
+
+echo "PASS: prune-build-cache removes incremental state and keeps artifacts"


### PR DESCRIPTION
## What changed

`just prune` reclaims Rust build-cache disk without discarding compiled artifacts — it deletes incremental-compilation state only, so every `.rlib`, binary, and build-script output survives and the next build is a normal non-incremental one rather than a cold rebuild. It skips any directory lacking cargo's `CACHEDIR.TAG`, since `CARGO_TARGET_DIR` comes from the caller's environment and the script deletes what it finds.

`knowledge/project/build-artifact-size.md` records the measured answer to "why are `everruns-core`/`platform`/`provider` so big", so the question does not get re-investigated from scratch. `codegen-units` tuning is recorded in dismissed-options with the numbers that rule it out.

No product code changed.

## Why

`everruns-core` produces a 32.9 MB debug rlib against 2.6 MB of source, which reads as bloat and invites speculative fixes. It is not bloat: executable code is ~10% of the file, and the rest is crate metadata plus ELF symbol/relocation bookkeeping proportional to public API surface.

Meanwhile the thing that actually consumes disk went unmeasured. Building core, platform, and provider alone left 2.6 GB of `target/debug/incremental` against 2.0 GB of real artifacts — roughly 20x the disk any crate-size work could recover.

Three candidate levers were measured and all three dismissed with evidence rather than opinion, which is the durable part of this PR.

## Before / After

`just prune` on a working checkout:

```
$ du -sh target
4.9G    target
$ just prune
Pruning Rust incremental caches...
   removed workspace debug/incremental (2.5 GB)
Freed 2.5 GB. Next build is non-incremental.
$ du -sh target
2.6G    target
$ cargo build -p everruns-core
    Finished `dev` profile [unoptimized] target(s) in 13.45s
```

Idempotent on a second run (`nothing to prune`), and artifacts survive — the rebuild above is a normal non-incremental compile, not a cold one.

Measured breakdown behind the knowledge concept (dev profile, default features, rustc 1.96.0):

| crate | rlib | `lib.rmeta` | objects | `.text` |
|---|---|---|---|---|
| everruns-core | 32.9 MB | 14 MB | 18 MB | 3.8 MB |
| everruns-platform | 23.6 MB | 10 MB | 13 MB | ~2.5 MB |
| everruns-provider | 20.7 MB | 8 MB | 12 MB | ~2.5 MB |

Section totals across core's 256 object files: `.strtab` 5.2 MB, `.text` 3.8 MB, `.rela*` 2.6 MB, `.symtab` 1.6 MB, plus ~3 MB of section headers for 48,443 sections.

Levers measured and dismissed:

- **`codegen-units`** — 33.6 MB at 256, 33.0 at 32, 32.8 at 16, 30.7 at 1. A 9% reduction at the extreme setting, paid for by serializing codegen workspace-wide.
- **Public API surface** — 222 of core's 989 named public items are referenced nowhere outside the crate. Demoting the 158 that are not root re-exports moved the rlib 32.9 → 32.7 MB and `lib.rmeta` 13.74 → 13.71 MB. Metadata is encoded for the crate's own use regardless of visibility, so a visibility audit buys API hygiene, not bytes.
- **Dead code** — that experiment exposed 95 `never used` warnings, all 95 triaged individually. None are deletable: 51 are the OTel GenAI semantic-convention constants `everruns-host` uses selectively, 24 are scaffolding for specified in-flight work (model router EVE-397, turn-completion gating), and the rest are either embedder-facing surface core exists to publish or artifacts of the experiment itself, where demoting a producer makes its product look unused.

Incremental compilation stays **on** for local development: a warm edit rebuild of `everruns-core` measures ~4 s against ~10 s with `CARGO_INCREMENTAL=0`. CI and pre-push already set it off.

One measurement trap is recorded in the concept: incremental and non-incremental builds of identical sources differ by ~0.6 MB (32.9 vs 33.5 MB), enough to fabricate a before/after result if the two sides are not built the same way.

## Risk

- **Low**
- `just prune` deletes directories. The blast radius is bounded to each profile's own incremental directory (`target/debug/incremental`, `target/release/incremental`) beneath a tree carrying cargo's `CACHEDIR.TAG`; a misspelled or foreign `CARGO_TARGET_DIR` is skipped with a message instead of walked. Both behaviors are asserted in `scripts/test-prune-build-cache.sh`, including that `.rlib`/`.rmeta`/build-script outputs survive.
- Worst case if the guard were wrong: a developer pays one non-incremental rebuild.
- No product code, runtime behavior, API, or migration is touched.

## Security

- Threat categories reviewed: no security-relevant product surface. The diff is developer tooling (one shell script, one `just` recipe), its test, and `knowledge/` documents — no runtime code, config, or infrastructure. The threat model's categories cover the product's trust boundaries (`TM-FS` is the session filesystem, not local build caches), so none applies.
- Findings and resolutions: one issue found and fixed during review — `prune_target` inherited `CARGO_TARGET_DIR` from the environment and deleted what it found beneath it, so a stray value could have turned into `rm -rf` against an unrelated tree. Now gated on cargo's `CACHEDIR.TAG`, with a regression test covering a non-cargo directory.

## Follow-ups

No follow-ups. The three size levers were measured to exhaustion and dismissed in this PR rather than deferred; the dead-code triage covers all 95 warnings with no residue.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)