### PR TITLE
fix(examples): reject duplicate subagent task ids

### DIFF
--- a/crates/everruns/examples/subagents.rs
+++ b/crates/everruns/examples/subagents.rs
@@ -7,7 +7,7 @@
 //! cargo run -p everruns --features openai --example subagents
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -18,6 +18,16 @@ use tokio::task::JoinHandle;
 
 type ChildResult = Result<String, String>;
 const MODEL_ID: &str = "gpt-5.6-terra";
+
+fn validate_wait_task_ids(task_ids: &[String]) -> Result<(), &'static str> {
+    if task_ids.len() != 5 {
+        return Err("wait_for_subagents expects five task IDs");
+    }
+    if task_ids.iter().collect::<HashSet<_>>().len() != task_ids.len() {
+        return Err("wait_for_subagents expects five unique task IDs");
+    }
+    Ok(())
+}
 
 #[derive(Default)]
 struct ChildTasks {
@@ -117,6 +127,9 @@ fn wait_tool(tasks: Arc<ChildTasks>) -> FunctionTool {
             "properties": {
                 "task_ids": {
                     "type": "array",
+                    "minItems": 5,
+                    "maxItems": 5,
+                    "uniqueItems": true,
                     "items": {"type": "string"}
                 }
             },
@@ -136,10 +149,8 @@ fn wait_tool(tasks: Arc<ChildTasks>) -> FunctionTool {
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default();
-                if task_ids.len() != 5 {
-                    return Ok::<_, String>(ToolResponse::error(
-                        "wait_for_subagents expects five task IDs",
-                    ));
+                if let Err(error) = validate_wait_task_ids(&task_ids) {
+                    return Ok::<_, String>(ToolResponse::error(error));
                 }
 
                 let handles = {
@@ -155,15 +166,16 @@ fn wait_tool(tasks: Arc<ChildTasks>) -> FunctionTool {
                             "unknown or already-waited task: {unknown}"
                         )));
                     }
-                    task_ids
-                        .iter()
-                        .map(|task_id| {
-                            (
-                                task_id.clone(),
-                                running.remove(task_id).expect("presence checked above"),
-                            )
-                        })
-                        .collect::<Vec<_>>()
+                    let mut handles = Vec::with_capacity(task_ids.len());
+                    for task_id in &task_ids {
+                        let Some(handle) = running.remove(task_id) else {
+                            return Ok(ToolResponse::error(format!(
+                                "unknown or already-waited task: {task_id}"
+                            )));
+                        };
+                        handles.push((task_id.clone(), handle));
+                    }
+                    handles
                 };
 
                 let mut results = Vec::with_capacity(handles.len());
@@ -187,6 +199,21 @@ fn wait_tool(tasks: Arc<ChildTasks>) -> FunctionTool {
             }
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_wait_task_ids;
+
+    #[test]
+    fn wait_task_ids_must_be_unique() {
+        let task_ids = ["one", "two", "three", "four", "one"].map(str::to_owned);
+
+        assert_eq!(
+            validate_wait_task_ids(&task_ids),
+            Err("wait_for_subagents expects five unique task IDs")
+        );
+    }
 }
 
 #[tokio::main]


### PR DESCRIPTION
## What changed
Reject duplicate task IDs before the `wait_for_subagents` example removes task handles. The tool schema now advertises exactly five unique IDs, and removal returns a model-visible error rather than panicking if a requested handle is unavailable.

A regression test covers the duplicate-ID validation path.

## Why
Model-generated tool arguments are untrusted. Five entries containing the same valid ID previously passed the initial membership check, then panicked when the handler tried to remove that handle twice.

## Before / After
Before: a five-item request with a duplicate valid task ID could terminate the example at `expect("presence checked above")`.

After: `cargo test --locked -p everruns --all-features --example subagents` passes the regression test and duplicate IDs produce `wait_for_subagents expects five unique task IDs` as a tool error.

## Risk
- Low
- Limited to argument validation in a runnable example; valid sets of five task IDs retain the existing behavior.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-DOS
- Findings and resolutions: duplicate LLM-controlled identifiers crossed the tool boundary without uniqueness validation and could panic the process. Runtime validation, advisory JSON Schema constraints, panic-free removal, and regression coverage resolve the finding. No production execution boundary or new threat category is introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
