### PR TITLE
feat(ui): allow chats with harnesses

### DIFF
--- a/apps/ui/src/__tests__/new-chat-form.test.tsx
+++ b/apps/ui/src/__tests__/new-chat-form.test.tsx
@@ -50,11 +50,11 @@ jest.mock("@/components/ui/select", () => {
   }) {
     return (
       <select
-        aria-label="Agent for this chat"
+        aria-label="Chat counterpart"
         value={value}
         onChange={(event) => onValueChange(event.target.value)}
       >
-        <option value="">Pick an agent</option>
+        <option value="">Pick an agent or harness</option>
         {collectOptions(children)}
       </select>
     );
@@ -68,7 +68,9 @@ jest.mock("@/components/ui/select", () => {
   return {
     Select,
     SelectContent: ({ children }: { children: mockReact.ReactNode }) => <>{children}</>,
+    SelectGroup: ({ children }: { children: mockReact.ReactNode }) => <>{children}</>,
     SelectItem,
+    SelectLabel: ({ children }: { children: mockReact.ReactNode }) => <>{children}</>,
     SelectTrigger: ({ children }: { children: mockReact.ReactNode }) => <>{children}</>,
     SelectValue: () => null,
   };
@@ -99,8 +101,8 @@ describe("NewChatForm", () => {
   it("creates an agent-bound thread and opens it", async () => {
     render(<NewChatForm />);
 
-    fireEvent.change(screen.getByRole("combobox", { name: "Agent for this chat" }), {
-      target: { value: "agent_1" },
+    fireEvent.change(screen.getByRole("combobox", { name: "Chat counterpart" }), {
+      target: { value: "agent:agent_1" },
     });
     fireEvent.click(screen.getByRole("button", { name: /Start chat/ }));
 
@@ -115,14 +117,40 @@ describe("NewChatForm", () => {
   it("binds a Platform Chat thread to the harness instead", async () => {
     render(<NewChatForm />);
 
-    fireEvent.change(screen.getByRole("combobox", { name: "Agent for this chat" }), {
-      target: { value: "__platform_chat__" },
+    fireEvent.change(screen.getByRole("combobox", { name: "Chat counterpart" }), {
+      target: { value: "harness:platform-chat" },
     });
     fireEvent.click(screen.getByRole("button", { name: /Start chat/ }));
 
     await waitFor(() =>
       expect(mutateAsync).toHaveBeenCalledWith({
         request: { harness_name: "platform-chat", tags: ["chat"] },
+      }),
+    );
+  });
+
+  it("creates a harness-bound thread without an agent", async () => {
+    setup({
+      harnesses: [
+        {
+          id: "harness_generic",
+          name: "generic",
+          display_name: "Generic",
+        },
+      ],
+    });
+
+    render(<NewChatForm />);
+
+    expect(screen.getByRole("option", { name: "Generic" })).toHaveValue("harness:generic");
+    fireEvent.change(screen.getByRole("combobox", { name: "Chat counterpart" }), {
+      target: { value: "harness:generic" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Start chat/ }));
+
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({
+        request: { harness_name: "generic", tags: ["chat"] },
       }),
     );
   });

--- a/apps/ui/src/app/(main)/chats/chats-page-client.tsx
+++ b/apps/ui/src/app/(main)/chats/chats-page-client.tsx
@@ -54,7 +54,7 @@ export default function ChatsPageClient() {
   // in the list cannot unmount the form mid-navigation.
   const [starting, setStarting] = useState(false);
   // Same counterpart rule as the thread header: the agent when there is one,
-  // otherwise the harness the thread is bound to (Platform Chat).
+  // otherwise the harness the thread is bound to.
   const agentNameById = new Map(agents.map((agent) => [agent.id, getDisplayName(agent)]));
   const harnessNameById = new Map(
     harnesses.map((harness) => [harness.id, getDisplayName(harness)]),
@@ -68,7 +68,7 @@ export default function ChatsPageClient() {
       <PageMasthead
         icon={<MessageCircle />}
         title="Chats"
-        description="Conversations with your agents. Each thread is an ordinary session you can open, share, and re-read."
+        description="Conversations with agents and harnesses. Each thread is an ordinary session you can open, share, and re-read."
         actions={
           <Link href="/chats/new" className={buttonVariants()}>
             <Plus className="size-4" />
@@ -87,7 +87,7 @@ export default function ChatsPageClient() {
           <EmptyState
             icon={<MessageCircle />}
             title="No chats yet"
-            description="Pick an agent and start talking. The thread is saved as a session you can come back to."
+            description="Pick an agent or harness and start talking. The thread is saved as a session you can come back to."
             action={<NewChatForm onStartingChange={setStarting} />}
           />
         )}

--- a/apps/ui/src/app/(main)/chats/new/new-chat-page-client.tsx
+++ b/apps/ui/src/app/(main)/chats/new/new-chat-page-client.tsx
@@ -12,7 +12,7 @@ export default function NewChatPageClient() {
         className="mt-6"
         icon={<MessageCircle />}
         title="New chat"
-        description="A thread is bound to one agent for its lifetime. Pick the agent you want to talk to."
+        description="A thread is bound to one agent or harness for its lifetime. Pick the counterpart you want to talk to."
         action={<NewChatForm />}
       />
     </PageContainer>

--- a/apps/ui/src/components/chat/new-chat-form.tsx
+++ b/apps/ui/src/components/chat/new-chat-form.tsx
@@ -1,16 +1,12 @@
 /**
- * New chat: pick who you are talking to, then talk. The counterpart is chosen up
- * front because a thread is bound to it for its lifetime — afterwards the
+ * New chat: pick a counterpart, then talk. The counterpart is chosen up front
+ * because a thread is bound to it for its lifetime — afterwards the
  * binding is shown as a fact, not an editable control
  * (knowledge/ui/information-architecture.md).
  *
- * A thread is an ordinary session: this posts `POST /v1/sessions` and lets the
- * harness be derived from the agent.
- *
- * Platform Chat stays available as a counterpart even though it is a harness
- * rather than an agent. It is the built-in operator chat, and it is how an org
- * with no agents yet creates its first one — dropping it would make the landing
- * surface a dead end on a fresh org.
+ * A thread is an ordinary session: this posts `POST /v1/sessions` with either
+ * an agent or a harness binding. Direct harness chats let users start from a
+ * configured runtime without creating an otherwise-empty agent first.
  */
 "use client";
 
@@ -21,19 +17,21 @@ import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 import { useAgents, useHarnesses } from "@/hooks";
 import { useCreateSession } from "@/hooks/use-sessions";
-import { CHAT_THREAD_TAG, PLATFORM_CHAT_HARNESS_NAME } from "@/lib/chat-threads";
+import { CHAT_THREAD_TAG } from "@/lib/chat-threads";
 import { getDisplayName } from "@/lib/entity-lifecycle";
 import type { CreateSessionRequest } from "@/lib/api/types";
 
-/** Sentinel select value for the harness-bound Platform Chat thread. */
-const PLATFORM_CHAT_VALUE = "__platform_chat__";
+const AGENT_VALUE_PREFIX = "agent:";
+const HARNESS_VALUE_PREFIX = "harness:";
 
 export function NewChatForm({
   onStartingChange,
@@ -48,23 +46,19 @@ export function NewChatForm({
 } = {}) {
   const router = useRouter();
   const { data: agents = [], isLoading: agentsLoading } = useAgents();
-  const { data: harnesses = [] } = useHarnesses();
+  const { data: harnesses = [], isLoading: harnessesLoading } = useHarnesses();
   const createSession = useCreateSession();
   const [selection, setSelection] = useState("");
   const [error, setError] = useState<string | null>(null);
-
-  const platformChatAvailable = harnesses.some(
-    (harness) => harness.name === PLATFORM_CHAT_HARNESS_NAME,
-  );
+  const optionsLoading = agentsLoading || harnessesLoading;
 
   const start = async () => {
     if (!selection) return;
     setError(null);
     onStartingChange?.(true);
-    const binding: Partial<CreateSessionRequest> =
-      selection === PLATFORM_CHAT_VALUE
-        ? { harness_name: PLATFORM_CHAT_HARNESS_NAME }
-        : { agent_id: selection };
+    const binding: Partial<CreateSessionRequest> = selection.startsWith(HARNESS_VALUE_PREFIX)
+      ? { harness_name: selection.slice(HARNESS_VALUE_PREFIX.length) }
+      : { agent_id: selection.slice(AGENT_VALUE_PREFIX.length) };
 
     try {
       const session = await createSession.mutateAsync({
@@ -77,11 +71,11 @@ export function NewChatForm({
     }
   };
 
-  if (!agentsLoading && agents.length === 0 && !platformChatAvailable) {
+  if (!optionsLoading && agents.length === 0 && harnesses.length === 0) {
     return (
       <div className="space-y-3">
         <p className="text-sm text-muted-foreground">
-          A chat is a conversation with an agent, so there is nothing to talk to yet.
+          There are no agents or harnesses available for a chat yet.
         </p>
         <Button onClick={() => router.push("/agents/new")}>Create an agent</Button>
       </div>
@@ -91,19 +85,33 @@ export function NewChatForm({
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center justify-center gap-2">
-        <Select value={selection} onValueChange={setSelection} disabled={agentsLoading}>
-          <SelectTrigger className="w-64" aria-label="Agent for this chat">
-            <SelectValue placeholder={agentsLoading ? "Loading agents..." : "Pick an agent"} />
+        <Select value={selection} onValueChange={setSelection} disabled={optionsLoading}>
+          <SelectTrigger className="w-64" aria-label="Chat counterpart">
+            <SelectValue
+              placeholder={optionsLoading ? "Loading options..." : "Pick an agent or harness"}
+            />
           </SelectTrigger>
           <SelectContent>
-            {platformChatAvailable && (
-              <SelectItem value={PLATFORM_CHAT_VALUE}>Platform Chat</SelectItem>
+            {harnesses.length > 0 && (
+              <SelectGroup>
+                <SelectLabel>Harnesses</SelectLabel>
+                {harnesses.map((harness) => (
+                  <SelectItem key={harness.id} value={`${HARNESS_VALUE_PREFIX}${harness.name}`}>
+                    {getDisplayName(harness)}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
             )}
-            {agents.map((agent) => (
-              <SelectItem key={agent.id} value={agent.id}>
-                {getDisplayName(agent)}
-              </SelectItem>
-            ))}
+            {agents.length > 0 && (
+              <SelectGroup>
+                <SelectLabel>Agents</SelectLabel>
+                {agents.map((agent) => (
+                  <SelectItem key={agent.id} value={`${AGENT_VALUE_PREFIX}${agent.id}`}>
+                    {getDisplayName(agent)}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            )}
           </SelectContent>
         </Select>
         <Button onClick={start} disabled={!selection || createSession.isPending}>

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -23,10 +23,7 @@ export { listEvents } from "./events";
 // Session CRUD
 // ============================================
 
-/**
- * Create a new session for an agent.
- * Sessions are direct children of organizations, with agent_id specifying which agent works in the session.
- */
+/** Create a new organization session bound to an agent or directly to a harness. */
 export async function createSession(request: CreateSessionRequest): Promise<Session> {
   const response = await api.post<Session>("/v1/sessions", request);
   return response.data;

--- a/knowledge/ui/information-architecture.md
+++ b/knowledge/ui/information-architecture.md
@@ -69,9 +69,10 @@ policy and dev-mode gating and stay out of the five groups for the same reason.
 * **Chats is the unconditional landing route.** It is core functionality, requires no feature
   opt-in, is the first thing in the sidebar, and is the default destination for every user with no
   other intent. A fresh organization can open Chats and start a thread without configuration.
-* **A thread is bound to exactly one agent.** Switching agents starts a new thread rather
-  than re-pointing an existing one; the thread's transcript is only meaningful against
-  the agent that produced it.
+* **A thread is bound to exactly one counterpart.** The counterpart may be an Agent or a Harness,
+  so users can talk to a configured runtime without creating an otherwise-empty Agent. Switching
+  counterparts starts a new thread rather than re-pointing an existing one; the transcript is only
+  meaningful against the counterpart that produced it.
 * **The nav's thread list is bounded.** Live threads in the nav mean the nav is never the
   same twice, so the Chats entry lists only the few most recently active threads and hands
   the rest to the all-threads page. It also holds its order steady while the pointer is

--- a/test_cases/ui/chats/TC014_harness_bound_chat.md
+++ b/test_cases/ui/chats/TC014_harness_bound_chat.md
@@ -1,0 +1,40 @@
+# TC014: Chats - Harness-Bound Thread
+
+## Description
+
+Verify that a user can start a chat directly from an active Harness without creating or selecting
+an Agent, and that the resulting thread remains bound to that Harness.
+
+## Preconditions
+
+- DB-backed stack running
+- User can access Chats
+- The active built-in Generic Harness is available
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Harness | Generic |
+| Message | `Reply with exactly: harness chat works` |
+
+## Steps
+
+1. Navigate to `/chats/new`.
+2. Open the counterpart picker and verify it separates Harnesses from Agents.
+3. Select **Generic** under Harnesses and press **Start chat**.
+4. Inspect the `POST /v1/sessions` request and response.
+5. Verify the browser lands on `/chats/{sessionId}` and the thread header names **Generic**.
+6. Send the test message and wait for the response.
+7. Return to `/chats` and verify the new thread is listed with its Harness-derived avatar.
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Picker | Active Harnesses and Agents appear in separate labelled groups |
+| Request | Session creation sends `harness_name: "generic"` and no Agent binding |
+| Response | The server returns 201 with the Generic Harness ID and `agent_id: null` |
+| Thread | `/chats/{sessionId}` loads with **Generic** as the fixed counterpart |
+| Conversation | The message sends successfully and the Harness produces `harness chat works` |
+| Thread list | The new thread appears with its Harness-derived avatar |


### PR DESCRIPTION
## What changed
Chats can now bind directly to any active Harness, including Generic, Base, and custom Harnesses, without requiring an otherwise-empty Agent. The New chat picker separates Harnesses from Agents and the surrounding copy now reflects both counterpart types.

The information-architecture contract and a durable manual test case now cover Harness-bound threads.

## Why
Platform Chat was a hard-coded Harness exception in an otherwise Agent-only picker. That made the existing backend support for Harness-only sessions undiscoverable and prevented users from starting a Generic or custom Harness chat directly.

## Before / After
Before: New chat showed Agents plus one hard-coded Platform Chat option. Generic and other active Harnesses were absent.

After: New chat shows labelled Harnesses and Agents groups. A DB-backed browser smoke test selected Generic and observed:

```text
POST /api/v1/sessions -> 201
session: session_01a027b22ef57512a43ff5e95b2fad8f
harness: harness_019feecf81b97630bebafb297442e0d4 (generic, active)
agent_id: null
turn: "Reply with exactly: harness chat works"
response: "harness chat works"
```

The thread loaded at `/chats/{sessionId}`, named Generic as the fixed counterpart, and appeared in the Chats list. Local before/after screenshots were captured during validation; external attachment upload was unavailable for this run.

## Risk
- Low
- Selection values now carry explicit `agent:` or `harness:` prefixes; a regression could bind the wrong counterpart or leave Start chat disabled.
- Mitigated by agent-bound, Platform Chat, and Generic Harness unit coverage plus the DB-backed browser smoke test.

## Security
- Threat categories reviewed: TM-WEB, TM-API, TM-AUTHZ, TM-TENANT
- Findings and resolutions: No new trust boundary or endpoint. Picker values come from the authenticated, org-scoped active Harness/Agent lists; the existing session API re-resolves the Harness name within the caller's organization and rejects unavailable resources. React escapes display labels. No threat-model update was required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review comments were posted)
