### PR TITLE
fix(release): cascade-bump integration crates to close the v0.21.0 cone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Independently versioned crates published this cycle (smallest compatible bump, b
 - `everruns-gemini` 0.18.0 → 0.18.1 (forwards connection `extra_headers`)
 - `everruns` 0.18.2 → 0.18.3 (function-tool errors redacted as internal; session delta events omit accumulated data; MCP server-name validation)
 
-Cone cascade — patch republish to re-pin `everruns-provider`/`everruns-platform` at `0.19` (own contract unchanged): `everruns-engine` 0.18.1, `everruns-mcp` 0.19.1, `everruns-cli` 0.18.1, `everruns-ard` 0.18.1, `everruns-test-support` 0.18.3, `everruns-turbopuffer` 0.18.1, `everruns-llmsim` 0.18.3, and the remaining wire-protocol drivers (`everruns-bedrock`, `everruns-fireworks`, `everruns-mai`, `everruns-meta`, `everruns-openai`, `everruns-openrouter`) 0.18.1.
+Cone cascade — patch republish to re-pin `everruns-provider`/`everruns-platform` at `0.19` (own contract unchanged): `everruns-engine` 0.18.1, `everruns-mcp` 0.19.1, `everruns-cli` 0.18.1, `everruns-ard` 0.18.1, `everruns-test-support` 0.18.3, `everruns-turbopuffer` 0.18.1, `everruns-llmsim` 0.18.3, the remaining wire-protocol drivers (`everruns-bedrock`, `everruns-fireworks`, `everruns-mai`, `everruns-meta`, `everruns-openai`, `everruns-openrouter`) 0.18.1, and every `everruns-integrations-*` crate (`bashkit`, `brave-search`, `browserless`, `cursor`, `daytona`, `deno`, `docker`, `duckduckgo`, `e2b`, `filesystem`, `github`, `lua`, `openai-image`, `openrouter-workspace`, `parallel`, `sprites`, `web-fetch`) 0.18.0 → 0.18.1.
 
 No crates were deleted or absorbed this cycle. `everruns-capability` had no public-contract change and is outside the cone, so it is not re-released.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d79c5e19acc7434830f5e1fab3beb2bc40a2ecb7e357ff6a94051da1e09a5a6"
+checksum = "eddf70256084490dc419937e9aae94d235a8da529be93e85bd7190b76ae12ebf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-bashkit"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-lua"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openrouter-workspace"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-web-fetch"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,12 +189,12 @@ everruns-ard = { path = "crates/ard", version = "0.18.0" }
 everruns-openai = { path = "crates/drivers/openai", version = "0.18.1" }
 everruns = { path = "crates/everruns", version = "0.18.0" }
 everruns-macros = { path = "crates/macros", version = "0.18.1" }
-everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.0" }
-everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.18.0" }
-everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.18.0" }
-everruns-integrations-duckduckgo = { path = "integrations/duckduckgo", version = "0.18.0" }
-everruns-integrations-lua = { path = "integrations/lua", version = "0.18.0" }
-everruns-integrations-openrouter-workspace = { path = "integrations/openrouter-workspace", version = "0.18.0" }
+everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.1" }
+everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.18.1" }
+everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.18.1" }
+everruns-integrations-duckduckgo = { path = "integrations/duckduckgo", version = "0.18.1" }
+everruns-integrations-lua = { path = "integrations/lua", version = "0.18.1" }
+everruns-integrations-openrouter-workspace = { path = "integrations/openrouter-workspace", version = "0.18.1" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/integrations/bashkit/Cargo.toml
+++ b/integrations/bashkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-bashkit"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/brave-search/Cargo.toml
+++ b/integrations/brave-search/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "everruns-integrations-brave-search"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/browserless/Cargo.toml
+++ b/integrations/browserless/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "everruns-integrations-browserless"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/cursor/Cargo.toml
+++ b/integrations/cursor/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "everruns-integrations-cursor"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/daytona/Cargo.toml
+++ b/integrations/daytona/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "everruns-integrations-daytona"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/deno/Cargo.toml
+++ b/integrations/deno/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "everruns-integrations-deno"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/docker/Cargo.toml
+++ b/integrations/docker/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "everruns-integrations-docker"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/duckduckgo/Cargo.toml
+++ b/integrations/duckduckgo/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-e2b"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/filesystem/Cargo.toml
+++ b/integrations/filesystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-filesystem"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-integrations-github"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/lua/Cargo.toml
+++ b/integrations/lua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-lua"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/openai-image/Cargo.toml
+++ b/integrations/openai-image/Cargo.toml
@@ -7,7 +7,7 @@
 [package]
 name = "everruns-integrations-openai-image"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/openrouter-workspace/Cargo.toml
+++ b/integrations/openrouter-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-openrouter-workspace"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/parallel/Cargo.toml
+++ b/integrations/parallel/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-integrations-parallel"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/sprites/Cargo.toml
+++ b/integrations/sprites/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "everruns-integrations-sprites"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/web-fetch/Cargo.toml
+++ b/integrations/web-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-web-fetch"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## What changed

Cascade-bump all 17 published `everruns-integrations-*` crates `0.18.0 → 0.18.1` so the Crate Release workflow republishes them re-pinned at `everruns-provider`/`everruns-platform` `^0.19`.

## Why

The v0.21.0 crate release (run [32594853586](https://github.com/everruns/everruns/actions/runs/32594853586)) left the release **partial**:

- v0.21.0 bumped `everruns-provider` and `everruns-platform` to `0.19.0` (breaking), but every published `everruns-integrations-*` crate still pins them at `^0.18`.
- Publishing the `everruns` facade failed while verifying its tarball — the graph pulled both `everruns-provider 0.19.0` and `0.18.0` (dragged in via `everruns-integrations-filesystem`), producing `expected ToolResultImage, found a different ToolResultImage` and `error: failed to verify package tarball`.
- The `strand-check` job then went red, listing the 17 integration crates (plus `everruns`, `everruns-ard`, `everruns-test-support`, `everruns-turbopuffer`, which already have higher unpublished workspace versions that self-resolve on republish).

The original audit closed the cone across `crates/` but missed the `integrations/` directory. This bumps the integration crates so the cone is complete.

## Before / After

- **Before:** Crate Release `release-crates` + `strand-check` red; `everruns` crate never published for v0.21.0.
- **After (local):** `sync-publish-pin-versions.py --check` → `verified for 40 package(s)`; `cargo metadata --locked` resolves for the workspace and the `external-consumer` fixture; all 17 integration crates at `0.18.1` pinning provider/platform `^0.19` (via `[workspace.dependencies]` at `0.19.0`).
- On merge, Crate Release republishes the integrations (and any remaining cone members) re-pinned at `^0.19`, unblocking the `everruns` facade publish and turning `strand-check` green. Idempotent: already-published crates (provider/platform `0.19.0`) are skipped.

## Risk
- Low
- Version-only bumps (no code change) plus lockfile refreshes; the `strand-check` job gates cone completeness on merge.

## Security
- Threat categories reviewed: none applicable (release metadata / version bumps only).
- Findings and resolutions: None.

## Checklist
- [x] Tests added or updated (n/a — crate-release metadata; guarded by CI `strand-check`)
- [x] Backward compatibility considered (patch republish; `^0.18` consumers still resolve, republished pins move to `^0.19`)