### PR TITLE
fix(everruns): reject ambiguous MCP server names

### DIFF
--- a/crates/everruns/src/mcp.rs
+++ b/crates/everruns/src/mcp.rs
@@ -1,8 +1,8 @@
 //! Application-facing MCP server configuration.
 
-use std::fmt;
+use std::{collections::HashSet, fmt};
 
-use everruns_core::{McpServerTransportType, ScopedMcpServer};
+use everruns_core::{McpServerTransportType, ScopedMcpServer, sanitize_mcp_server_name};
 
 /// A scoped MCP server available to an agent.
 ///
@@ -108,10 +108,20 @@ pub(crate) fn into_scoped(
     servers: Vec<McpServer>,
 ) -> Result<everruns_core::ScopedMcpServers, String> {
     let mut scoped = everruns_core::ScopedMcpServers::new();
+    let mut sanitized_names = HashSet::new();
     for server in servers {
         let name = server.name.trim();
         if name.is_empty() {
             return Err("MCP server name must not be blank".to_string());
+        }
+        let sanitized_name = sanitize_mcp_server_name(name);
+        if sanitized_name.contains("__") {
+            return Err(format!(
+                "MCP server name {name:?} is invalid after sanitization: consecutive underscores are reserved"
+            ));
+        }
+        if !sanitized_names.insert(sanitized_name) {
+            return Err("MCP server names must be unique after sanitization".to_string());
         }
         match server.inner.transport_type {
             McpServerTransportType::Http if server.inner.url.trim().is_empty() => {

--- a/crates/everruns/tests/agent_builder.rs
+++ b/crates/everruns/tests/agent_builder.rs
@@ -56,3 +56,30 @@ fn duplicate_mcp_names_are_a_typed_error() {
         .unwrap_err();
     assert!(matches!(err, BuildError::InvalidMcpServer { .. }));
 }
+
+#[test]
+fn colliding_sanitized_mcp_names_are_a_typed_error() {
+    use everruns::{BuildError, McpServer};
+
+    let err = Agent::builder()
+        .instructions("You are concise.")
+        .model(Model::simulated("ok"))
+        .mcp_server(McpServer::http("github-prod", "https://one.invalid/mcp"))
+        .mcp_server(McpServer::http("github_prod", "https://two.invalid/mcp"))
+        .build()
+        .unwrap_err();
+    assert!(matches!(err, BuildError::InvalidMcpServer { .. }));
+}
+
+#[test]
+fn reserved_mcp_name_delimiter_is_a_typed_error() {
+    use everruns::{BuildError, McpServer};
+
+    let err = Agent::builder()
+        .instructions("You are concise.")
+        .model(Model::simulated("ok"))
+        .mcp_server(McpServer::http("a__b", "https://one.invalid/mcp"))
+        .build()
+        .unwrap_err();
+    assert!(matches!(err, BuildError::InvalidMcpServer { .. }));
+}


### PR DESCRIPTION
## Summary
- reject MCP server names containing the reserved delimiter after sanitization
- reject server-name collisions after sanitization before routing is constructed
- cover collision and delimiter cases through the public agent builder

## Testing
- `cargo test -p everruns --test agent_builder`
- `cargo fmt --all -- --check`
- `just pre-push` (all applicable checks passed except migration immutability, because the checkout initially had no `origin/main` ref)