### PR TITLE
fix(platform): saturate discovery scores

### DIFF
--- a/crates/server/src/services/platform_command_surface.rs
+++ b/crates/server/src/services/platform_command_surface.rs
@@ -194,30 +194,30 @@ fn catalog_entry_score(entry: &crate::domains::common::CommandCatalogEntry, quer
         .filter(|term| term.len() > 1)
         .collect::<Vec<_>>();
 
-    let mut score = 0;
+    let mut score: u16 = 0;
     for term in terms {
         if name
             .split_whitespace()
             .any(|part| normalize_search_term(part) == term)
         {
-            score += 8;
+            score = score.saturating_add(8);
         } else if name.contains(&term) {
-            score += 5;
+            score = score.saturating_add(5);
         }
         if category == term {
-            score += 7;
+            score = score.saturating_add(7);
         } else if category.contains(&term) {
-            score += 3;
+            score = score.saturating_add(3);
         }
         if description.contains(&term) {
-            score += 1;
+            score = score.saturating_add(1);
         }
     }
     if score > 0 && entry.read_only {
-        score += 4;
+        score = score.saturating_add(4);
     }
     if score > 0 && (name.starts_with("list ") || name.starts_with("get ")) {
-        score += 4;
+        score = score.saturating_add(4);
     }
     score
 }
@@ -485,6 +485,22 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn discovery_score_saturates_for_many_matching_terms() {
+        let query = "agent ".repeat(4_096);
+        let output = discover_for_test(&json!({ "query": query, "include_schemas": false }))
+            .expect("discovery with many matching terms");
+        let value: Value = serde_json::from_str(&output).expect("discover JSON");
+        let names = value["operations"]
+            .as_array()
+            .expect("operations")
+            .iter()
+            .filter_map(|operation| operation["name"].as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"list_agents"), "got {names:?}");
     }
 
     #[test]


### PR DESCRIPTION
## What changed
Discovery scoring now saturates at the existing `u16` maximum instead of overflowing when a query contains many matching terms. A regression test exercises 4,096 repeated matching terms through the real discovery path.

## Why
Caller-controlled discovery queries can contain enough matching terms to overflow the score. Checked-overflow builds panic while unchecked builds wrap and produce incorrect ranking.

## Before / After
Before: a query containing 4,096 repetitions of `agent` overflows the score for catalog entries such as `list_agents`, panicking in checked-overflow builds.

After: `cargo test -p everruns-server --lib services::platform_command_surface::tests` completes successfully, including the 4,096-term regression case, and `list_agents` remains discoverable.

## Risk
- Low
- Only scores beyond `u16::MAX` change; they now tie at the maximum rather than panic or wrap. Normal-query ranking is unchanged.

## Security
- Threat categories reviewed: TM-API, TM-TOOL/MCP, TM-DOS.
- Findings and resolutions: the externally supplied discovery query could overflow numeric scoring. Saturating every score increment prevents the panic and wrapped ranking without expanding the response or catalog result bound. Existing unbounded query allocation/work is unchanged and remains subject to upstream request limits.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
