### PR TITLE
fix(sessions): rejoin users when they send messages

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -10,6 +10,7 @@ const mockUseFeatureFlag = jest.fn((..._args: unknown[]) => false);
 const mockStartSessionVoice = jest.fn();
 const mockEndSessionVoice = jest.fn();
 const mockModelEffortMenu = jest.fn((_props: Record<string, unknown>) => null);
+const mockRefetchParticipants = jest.fn();
 const mockParticipants: Array<Record<string, unknown>> = [];
 const mockAgents: Array<Record<string, unknown>> = [];
 
@@ -71,7 +72,10 @@ jest.mock("@/hooks", () => ({
   useModels: () => ({ data: [], isLoading: false }),
   useProviders: () => ({ data: [] }),
   useAgents: () => ({ data: mockAgents }),
-  useSessionParticipants: () => ({ data: mockParticipants }),
+  useSessionParticipants: () => ({
+    data: mockParticipants,
+    refetch: mockRefetchParticipants,
+  }),
   useImageAttachments: () => ({
     pendingImages: [],
     allUploaded: true,
@@ -245,6 +249,7 @@ beforeEach(() => {
   mockUseFeatureFlag.mockReturnValue(false);
   mockStartSessionVoice.mockReset();
   mockEndSessionVoice.mockReset();
+  mockRefetchParticipants.mockReset();
   mockParticipants.length = 0;
   mockAgents.length = 0;
 });
@@ -437,6 +442,7 @@ describe("ChatPanel placeholder", () => {
     await waitFor(() =>
       expect(screen.queryByTestId("participant-mention-token")).not.toBeInTheDocument(),
     );
+    expect(mockRefetchParticipants).toHaveBeenCalledTimes(1);
   });
 
   it("disambiguates duplicate participant display names and supports mention removal", () => {

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -131,7 +131,7 @@ export function ChatPanel({ replyToLabel, showRunCards = false }: ChatPanelProps
   } = useSessionContext();
 
   const { data: models = [], isLoading: modelsLoading } = useModels();
-  const { data: participants } = useSessionParticipants(sessionId);
+  const { data: participants, refetch: refetchParticipants } = useSessionParticipants(sessionId);
   const { data: agents } = useAgents();
   const [inputValue, setInputValue] = useState("");
   const [addressedParticipantId, setAddressedParticipantId] = useState<string | null>(null);
@@ -505,6 +505,7 @@ export function ChatPanel({ replyToLabel, showRunCards = false }: ChatPanelProps
         });
       }
 
+      void refetchParticipants();
       persistSelection();
       setInputValue("");
       setAddressedParticipantId(null);

--- a/crates/server/src/domains/messages/service.rs
+++ b/crates/server/src/domains/messages/service.rs
@@ -12,14 +12,15 @@ use crate::errors::{BadRequestError, ResourceNotFoundError};
 use crate::execution_metadata;
 use crate::services::{EventService, PrincipalService};
 use crate::storage::StorageBackend;
-use crate::storage::models::ReserveActiveTurnSlotResult;
+use crate::storage::models::{CreateSessionParticipantRow, ReserveActiveTurnSlotResult};
 use anyhow::Result;
 use chrono::Utc;
 use everruns_core::Event;
 use everruns_core::events::{
     EventContext, EventRequest, InputMessageData, OutputMessageCompletedData, ToolCompletedData,
 };
-use everruns_provider::typed_id::{AgentId, HarnessId, MessageId, SessionId};
+use everruns_platform::{SessionParticipantKind, SessionParticipantRole};
+use everruns_provider::typed_id::{AgentId, HarnessId, MessageId, PrincipalId, SessionId};
 use everruns_worker::AgentRunner;
 use serde_json::json;
 use std::sync::Arc;
@@ -67,6 +68,40 @@ impl MessageService {
     pub fn with_caps(mut self, caps: OrgCaps) -> Self {
         self.caps = caps;
         self
+    }
+
+    async fn ensure_active_user_participant(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        user_id: Uuid,
+    ) -> Result<PrincipalId> {
+        let principal = PrincipalService::new(self.db.clone())
+            .ensure_user_principal(org_id, user_id)
+            .await?;
+        let display_name = self
+            .db
+            .get_user(user_id)
+            .await?
+            .map(|user| user.name.trim().to_string())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| "User".to_string());
+
+        self.db
+            .ensure_active_user_session_participant(CreateSessionParticipantRow {
+                org_id,
+                session_id,
+                kind: SessionParticipantKind::User,
+                agent_id: None,
+                agent_version_id: None,
+                principal_id: principal.id,
+                display_name: Some(display_name),
+                role: SessionParticipantRole::Member,
+                joined_at: None,
+            })
+            .await?;
+
+        Ok(principal.id)
     }
 
     /// Create a user message from API request
@@ -151,23 +186,10 @@ impl MessageService {
             let event_metadata = if let Some(metadata) = ctx.event_metadata {
                 Some(metadata)
             } else if let Some(user_id) = ctx.user_id {
-                let principal_id = match PrincipalService::new(self.db.clone())
-                    .ensure_user_principal(ctx.org_id, user_id)
-                    .await
-                {
-                    Ok(principal) => Some(principal.id),
-                    Err(err) => {
-                        tracing::warn!(
-                            org_id = ctx.org_id,
-                            user_id = %user_id,
-                            session_id = %ctx.session_id,
-                            error = %err,
-                            "Failed to resolve user principal for message metadata"
-                        );
-                        None
-                    }
-                };
-                execution_metadata::interactive_user_metadata(Some(user_id), principal_id)
+                let principal_id = self
+                    .ensure_active_user_participant(ctx.org_id, session_id_typed, user_id)
+                    .await?;
+                execution_metadata::interactive_user_metadata(Some(user_id), Some(principal_id))
             } else {
                 self.session_owner_message_metadata(ctx.org_id, session_id_typed)
                     .await
@@ -457,7 +479,10 @@ mod tests {
     use super::*;
     use crate::domains::sessions::limits::OrgCaps;
     use crate::errors::BadRequestError;
-    use crate::storage::{StorageBackend, models::UpdateSession};
+    use crate::storage::{
+        StorageBackend,
+        models::{CreateUserRow, UpdateSession},
+    };
     use async_trait::async_trait;
     use everruns_provider::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 
@@ -642,6 +667,99 @@ mod tests {
                 .get("participant_id")
                 .and_then(|value| value.as_str()),
             Some(owner_participant.id.to_string().as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn create_message_rejoins_user_who_left_session() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let runner: Arc<dyn AgentRunner> = Arc::new(NoopRunner);
+        let delivery = crate::event_delivery::EventDelivery::in_memory();
+        let svc = MessageService::new(db.clone(), runner, false, delivery).with_caps(OrgCaps {
+            max_concurrent_sessions: 10_000,
+            max_active_turns: 10_000,
+        });
+
+        let user = db
+            .create_user(CreateUserRow {
+                email: "returning-user@example.com".to_string(),
+                name: "Returning User".to_string(),
+                avatar_url: None,
+                roles: vec!["user".to_string()],
+                password_hash: None,
+                email_verified: true,
+                auth_provider: None,
+                auth_provider_id: None,
+                external_id: None,
+            })
+            .await
+            .unwrap();
+        let principal = PrincipalService::new(db.clone())
+            .ensure_user_principal(1, user.id)
+            .await
+            .unwrap();
+        let session = create_test_session(&db, 1).await;
+        let original_participant = db
+            .ensure_active_user_session_participant(CreateSessionParticipantRow {
+                org_id: 1,
+                session_id: session.id,
+                kind: SessionParticipantKind::User,
+                agent_id: None,
+                agent_version_id: None,
+                principal_id: principal.id,
+                display_name: Some("Returning User".to_string()),
+                role: SessionParticipantRole::Member,
+                joined_at: None,
+            })
+            .await
+            .unwrap();
+        db.leave_session_participant(1, session.id, original_participant.id)
+            .await
+            .unwrap()
+            .expect("leave initial participant");
+
+        svc.create(
+            CreateMessageContext {
+                org_id: 1,
+                user_id: Some(user.id),
+                harness_id: session.id.uuid(),
+                agent_id: None,
+                session_id: session.id.uuid(),
+                event_metadata: None,
+                request_id: None,
+            },
+            CreateMessageRequest::user("I am back"),
+        )
+        .await
+        .unwrap();
+
+        let participants = db.list_session_participants(1, session.id).await.unwrap();
+        let active_participant = participants
+            .iter()
+            .find(|row| row.principal_id == principal.id && row.left_at.is_none())
+            .expect("returning user rejoins");
+        assert_ne!(active_participant.id, original_participant.id);
+        assert_eq!(active_participant.principal_id, principal.id);
+        assert_eq!(
+            active_participant.display_name.as_deref(),
+            Some("Returning User")
+        );
+
+        let events = db
+            .list_message_events_limited(session.id, None)
+            .await
+            .unwrap();
+        let input = events
+            .into_iter()
+            .find(|row| row.event_type == "input.message")
+            .expect("input message event");
+        assert_eq!(
+            input
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("participant_id"))
+                .and_then(|value| value.as_str()),
+            Some(active_participant.id.to_string().as_str())
         );
     }
 

--- a/docs/features/session-participants.md
+++ b/docs/features/session-participants.md
@@ -27,7 +27,7 @@ To add an agent:
 2. Select **Invite agent**.
 3. Choose an agent that is not already active in the session.
 
-The agent joins as a member. The rail also shows participants who have left. Use the remove action on an active member to make it leave; the host cannot leave through the ordinary participant action.
+The agent joins as a member. The rail also shows participants who have left. Use the remove action on an active member to make it leave; the host cannot leave through the ordinary participant action. If a user who left sends another message, that user rejoins automatically with a new participation interval.
 
 Agents can perform the same operation with invite-mode handoff. An agent with the `agent_handoff` capability calls `spawn_agent` with `mode = invite`. Unlike foreground or background handoff, invite mode joins the target agent to the current session instead of creating a child session.
 

--- a/knowledge/runtime-resources/session-participants.md
+++ b/knowledge/runtime-resources/session-participants.md
@@ -57,10 +57,11 @@ Participant ids use the `part_` prefix (see `knowledge/foundations/id-schema.md`
   environment.
 - **Membership history is append-only in spirit.** Leaving sets `left_at`; rows
   are not deleted, so provenance and the join/leave timeline stay reconstructable.
-- **User membership is idempotent.** A user acting in a session is ensured as an
-  active member participant exactly once
-  (`ensure_active_user_session_participant`), rather than creating a row per
-  turn.
+- **User membership follows activity.** Before an authenticated user's message
+  is emitted, that user is ensured as an active member participant
+  (`ensure_active_user_session_participant`). An existing active row is reused;
+  if the user previously left, the message creates a new row for the new
+  participation interval. The message is attributed to that active row.
 
 ## API
 

--- a/test_cases/ui/session_participants/TC001_manage_session_participants.md
+++ b/test_cases/ui/session_participants/TC001_manage_session_participants.md
@@ -31,6 +31,9 @@ Verify that the session participant rail identifies the host and members, suppor
 6. Wait for the response and verify the reply is attributed to `Participant Specialist`, not the host.
 7. Use the leave/remove control for `Participant Specialist`.
 8. Verify the participant rail no longer shows the guest as active and the transcript renders a system line recording that it left.
+9. Use the leave/remove control for the current user.
+10. Verify the current user moves to **Left**, then send `I am back`.
+11. Verify the current user returns to the active members and the new message appears after a fresh join marker.
 
 ## Expected Result
 
@@ -40,3 +43,5 @@ Verify that the session participant rail identifies the host and members, suppor
 - Inviting an agent adds it as a member while preserving the original host.
 - An addressed turn routes to the selected active agent and attributes its reply to that participant.
 - Removing the guest retains membership history and renders a leave system line in the transcript.
+- A user who sends after leaving automatically rejoins with a new participation interval; the
+  participant rail and transcript show the renewed active membership without a page reload.


### PR DESCRIPTION
## What changed

Authenticated users now automatically rejoin a session when they send a message after leaving. The message is attributed to the new active participation interval, and the participant rail refreshes immediately after a successful send.

Public behavior documentation and the manual participant regression case now describe the leave → send → rejoin lifecycle.

## Why

Leaving previously marked the user participant inactive without preventing message submission. A later message was accepted while the user remained under **Left**, producing contradictory session membership and attribution.

## Before / After

- Before: a user could leave, send another message, and remain listed only under **Left**.
- After: the same send creates a fresh active participant interval, records a new join marker, attributes the message to that interval, and updates the rail without a page reload.
- A headless Chromium smoke test verified the rail immediately restored the active-user Remove control. The local API verified the left row remained historical and a different participant ID became active.

## Risk

- Medium
- Authenticated message creation now requires principal/participant activation to succeed before emitting the input event.
- Each successful UI send performs one participant-query refresh; the backend upsert reuses the current active row and only creates a row after a prior leave.
- Message request and response contracts are unchanged.

## Security

- Threat categories reviewed: TM-AUTHZ, TM-TENANT, TM-API, TM-WEB, TM-DOS
- Findings and resolutions: existing `SESSION_MANAGE` command-policy enforcement is unchanged; every new principal and participant operation remains organization/session scoped; no new input, SQL construction, browser rendering, or trust boundary was introduced; each send performs a bounded existing participant upsert and UI query. No new threat-model entry is required.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
