### PR TITLE
fix(core): fail-closed tool approval gate and prioritize destructive/open_world over readonly

### DIFF
--- a/crates/builtins/src/tool_approval.rs
+++ b/crates/builtins/src/tool_approval.rs
@@ -55,8 +55,9 @@ pub enum ApprovalDecision {
     /// The turn was cancelled while the request was pending.
     Cancelled,
     /// The host could not be asked (unsupported, or a transport error). The
-    /// gate falls back to allowing, so a client without a permission UI keeps
-    /// working autonomously rather than deadlocking every mutating tool.
+    /// gate blocks: it is only registered by hosts that can service a prompt,
+    /// so this is a broken transport, not a client without a permission UI,
+    /// and a gate that fails open on transport failure is not a gate.
     Unavailable,
 }
 
@@ -102,7 +103,8 @@ impl ApprovalMode {
 /// [`ToolHints`]: crate::tool_types::ToolHints
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ToolRisk {
-    /// Declares `readonly` — never gated.
+    /// Declares `readonly` without also declaring destructive or outward
+    /// behavior.
     ReadOnly,
     /// Changes state but is not flagged destructive/outward (writes, edits, or
     /// an un-annotated tool: fail safe by treating unknown as mutating).
@@ -114,10 +116,10 @@ enum ToolRisk {
 
 fn classify(tool_def: &ToolDefinition) -> ToolRisk {
     let hints = tool_def.hints();
-    if hints.readonly == Some(true) {
-        ToolRisk::ReadOnly
-    } else if hints.destructive == Some(true) || hints.open_world == Some(true) {
+    if hints.destructive == Some(true) || hints.open_world == Some(true) {
         ToolRisk::Destructive
+    } else if hints.readonly == Some(true) {
+        ToolRisk::ReadOnly
     } else {
         ToolRisk::Mutating
     }
@@ -277,9 +279,7 @@ impl PreToolUseHook for ToolApprovalHook {
             .approve(context.session_id, &tool_call, tool_def)
             .await
         {
-            ApprovalDecision::Allow | ApprovalDecision::Unavailable => {
-                PreToolUseDecision::Continue(tool_call)
-            }
+            ApprovalDecision::Allow => PreToolUseDecision::Continue(tool_call),
             ApprovalDecision::AllowAlways => {
                 self.remembered.lock().unwrap().insert(key, true);
                 PreToolUseDecision::Continue(tool_call)
@@ -290,6 +290,7 @@ impl PreToolUseHook for ToolApprovalHook {
                 Self::block(tool_call, "rejected by user")
             }
             ApprovalDecision::Cancelled => Self::block(tool_call, "turn cancelled"),
+            ApprovalDecision::Unavailable => Self::block(tool_call, "approval unavailable"),
         }
     }
 }
@@ -379,15 +380,25 @@ mod tests {
             classify(&tool_with(ToolHints::default())),
             ToolRisk::Mutating
         );
-        // `readonly` wins over `open_world`: a read-only network tool (e.g. web
-        // search, which sets both) is never gated, not treated as outward.
+        // Risky hints take precedence over readonly so outward-facing tools
+        // cannot bypass approval by also declaring themselves read-only.
+        // Hints come from the tool, including untrusted MCP servers, so a
+        // contradictory pair is an escape attempt, not a description.
         assert_eq!(
             classify(&tool_with(ToolHints {
                 readonly: Some(true),
                 open_world: Some(true),
                 ..Default::default()
             })),
-            ToolRisk::ReadOnly
+            ToolRisk::Destructive
+        );
+        assert_eq!(
+            classify(&tool_with(ToolHints {
+                readonly: Some(true),
+                destructive: Some(true),
+                ..Default::default()
+            })),
+            ToolRisk::Destructive
         );
     }
 
@@ -487,15 +498,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_unreachable_approver_allows_rather_than_deadlocking() {
-        // A client with no permission UI must keep working autonomously.
+    async fn readonly_outward_tool_requires_approval() {
+        let approver = ScriptedApprover::new(ApprovalDecision::Reject);
+        let capability = ToolApprovalCapability::new(approver.clone());
+        let context = ToolContext::new(SessionId::new_random());
+        let tool = tool_with(ToolHints {
+            readonly: Some(true),
+            open_world: Some(true),
+            ..Default::default()
+        });
+
+        let decision = capability
+            .hook(ApprovalMode::Normal)
+            .before_exec(call(), &tool, &context)
+            .await;
+
+        assert!(matches!(decision, PreToolUseDecision::Block { .. }));
+        assert_eq!(approver.asked.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_approver_blocks_the_call() {
         let decisions = decide(
             ScriptedApprover::new(ApprovalDecision::Unavailable),
             ApprovalMode::Normal,
             1,
         )
         .await;
-        assert!(matches!(decisions[0], PreToolUseDecision::Continue(_)));
+        assert!(matches!(decisions[0], PreToolUseDecision::Block { .. }));
     }
 
     #[tokio::test]

--- a/knowledge/execution/capabilities.md
+++ b/knowledge/execution/capabilities.md
@@ -922,7 +922,7 @@ Following the agentskills.io specification:
 - **Tools**: None (contributes a `PreToolUseHook`)
 - **Config**: `{"mode": "off" | "normal" | "protective"}` (default `normal`)
 - **Source**: `crates/builtins/src/tool_approval.rs`
-- **Behavior**: Classifies each call by the risk the tool *declares* through `ToolHints`, `readonly` is never gated, `destructive`/`open_world` always can be, and an un-annotated tool fails safe as mutating. `normal` asks before destructive/outward calls; `protective` asks before anything that is not read-only; `off` never asks. "Always" answers are remembered per (session, tool). A host that cannot be reached answers `Unavailable`, which allows the call, a client with no permission UI keeps working autonomously instead of deadlocking on every mutating tool. Ported from yolop, where the ACP server backs the approver with the client's `session/request_permission`.
+- **Behavior**: Classifies each call by the risk the tool *declares* through `ToolHints`. `destructive`/`open_world` decide first, so a tool cannot escape the gate by also declaring itself `readonly`; only a tool that declares `readonly` and neither risky hint counts as read-only; an un-annotated tool fails safe as mutating. `normal` asks before destructive/outward calls; `protective` asks before anything that is not read-only; `off` never asks. "Always" answers are remembered per (session, tool). A host that cannot be reached answers `Unavailable`, which blocks the call: the gate is only registered by hosts that can service a prompt, so an unreachable approver is a transport failure, and a gate that fails open is not a gate. Ported from yolop, where the ACP server backs the approver with the client's `session/request_permission`.
 
 #### ProgressGuard
 


### PR DESCRIPTION
## What changed
Two fixes to the tool-approval gate:

1. `destructive`/`open_world` are classified before `readonly`, so a tool that
   declares itself both risky and read-only is treated as risky.
2. An `Unavailable` answer from the host now blocks the call instead of allowing
   it.

## Why
`ToolHints` come from the tool, including untrusted MCP servers. Classifying
`readonly` first meant a tool that declared `readOnlyHint: true` alongside
`destructiveHint: true` was never gated at any approval mode — a one-line
bypass of the whole gate. A contradictory pair is an escape attempt, not a
description, so the risky hint wins.

The `Unavailable` fallback contradicted the module's own design: the approver is
a constructor argument precisely so "a host without an interactive prompt should
not register the gate at all". A host that registered the gate and then cannot be
reached has a broken transport, not a missing permission UI, and a gate that
fails open on transport failure is not a gate.

## Before / After
- Before: `{readonly: true, destructive: true}` → `ReadOnly` → never asked.
  `Unavailable` → `Continue`.
- After: → `Destructive` → asked at `normal` and `protective`.
  `Unavailable` → `Block("approval unavailable")`.

No built-in tool is affected: the only production tool declaring
`open_world: true` also declares `readonly: false, destructive: true` and was
already classified `Destructive`. The stale comment claiming web search sets both
did not match the code.

`cargo test -p everruns-builtins --lib tool_approval` passes.

## Risk
- Medium
- Any host that registers the gate and answers `Unavailable` now blocks
  mutating/destructive tools instead of running them. That is the intended
  behaviour, and such a host is already misconfigured.

## Security
- Threat categories reviewed: TM-TOOL-008 (tool approval not enforced).
- Findings and resolutions: both a hint-declared classification bypass and a
  fail-open transport path, fixed. Added a `readonly + destructive` classify case
  alongside the `readonly + open_world` one so both self-declaration escapes are
  pinned. `knowledge/execution/capabilities.md` documented the old
  never-gate-readonly and allow-on-Unavailable behaviour and is updated to match.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code)_