### PR TITLE
ci: restore the full Rust and integration matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_ci: ${{ steps.ci_event.outputs.run_ci }}
-      # Temporary architecture-work switch. Change the step output below to
-      # true to restore the full Rust/integration matrix.
-      slow_ci_enabled: ${{ steps.slow_ci_mode.outputs.enabled }}
       rust: ${{ steps.core_filter.outputs.rust }}
       daytona: ${{ steps.live_filter.outputs.daytona }}
       deno: ${{ steps.live_filter.outputs.deno }}
@@ -76,10 +73,6 @@ jobs:
 
       - name: Check release workflow security
         run: bash scripts/test-release-workflow-security.sh
-
-      - name: Resolve temporary slow CI mode
-        id: slow_ci_mode
-        run: echo "enabled=false" >> "$GITHUB_OUTPUT"
 
       - name: Resolve CI event gate
         id: ci_event
@@ -645,7 +638,7 @@ jobs:
     name: Unit Tests (Pure)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     timeout-minutes: 30
 
     steps:
@@ -918,7 +911,7 @@ jobs:
     name: Integration Tests (PostgreSQL)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.postgres_integration == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.postgres_integration == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
     timeout-minutes: 40
     services:
       postgres:
@@ -1102,7 +1095,7 @@ jobs:
     name: Integration Tests (S3 Blob Backend)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.object_storage == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.object_storage == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
     timeout-minutes: 30
     services:
       postgres:
@@ -1224,7 +1217,7 @@ jobs:
     name: Build Release Binaries
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.slow_ci_enabled == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     timeout-minutes: 40
 
     steps:

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -4931,10 +4931,7 @@ export interface components {
       /** @description Number of secrets stored */
       count: number;
     };
-    /**
-     * @description Budget — a spending cap for a subject in a currency.
-     *     API response DTO.
-     */
+    /** @description Budget — a stored spending cap for a platform subject. */
     Budget: {
       /**
        * Format: double
@@ -8789,7 +8786,7 @@ export interface components {
      * @enum {string}
      */
     LeasedResourceStatus: "active" | "cleaning" | "released" | "cleanup_failed";
-    /** @description Immutable ledger entry recording resource consumption or credit against a budget. */
+    /** @description Immutable platform ledger record for resource consumption or credit. */
     LedgerEntry: {
       /**
        * Format: double

--- a/crates/platform/src/budget.rs
+++ b/crates/platform/src/budget.rs
@@ -16,16 +16,26 @@ pub struct Budget {
     pub id: BudgetId,
     pub organization_id: String,
     pub subject_type: BudgetSubjectType,
+    /// Public ID of the subject entity.
     pub subject_id: String,
+    /// Currency: "usd", "tokens", "credits", or custom.
     pub currency: String,
+    /// Hard limit — budget ceiling.
     pub limit: f64,
+    /// Soft limit — triggers pause/warn when balance drops below this.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub soft_limit: Option<f64>,
+    /// Current remaining balance (limit minus consumed).
     pub balance: f64,
+    /// Optional period for recurring budgets.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub period: Option<BudgetPeriod>,
+    /// When the current period started (used to detect period rollover for
+    /// `Duration` / `Rolling` periods, and to display "resets at" in the UI).
+    /// `None` for budgets without a period.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub period_started_at: Option<DateTime<Utc>>,
+    /// Arbitrary metadata.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
     pub status: BudgetStatus,
@@ -40,12 +50,17 @@ pub struct LedgerEntry {
     pub id: String,
     #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub budget_id: BudgetId,
+    /// Positive = debit (consumption), negative = credit (top-up/refund).
     pub amount: f64,
+    /// Which meter produced this: "llm_tokens", "tool_calls", etc.
     pub meter_source: String,
+    /// Reference entity type: "llm_generation", "tool_execution", "manual".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ref_type: Option<String>,
+    /// Reference entity ID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ref_id: Option<String>,
+    /// Session context for this entry.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub session_id: Option<SessionId>,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -17493,7 +17493,7 @@
       },
       "Budget": {
         "type": "object",
-        "description": "Budget — a spending cap for a subject in a currency.\nAPI response DTO.",
+        "description": "Budget — a stored spending cap for a platform subject.",
         "required": [
           "id",
           "organization_id",
@@ -24271,7 +24271,7 @@
       },
       "LedgerEntry": {
         "type": "object",
-        "description": "Immutable ledger entry recording resource consumption or credit against a budget.",
+        "description": "Immutable platform ledger record for resource consumption or credit.",
         "required": [
           "id",
           "budget_id",


### PR DESCRIPTION
## What changed

Removes the temporary `slow_ci_enabled` switch from `ci.yml`, so four jobs run again on every PR and push:

- `unit-test` — Unit Tests (Pure)
- `integration-test` — Integration Tests (PostgreSQL)
- `s3-integration-test` — Integration Tests (S3 Blob Backend)
- `build-binaries` — Build Release Binaries

Two more jobs come back with them, because both declare `needs: build-binaries`: `cli-e2e-test` (push-only, so it runs on merge) and `openapi-check` (OpenAPI Spec Freshness). EVE-922 identified the first; the second turned up while working this.

This is an exact revert of the three pieces `0838d26` added: the `changes` job output, the step that hardcoded it, and the extra `slow_ci_enabled == &#39;true&#39; &amp;&amp;` clause on the four job conditions. The gates return to their pre-`0838d26` form. Removing the switch rather than flipping it to `true` avoids leaving a dead lever that reads as a supported control — `ci:skip-slow-rust` and `ci:skip-postgres-integration` remain the supported way to shed the slow matrix on a single PR.

The restored matrix then surfaced one real regression, fixed in the following three commits (detail below).

## Why

The switch landed in `0838d26` (`refactor(engine): unify in-process and durable execution`, #3173) to keep the slow Rust jobs out of the way during the engine unification work. It hardcoded `enabled=false`:

```yaml
- name: Resolve temporary slow CI mode
  id: slow_ci_mode
  run: echo &#34;enabled=false&#34; &gt;&gt; &#34;$GITHUB_OUTPUT&#34;
```

so those jobs have been skipped on every run since 2026-08-14 — five days of merges with no pure unit tests, no Postgres integration tests, no S3 blob-backend tests, no release-binary build, and no OpenAPI freshness check.

The failure mode is that this was invisible. `ci-success` stayed green throughout, because a gated-off job reports `skipped`, which is indistinguishable from &#34;this diff did not touch that surface&#34;. A source comment was the only record that the matrix was off, with no expiry and no CI signal.

## What the restored matrix found

`251e69a` (#3182, `refactor(framework): complete library boundary cleanup`) moved `Budget` and `LedgerEntry` from `crates/core/src/budget.rs` to `crates/platform/src/budget.rs` and dropped all thirteen field doc comments. utoipa surfaces those as OpenAPI schema field descriptions, so the published spec silently lost them. Three gates catch this and all three were dark:

- `openapi_descriptions_test::field_description_coverage_does_not_regress` — fell to `1855/2089 = 88%` against an 89% floor (runs in the PostgreSQL integration job)
- `OpenAPI Spec Freshness` — committed `docs/api/openapi.json` still carried descriptions the code no longer emits
- `UI Build, Lint &amp; Test` → `api-types:check` — the UI regenerates TypeScript bindings from that spec and diffs

Fixed in `8886a74` (restore the thirteen comments verbatim from `251e69a^`), `36d84bc` (regenerate the spec) and `1dcd6f7` (regenerate the UI bindings).

The struct-level wording stays as #3182 rewrote it — these types are now both the persistence record and the API projection, so &#34;a stored spending cap for a platform subject&#34; is more accurate than the old &#34;API response DTO&#34;. That is why the regenerated spec moves two lines rather than none: the thirteen field descriptions already matched what the committed spec carried, which is the tell that the drift was code losing descriptions, not the spec running ahead.

## Before / After

Job outcomes on the most recent `main` push run before this change ([32316670401](https://github.com/everruns/everruns/actions/runs/32316670401), `69ba363`):

```
skipped    Unit Tests (Pure)
skipped    Integration Tests (PostgreSQL)
skipped    Integration Tests (S3 Blob Backend)
skipped    Build Release Binaries
skipped    CLI E2E Tests
skipped    OpenAPI Spec Freshness
```

After, on this PR's own run — `.github/workflows/ci.yml` is in the `rust`, `postgres_integration` and `object_storage` path filters, so the restored jobs execute against this diff rather than needing a follow-up push to prove it:

```
success    Unit Tests (Pure)
success    Integration Tests (PostgreSQL)
success    Integration Tests (S3 Blob Backend)
success    Build Release Binaries
success    OpenAPI Spec Freshness
success    UI Build, Lint & Test
skipped    CLI E2E Tests          # `github.event_name == 'push'` by design; runs on merge
```

53 checks, 0 failing.

Description coverage, recomputed from the regenerated spec with the same counting logic the test uses:

```
field descriptions:  1868/2089 = 89%   floor 89  -> PASS   (was 1855 = 88%)
schema descriptions:  510/536  = 95%   floor 95  -> PASS
```

Local validation beyond CI: all 22 commands in the `unit-test` job's script pass; both `ci.yml` guard scripts pass (`test-ci-job-timeouts.sh`, `test-release-workflow-security.sh`); UI format check, typecheck, `api-types:check` and 1453 Jest tests pass.

## Risk

- **Medium**

The workflow change itself cannot break runtime behavior — it is three deletions in a YAML file. The risk was in what the restored jobs would report, and that has now played out: one documentation regression, fixed here. Everything else came back green first time, so five days of unverified merges cost one lost set of doc comments and no behavioral defect.

The Rust change is doc comments only. The two generated files are mechanical output of `./scripts/export-openapi.sh` and `pnpm run api-types:generate`.

`timeout-minutes` ceilings for all four jobs are already in place from EVE-921, so a restored job that hangs is bounded rather than pinning the queue for six hours.

## Security

- **Threat categories reviewed:** CI/CD supply chain and secret exposure to untrusted PR code.
- **Findings and resolutions:** No new exposure; no change required.

Re-enabling a job on `pull_request` events means PR-controlled `cargo test` (and therefore arbitrary `build.rs`, proc-macro and test-body code) runs in these jobs, so each was checked for secret reachability:

- `unit-test`, `s3-integration-test`, `build-binaries` — reference no secrets at all.
- `integration-test` — references `secrets.DOPPLER_TOKEN`, but deliberately keeps it **out of job scope**. The only two steps that instantiate it (Slack integration tests, LLM integration tests) are already gated `if: github.event_name == &#39;push&#39;`, precisely so a fork-PR context never sees the token. That protection is independent of the switch and is unaffected here.

`DOPPLER_TOKEN` remains absent from workflow scope. Workflow `permissions` (`contents: read`, `pull-requests: read`) are unchanged, no `pull_request_target` trigger is involved, and no action pins were touched. The doc-comment and generated-file changes carry no security surface.

## Follow-ups

No follow-ups.

The 89% field-description floor is left where it is rather than ratcheted up: this restores the pre-#3182 baseline rather than adding new coverage.

## Checklist
- [x] Tests added or updated — n/a, the change *is* test restoration; the regression it surfaced is caught by three existing gates that now run again
- [x] Backward compatibility considered — no runtime surface; `ci:skip-slow-rust` / `ci:skip-postgres-integration` still shed the matrix per-PR
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — 53 checks, 0 failing, including all four restored jobs
- [x] All review comments addressed (code change or written reasoning) — no review comments; the only bot comment is the Cloudflare Pages deploy notice (successful)

Fixes EVE-922.