### PR TITLE
fix(sandbox): reserve session_sandbox secret and bind Daytona recovery to session

### DIFF
--- a/crates/host/src/session_services/capabilities/session_storage.rs
+++ b/crates/host/src/session_services/capabilities/session_storage.rs
@@ -25,6 +25,12 @@ const INTERNAL_KV_PREFIXES: &[&str] = &[
     everruns_core::ard_attachment::ARD_DISCOVERY_KV_PREFIX,
 ];
 const INTERNAL_SECRET_PREFIXES: &[&str] = &["browserless_internal:", "mcp_oauth:"];
+// Exact reserved secret names. Unlike the prefixes above, this one cannot
+// reference its canonical constant: SESSION_SANDBOX_SECRET_NAME is defined in
+// the platform crate, which depends on this one and which host source must not
+// reference (check-agent-record-isolation.sh). The name is repeated here and
+// pinned to the constant by a test beside that definition.
+const INTERNAL_SECRET_NAMES: &[&str] = &["session_sandbox"];
 
 pub fn is_internal_session_kv_key(key: &str) -> bool {
     INTERNAL_KV_PREFIXES
@@ -37,9 +43,10 @@ fn reserved_kv_key_error() -> ToolExecutionResult {
 }
 
 pub fn is_internal_session_secret_name(name: &str) -> bool {
-    INTERNAL_SECRET_PREFIXES
-        .iter()
-        .any(|prefix| name.starts_with(prefix))
+    INTERNAL_SECRET_NAMES.contains(&name)
+        || INTERNAL_SECRET_PREFIXES
+            .iter()
+            .any(|prefix| name.starts_with(prefix))
 }
 
 pub const SESSION_STORAGE_CAPABILITY_ID: &str = "session_storage";
@@ -650,6 +657,7 @@ mod tests {
         assert!(is_internal_session_secret_name(
             "mcp_oauth:server:access_token"
         ));
+        assert!(is_internal_session_secret_name("session_sandbox"));
         assert!(!is_internal_session_secret_name("api_key"));
     }
 

--- a/crates/platform/src/session_sandbox.rs
+++ b/crates/platform/src/session_sandbox.rs
@@ -678,6 +678,18 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, LazyLock, Mutex};
 
+    // `everruns-host` reserves this name from the user-facing secret_store, but
+    // it cannot name the constant: host is a dependency of this crate, not the
+    // other way round. Pin the two together here, where the constant is
+    // defined, so a rename cannot quietly reopen the write path that lets a
+    // session point Daytona recovery at another session's state.
+    #[test]
+    fn the_sandbox_secret_name_is_reserved_from_session_storage() {
+        assert!(crate::capabilities::is_internal_session_secret_name(
+            SESSION_SANDBOX_SECRET_NAME
+        ));
+    }
+
     #[derive(Clone, Default)]
     struct MemorySecrets {
         secrets: Arc<Mutex<HashMap<String, String>>>,

--- a/integrations/daytona/src/session_sandbox_provider.rs
+++ b/integrations/daytona/src/session_sandbox_provider.rs
@@ -9,6 +9,7 @@ use everruns_platform::session_sandbox::{
     SessionSandboxState, SessionSandboxStatus, SessionSandboxStatusResponse,
     SessionSandboxWriteFileResponse,
 };
+use everruns_provider::typed_id::SessionId;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;
@@ -146,6 +147,7 @@ fn recovery_settings(
 }
 
 fn recovery_binding(
+    session_id: &SessionId,
     instance: &SessionSandboxInstance,
 ) -> Result<Option<DaytonaRecoveryBinding>, ToolExecutionResult> {
     let Some(value) = instance.provider_state.get("recovery") else {
@@ -168,6 +170,7 @@ fn recovery_binding(
         || binding.subpath.starts_with('/')
         || binding.subpath.contains("..")
         || binding.subpath.contains("//")
+        || binding.subpath != format!("sessions/{session_id}")
         || !(2..=100).contains(&binding.retained_revisions)
         || binding
             .head_revision
@@ -659,7 +662,7 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
     ) -> Result<SessionSandboxInstance, ToolExecutionResult> {
         let api_key = get_api_key(context).await?;
         let client = build_client(api_key, config);
-        let Some(recovery) = recovery_binding(instance)? else {
+        let Some(recovery) = recovery_binding(&context.session_id, instance)? else {
             let info = ensure_sandbox_started(&client, &instance.external_id).await?;
             let workspace_path = instance
                 .workspace_path
@@ -745,7 +748,7 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
                 return Ok(SessionSandboxInstance {
                     metadata: json!({
                         "remote_state": "lost",
-                        "recoverable": recovery_binding(instance)?.is_some(),
+                        "recoverable": recovery_binding(&context.session_id, instance)?.is_some(),
                     }),
                     ..instance.clone()
                 });
@@ -768,7 +771,7 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
     ) -> Result<(), ToolExecutionResult> {
         let api_key = get_api_key(context).await?;
         let client = build_client(api_key, config);
-        let recovery = recovery_binding(instance)?;
+        let recovery = recovery_binding(&context.session_id, instance)?;
         let delete_instance = if let Some(recovery) = &recovery {
             match client.get_sandbox(&instance.external_id).await {
                 Ok(_) => {
@@ -949,7 +952,7 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
         config: &SessionSandboxConfig,
         instance: &SessionSandboxInstance,
     ) -> Result<SessionSandboxInstance, ToolExecutionResult> {
-        let Some(mut recovery) = recovery_binding(instance)? else {
+        let Some(mut recovery) = recovery_binding(&context.session_id, instance)? else {
             return Ok(instance.clone());
         };
         let api_key = get_api_key(context).await?;
@@ -1012,7 +1015,7 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
                     workspace_path: state.instance.workspace_path.clone(),
                     metadata: json!({
                         "remote_state": "lost",
-                        "recoverable": recovery_binding(&state.instance)?.is_some(),
+                        "recoverable": recovery_binding(&context.session_id, &state.instance)?.is_some(),
                     }),
                 });
             }
@@ -1131,7 +1134,11 @@ fn shell_escape(s: &str) -> String {
 mod tests {
     use super::*;
 
-    fn recovery_instance(mount_path: &str, head_revision: Option<&str>) -> SessionSandboxInstance {
+    fn recovery_instance(
+        session_id: &SessionId,
+        mount_path: &str,
+        head_revision: Option<&str>,
+    ) -> SessionSandboxInstance {
         SessionSandboxInstance {
             external_id: "sb_test".to_string(),
             display_name: None,
@@ -1141,7 +1148,7 @@ mod tests {
                     "volume_id": "vol_test",
                     "volume_name": "everruns-recovery",
                     "mount_path": mount_path,
-                    "subpath": "sessions/session_123",
+                    "subpath": format!("sessions/{session_id}"),
                     "retained_revisions": 10,
                     "head_revision": head_revision,
                 }
@@ -1152,23 +1159,40 @@ mod tests {
 
     #[test]
     fn recovery_binding_rejects_non_normalized_mount_path() {
-        let instance = recovery_instance("/mnt/recovery/../workspace", Some("rev-1"));
+        let session_id = SessionId::new();
+        let instance = recovery_instance(&session_id, "/mnt/recovery/../workspace", Some("rev-1"));
 
-        assert!(recovery_binding(&instance).is_err());
+        assert!(recovery_binding(&session_id, &instance).is_err());
     }
 
     #[test]
     fn recovery_binding_rejects_revision_path_traversal() {
-        let instance = recovery_instance("/mnt/recovery", Some("rev-1/../../workspace"));
+        let session_id = SessionId::new();
+        let instance =
+            recovery_instance(&session_id, "/mnt/recovery", Some("rev-1/../../workspace"));
 
-        assert!(recovery_binding(&instance).is_err());
+        assert!(recovery_binding(&session_id, &instance).is_err());
+    }
+
+    #[test]
+    fn recovery_binding_rejects_another_sessions_subpath() {
+        let owner_session_id = SessionId::new();
+        let attacker_session_id = SessionId::new();
+        let instance = recovery_instance(&owner_session_id, "/mnt/recovery", Some("rev-1"));
+
+        assert!(recovery_binding(&attacker_session_id, &instance).is_err());
     }
 
     #[test]
     fn recovery_binding_accepts_generated_revision() {
-        let instance = recovery_instance("/mnt/recovery", Some("rev-1723223212345678900"));
+        let session_id = SessionId::new();
+        let instance = recovery_instance(
+            &session_id,
+            "/mnt/recovery",
+            Some("rev-1723223212345678900"),
+        );
 
-        assert!(recovery_binding(&instance).is_ok());
+        assert!(recovery_binding(&session_id, &instance).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## What changed
Daytona sandbox recovery now refuses a recovery binding whose `subpath` is not
this session's, and `session_sandbox` is reserved from the user-facing
`secret_store` so a session cannot write that state in the first place.

## Why
`recovery_binding` validated the stored `subpath` for traversal but never checked
whose it was. The binding lives in the session's `session_sandbox` secret, which
`secret_store` let a session write: a session could point its own recovery at
`sessions/<other-session-id>` and read or overwrite another session's recovered
workspace on the shared recovery volume.

Two layers, because either alone is thin: reserving the secret name closes the
write path, and the subpath check makes a binding that arrives any other way
unusable.

## Before / After
- Before: `recovery_binding` accepts any traversal-free `subpath`;
  `secret_store` accepts `session_sandbox`.
- After: a binding whose subpath is not `sessions/{session_id}` is a corrupt
  binding; `secret_store` rejects `session_sandbox` on set/get/delete and hides
  it from list, the same treatment as the `browserless_internal:` and
  `mcp_oauth:` prefixes.

New test `recovery_binding_rejects_another_sessions_subpath`. Verified locally:
`cargo test -p everruns-integrations-daytona --lib recovery` (5 passed),
`-p everruns-host --lib session_storage` (8 passed), `-p everruns-platform --lib
session_sandbox` (20 passed), `cargo fmt --check`, and
`scripts/lib/check-agent-record-isolation.sh`.

## Before / After (rebase note)
This branch was 132 commits behind `main` and did not build after rebase:
`session_sandbox` moved to the platform crate and `SessionId` is no longer at
`everruns_core`'s root. Both imports are corrected here.

## Risk
- Medium
- Any existing recovery binding whose subpath is not `sessions/{session_id}` now
  fails closed rather than recovering. That is the intended trade; the affected
  state is exactly the state that could not be trusted.

## Security
- Threat categories reviewed: TM-DAYTONA-009 (persisted provider state validated
  before becoming a mount or a shell path), TM-TOOL (session-controlled writes to
  internal state).
- Findings and resolutions: cross-session recovery-state binding, fixed on both
  the read and the write path as described. The reserved name is duplicated in
  `everruns-host` rather than referenced, because the constant lives in the
  platform crate, which depends on host and which host source may not reference
  (`check-agent-record-isolation.sh`). A test beside the constant asserts the
  host predicate reserves it, so a rename cannot silently reopen the write path.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code)_