### PR TITLE
fix(everruns): redact function tool handler errors

### DIFF
--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -1583,7 +1583,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn function_tool_handler_error_is_model_visible_not_a_panic() {
+    async fn function_tool_handler_error_is_redacted_not_a_panic() {
         let tool = FunctionTool::new(
             "always_fails",
             "Always returns an error.",
@@ -1609,8 +1609,8 @@ mod tests {
             .expect("valid agent");
 
         let session = InMemoryEngine::new().create(agent.clone());
-        // The handler error becomes a tool result the model consumes; the turn
-        // still completes rather than panicking.
+        // The handler error becomes a redacted tool result the model consumes;
+        // the turn still completes rather than panicking.
         let turn = session.run("go").await.expect("turn runs");
         assert!(turn.success, "turn should recover from a tool error");
         assert_eq!(turn.tool_calls, 1);

--- a/crates/everruns/src/tool.rs
+++ b/crates/everruns/src/tool.rs
@@ -16,8 +16,8 @@
 //! contract ([`everruns_core::tools::Tool`]) and registered as a single-tool,
 //! closure-backed [`Capability`](everruns_core::capabilities::Capability) on the
 //! in-process runtime, so the model can call it and the result flows back like
-//! any built-in tool. Handler errors become model-visible tool errors; a handler
-//! never panics the turn.
+//! any built-in tool. Handler errors are treated as internal errors and redacted
+//! before reaching the model; a handler never panics the turn.
 //!
 //! # Example
 //!
@@ -128,8 +128,18 @@ type HandlerFn =
 /// Construct one with [`FunctionTool::new`] and hand it to
 /// [`AgentBuilder::tool`](crate::AgentBuilder::tool). The handler is invoked
 /// with the model's call arguments deserialized into a [`serde_json::Value`]
-/// and returns any [`IntoToolResult`]. A returned `Err` becomes a model-visible
-/// tool error — the turn is never panicked by a handler.
+/// and returns any [`IntoToolResult`]. A returned `Err` becomes a redacted
+/// internal error — the turn is never panicked by a handler. Return
+/// [`ToolResponse::error`] from the `Ok` path for errors that are safe to show
+/// to the model.
+///
+/// The `Err` channel is redacted because a handler's error text is written
+/// against the host — a path, a query, a connection string — and the model is
+/// an untrusted reader of anything it is shown. The full error is still logged
+/// with the tool name and call id, so nothing is lost for the developer.
+/// `#[everruns::tool]` is unaffected: it maps a function's own `Err` to a
+/// model-visible tool error before it reaches this channel, and reserves this
+/// channel for failures the model did not cause.
 ///
 /// A `FunctionTool` is cheap to clone (the handler is reference-counted) and is
 /// `Send + Sync`, so the same tool can execute calls concurrently.
@@ -151,8 +161,8 @@ impl FunctionTool {
     ///   at build time).
     /// - `handler` is an async `Fn(serde_json::Value) -> Result<T, E>` where
     ///   `T: IntoToolResult` (a `Value`, a `String`, or a [`ToolResponse`]) and
-    ///   `E: Display`. On `Err`, the error's `Display` text is returned to the
-    ///   model as a tool error.
+    ///   `E: Display`. On `Err`, the error's `Display` text is retained for
+    ///   internal diagnostics but redacted from the model-facing tool result.
     pub fn new<F, Fut, T, E>(
         name: impl Into<String>,
         description: impl Into<String>,
@@ -170,7 +180,7 @@ impl FunctionTool {
             Box::pin(async move {
                 match fut.await {
                     Ok(value) => value.into_tool_result(),
-                    Err(err) => ToolExecutionResult::tool_error(err.to_string()),
+                    Err(err) => ToolExecutionResult::internal_error_msg(err.to_string()),
                 }
             })
         });
@@ -405,7 +415,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handler_error_maps_to_tool_error_without_panicking() {
+    async fn handler_error_maps_to_internal_error_without_panicking() {
         let tool = FunctionTool::new(
             "boom",
             "Always fails.",
@@ -413,10 +423,17 @@ mod tests {
             |_args: Value| async move { Err::<Value, String>("kaboom".to_string()) },
         );
         let result = tool.execute(json!({})).await;
-        match result {
-            ToolExecutionResult::ToolError(message) => assert_eq!(message, "kaboom"),
-            other => panic!("expected tool error, got {other:?}"),
-        }
+        assert!(matches!(result, ToolExecutionResult::InternalError(_)));
+
+        let visible = result
+            .into_tool_result("call_boom", "boom")
+            .error
+            .expect("model-visible error");
+        assert_eq!(
+            visible,
+            "An internal error occurred while executing the tool"
+        );
+        assert!(!visible.contains("kaboom"));
     }
 
     #[tokio::test]

--- a/crates/everruns/src/tool_macro_tests.rs
+++ b/crates/everruns/src/tool_macro_tests.rs
@@ -165,12 +165,20 @@ async fn unit_return_tool_executes() {
 async fn invalid_arguments_surface_as_a_tool_error() {
     // Missing the required `city` field: deserialization fails and the adapter
     // returns a tool error string instead of panicking.
+    //
+    // This stays model-visible even though handler errors are now redacted. The
+    // model wrote these arguments; naming the bad field is what lets it correct
+    // its own call, and the message describes the call, not the host.
     let tool = weather();
     match CoreTool::execute(&tool, json!({ "unit": "C" })).await {
         everruns_core::tools::ToolExecutionResult::ToolError(message) => {
             assert!(
                 message.contains("invalid arguments for tool `weather`"),
                 "unexpected message: {message}"
+            );
+            assert!(
+                message.contains("city"),
+                "the model needs the offending field named: {message}"
             );
         }
         other => panic!("expected a tool error, got {other:?}"),

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -266,11 +266,17 @@ fn expand(args: ToolArgs, func: ItemFn) -> syn::Result<TokenStream2> {
                     let __parsed: __Args = match ::everruns::__macro_support::from_value(__args) {
                         ::core::result::Result::Ok(__v) => __v,
                         ::core::result::Result::Err(__e) => {
-                            return ::core::result::Result::Err(::std::format!(
-                                "invalid arguments for tool `{}`: {}",
-                                #tool_name,
-                                __e,
-                            ));
+                            // Model-visible on purpose, unlike the `Err` channel
+                            // below: the model wrote these arguments, so naming
+                            // the bad field is what lets it fix its own call.
+                            // It describes the call, never the host.
+                            return ::core::result::Result::Ok(
+                                ::everruns::ToolResponse::error(::std::format!(
+                                    "invalid arguments for tool `{}`: {}",
+                                    #tool_name,
+                                    __e,
+                                )),
+                            );
                         }
                     };
                     let __out = #impl_ident(#(__parsed.#field_idents),*).await;


### PR DESCRIPTION
## What changed
Function tool handler `Err` values now follow the core internal-error path: detailed `Display` text remains available to internal diagnostics while the model and client receive the standard generic error. Callers can still return `Ok(ToolResponse::error(...))` for validation messages that are explicitly safe to expose.

The regression test now verifies both the internal classification and model-boundary redaction, while the end-to-end test continues to prove a handler failure does not panic or abort the turn.

## Why
`FunctionTool::new` previously converted every handler error into a model-visible tool error. Handlers commonly propagate database, HTTP, filesystem, or other internal failures with `?`, so crafted tool arguments could expose sensitive error details to the model or client.

## Before / After
Before: `Err::<Value, String>("kaboom")` produced `ToolExecutionResult::ToolError("kaboom")`, which serialized the raw message into the model-facing result.

After: the same handler produces `ToolExecutionResult::InternalError`; conversion at the existing core boundary returns `An internal error occurred while executing the tool`, and the regression test asserts that `kaboom` is absent.

Evidence: `cargo test -p everruns handler_error --lib` passes both the direct redaction test and the end-to-end non-panicking flow.

## Risk
- Low
- Handler `Err` text is no longer model-visible. Applications intentionally using `Err` for user-facing validation must use the already-supported `Ok(ToolResponse::error(...))` API instead.

## Security
- Threat categories reviewed: TM-TOOL and TM-LLM.
- Findings and resolutions: confirmed an information-disclosure path where arbitrary handler `Display` text crossed the model boundary. Resolved by mapping handler failures to the existing `InternalError` redaction path and adding a regression assertion that sensitive text is absent. Explicit `ToolResponse::error` behavior remains unchanged for intentionally model-visible messages. No new dependencies, network access, authorization surface, or resource-consumption behavior.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
