### PR TITLE
docs(everruns): rewrite framework readme

### DIFF
--- a/crates/everruns/README.md
+++ b/crates/everruns/README.md
@@ -1,338 +1,230 @@
 # everruns
 
-> The application-facing crate for building and running agents with the Everruns Framework.
+> Build durable, tool-using AI agents in Rust.
 
 [![Crates.io](https://img.shields.io/crates/v/everruns.svg)](https://crates.io/crates/everruns)
 [![Documentation](https://docs.rs/everruns/badge.svg)](https://docs.rs/everruns)
 [![License](https://img.shields.io/crates/l/everruns.svg)](https://github.com/everruns/everruns/blob/main/LICENSE)
 
-`everruns` provides value-first agents, plain model ids, open provider configuration,
-typed tools, isolated multi-turn sessions, live events, cancellation, files,
-typed lifecycle hooks, MCP, plugins, and context inspection without requiring
-a server, worker, or database.
+The [Everruns Framework](https://everruns.com) gives you the building blocks
+for agents that do real work: model providers, typed tools, multi-turn
+sessions, live events, cancellation, background work, files, workspaces,
+lifecycle hooks, MCP, and durable local state. It runs inside your Rust
+process, so you can start with one agent and grow into a custom runtime without
+replacing the core programming model.
 
-It is the primary library crate in the [Everruns](https://everruns.com)
-ecosystem. Normal Rust applications should start here; focused core, engine,
-host, provider, and platform crates support the implementation and advanced
-execution hosts.
-
-The concrete `Engine` owns process-local sessions. It uses `everruns-engine`,
-the shared execution kernel for Input/Reason/Act and turn planning. The same
-kernel also drives the Everruns Platform's durable server/worker path.
-
-## Installation
-
-```bash
-cargo add everruns
+```text
+Agent + Provider + Tools  ->  Engine  ->  Session  ->  Turns and Events
 ```
 
-Default features stay offline and include the typed tool macro plus the
-host-contained session filesystem. Opt into execution/network integrations only
-when needed:
+## Quick start
+
+Create a project and add Everruns with the OpenAI provider:
 
 ```bash
 cargo add everruns --features openai
-cargo add everruns --features bashkit,web-fetch
-cargo add everruns --features lua
-cargo add everruns --features mcp        # HTTP MCP
-cargo add everruns --features mcp-stdio  # also permits local processes
-cargo add everruns --features local      # durable local state and Git heads
+cargo add tokio --features macros,rt-multi-thread
+export OPENAI_API_KEY=sk-...
 ```
 
-See [Capability integrations](https://docs.everruns.com/framework/capability-integrations/)
-for feature boundaries and advanced-host composition.
-
-## Offline Quickstart
+Define a typed tool, give it to an agent powered by GPT-5.6 Terra, and run a
+turn:
 
 ```rust
-use everruns::{Agent, Engine, Model};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use everruns::{Agent, Engine, OpenAI};
+
+/// Return the current Unix time in seconds.
+#[everruns::tool]
+async fn current_time() -> Result<u64, String> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|error| error.to_string())
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent = Agent::builder()
-        .instructions("Answer in one short sentence.")
-        .model(Model::simulated("Hello from Everruns."))
+        .name("assistant")
+        .instructions("Use current_time when asked about time. Be concise.")
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5.6-terra")
+        .tool(current_time())
         .build()?;
 
-    let engine = Engine::new();
-    let session = engine.create(agent);
-    let session_id = session.session_id();
-    let turn = session.send_and_wait("Say hello.").await?;
-    assert_eq!(turn.response, "Hello from Everruns.");
-    drop(session);
-    let _resumed = engine.resume(session_id).await?;
+    let session = Engine::new().create(agent);
+    let turn = session.send_and_wait("What time is it?").await?;
+
+    println!("{}", turn.response);
     Ok(())
 }
 ```
 
-`Model::simulated` uses the normal provider/execution path and returns a fixed
-response locally. It needs no credential or network connection.
+`#[everruns::tool]` derives the tool's JSON schema and adapter from the Rust
+function. The model can call it during the turn, and the result is returned to
+the model before the final response is produced.
 
-`Engine` owns Agent snapshots, the process-local session catalog, and
-runtime state. `engine.create(agent)` and `engine.resume(session_id)` return the
-same first-class `Session` abstraction. Agents never own hidden execution
-engines or session catalogs.
+## The programming model
 
-## Open Provider Setup
+Everruns keeps the core pieces explicit:
 
-With the `openai` feature, attach the provider while keeping model identity free
-of credentials:
+- **`Agent`** describes behavior: instructions, model, provider, tools,
+  capabilities, files, and lifecycle hooks.
+- **`Engine`** owns runtime resources and the session catalog. Keep it around
+  when you want to resume sessions.
+- **`Session`** is an isolated, multi-turn conversation. It exposes sending,
+  steering, events, cancellation, history, and context inspection.
+- **`Turn`** contains the response, status, iteration count, and tool-call
+  count for one run.
+
+Agents are immutable values. An engine snapshots an agent when it creates a
+session, which makes ownership and isolation predictable even when many
+sessions run concurrently.
+
+## Give agents tools and capabilities
+
+For a single operation, annotate an async Rust function with
+`#[everruns::tool]` and add it with `.tool(...)`. Inputs are deserialized into
+typed parameters, results are serialized for the model, and errors stay
+explicit.
+
+Capabilities are the next step when a feature needs several tools, shared
+state, metadata, progress events, or call-scoped cancellation. Built-in and
+custom capabilities share one builder API:
 
 ```rust
-use everruns::{Agent, OpenAI};
+use everruns::{Agent, CompactionConfig, ToolSearch};
 
 let agent = Agent::builder()
-    .instructions("You are concise.")
-    .provider(OpenAI::from_env()?)
+    .instructions("Find the right tool and keep long sessions focused.")
+    .provider(everruns::OpenAI::from_env()?)
     .model("gpt-5.6-terra")
+    .capability(ToolSearch::automatic())
+    .capability(CompactionConfig::new().budget_percent(0.85))
     .build()?;
-# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-Custom services use the same open boundary: attach a `Provider` backed by your
-`ChatDriver`, then select its model with a plain string id. No `ModelSpec`,
-closed model enum, or provider-specific application branch is required.
+You can also define reusable capability packages in Rust or load open,
+configuration-driven capability references. See [Tools and
+macros](https://docs.everruns.com/framework/tools-and-macros/), [capability
+integrations](https://docs.everruns.com/framework/capability-integrations/),
+and [authoring advanced
+capabilities](https://docs.everruns.com/framework/advanced-capabilities/).
 
-## Typed Tools
+## Sessions that go beyond request/response
+
+Use `send_and_wait` for a simple turn. Use `send` when you want to subscribe to
+events, steer a running agent, cancel work, or wait separately:
 
 ```rust
-use everruns::{Agent, Model};
+use everruns::{CancellationToken, RunOptions};
 
-#[everruns::tool]
-/// Add two integers.
-async fn add(left: i64, right: i64) -> Result<i64, String> {
-    Ok(left + right)
+let mut events = session.events();
+let pending = session.send("Research three options.").await?;
+
+while let Some(event) = events.recv().await? {
+    println!("{}", event.event_type());
+    if event.kind.is_terminal() {
+        break;
+    }
 }
 
-let agent = Agent::builder()
-    .instructions("Use the add tool for arithmetic.")
-    .model(Model::simulated("Tool registered."))
-    .tool(add())
-    .build()?;
-# Ok::<(), everruns::BuildError>(())
-```
-
-The default-enabled macro generates the argument schema and adapter. The
-`everruns-macros` package is an implementation crate re-exported as
-`everruns::tool`; applications do not need to depend on it directly.
-
-## Unified Capability Configuration
-
-Every capability uses one scalable builder entrypoint. Typed built-ins,
-code-defined packages, open third-party values, plain default-config IDs, and
-dynamic JSON references all implement `IntoCapability`:
-
-```rust
-use everruns::{
-    Agent, CapabilityRef, CompactionConfig, Model, ToolSearch, capability,
-};
-use serde_json::json;
-
-let weather_definition = capability::Definition::new(
-    "weather",
-    "Weather",
-    "Application-defined weather tools.",
-).tool(weather_handler);
-
-let agent = Agent::builder()
-    .instructions("Use configured capabilities when relevant.")
-    .model(Model::simulated("Done."))
-    .capability(CompactionConfig::new().budget_percent(0.85))
-    .capability(ToolSearch::automatic())
-    .capability(weather_definition)
-    .capability(
-        CapabilityRef::new("vendor.custom")
-            .config(json!({ "mode": "database-driven" })),
-    )
-    .build()?;
-# Ok::<(), everruns::BuildError>(())
-```
-
-`CapabilityRef` is the explicit database/plugin escape hatch: the Framework
-validates its stable open ID and JSON object at build time, and known built-ins
-validate their own schemas. Duplicate IDs and code-implementation collisions
-are errors, never silent overwrites. Third-party crates can implement the
-non-sealed `IntoCapability` trait without importing `everruns-core`.
-
-The default Framework registry advertises only portable capabilities. Hosted
-knowledge, delegation, session-task, user-hook, and platform-management IDs
-remain valid open references but require a product host that explicitly
-registers their implementations and services. See the
-[portable and hosted capability boundary](https://docs.everruns.com/framework/capability-boundaries/).
-
-Keep ordinary functions on `#[everruns::tool]` and `.tool(...)`; a function
-tool is not a capability reference.
-
-The default `builtins` feature supplies the backend-neutral policy catalog and
-typed `CompactionConfig` and `ToolSearch` values through `everruns-builtins`.
-Build with `default-features = false` when supplying a completely custom
-registry; that keeps the policy implementation bundle out of the dependency
-graph.
-
-## Sessions, Events, and Cancellation
-
-An engine creates independent live sessions from Agent behavior. `send` accepts a message immediately,
-automatically steering an active turn or starting the next turn after
-completion. `send_and_wait` is the request/response convenience. Subscribe
-before sending to observe live events, or pass a cancellation token through
-`RunOptions`.
-
-```rust
-use everruns::{CancellationToken, Engine, RunOptions};
-
-let engine = Engine::new();
-let session = engine.create(agent);
-let mut events = session.events();
-let first = session.send("Remember this turn.").await?;
-
-let turn = first.wait().await?;
+let turn = pending.wait().await?;
+println!("{}", turn.response);
 
 let cancel = CancellationToken::new();
 let options = RunOptions::new().cancel_token(cancel.clone());
 cancel.cancel();
-let stopped = session.run_with("Do not start.", options).await?;
-
-assert!(turn.success);
+let stopped = session.run_with("Start another task.", options).await?;
 assert!(!stopped.success);
-while let Some(event) = events.try_recv()? {
-    println!("{}", event.event_type());
-}
-# Ok::<(), everruns::RunError>(())
 ```
 
-`Session::inspect` exposes the application-facing context assembled for the
-next model call without exposing backend records.
+The `local` feature adds a durable event log, session resume, scheduled work,
+and Git-backed workspace heads. Sessions can bind to isolated mutable project
+views and reopen the exact same workspace after a restart.
 
-## Workspace Heads and Environments
+## Features
 
-Simple applications retain an `Engine` and may use
-`AgentBuilder::workspace(path)` as shorthand for one shared local directory.
-Applications that need isolated mutable project views use the open
-`WorkspaceProvider` SPI, create a `WorkspaceHead`, and permanently bind it
-before execution:
+The default feature set includes typed tools, capabilities, built-ins, and the
+session filesystem. Network providers and heavier runtime integrations are
+opt-in.
 
-```rust
-use std::sync::Arc;
-use everruns::{Environment, Engine, LocalGitWorkspaceProvider, Workspace};
-
-# async fn bind(agent: &everruns::Agent, repository: &std::path::Path, state: &std::path::Path)
-# -> Result<(), Box<dyn std::error::Error>> {
-let provider = Arc::new(LocalGitWorkspaceProvider::new(state)?);
-let workspace = Workspace::open(provider, repository.to_string_lossy()).await?;
-let head = workspace.head("feature").from_revision("main").create().await?;
-let environment = Environment::builder().workspace(head).build()?;
-let engine = Engine::new();
-let session = engine.create(agent.clone()).environment(environment).start().await?;
-assert!(session.workspace_head().is_some());
-# Ok(())
-# }
-```
-
-This local Git provider is available with the `local` feature. Heads are
-isolated by default; sharing is an explicit head-creation choice. Typed resume
-reopens the recorded provider/workspace/head binding or fails structurally, it
-never substitutes another directory. Archive and destroy are explicit, and
-Drop never removes worktrees or branches. See [Workspaces and
-Environments](https://docs.everruns.com/framework/workspaces-and-environments/).
-
-## Lifecycle Hooks
-
-Register async handlers on `Agent::builder()` when application work must be
-awaited at an agent, turn, tool, or completion boundary. Handlers receive owned,
-typed Framework contexts and never require persisted hook records or runtime
-imports. Use session events instead for non-blocking observation.
-
-```rust
-use everruns::{Agent, Model};
-
-let agent = Agent::builder()
-    .instructions("You are concise.")
-    .model(Model::simulated("Ready."))
-    .on_agent_start(|context| async move {
-        println!("started {}", context.session_id);
-    })
-    .on_completion(|context| async move {
-        println!("completed {}", context.turn.turn_id);
-    })
-    .build()?;
-# Ok::<(), everruns::BuildError>(())
-```
-
-## Persistence
-
-By default, conversation history is offline, database-free, and retained for
-the lifetime of an engine and its sessions. Keep a typed `SessionId` and call
-`Engine::resume`; use `Session::history().page()` for bounded event-derived
-reads. The `local` feature adds a crash-durable canonical event log and session
-catalog alongside its real workspace and task/schedule state.
-
-## What It Provides
-
-- Value-first `Agent`, plain model ids, open `Provider`, and deterministic simulation
-- Typed and dynamic function tools
-- Independent multi-turn `Session`s, typed resume, bounded history, and next-turn context inspection
-- Live typed events, lossless canonical envelopes, and cancellation
-- Session-owned immediate and scheduled work with leased, at-least-once delivery
-- Awaited, typed lifecycle hooks with explicit failure isolation
-- Editable/read-only files, one trusted workspace, scoped MCP, and plugins
-- Open workspace providers, isolated or explicitly shared heads, and session environments
-- Optional OpenAI and local profiles without enlarging the offline default
-
-## Runnable Examples
-
-The [example catalog](./examples/README.md) includes:
-
-- `workspace_policy`, secure workspace scopes with an offline simulator
-- `hello`, smallest live-provider program
-- `production_agent`, production-style composition
-- `github_monitor --simulate`, credential-free typed-tool flow
-- `session_work`, offline background work and completion wakes
-- `canonical_events`, offline lossless event recording and typed rendering
-- `subagents`, public-facade delegation
-- `observe_and_cancel`, events and cancellation
-- `session_history`, offline durable resume and bounded history pages
-- `workspace_heads`, local Git heads, Environments, and durable exact binding
-- `lifecycle_hooks`, agent, turn, tool, and completion handlers
-
-Examples are compiled in CI and import only `everruns`.
-
-## Which Crate Should I Use?
-
-| Need | Start with |
+| Feature | Adds |
 | --- | --- |
-| Build and run agents in a Rust application | `everruns` |
-| Implement or configure a focused model provider | `everruns` plus the provider crate |
-| Call a remote Everruns deployment | an Everruns SDK |
-| Compose low-level execution backends | `everruns` plus `everruns-host` and focused sibling crates |
-| Operate durable server/worker/UI infrastructure | the Everruns Platform |
+| `openai` | OpenAI Responses API provider configuration |
+| `bashkit` | Sandboxed shell execution |
+| `web-fetch` | HTTP content fetching |
+| `duckduckgo` | DuckDuckGo search |
+| `lua` | Lua execution |
+| `mcp` | Remote HTTP MCP servers |
+| `mcp-stdio` | Local-process MCP servers, plus HTTP MCP |
+| `local` | Durable local sessions, work, schedules, and Git workspace heads |
+| `a2a` | Outbound Agent2Agent delegation; includes `local` |
+
+Combine features as needed:
+
+```bash
+cargo add everruns --features openai,bashkit,web-fetch,mcp
+```
+
+## Examples
+
+Every example imports only `everruns`. The [example catalog](examples/README.md)
+includes the exact command for each one.
+
+### Start here
+
+- [`hello`](examples/hello.rs) — a small GPT-5.6 Terra agent with a typed tool
+  and live events.
+- [`production_agent`](examples/production_agent.rs) — defensive tool
+  boundaries and a multi-turn support agent.
+- [`engine_sessions`](examples/engine_sessions.rs) — engine ownership,
+  isolated sessions, and resume.
+- [`live_session`](examples/live_session.rs) — non-blocking sends, steering,
+  and waiting.
+
+### Tools, capabilities, and orchestration
+
+- [`capability_configuration`](examples/capability_configuration.rs) — typed,
+  code-defined, and dynamic capabilities through one API.
+- [`advanced_capability`](examples/advanced_capability.rs) — reusable tools,
+  metadata, progress, typed results, and structured errors.
+- [`subagents`](examples/subagents.rs) — concurrent child agents coordinated by
+  a parent agent.
+- [`github_monitor`](examples/github_monitor.rs) — background work that wakes
+  an agent when a pull request check completes.
+- [`session_work`](examples/session_work.rs) — session-owned tasks, delivery,
+  and completion wakes.
+
+### Control, state, and observability
+
+- [`observe_and_cancel`](examples/observe_and_cancel.rs) — event streaming and
+  cooperative cancellation.
+- [`canonical_events`](examples/canonical_events.rs) — lossless event recording
+  and typed rendering.
+- [`lifecycle_hooks`](examples/lifecycle_hooks.rs) — awaited agent, turn, tool,
+  and completion handlers.
+- [`session_history`](examples/session_history.rs) — durable resume and bounded
+  history pages.
+- [`workspace_policy`](examples/workspace_policy.rs) — portable read/write
+  scopes and trusted starter files.
+- [`workspace_heads`](examples/workspace_heads.rs) — isolated Git heads,
+  environments, and durable workspace binding.
 
 ## Documentation
 
-- [Everruns Framework](https://docs.everruns.com/framework/)
-- [Framework architecture](https://docs.everruns.com/framework/architecture/)
-- [Framework quickstart](https://docs.everruns.com/framework/quickstart/)
-- [Workspace security](https://docs.everruns.com/framework/workspace-security/)
-- [Workspaces and environments](https://docs.everruns.com/framework/workspaces-and-environments/)
+- [Framework guide](https://docs.everruns.com/framework/)
+- [Agents](https://docs.everruns.com/framework/agents/)
 - [Models and providers](https://docs.everruns.com/framework/models-and-providers/)
-- [Tools and macros](https://docs.everruns.com/framework/tools-and-macros/)
 - [Sessions](https://docs.everruns.com/framework/sessions/)
-- [Session history and resume](https://docs.everruns.com/framework/session-history/)
-- [Persistence](https://docs.everruns.com/framework/persistence/)
-- [Session work and wakes](https://docs.everruns.com/framework/background-work/)
 - [Events and cancellation](https://docs.everruns.com/framework/events-and-cancellation/)
-- [Lifecycle hooks](https://docs.everruns.com/framework/lifecycle-hooks/)
-- [Canonical events](https://docs.everruns.com/framework/canonical-events/)
+- [Persistence](https://docs.everruns.com/framework/persistence/)
+- [Workspaces and environments](https://docs.everruns.com/framework/workspaces-and-environments/)
+- [Custom providers](https://docs.everruns.com/framework/custom-providers/)
+- [Custom backends](https://docs.everruns.com/framework/custom-backends/)
 - [API reference](https://docs.rs/everruns)
-
-## Extend agents
-
-Use `#[everruns::tool]` for an ordinary typed async function. Reusable packages
-that need multiple typed tools, capability metadata, execution context,
-progress, or call-scoped cancellation use the curated `everruns::capability`
-SPI and the same `AgentBuilder::capability` entrypoint.
-
-See the [Framework capability-authoring guide](../../docs/framework/advanced-capabilities.md)
-and the [runnable advanced example](examples/advanced_capability.rs).
 
 ## License
 

--- a/crates/everruns/examples/README.md
+++ b/crates/everruns/examples/README.md
@@ -1,6 +1,6 @@
 # `everruns` examples
 
-These examples use the application-facing [`everruns`](../README.md) crate.
+These examples use the [`everruns`](../README.md) crate.
 Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`;
 `capability_configuration`, `canonical_events`, `live_session`, `session_work`,
 `workspace_policy`, and `session_history` run entirely offline.


### PR DESCRIPTION
## What changed

Rewrites the `everruns` crate README as the entry point to the Everruns Framework. It now leads with a live GPT-5.6 Terra quickstart, explains the Agent/Engine/Session programming model, presents tools and capabilities concretely, summarizes opt-in features, and links every runnable crate example.

The examples catalog also drops the redundant "application-facing" label.

## Why

The previous README emphasized internal boundaries and deterministic simulation before showing the framework experience. Readers need a direct path from installation to a useful live agent, followed by a clear map of the framework and its examples.

## Before / After

Before: the README opened with an offline simulated turn, repeated implementation-boundary language, buried example links, and ended with an abstract "Extend agents" note.

After: it opens with an executable GPT-5.6 Terra tool-calling agent, explains the core programming model in user terms, turns extension guidance into a practical tools-and-capabilities section, and directly links all 15 examples.

No runtime behavior changes; this is published crate documentation only.

## Risk

- Low
- Documentation could drift from the public API or violate the published-crate README contract. The OpenAI example compiles, the example inventory is complete, and the published documentation contract passes.

## Security

- Threat categories reviewed: No security-relevant code changes; only Markdown documentation changed.
- Findings and resolutions: None.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated — not applicable; documentation-only change
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning) — no comments received
