### PR TITLE
fix(ui): show full WebMCP message for approval

### DIFF
--- a/apps/ui/src/__tests__/webmcp-provider.test.tsx
+++ b/apps/ui/src/__tests__/webmcp-provider.test.tsx
@@ -1,5 +1,6 @@
-import { render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { WebMcpProvider, getEverrunsPageContext } from "@/providers/webmcp-provider";
+import { useWebMcp } from "@/providers/webmcp-context";
 import type { WebMcpToolDefinition } from "@/lib/webmcp/types";
 
 const mockPush = jest.fn();
@@ -84,6 +85,46 @@ describe("WebMcpProvider", () => {
 
     view.unmount();
     expect(tools.size).toBe(0);
+  });
+
+  it("shows the whole approval description in a bounded, scrollable region", async () => {
+    const description = `Send to this session: “${"x".repeat(8_000)}”`;
+
+    function RequestApproval() {
+      const webmcp = useWebMcp();
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            void webmcp
+              .requestApproval({
+                title: "Send this agent message?",
+                description,
+                confirmLabel: "Send message",
+              })
+              .catch(() => {});
+          }}
+        >
+          ask
+        </button>
+      );
+    }
+
+    render(
+      <WebMcpProvider>
+        <RequestApproval />
+      </WebMcpProvider>,
+    );
+    act(() => screen.getByRole("button", { name: "ask" }).click());
+
+    const rendered = await screen.findByText(description);
+    // Nothing is elided: the user approves exactly the text that gets sent.
+    expect(rendered).toHaveTextContent(description, { normalizeWhitespace: false });
+    // And the dialog stays usable: the description scrolls inside a bounded
+    // box instead of pushing the decision buttons out of the viewport.
+    expect(rendered).toHaveClass("max-h-[40svh]", "overflow-y-auto");
+    expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send message" })).toBeInTheDocument();
   });
 
   it("does not register tools when the feature is disabled", async () => {

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -346,10 +346,9 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
           throw new TypeError("message must be a non-empty string");
         }
         const message = input.message.trim().slice(0, 8_000);
-        const preview = message.length > 200 ? `${message.slice(0, 199)}…` : message;
         await webmcp.requestApproval({
           title: "Send this agent message?",
-          description: `Send to ${session.title || "this session"}: “${preview}” This starts a potentially billable agent turn.`,
+          description: `Send to ${session.title || "this session"}: “${message}” This starts a potentially billable agent turn.`,
           confirmLabel: "Send message",
         });
         webmcp.assertBinding(webmcp.bindingToken);

--- a/apps/ui/src/providers/webmcp-provider.tsx
+++ b/apps/ui/src/providers/webmcp-provider.tsx
@@ -287,7 +287,14 @@ export function WebMcpProvider({ children }: { children: ReactNode }) {
         <DialogContent showCloseButton={false} data-testid="webmcp-approval-dialog">
           <DialogHeader>
             <DialogTitle>{pending?.request.title}</DialogTitle>
-            <DialogDescription>{pending?.request.description}</DialogDescription>
+            {/* THREAT[TM-WEB-013]: the description carries agent-supplied text
+                of unbounded length. Bound and scroll it here rather than
+                truncating at the call site: a truncated preview approves
+                something other than what is sent, and an unbounded one pushes
+                Reject/Approve out of a viewport the dialog has locked. */}
+            <DialogDescription className="max-h-[40svh] overflow-y-auto break-words whitespace-pre-wrap">
+              {pending?.request.description}
+            </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => settle(false)}>


### PR DESCRIPTION
## What changed
The WebMCP "Send this agent message?" dialog now shows the whole message it is
about to send, and the description is rendered in a bounded, scrollable region
so the Reject/Approve buttons always stay on screen.

## Why
The dialog truncated the message at 200 characters while the tool sent up to
8,000, so the user approved a preview rather than the payload — anything after
character 200 was submitted unseen. Removing the truncation alone is not enough:
`DialogContent` is `fixed`, vertically centred, and has no max height, and the
dialog locks page scroll, so an 8,000-character description pushes the decision
buttons out of the viewport with no way to reach them. Both halves are needed
for the approval to mean anything.

## Before / After
- Before: message longer than 200 chars → dialog shows `"first 199 chars…"`, the
  full text is sent on approve.
- After: dialog shows the full text; the description scrolls inside
  `max-h-[40svh]` and the footer stays visible.

`apps/ui` tests, `format:check`, `lint`, and `typecheck` all pass locally. New
test `shows the whole approval description in a bounded, scrollable region`
asserts the untruncated text is rendered, that the description carries the
bounding/scroll classes, and that both decision buttons are present.

## Risk
- Low
- A very long message now occupies more of the dialog. The bounded scroll region
  caps that; nothing else on the page changes.

## Security
- Threat categories reviewed: TM-WEB-013 (side-effecting WebMCP tools require a
  visible human approval of the action and target).
- Findings and resolutions: the original truncation broke the guarantee
  TM-WEB-013 depends on — the human approved text that differed from what was
  sent. Fixed. The naive fix reintroduced the same failure in another form (an
  unreachable Approve/Reject), fixed by bounding the description rather than the
  message. Description text is rendered as React text, not HTML, so there is no
  injection surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code)_