### PR TITLE
fix(ui): bound tag chip rendering

### DIFF
--- a/apps/ui/src/__tests__/tag-input.test.tsx
+++ b/apps/ui/src/__tests__/tag-input.test.tsx
@@ -59,4 +59,19 @@ describe("TagInput", () => {
     expect(screen.getByTestId("value")).toHaveTextContent("ops");
     expect(screen.queryByText("alerts")).not.toBeInTheDocument();
   });
+
+  it("bounds the number of chips created from comma-heavy stored values", () => {
+    const value = Array.from({ length: 1_000 }, (_, index) => `tag-${index}`).join(",");
+
+    render(<ControlledTagInput initialValue={value} />);
+
+    const removeButtons = screen.getAllByRole("button", { name: /^Remove / });
+    expect(removeButtons).toHaveLength(100);
+    expect(screen.getByTestId("value")).toHaveTextContent(value);
+    // The overflow chip carries every remaining tag, so its accessible name
+    // must stay bounded rather than growing with the stored value.
+    for (const button of removeButtons) {
+      expect(button.getAttribute("aria-label")!.length).toBeLessThanOrEqual(48);
+    }
+  });
 });

--- a/apps/ui/src/components/ui/tag-input.tsx
+++ b/apps/ui/src/components/ui/tag-input.tsx
@@ -6,11 +6,38 @@ import { X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
+const MAX_RENDERED_TAGS = 100;
+
 function parseTags(value: string): string[] {
-  return value
-    .split(",")
-    .map((tag) => tag.trim())
-    .filter((tag, index, tags) => tag.length > 0 && tags.indexOf(tag) === index);
+  const tags: string[] = [];
+  const seen = new Set<string>();
+  let start = 0;
+
+  while (tags.length < MAX_RENDERED_TAGS - 1) {
+    const comma = value.indexOf(",", start);
+    if (comma === -1) break;
+
+    const tag = value.slice(start, comma).trim();
+    if (tag.length > 0 && !seen.has(tag)) {
+      tags.push(tag);
+      seen.add(tag);
+    }
+    start = comma + 1;
+  }
+
+  // Keep excess input intact in one chip so persisted comma-heavy values cannot
+  // create unbounded DOM nodes and editing does not silently discard their data.
+  const remainder = value.slice(start).trim();
+  if (remainder.length > 0 && !seen.has(remainder)) tags.push(remainder);
+
+  return tags;
+}
+
+// The last chip can hold every tag past the cap, so neither its rendered text
+// nor its accessible name may grow with the stored value. The chip truncates
+// visually; this keeps the screen-reader label finite too.
+function shortLabel(tag: string): string {
+  return tag.length > 40 ? `${tag.slice(0, 39)}…` : tag;
 }
 
 interface TagInputProps {
@@ -78,8 +105,10 @@ export function TagInput({
       )}
     >
       {tags.map((tag) => (
-        <Badge key={tag} variant="secondary" className="gap-1 pl-2 text-xs">
-          {tag}
+        <Badge key={tag} variant="secondary" className="max-w-64 gap-1 pl-2 text-xs">
+          <span className="truncate" title={tag}>
+            {tag}
+          </span>
           <button
             type="button"
             className="-mr-1 inline-flex size-4 items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -88,7 +117,7 @@ export function TagInput({
               removeTag(tag);
             }}
             disabled={disabled}
-            aria-label={`Remove ${tag}`}
+            aria-label={`Remove ${shortLabel(tag)}`}
           >
             <X className="size-3" />
           </button>


### PR DESCRIPTION
## What changed
`TagInput` renders at most 100 chips regardless of how many commas the stored
value contains. Everything past the cap stays in the last chip, so editing the
field does not discard it. Chip labels are truncated visually and their
accessible names are bounded.

## Why
`parseTags` split the entire stored value on commas and rendered one chip per
entry, so a value with thousands of commas produced thousands of DOM nodes and
could pin the browser on any form using the control.

Keeping the overflow in the final chip preserves the value: chips are the source
of truth on write (`updateTags` joins them back), so dropping the tail on render
would delete it on the next save. That chip can then hold every remaining tag,
which is why its rendered text and `aria-label` are bounded too — otherwise the
fix trades unbounded node count for one unbounded text node and one unbounded
accessible name.

## Before / After
- Before: 1,000 comma-separated tags → 1,000 chips and 1,000 remove buttons.
- After: 100 chips; the stored value round-trips unchanged; every remove button's
  accessible name is at most 48 characters.

`apps/ui` tests, `format:check`, `lint`, and `typecheck` pass locally.

## Risk
- Low
- A value with more than 100 tags shows its tail as one chip instead of many.
  Removing that chip removes the tail, which matches the existing "a chip is a
  unit you delete" behaviour.

## Security
- Threat categories reviewed: TM-DOS (client-side resource exhaustion from
  stored, attacker-influenced values).
- Findings and resolutions: the unbounded render was the finding; capped. No
  authz, network, or data-handling paths change. Nothing is newly rendered as
  HTML.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code)_