### PR TITLE
chore(deps): bump bashkit to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace171a860c49083fbb7dd7fe6ebda7c6535aa24cdcf396b9edd9c71c4dd1d37"
+checksum = "9d79c5e19acc7434830f5e1fab3beb2bc40a2ecb7e357ff6a94051da1e09a5a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "getrandom 0.4.3",
- "gloo-timers",
  "hmac",
  "jaq-core",
  "jaq-json",
@@ -891,7 +890,6 @@ dependencies = [
  "regex",
  "reqwest 0.13.4",
  "rustls",
- "send_wrapper",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -902,7 +900,6 @@ dependencies = [
  "tower",
  "unit-prefix",
  "url",
- "web-time",
  "zeroize",
 ]
 
@@ -3751,18 +3748,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -7221,15 +7206,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "serde"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -84,7 +84,7 @@ futures-util.workspace = true
 flate2.workspace = true
 tar.workspace = true
 
-bashkit = { version = "0.16.0", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.17.0", features = ["scripted_tool", "jq"] }
 
 everruns-capability = { workspace = true }
 everruns-core = { path = "../core", features = ["openapi", "tree-sitter-outlines"] }

--- a/integrations/bashkit/Cargo.toml
+++ b/integrations/bashkit/Cargo.toml
@@ -21,7 +21,7 @@ everruns-capability.workspace = true
 everruns-core.workspace = true
 everruns-provider.workspace = true
 async-trait.workspace = true
-bashkit = { version = "0.16.0", features = ["jq", "http_client", "bot-auth"] }
+bashkit = { version = "0.17.0", features = ["jq", "http_client", "bot-auth"] }
 serde_json.workspace = true
 futures.workspace = true
 tokio = { workspace = true, features = ["rt", "sync", "time"] }


### PR DESCRIPTION
## What changed

Bumps the `bashkit` interpreter from 0.16.0 to 0.17.0 in `integrations/bashkit` (the `bashkit_shell` capability) and `crates/server` (the MCP endpoint's `query`/`execute` ScriptedTool). No API or behavior change on our side; 0.17.0 is a security-and-hardening release for the sandboxed shell:

- Untrusted input now costs bounded work everywhere it is parsed (script analysis, zip buffers, pipeline stderr aggregation, real-fs appends, snapshot chunk expansion, stdin reads).
- Sandbox escapes closed at the host boundary: no shell interpolation in the host bridge, VFS path normalization in `HostMounts`, backend symlink reads refused, YAML aliases rejected, arithmetic command substitutions flagged by static analysis.
- 16 wasmtime advisories cleared; every lockfile in the upstream tree audited.
- Always-on dependency graph is 21 crates smaller — visible here as `gloo-timers`, `send_wrapper`, and `web-time` dropping out of `Cargo.lock`.

Upstream's three breaking changes only affect `--no-default-features` consumers: `http_client` no longer implies a rustls crypto backend, timezone data moved behind a default-on `tzdata` feature, and non-ASCII domain names in HTTP allowlists are rejected rather than UTS-46 normalized. Both of our dependents keep default features, so `ring` and `tzdata` stay enabled and nothing needed adjusting. Everruns does not put internationalized domains in bashkit HTTP allowlists.

Release notes: https://github.com/everruns/bashkit/releases/tag/v0.17.0

## Why

Pick up the sandbox-hardening and advisory fixes in the shell interpreter that backs `bashkit_shell` and the MCP scripted tools.

## Before / After

No observable behavior change is intended. Verified the shell paths still behave identically on 0.17.0.

`bashkit_shell` end to end, via a session on the local agent stack (`PORT_PREFIX=271 AUTH_MODE=none`, Claude Sonnet 5), asking the agent to run a script through the tool:

```
tool_call   bash  commands: printf 'SMOKE-%s\n' "$(echo bashkit017 | tr a-z A-Z)" > /workspace/smoke.txt
                            cat /workspace/smoke.txt
                            echo '{"a":41}' | jq '.a + 1'
                            date -u +%Y

tool_result {"exit_code":0,"success":true,"truncated":false,
             "stdout":"SMOKE-BASHKIT017\n42\n2026\n"}
```

Redirection into `/workspace`, command substitution, `tr`, `cat`, `jq` arithmetic, and `date -u +%Y` (proving `tzdata` is still compiled in) all work, exit 0.

Server MCP endpoint, `query` tool (bashkit `ScriptedTool` + API builtins) — request `tools/call` `query` with
`commands: agents list --limit 3 | jq -r ".[].name // empty" ; printf "bashkit-ok %s\n" "$(echo hi | tr a-z A-Z)"`:

```
{"jsonrpc":"2.0","id":3,"result":{"content":[{"text":"bashkit-ok HI\n","type":"text"}]}}
```

Test and gate evidence:

```
$ cargo test -p everruns-integrations-bashkit --all-features
test result: ok. 99 passed; 0 failed
   Doc-tests: ok. 1 passed; 0 failed

$ cargo check -p everruns-server --all-targets --all-features
    Finished `dev` profile

$ just pre-push
✅ All pre-push checks passed.   (22/22, incl. fmt, clippy, Cargo.lock freshness)
```

CI on this PR: 43 checks green, 10 skipped, 0 failed.

## Risk

- Low
- The interpreter's hardening tightens bounds on untrusted input, so a pathological script that previously ran unbounded may now be refused. That is the intent of the release, and normal shell usage is unaffected — verified by the smoke tests above. No allowlist in this repo uses internationalized domain names, so the IDNA change is inert here.

## Security

- Threat categories reviewed: TM-EXEC (sandboxed shell execution) and TM-SUPPLY (dependency intake). The change is a version bump only — no Everruns code, config, or infrastructure changed. It strictly reduces exposure: it closes upstream sandbox-escape paths, adds resource bounds on untrusted script/archive/stream input, and clears 16 wasmtime advisories.
- Findings and resolutions: none. Checked that neither dependent disables default features, so dropping the implicit rustls backend does not silently leave `http_client` without `ring`.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated (existing `everruns-integrations-bashkit` suite covers the adapter; a version bump adds no new behavior to test)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)