### PR TITLE
fix(build): secure shared pre-push cache

### DIFF
--- a/scripts/lib/pre-push-context.sh
+++ b/scripts/lib/pre-push-context.sh
@@ -50,8 +50,17 @@ pre_push_core_api_changed() {
     pre_push_changed_files_match '^crates/(core|engine)/|^scripts/lib/check-core-public-api\.sh$|^Cargo\.(toml|lock)$|^rust-toolchain(\.toml)?$'
 }
 
+# One stat field, on either stat. `stat -c` is GNU and `stat -f` is BSD, and
+# `just pre-push` runs on macOS as well as Linux, so asking for only one of them
+# would fail the ownership check on the other and refuse every cache root.
+pre_push_stat_field() {
+  local gnu_format="$1" bsd_format="$2" path="$3"
+  stat -c "$gnu_format" "$path" 2>/dev/null ||
+    stat -f "$bsd_format" "$path" 2>/dev/null
+}
+
 pre_push_shared_target_dir() {
-  local cache_key common_git_dir temp_root
+  local cache_key cache_root common_git_dir mode owner_id temp_root
 
   common_git_dir="$(git rev-parse --git-common-dir)"
   if [[ "$common_git_dir" != /* ]]; then
@@ -60,7 +69,26 @@ pre_push_shared_target_dir() {
   common_git_dir="$(cd "$common_git_dir" && pwd -P)"
   cache_key="$(printf '%s' "$common_git_dir" | cksum | awk '{print $1}')"
   temp_root="${TMPDIR:-/tmp}"
-  printf '%s\n' "${temp_root%/}/everruns-build-$cache_key/pre-push-target"
+  cache_root="${temp_root%/}/everruns-build-$(id -u)"
+
+  # This directory is a security boundary: Cargo can execute artifacts from
+  # its target directory. Refuse attacker-created paths instead of repairing
+  # their ownership or permissions.
+  if [ ! -e "$cache_root" ] && [ ! -L "$cache_root" ]; then
+    # A concurrent pre-push may win creation; validation below decides whether
+    # the resulting path is safe.
+    (umask 077 && mkdir "$cache_root") 2>/dev/null || true
+  fi
+  owner_id="$(pre_push_stat_field '%u' '%u' "$cache_root")" || return 1
+  mode="$(pre_push_stat_field '%a' '%Lp' "$cache_root")" || return 1
+  if [ -L "$cache_root" ] || [ ! -d "$cache_root" ] ||
+    [ "$owner_id" != "$(id -u)" ] || [ "$mode" != "700" ]; then
+    echo "Refusing insecure pre-push cache root: $cache_root" >&2
+    return 1
+  fi
+
+  (umask 077 && mkdir -p "$cache_root/$cache_key/pre-push-target") || return 1
+  printf '%s\n' "$cache_root/$cache_key/pre-push-target"
 }
 
 configure_pre_push_build_cache() {

--- a/scripts/test-pre-push-context.sh
+++ b/scripts/test-pre-push-context.sh
@@ -49,12 +49,30 @@ assert_true "pre-push workflow changes exercise the core API guard" pre_push_cor
 common_git_dir="$(cd "$(git rev-parse --git-common-dir)" && pwd -P)"
 cache_key="$(printf '%s' "$common_git_dir" | cksum | awk '{print $1}')"
 temp_root="${TMPDIR:-/tmp}"
-expected_target="${temp_root%/}/everruns-build-$cache_key/pre-push-target"
+expected_target="${temp_root%/}/everruns-build-$(id -u)/$cache_key/pre-push-target"
 actual_target="$(pre_push_shared_target_dir)"
 if [ "$actual_target" != "$expected_target" ]; then
   echo "FAIL: shared target mismatch: $actual_target != $expected_target" >&2
   exit 1
 fi
+
+cache_test_root="$(mktemp -d)"
+mkdir "$cache_test_root/everruns-build-$(id -u)"
+chmod 0777 "$cache_test_root/everruns-build-$(id -u)"
+if TMPDIR="$cache_test_root" pre_push_shared_target_dir >/dev/null 2>&1; then
+  echo "FAIL: insecure pre-created cache root was accepted" >&2
+  exit 1
+fi
+rm -rf "$cache_test_root"
+
+cache_test_root="$(mktemp -d)"
+mkdir "$cache_test_root/attacker-target"
+ln -s "$cache_test_root/attacker-target" "$cache_test_root/everruns-build-$(id -u)"
+if TMPDIR="$cache_test_root" pre_push_shared_target_dir >/dev/null 2>&1; then
+  echo "FAIL: symlinked cache root was accepted" >&2
+  exit 1
+fi
+rm -rf "$cache_test_root"
 
 (
   CARGO_TARGET_DIR="/tmp/everruns-custom-target"


### PR DESCRIPTION
## Summary
- place shared Cargo artifacts beneath a per-user cache root
- create the cache root with owner-only permissions and reject symlinks, foreign ownership, or permissive modes
- cover insecure pre-created directories and symlink attacks with regression tests

## Testing
- `bash scripts/test-pre-push-context.sh`
- `bash -n scripts/lib/pre-push-context.sh scripts/test-pre-push-context.sh`
- `git diff --check`
- `just pre-push` *(all applicable checks passed except migration immutability, because this checkout initially lacked `origin/main`)*