### PR TITLE
fix(llm-tests): require live tool execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1080,7 +1080,10 @@ jobs:
         # breaks still fail the step.
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-        # Sampling misses pass with a ::warning annotation; expose captured test output.
+        # A sampling miss fails the step once the in-test retries are exhausted:
+        # a turn that never called the advertised tool proves nothing about the
+        # provider's wire serialization, which is what this matrix exists to
+        # check. `--nocapture` exposes the generations behind the failure.
         run: doppler run --preserve-env="DATABASE_URL" -- cargo test -p everruns-llm-tests --test agent_run_basic --test agent_run_with_thinking --test subagent_live_test --all-features -- --nocapture
 
   # S3 blob-backend integration tests.

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -93,8 +93,7 @@ async fn test_tool_call(#[case] config: ProviderModelConfig) {
 
     // Retry live sampling and transient transport failures. If all successful
     // attempts cleanly decline an advertised tool, the contract check below
-    // reports a non-blocking sampling miss. Missing tool definitions and parsed
-    // tool-call mismatches remain merge-blocking failures.
+    // fails because the runtime summary cannot prove provider wire serialization.
     let Some(result) = run_live_turn!(
         config,
         3,
@@ -118,9 +117,7 @@ async fn test_tool_call(#[case] config: ProviderModelConfig) {
     };
 
     assert!(result.success, "Turn should succeed: {:?}", result.error);
-    if !assert_live_tool_call_contract(&result, "get_current_time", &config.label()) {
-        return;
-    }
+    assert_live_tool_call_contract(&result, "get_current_time", &config.label());
     assert!(
         result.iterations > 1,
         "Should have multiple iterations (reason -> act -> reason); iterations={}",

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -378,24 +378,19 @@ pub fn classify_live_tool_call(result: &TurnResult, expected_tool: &str) -> Live
     }
 }
 
-/// Enforce live tool-call contracts while keeping clean model sampling misses
-/// out of the merge gate. Returns whether the tool path was exercised.
-pub fn assert_live_tool_call_contract(
-    result: &TurnResult,
-    expected_tool: &str,
-    label: &str,
-) -> bool {
+/// Enforce live tool-call contracts after the caller exhausts its sampling retries.
+/// A clean sampling miss is still useful diagnostic evidence, but cannot prove
+/// that the provider serialized the tool definition onto the wire.
+pub fn assert_live_tool_call_contract(result: &TurnResult, expected_tool: &str, label: &str) {
     let outcome = classify_live_tool_call(result, expected_tool);
     match outcome {
-        LiveToolCallOutcome::Exercised => true,
-        LiveToolCallOutcome::SamplingMiss => {
-            eprintln!(
-                "::warning title=Live LLM sampling miss::{label} advertised {expected_tool} \
-                 but the model cleanly returned without calling it"
-            );
-            eprintln!("SAMPLING MISS: generations={:?}", result.llm_generations,);
-            false
-        }
+        LiveToolCallOutcome::Exercised => {}
+        LiveToolCallOutcome::SamplingMiss => panic!(
+            "TOOL CONTRACT FAILURE: {label} did not call {expected_tool:?} after sampling retries; \
+             the in-memory advertised-tool summary is not wire-level request evidence; \
+             generations={:?}",
+            result.llm_generations,
+        ),
         LiveToolCallOutcome::MissingToolDefinition => panic!(
             "TOOL CONTRACT FAILURE: {label} did not advertise {expected_tool:?} on every \
              successful generation; generations={:?}",
@@ -494,7 +489,10 @@ pub fn all_providers_registry() -> DriverRegistry {
 
 #[cfg(test)]
 mod quota_detector_tests {
-    use super::{LiveToolCallOutcome, classify_live_tool_call, is_quota_exhausted};
+    use super::{
+        LiveToolCallOutcome, assert_live_tool_call_contract, classify_live_tool_call,
+        is_quota_exhausted,
+    };
     use everruns_core::turn::TurnStopReason;
     use everruns_provider::typed_id::TurnId;
     use everruns_test_support::in_memory_loop::{LlmGenerationSummary, TurnResult};
@@ -532,6 +530,13 @@ mod quota_detector_tests {
             classify_live_tool_call(&result, "get_current_time"),
             LiveToolCallOutcome::SamplingMiss
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "did not call \"get_current_time\" after sampling retries")]
+    fn sampling_miss_does_not_satisfy_live_contract() {
+        let result = tool_result(&["get_current_time"], 0, &["stop"], 0);
+        assert_live_tool_call_contract(&result, "get_current_time", "test provider");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Make a clean no-tool response fail the live tool-call contract after bounded sampling retries.
- Remove the basic live test's early-success path for sampling misses.
- Add regression coverage proving an in-memory advertised-tool summary without execution cannot satisfy the contract.

## Why

The advertised-tool summary comes from the runtime's registered tools, not the provider request body. Treating that summary as enough evidence allowed a provider serialization regression to pass as a model sampling miss.

## Before / After

Before: a successful generation with `available_tools=["get_current_time"]`, no provider-reported tool calls, and zero executed tool calls emitted a warning and passed the live test.

After: the focused regression test exercises that same result and verifies the contract panics with `did not call "get_current_time" after sampling retries`; live tests now require end-to-end tool execution after their three attempts.

## Risk

- Low.
- Live provider CI may surface genuine model sampling exhaustion more often, but it can no longer silently accept missing wire-level tool contracts.
- Production runtime behavior is unchanged; only test enforcement changed.

## Security

- Threat categories reviewed: TM-TOOL, TM-LLM, TM-CI.
- Findings and resolutions: the prior non-wire evidence could weaken provider contract coverage; requiring executed tool calls restores the merge gate. No production security surface, secrets, prompts, or provider payload logging changed.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
