### PR TITLE
fix(sessions): return public IDs in agent facets

### DIFF
--- a/crates/server/src/domains/sessions/list_filters_tests.rs
+++ b/crates/server/src/domains/sessions/list_filters_tests.rs
@@ -6,11 +6,11 @@
 
 use super::{GetSessionFacets, ListSessions, SessionFilterArgs, SessionService};
 use crate::domains::common::{Command, Ctx};
-use crate::storage::{CreateEventRow, CreateSessionRow, StorageBackend};
+use crate::storage::{CreateAgentRow, CreateEventRow, CreateSessionRow, StorageBackend};
 use everruns_core::{Caller, DEFAULT_ORG_ID, DefaultPermissionResolver, OrgRole};
 use everruns_platform::SessionSource;
 use everruns_provider::typed_id::AgentId;
-use everruns_provider::typed_id::{PrincipalId, SessionId};
+use everruns_provider::typed_id::{HarnessId, PrincipalId, SessionId};
 use serde_json::json;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -39,6 +39,7 @@ struct Seed {
     source: SessionSource,
     title: &'static str,
     owner_user_id: Option<Uuid>,
+    agent_id: Option<AgentId>,
     /// Terminal turn to record, e.g. `turn.completed`.
     last_turn: Option<&'static str>,
 }
@@ -62,7 +63,7 @@ async fn seed(db: &Arc<StorageBackend>, spec: Seed) -> SessionId {
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
-            agent_id: None,
+            agent_id: spec.agent_id,
             agent_version_id: None,
             agent_config_hash: None,
             agent_identity_id: None,
@@ -146,6 +147,7 @@ async fn seeded_db() -> Arc<StorageBackend> {
             source: SessionSource::Chat,
             title: "chat thread",
             owner_user_id: None,
+            agent_id: None,
             last_turn: Some("turn.completed"),
         },
     )
@@ -156,6 +158,7 @@ async fn seeded_db() -> Arc<StorageBackend> {
             source: SessionSource::Schedule,
             title: "nightly report",
             owner_user_id: None,
+            agent_id: None,
             last_turn: Some("turn.failed"),
         },
     )
@@ -166,6 +169,7 @@ async fn seeded_db() -> Arc<StorageBackend> {
             source: SessionSource::Schedule,
             title: "hourly sync",
             owner_user_id: None,
+            agent_id: None,
             last_turn: None,
         },
     )
@@ -241,6 +245,7 @@ async fn mine_restricts_to_the_callers_sessions() {
             source: SessionSource::Chat,
             title: "my thread",
             owner_user_id: Some(user),
+            agent_id: None,
             last_turn: None,
         },
     )
@@ -251,6 +256,7 @@ async fn mine_restricts_to_the_callers_sessions() {
             source: SessionSource::Chat,
             title: "someone else's thread",
             owner_user_id: Some(Uuid::now_v7()),
+            agent_id: None,
             last_turn: None,
         },
     )
@@ -291,6 +297,66 @@ async fn facets_count_every_dimension_over_the_applied_filters() {
 }
 
 #[tokio::test]
+async fn agent_facets_return_public_ids_that_can_be_used_as_filters() {
+    let db = new_db(&[DEFAULT_ORG_ID]).await;
+    let public_id = AgentId::new();
+    let agent = db
+        .create_agent(
+            DEFAULT_ORG_ID,
+            CreateAgentRow {
+                public_id: public_id.to_string(),
+                name: "facet-agent".to_string(),
+                display_name: None,
+                description: None,
+                system_prompt: String::new(),
+                default_model_id: None,
+                harness_id: HarnessId::from_uuid(Uuid::nil()),
+                tags: vec![],
+                initial_files: json!([]),
+                tools: json!([]),
+                mcp_servers: json!({}),
+                network_access: None,
+                max_iterations: None,
+                parallel_tool_calls: None,
+                is_built_in: false,
+            },
+        )
+        .await
+        .expect("create agent");
+    seed(
+        &db,
+        Seed {
+            source: SessionSource::Api,
+            title: "agent session",
+            owner_user_id: None,
+            agent_id: Some(agent.id),
+            last_turn: None,
+        },
+    )
+    .await;
+
+    let ctx = ctx_for(db, None);
+    let facets = GetSessionFacets {
+        filters: SessionFilterArgs::default(),
+    }
+    .execute(&ctx)
+    .await
+    .expect("facets");
+    assert_eq!(bucket(&facets.by_agent, &public_id.to_string()), 1);
+    assert_eq!(bucket(&facets.by_agent, &agent.id.to_string()), 0);
+
+    let found = titles(
+        &ctx,
+        SessionFilterArgs {
+            agent_id: Some(public_id),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_eq!(found, vec!["agent session"]);
+}
+
+#[tokio::test]
 async fn a_facet_dimension_excludes_its_own_selection() {
     let ctx = ctx_for(seeded_db().await, None);
     let facets = GetSessionFacets {
@@ -320,6 +386,7 @@ async fn facets_never_count_across_organizations() {
             source: SessionSource::Chat,
             title: "ours",
             owner_user_id: None,
+            agent_id: None,
             last_turn: None,
         },
     )

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -1457,16 +1457,7 @@ impl SessionService {
             total: row.total as u64,
             by_activity: bucket(row.by_activity),
             by_source: bucket(row.by_source),
-            by_agent: row
-                .by_agent
-                .into_iter()
-                .filter_map(|b| {
-                    Uuid::parse_str(&b.value).ok().map(|id| SessionFacetCount {
-                        value: AgentId::from_uuid(id).to_string(),
-                        count: b.count as u64,
-                    })
-                })
-                .collect(),
+            by_agent: bucket(row.by_agent),
             active_now: row.active_now as u64,
             failed_today: row.failed_today as u64,
             p95_duration_ms: row.p95_duration_ms as u64,

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -333,11 +333,18 @@ impl InMemoryDatabase {
                     .iter()
                     .map(|s| s.source.clone()),
             ),
-            by_agent: count_by(
-                self.filtered_sessions(org_id, filters, FacetDimension::Agent)
-                    .iter()
-                    .filter_map(|s| s.agent_id.map(|a| a.uuid().to_string())),
-            ),
+            by_agent: {
+                let agents = self.agents.read();
+                count_by(
+                    self.filtered_sessions(org_id, filters, FacetDimension::Agent)
+                        .iter()
+                        .filter_map(|s| {
+                            s.agent_id
+                                .and_then(|agent_id| agents.get(&agent_id))
+                                .map(|agent| agent.public_id.clone())
+                        }),
+                )
+            },
             active_now: matched
                 .iter()
                 .filter(|s| matches!(s.status.as_str(), "active" | "waiting_for_tool_results"))

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -920,7 +920,7 @@ pub struct SessionFacetsRow {
     pub total: i64,
     pub by_activity: Vec<SessionFacetBucket>,
     pub by_source: Vec<SessionFacetBucket>,
-    /// `value` holds the agent's internal UUID as text; `NULL` agents are omitted.
+    /// `value` holds the agent's public id; `NULL` agents are omitted.
     pub by_agent: Vec<SessionFacetBucket>,
     pub active_now: i64,
     pub failed_today: i64,

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -517,8 +517,9 @@ impl Database {
             SELECT 'source', source, COUNT(*)::bigint
               FROM base WHERE TRUE{activity_pred}{agent_pred} GROUP BY source
             UNION ALL
-            SELECT 'agent', agent_id::text, COUNT(*)::bigint
-              FROM base WHERE agent_id IS NOT NULL{activity_pred}{source_pred} GROUP BY agent_id
+            SELECT 'agent', agents.public_id, COUNT(*)::bigint
+              FROM base JOIN agents ON agents.id = base.agent_id
+              WHERE TRUE{activity_pred}{source_pred} GROUP BY agents.public_id
             UNION ALL
             SELECT 'total', '', COUNT(*)::bigint
               FROM base WHERE TRUE{activity_pred}{source_pred}{agent_pred}


### PR DESCRIPTION
## What changed
Session agent facet buckets now expose each agent's stored public ID in both PostgreSQL and in-memory storage. The service forwards that public ID unchanged, so callers can use the returned value with the existing `agent_id` filter.

A regression test covers an agent whose caller-supplied public ID differs from its internal ID and verifies that the facet value filters the corresponding session.

## Why
The facets query grouped sessions by internal agent UUID and the service converted that UUID into a typed ID. For caller-supplied public IDs, this exposed an internal identifier and returned a value that the public-ID-based filter could not resolve.

## Before / After
Before: an agent stored with public ID `agent_<public>` produced a `by_agent` bucket keyed as `agent_<internal>`, and filtering with that returned value matched no agent.

After: the regression test proves the bucket is keyed as `agent_<public>`, omits `agent_<internal>`, and the public facet value filters the expected session.

Evidence: `cargo test -p everruns-server domains::sessions::list_filters_tests::agent_facets_return_public_ids_that_can_be_used_as_filters` passes.

## Risk
- Low
- The PostgreSQL facet query adds an indexed primary-key join from `sessions.agent_id` to `agents.id`; agents deleted or missing from storage are omitted as before.
- The storage facet contract changes only for the affected agent dimension, from an internal implementation ID to the documented public ID.

## Security
- Threat categories reviewed: TM-API, TM-TENANT.
- Findings and resolutions: removed internal agent UUID disclosure from the facet API. Existing organization scoping remains in the base sessions predicate, and the agent join uses the session's foreign-keyed agent ID. Dynamic predicates remain closed, parameterized fragments, so the change adds no SQL-injection path.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
