### PR TITLE
fix(auth): reject admin mode without credentials

### DIFF
--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -475,11 +475,20 @@ impl AuthConfig {
     /// channel without further translation.
     ///
     /// Currently enforces:
+    /// - `mode == Admin` requires configured admin credentials. Without them,
+    ///   no user can log in.
     /// - `mode == External` is incompatible with any built-in OAuth provider
     ///   (`google` or `github`). External mode delegates identity to a
     ///   third-party provider; configuring both at once is ambiguous and
     ///   was the source of the silent 401s in #1492.
     pub fn validate(&self) -> Result<(), String> {
+        if self.mode == AuthMode::Admin && self.admin.is_none() {
+            return Err(
+                "AUTH_ADMIN_EMAIL and AUTH_ADMIN_PASSWORD must both be set when AUTH_MODE=admin"
+                    .to_string(),
+            );
+        }
+
         if self.mode == AuthMode::External {
             let mut configured: Vec<&str> = Vec::new();
             if self.google.is_some() {
@@ -891,15 +900,17 @@ mod tests {
 
     #[test]
     fn test_admin_mode_requires_admin_config() {
-        // Admin mode without admin config
         let config_no_admin = AuthConfig {
             mode: AuthMode::Admin,
             admin: None,
             ..Default::default()
         };
-        assert!(config_no_admin.admin.is_none(), "Admin config can be None");
+        let err = config_no_admin
+            .validate()
+            .expect_err("admin mode without credentials must be rejected");
+        assert!(err.contains("AUTH_ADMIN_EMAIL"), "got: {err}");
+        assert!(err.contains("AUTH_ADMIN_PASSWORD"), "got: {err}");
 
-        // Admin mode with admin config
         let config_with_admin = AuthConfig {
             mode: AuthMode::Admin,
             admin: Some(AdminConfig {
@@ -912,6 +923,9 @@ mod tests {
             config_with_admin.admin.is_some(),
             "Admin config should be set"
         );
+        config_with_admin
+            .validate()
+            .expect("admin mode with credentials should pass validation");
         let admin = config_with_admin.admin.unwrap();
         assert_eq!(admin.email, "admin@example.com");
         assert_eq!(admin.password, "changeme");
@@ -1037,11 +1051,14 @@ mod tests {
 
     #[test]
     fn test_validate_admin_mode_with_oauth_passes() {
-        // Admin mode doesn't surface OAuth either, but the validator only
-        // catches the External-mode conflict — Admin + configured OAuth is
-        // unusual but harmless (login goes through admin credentials).
+        // Admin mode doesn't surface OAuth. Configuring it is unusual but
+        // harmless because login still goes through the admin credentials.
         let config = AuthConfig {
             mode: AuthMode::Admin,
+            admin: Some(AdminConfig {
+                email: "admin@example.com".to_string(),
+                password: "secret".to_string(),
+            }),
             google: Some(make_google_config()),
             ..Default::default()
         };

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -17,6 +17,9 @@
 #   2. Create .env file with:
 #      SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
 #      WORKER_GRPC_AUTH_TOKEN=<your-token>  # Required: worker gRPC auth token
+#      AUTH_JWT_SECRET=<your-random-secret> # Required: JWT signing secret
+#      AUTH_ADMIN_EMAIL=admin@example.com   # Required: admin login email
+#      AUTH_ADMIN_PASSWORD=<your-password>  # Required: admin login password
 #      DEFAULT_OPENAI_API_KEY=sk-...        # Optional: OpenAI API key
 #      DEFAULT_ANTHROPIC_API_KEY=sk-ant-... # Optional: Anthropic API key
 #      DEFAULT_GEMINI_API_KEY=...           # Optional: Google Gemini API key

--- a/knowledge/security/authentication.md
+++ b/knowledge/security/authentication.md
@@ -175,6 +175,10 @@ fallback exposes nothing the public register endpoint doesn't already (its
 failures are equally generic). The visible difference between "logged in" and
 "account created" is inherent to open signup, not an oracle.
 
+### Admin Mode Requires Credentials
+
+`AUTH_MODE=admin` without `AUTH_ADMIN_EMAIL` and `AUTH_ADMIN_PASSWORD` produces a deployment nobody can log into: admin mode checks credentials directly instead of looking users up in the database, and no admin user is seeded. `AuthConfig::validate()` rejects that combination at startup for the same fail-fast reason as the External-mode conflict below, so an operator sees the missing variables at deploy time rather than as a login screen that never accepts anything.
+
 ### External Mode and OAuth Providers
 
 `AUTH_MODE=external` and the built-in OAuth flow are mutually exclusive. External mode delegates user identity to a third-party provider (PropelAuth, Auth0, Clerk, etc.); the platform's own OAuth handlers (`/v1/auth/oauth/{provider}`, `/v1/auth/callback/{provider}`) are disabled.


### PR DESCRIPTION
## What changed
`AUTH_MODE=admin` without `AUTH_ADMIN_EMAIL` and `AUTH_ADMIN_PASSWORD` now fails
startup with a message naming both variables, instead of booting a server nobody
can log into. The compose example lists the variables admin mode actually
requires.

## Why
Admin mode checks the configured credentials directly rather than looking users
up in the database (`auth/routes.rs::login`), and `seed.rs` only seeds an admin
user when `admin` config is present. With neither set, every login attempt fails
and there is no account to fix it with — the failure surfaces as an unexplained
401 at the login screen long after deploy. This is the same fail-fast reasoning
already applied to the External-mode/OAuth conflict in the same validator.

`examples/docker-compose-full.yaml` defaults `AUTH_MODE` to `admin` and passes
`AUTH_ADMIN_EMAIL`/`AUTH_ADMIN_PASSWORD` through as optional, so following the
example's documented setup produced exactly this state.

## Before / After
- Before: `AUTH_MODE=admin` with no credentials starts normally; every login
  returns 401.
- After: startup panics with
  `AUTH_ADMIN_EMAIL and AUTH_ADMIN_PASSWORD must both be set when AUTH_MODE=admin`.

`test_admin_mode_requires_admin_config` now exercises `validate()` on both the
rejected and accepted configs rather than only asserting the field is `Option`.

## Risk
- Low
- A deployment running admin mode with no credentials will now fail to start.
  That deployment is already non-functional; no repo path (`.env.example`,
  `scripts/start-agent-dev.sh`, the compose examples, the auth tests) sets admin
  mode without credentials.

## Security
- Threat categories reviewed: TM-AUTH (authentication configuration and
  fail-closed startup).
- Findings and resolutions: the misconfiguration is a denial of access rather
  than an access grant, so this is availability and operability, not a bypass.
  Fixed by validating at startup. Checked that no other repo path relies on the
  previous permissiveness. `knowledge/security/authentication.md` records the new
  invariant next to the existing External-mode one.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code)_