### PR TITLE
chore(release): prepare v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-22
+
+### Highlights
+
+- **Chat with harnesses, archive chats, and generated run summaries** - Sessions gained interactive chats against harnesses, the ability to archive chats and toggle showing all of them, and automatically generated run summaries, with count badges on session detail tabs ([#3262](https://github.com/everruns/everruns/pull/3262), [#3265](https://github.com/everruns/everruns/pull/3265), [#3260](https://github.com/everruns/everruns/pull/3260), [#3266](https://github.com/everruns/everruns/pull/3266)).
+- **Connection-level custom provider headers** - Providers can now carry custom headers at the connection level, with cache diagnostics to see how they resolve; header values are redacted in diagnostics ([#3232](https://github.com/everruns/everruns/pull/3232), [#3240](https://github.com/everruns/everruns/pull/3240)).
+- **Leaner supply chain and smaller binaries** - Owning 114 small third-party contracts in-tree removed those dependencies from the build, and stripping plus CLI dispatch boxing shrank shipped binaries by ~22% ([#3245](https://github.com/everruns/everruns/pull/3245), [#3227](https://github.com/everruns/everruns/pull/3227)).
+
+### What's Changed
+
+- chore(deps): bump bashkit to 0.17.0 ([#3268](https://github.com/everruns/everruns/pull/3268)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): count badges on session detail tabs ([#3266](https://github.com/everruns/everruns/pull/3266)) by [@chaliy](https://github.com/chaliy)
+- chore(security): record why a scheduled session cannot read Dependabot alerts ([#3267](https://github.com/everruns/everruns/pull/3267)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): terminalize model-less chat turns ([#3264](https://github.com/everruns/everruns/pull/3264)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): archive chats and switch to show all ([#3265](https://github.com/everruns/everruns/pull/3265)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): rejoin users when they send messages ([#3263](https://github.com/everruns/everruns/pull/3263)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): allow chats with harnesses ([#3262](https://github.com/everruns/everruns/pull/3262)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): generated run summary ([#3260](https://github.com/everruns/everruns/pull/3260)) by [@chaliy](https://github.com/chaliy)
+- chore(skills): note that exporting OpenAPI requires regenerating UI types ([#3261](https://github.com/everruns/everruns/pull/3261)) by [@chaliy](https://github.com/chaliy)
+- fix(llm-tests): require live tool execution ([#3255](https://github.com/everruns/everruns/pull/3255)) by [@chaliy](https://github.com/chaliy)
+- fix(server): bound hydrated capability transport ([#3258](https://github.com/everruns/everruns/pull/3258)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): return public IDs in agent facets ([#3257](https://github.com/everruns/everruns/pull/3257)) by [@chaliy](https://github.com/chaliy)
+- fix(storage): release database connection during blob upload ([#3256](https://github.com/everruns/everruns/pull/3256)) by [@chaliy](https://github.com/chaliy)
+- fix(worker): cancel queued durable tasks ([#3254](https://github.com/everruns/everruns/pull/3254)) by [@chaliy](https://github.com/chaliy)
+- fix(platform): saturate discovery scores ([#3252](https://github.com/everruns/everruns/pull/3252)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): match runtime model resolution ([#3251](https://github.com/everruns/everruns/pull/3251)) by [@chaliy](https://github.com/chaliy)
+- fix(examples): reject duplicate subagent task ids ([#3250](https://github.com/everruns/everruns/pull/3250)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve case in workspace allow scopes ([#3249](https://github.com/everruns/everruns/pull/3249)) by [@chaliy](https://github.com/chaliy)
+- fix(everruns): reject ambiguous MCP server names ([#3248](https://github.com/everruns/everruns/pull/3248)) by [@chaliy](https://github.com/chaliy)
+- fix(build): secure shared pre-push cache ([#3246](https://github.com/everruns/everruns/pull/3246)) by [@chaliy](https://github.com/chaliy)
+- fix(everruns): bound live delta memory ([#3244](https://github.com/everruns/everruns/pull/3244)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): restrict chat routes to mutable threads ([#3243](https://github.com/everruns/everruns/pull/3243)) by [@chaliy](https://github.com/chaliy)
+- fix(everruns): redact function tool handler errors ([#3242](https://github.com/everruns/everruns/pull/3242)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): neutralize formulas in session CSV exports ([#3241](https://github.com/everruns/everruns/pull/3241)) by [@chaliy](https://github.com/chaliy)
+- fix(sandbox): reconcile uncommitted checkpoints on resume ([#3259](https://github.com/everruns/everruns/pull/3259)) by [@chaliy](https://github.com/chaliy)
+- fix(providers): redact custom header values ([#3240](https://github.com/everruns/everruns/pull/3240)) by [@chaliy](https://github.com/chaliy)
+- fix(sandbox): bind recovery state to session ([#3235](https://github.com/everruns/everruns/pull/3235)) by [@chaliy](https://github.com/chaliy)
+- refactor: remove 114 third-party crates by owning small contracts in-tree ([#3245](https://github.com/everruns/everruns/pull/3245)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): reject admin mode without credentials ([#3239](https://github.com/everruns/everruns/pull/3239)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): bound tag chip rendering ([#3238](https://github.com/everruns/everruns/pull/3238)) by [@chaliy](https://github.com/chaliy)
+- fix(core): fail closed in tool approval gate ([#3237](https://github.com/everruns/everruns/pull/3237)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): show full WebMCP message for approval ([#3236](https://github.com/everruns/everruns/pull/3236)) by [@chaliy](https://github.com/chaliy)
+- docs(everruns): rewrite framework readme by [@chaliy](https://github.com/chaliy)
+- feat(ci): publish open security alerts into a readable job log ([#3233](https://github.com/everruns/everruns/pull/3233)) by [@chaliy](https://github.com/chaliy)
+- feat(providers): connection-level custom headers and cache diagnostics ([#3232](https://github.com/everruns/everruns/pull/3232)) by [@chaliy](https://github.com/chaliy)
+- ci: restore the full Rust and integration matrix ([#3231](https://github.com/everruns/everruns/pull/3231)) by [@chaliy](https://github.com/chaliy)
+- chore(build): add just prune and settle why the library crates are large ([#3230](https://github.com/everruns/everruns/pull/3230)) by [@chaliy](https://github.com/chaliy)
+- chore(release): republish everruns-host as 0.20.1 by [@chaliy](https://github.com/chaliy)
+- perf: shrink shipped binaries by ~22% (strip + CLI dispatch boxing) ([#3227](https://github.com/everruns/everruns/pull/3227)) by [@chaliy](https://github.com/chaliy)
+- fix(release): break the crate-publish dev-dependency deadlock for 0.20.0 by [@chaliy](https://github.com/chaliy)
+
+### Crate Releases
+
+Independently versioned crates published this cycle (smallest compatible bump, breaking classification from the public-API diff):
+
+- `everruns-provider` 0.18.0 → 0.19.0 (breaking: new public fields `extra_headers`/`cache_diagnostics` on the constructible, non-`#[non_exhaustive]` structs `LlmCallConfig`, `ProviderConfig`, and `LlmCompletionMetadata`; new public `ProviderRequestOptions`/`ProviderRequestHeader`/`CacheDiagnosticsConfig`, `merge_request_headers`, and `AgentLoopError::model_not_configured`)
+- `everruns-platform` 0.18.2 → 0.19.0 (breaking: `SandboxCheckpointStore` gained a new required method `rollback_current_checkpoint`; new public fields on the constructible `Session` struct and new public `DurableToolResultStoreExt`)
+- `everruns-host` 0.20.1 → 0.20.2 (public `is_internal_session_secret_name` now reserves `session_sandbox`; typed model-not-configured error)
+- `everruns-core` 0.18.0 → 0.18.1 (`WorkspacePolicy` deny-matching is now case-insensitive)
+- `everruns-builtins` 0.18.1 → 0.18.2 (tool approval hook now fails closed and gates readonly + destructive/open-world tools)
+- `everruns-macros` 0.18.0 → 0.18.1 (`#[tool]` generated code returns a tool error instead of `Err` on bad arguments)
+- `everruns-anthropic` 0.18.0 → 0.18.1 (prompt-cache diagnostics; forwards connection `extra_headers`)
+- `everruns-gemini` 0.18.0 → 0.18.1 (forwards connection `extra_headers`)
+- `everruns` 0.18.2 → 0.18.3 (function-tool errors redacted as internal; session delta events omit accumulated data; MCP server-name validation)
+
+Cone cascade — patch republish to re-pin `everruns-provider`/`everruns-platform` at `0.19` (own contract unchanged): `everruns-engine` 0.18.1, `everruns-mcp` 0.19.1, `everruns-cli` 0.18.1, `everruns-ard` 0.18.1, `everruns-test-support` 0.18.3, `everruns-turbopuffer` 0.18.1, `everruns-llmsim` 0.18.3, and the remaining wire-protocol drivers (`everruns-bedrock`, `everruns-fireworks`, `everruns-mai`, `everruns-meta`, `everruns-openai`, `everruns-openrouter`) 0.18.1.
+
+No crates were deleted or absorbed this cycle. `everruns-capability` had no public-contract change and is outside the cone, so it is not re-released.
+
 ## [0.20.0] - 2026-08-19
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,16 +117,16 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+checksum = "7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f"
 dependencies = [
  "aead",
  "aes",
  "cipher",
  "ctr",
+ "ctutils",
  "ghash",
- "subtle",
 ]
 
 [[package]]
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.140.0"
+version = "1.141.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bca4d762965c0b7f5fb88ec0a4b48cfa1a22502e1a0283e5fd5d9498dae52b6"
+checksum = "6418b1f5feb3a8cc0fa10fb9af5693c88135ee03bae3ff48c8cdbf6a918daa07"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1528,9 +1528,9 @@ checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1735,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1745,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
@@ -1758,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
@@ -2034,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
 ]
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "everruns-provider",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "everruns-capability",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3040,15 +3040,16 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdd82ec52ab8b8a0e833d66b03f4bfeba24f34bbc4496201aa911b39d1c873"
+checksum = "44e81b00ef3e6c06be354695938d82584cd52250aef3b649fb2f493bd15118d4"
 dependencies = [
  "async-stream",
- "futures",
+ "eventsource-stream",
+ "futures-core",
+ "futures-util",
  "getrandom 0.4.3",
- "reqwest 0.12.28",
- "reqwest-eventsource",
+ "reqwest 0.13.4",
  "secrecy",
  "serde",
  "serde_json",
@@ -3060,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3161,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-test-support"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3184,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3202,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3463,21 +3464,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3786,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4110,22 +4096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4244,9 +4214,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4820,9 +4790,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.7+1.9.6"
+version = "0.18.8+1.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",
@@ -4924,9 +4894,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "logos"
@@ -5262,23 +5232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5558,47 +5511,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -6792,12 +6708,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -6807,7 +6721,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -6865,22 +6778,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.5.0",
  "web-sys",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest 0.12.28",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7071,9 +6968,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -8264,16 +8161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8924,9 +8811,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -9679,9 +9566,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -176,19 +176,19 @@ futures-util = "0.3"
 # Everruns SDK
 everruns-sdk = "0.2.0"
 everruns-capability = { path = "crates/capability", version = "0.18.0", default-features = false }
-everruns-builtins = { path = "crates/builtins", version = "0.18.1" }
-everruns-core = { path = "crates/core", version = "0.18.0" }
-everruns-engine = { path = "crates/engine", version = "0.18.0" }
-everruns-host = { path = "crates/host", version = "0.20.1" }
-everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.2", default-features = false }
+everruns-builtins = { path = "crates/builtins", version = "0.18.2" }
+everruns-core = { path = "crates/core", version = "0.18.1" }
+everruns-engine = { path = "crates/engine", version = "0.18.1" }
+everruns-host = { path = "crates/host", version = "0.20.2" }
+everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.3", default-features = false }
 everruns-test-support = { path = "crates/test-support", version = "0.18.2", default-features = false }
-everruns-platform = { path = "crates/platform", version = "0.18.2" }
-everruns-provider = { path = "crates/provider", version = "0.18.0", default-features = false }
-everruns-mcp = { path = "crates/mcp", version = "0.19.0" }
+everruns-platform = { path = "crates/platform", version = "0.19.0" }
+everruns-provider = { path = "crates/provider", version = "0.19.0", default-features = false }
+everruns-mcp = { path = "crates/mcp", version = "0.19.1" }
 everruns-ard = { path = "crates/ard", version = "0.18.0" }
-everruns-openai = { path = "crates/drivers/openai", version = "0.18.0" }
+everruns-openai = { path = "crates/drivers/openai", version = "0.18.1" }
 everruns = { path = "crates/everruns", version = "0.18.0" }
-everruns-macros = { path = "crates/macros", version = "0.18.0" }
+everruns-macros = { path = "crates/macros", version = "0.18.1" }
 everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.0" }
 everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.18.0" }
 everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.18.0" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/ard/Cargo.toml
+++ b/crates/ard/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 name = "everruns-ard"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-builtins"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ categories = ["development-tools", "asynchronous"]
 # execution values. It owns no host, platform, database, network, process, or
 # interpreter implementation edge.
 everruns-capability.workspace = true
-everruns-core = { path = "../core", version = "0.18.0", default-features = false }
+everruns-core = { path = "../core", version = "0.18.1", default-features = false }
 everruns-provider.workspace = true
 
 async-trait.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "everruns-cli"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-core"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/drivers/anthropic/Cargo.toml
+++ b/crates/drivers/anthropic/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-anthropic"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -43,7 +43,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.18.0" }
+everruns-provider = { path = "../../provider", version = "0.19.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/bedrock/Cargo.toml
+++ b/crates/drivers/bedrock/Cargo.toml
@@ -8,7 +8,7 @@ name = "everruns-bedrock"
 readme = "README.md"
 keywords = ["agent", "llm", "ai", "bedrock", "aws"]
 categories = ["api-bindings", "asynchronous"]
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -39,7 +39,7 @@ base64.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.18.0" }
+everruns-provider = { path = "../../provider", version = "0.19.0" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/drivers/fireworks/Cargo.toml
+++ b/crates/drivers/fireworks/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-fireworks"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -35,7 +35,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { version = "0.18.0", path = "../../provider" }
+everruns-provider = { version = "0.19.0", path = "../../provider" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures discovery requests;

--- a/crates/drivers/gemini/Cargo.toml
+++ b/crates/drivers/gemini/Cargo.toml
@@ -7,7 +7,7 @@ name = "everruns-gemini"
 readme = "README.md"
 keywords = ["agent", "llm", "ai", "gemini", "google"]
 categories = ["api-bindings", "asynchronous"]
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -39,7 +39,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.18.0" }
+everruns-provider = { path = "../../provider", version = "0.19.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/llmsim/Cargo.toml
+++ b/crates/drivers/llmsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-llmsim"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/drivers/mai/Cargo.toml
+++ b/crates/drivers/mai/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-mai"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { version = "0.18.0", path = "../../provider" }
+everruns-provider = { version = "0.19.0", path = "../../provider" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver/token requests;

--- a/crates/drivers/meta/Cargo.toml
+++ b/crates/drivers/meta/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "everruns-meta"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -24,7 +24,7 @@ serde.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.18.0" }
+everruns-provider = { path = "../../provider", version = "0.19.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/openai/Cargo.toml
+++ b/crates/drivers/openai/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-openai"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.18.0" }
+everruns-provider = { path = "../../provider", version = "0.19.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/openrouter/Cargo.toml
+++ b/crates/drivers/openrouter/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-openrouter"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -34,7 +34,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.18.0" }
+everruns-provider = { path = "../../provider", version = "0.19.0" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "everruns-engine"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "everruns-host"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -9,7 +9,7 @@
 
 [package]
 name = "everruns-macros"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-mcp"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "everruns-platform"
-version = "0.18.2"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns-provider"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "everruns-test-support"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -44,7 +44,7 @@ fixtures = ["dep:everruns-platform"]
 host = ["dep:everruns-host", "sim", "everruns-llmsim/host"]
 
 [dependencies]
-everruns-core = { path = "../core", version = "0.18.0", default-features = false }
+everruns-core = { path = "../core", version = "0.18.1", default-features = false }
 everruns-engine.workspace = true
 everruns-capability.workspace = true
 everruns-provider.workspace = true

--- a/crates/turbopuffer/Cargo.toml
+++ b/crates/turbopuffer/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-turbopuffer"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1093,9 +1093,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -1920,9 +1920,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2536,9 +2536,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2971,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## What changed

Cuts product release **v0.21.0** (from v0.20.0). Bumps `Cargo.toml` and `apps/ui/package.json` to `0.21.0`, adds the CHANGELOG entry, refreshes lockfiles, and performs the mandatory library-crate release audit.

Highlights this cycle: interactive chats against harnesses, archivable chats with show-all, generated run summaries and session tab count badges; connection-level custom provider headers with cache diagnostics; and a leaner supply chain (114 third-party crates owned in-tree, ~22% smaller shipped binaries).

### Library-crate release audit

Public-contract diffs since each crate's last crates.io release were reviewed. Crates released this cycle (smallest compatible bump):

**Own-merit contract changes**
- `everruns-provider` 0.18.0 → **0.19.0** (breaking): new public fields on the constructible, non-`#[non_exhaustive]` structs `LlmCallConfig`/`ProviderConfig`/`LlmCompletionMetadata`; new public `ProviderRequestOptions`/`ProviderRequestHeader`/`CacheDiagnosticsConfig`, `merge_request_headers`, `AgentLoopError::model_not_configured`.
- `everruns-platform` 0.18.2 → **0.19.0** (breaking): `SandboxCheckpointStore` gained a new required method `rollback_current_checkpoint`; new public fields on `Session`; new public `DurableToolResultStoreExt`.
- `everruns-host` 0.20.1 → **0.20.2** (patch): public `is_internal_session_secret_name` now reserves `session_sandbox`; typed model-not-configured error.
- `everruns-core` 0.18.0 → **0.18.1** (patch): case-insensitive `WorkspacePolicy` deny-matching.
- `everruns-builtins` 0.18.1 → **0.18.2** (patch): approval hook fails closed / gates readonly + risky tools.
- `everruns-macros` 0.18.0 → **0.18.1** (patch): `#[tool]` returns a tool error instead of `Err` on bad args.
- `everruns-anthropic` 0.18.0 → **0.18.1** (patch): cache diagnostics + forwards `extra_headers`.
- `everruns-gemini` 0.18.0 → **0.18.1** (patch): forwards `extra_headers`.
- `everruns` 0.18.2 → **0.18.3** (patch): function-tool error redaction; delta events omit accumulated data; MCP name validation.

**Cone cascade** (patch republish to re-pin `provider`/`platform` at 0.19; own contract unchanged): `everruns-engine` 0.18.1, `everruns-mcp` 0.19.1, `everruns-cli` 0.18.1, `everruns-ard` 0.18.1, `everruns-test-support` 0.18.3, `everruns-turbopuffer` 0.18.1, `everruns-llmsim` 0.18.3, `everruns-bedrock`/`everruns-fireworks`/`everruns-mai`/`everruns-meta`/`everruns-openai`/`everruns-openrouter` 0.18.1.

No crates deleted or absorbed. `everruns-capability` had no contract change and is outside the cone — not re-released. `python3 scripts/sync-publish-pin-versions.py --check` passes (40 packages).

## Why

Ship the accumulated changes since v0.20.0 as a released product version and publish the library crates whose public contracts moved, so crates.io does not drift behind source.

## Before / After

Release-mechanics change; no runtime behavior in this PR.
- `Cargo.toml` / `apps/ui/package.json`: `0.20.0` → `0.21.0`.
- Migrations verified strictly sequential (`001..125`).
- Pin cone verified: `sync-publish-pin-versions.py --check` → `verified for 40 package(s)`.
- External-consumer fixture lockfile refreshed to the new crate versions (was stale under `--locked`).
- Latest Integration Live Sweep on `main` is green.

## Risk
- Low
- Version/changelog/lockfile-only for the product; crate bumps are the audited minimum, and the Crate Release `strand-check` job gates cone completeness on merge.

## Security
- Threat categories reviewed: No security-relevant code changes in this PR (release metadata only). Included fixes (approval fail-closed, error redaction, MCP name validation) landed in their own reviewed PRs.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — release metadata; code changes tested in their own PRs)
- [x] Backward compatibility considered (breaking crate bumps classified; cone closed)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)