### PR TITLE
fix(ui): restrict chat routes to mutable threads

### DIFF
--- a/apps/ui/src/__tests__/chats-page.test.tsx
+++ b/apps/ui/src/__tests__/chats-page.test.tsx
@@ -169,6 +169,20 @@ describe("Thread surface", () => {
     expect(screen.getByText("chat-panel:Scout")).toBeInTheDocument();
   });
 
+  it("does not mount mutable chat controls for a recording", async () => {
+    mockSessionContext.mockReturnValue({
+      session: thread({ id: "sess_1", tags: ["recording"] }),
+      agent: { id: "agent_1", name: "scout", display_name: "Scout" },
+      agentId: "agent_1",
+      sessionLoading: false,
+    });
+
+    await renderThread();
+
+    expect(screen.queryByText("chat-panel:Scout")).not.toBeInTheDocument();
+    expect(screen.getByText("Thread not found")).toBeInTheDocument();
+  });
+
   it("shows the bound agent in the header and names it in the composer", async () => {
     await renderThread();
 

--- a/apps/ui/src/__tests__/session-layout.test.tsx
+++ b/apps/ui/src/__tests__/session-layout.test.tsx
@@ -186,6 +186,7 @@ describe("SessionLayout", () => {
       status: "idle",
       created_at: "2025-01-01T00:00:00Z",
       active_schedule_count: 0,
+      tags: ["recording"],
       features: ["file_system", "secrets", "key_value", "schedules"],
     };
   });
@@ -314,7 +315,10 @@ describe("SessionLayout", () => {
     fireEvent.click(screen.getByRole("button", { name: /fork into chat/i }));
 
     expect(mockForkMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: "ses-abc12345" }),
+      expect.objectContaining({
+        sessionId: "ses-abc12345",
+        request: expect.objectContaining({ tags: ["recording", "chat"] }),
+      }),
       expect.anything(),
     );
   });

--- a/apps/ui/src/app/(main)/chats/[threadId]/page.tsx
+++ b/apps/ui/src/app/(main)/chats/[threadId]/page.tsx
@@ -24,7 +24,7 @@ import { ResourceNotFound } from "@/components/resource-not-found";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useHarnesses, usePageTitle } from "@/hooks";
 import { useChatThreads } from "@/hooks/use-chat-threads";
-import { threadTitle } from "@/lib/chat-threads";
+import { isChatThread, threadTitle } from "@/lib/chat-threads";
 import { getDisplayName } from "@/lib/entity-lifecycle";
 
 function ThreadContent({ threadId }: { threadId: string }) {
@@ -69,6 +69,18 @@ function ThreadContent({ threadId }: { threadId: string }) {
         description="This thread may have been deleted, moved to another organization, or the URL may be wrong."
         backHref="/chats"
         backLabel="Back to chats"
+        resourceId={threadId}
+      />
+    );
+  }
+
+  if (!isChatThread(session)) {
+    return (
+      <ResourceNotFound
+        title="Thread not found"
+        description="This session is a read-only recording. Fork it into a chat before continuing the conversation."
+        backHref={`/sessions/${threadId}/transcript`}
+        backLabel="Open recording"
         resourceId={threadId}
       />
     );

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -14,6 +14,7 @@ import { useAgent, useSession, useEvents, useModel, useSessionResolvedModel } fr
 import { sendUserMessage, cancelTurn } from "@/lib/api/sessions";
 import { useMutation } from "@tanstack/react-query";
 import { usePathname } from "next/navigation";
+import { isChatThread } from "@/lib/chat-threads";
 import { useOrg } from "@/providers/org-provider";
 import { useLocale } from "@/providers/locale-provider";
 import type {
@@ -315,7 +316,10 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
   // Browser-agent messaging is offered only on a surface that has a composer.
   // Session detail is a read-only recording (EVE-854), so registering these
   // tools there would hand a browser agent a mutation the page itself refuses.
-  const isChatSurface = pathname === "/chat" || pathname === `/chats/${sessionId}`;
+  const isChatSurface =
+    !!session &&
+    isChatThread(session) &&
+    (pathname === "/chat" || pathname === `/chats/${sessionId}`);
   const canSendWebMcpMessage = effectiveStatus === "idle" || effectiveStatus === "started";
 
   const sendMessageTool = useMemo<WebMcpToolDefinition>(

--- a/apps/ui/src/components/session/session-header.tsx
+++ b/apps/ui/src/components/session/session-header.tsx
@@ -26,6 +26,7 @@ import {
   getEntityReferenceLabel,
 } from "@/lib/entity-lifecycle";
 import { formatTokens } from "@/lib/formatting";
+import { CHAT_THREAD_TAG } from "@/lib/chat-threads";
 import { cn, shortenId } from "@/lib/utils";
 import {
   Activity,
@@ -216,10 +217,12 @@ function SessionRecordingActions({
   sessionId,
   agentId,
   sessionTitle,
+  sessionTags,
 }: {
   sessionId: string;
   agentId?: string;
   sessionTitle: string | null;
+  sessionTags: string[];
 }) {
   const router = useRouter();
   const { locale } = useLocale();
@@ -232,9 +235,13 @@ function SessionRecordingActions({
     forkSession.mutate(
       {
         sessionId,
-        // Title is the only override worth setting: agent, model, locale, goal
-        // and tags should all inherit so the fork is the same run continued.
-        request: { title: sessionTitle ? `${sessionTitle} (chat)` : undefined },
+        // Preserve the recording's tags and mark the fork as a chat thread;
+        // the thread route rejects unmarked sessions to prevent direct URL
+        // navigation from making a recording mutable.
+        request: {
+          title: sessionTitle ? `${sessionTitle} (chat)` : undefined,
+          tags: Array.from(new Set([...sessionTags, CHAT_THREAD_TAG])),
+        },
       },
       {
         onSuccess: (session) => router.push(`/chats/${session.id}`),
@@ -420,6 +427,7 @@ export function SessionHeader({
             sessionId={sessionId}
             agentId={agent && agentId ? agentId : undefined}
             sessionTitle={session.title ?? null}
+            sessionTags={session.tags ?? []}
           />
         </div>
       </div>


### PR DESCRIPTION
## What changed
Chat thread routes now render mutable controls only for sessions carrying an established chat-thread tag. Forking a recording preserves its existing tags and adds the chat tag, so the supported escape hatch continues to land on a mutable thread. WebMCP send/cancel tools use the same eligibility check.

## Why
Direct navigation to `/chats/{recording_id}` previously mounted the composer and enabled browser-agent mutation tools for a read-only session recording, bypassing the recording UI's fork-only integrity boundary.

## Before / After
Before: any accessible session ID supplied to `/chats/{id}` mounted `ChatPanel` and enabled pathname-gated WebMCP mutations.

After: the regression test `does not mount mutable chat controls for a recording` proves an untagged recording receives the non-thread state and no `ChatPanel`; 29 focused UI tests pass. A runtime screenshot could not be captured because the canonical stack cannot start in this environment (`sqlx is required. Run: just init`).

## Risk
- Low
- Incorrectly tagged historical chat sessions could be rejected; both current `chat` and legacy `global-chat` tags remain accepted.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TOOL, TM-WEB, TM-DOS
- Findings and resolutions: closed the direct-route authorization-state mismatch by sharing the existing chat-thread predicate across rendering and WebMCP registration. Forks are explicitly tagged to preserve the intended workflow. No new input, dependency, query, or unbounded-work surface was introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
