### PR TITLE
fix(release): republish everruns facade as 0.18.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Independently versioned crates published this cycle (smallest compatible bump, b
 - `everruns-macros` 0.18.0 → 0.18.1 (`#[tool]` generated code returns a tool error instead of `Err` on bad arguments)
 - `everruns-anthropic` 0.18.0 → 0.18.1 (prompt-cache diagnostics; forwards connection `extra_headers`)
 - `everruns-gemini` 0.18.0 → 0.18.1 (forwards connection `extra_headers`)
-- `everruns` 0.18.2 → 0.18.3 (function-tool errors redacted as internal; session delta events omit accumulated data; MCP server-name validation)
+- `everruns` 0.18.2 → 0.18.4 (function-tool errors redacted as internal; session delta events omit accumulated data; MCP server-name validation. Published as 0.18.4: the 0.18.3 crate publish was blocked by the integration-cone strand, and its `crate/everruns/v0.18.3` tag was left pinned to the pre-fix commit, so 0.18.4 is the identical facade republished under a fresh tag once the cone was closed.)
 
 Cone cascade — patch republish to re-pin `everruns-provider`/`everruns-platform` at `0.19` (own contract unchanged): `everruns-engine` 0.18.1, `everruns-mcp` 0.19.1, `everruns-cli` 0.18.1, `everruns-ard` 0.18.1, `everruns-test-support` 0.18.3, `everruns-turbopuffer` 0.18.1, `everruns-llmsim` 0.18.3, the remaining wire-protocol drivers (`everruns-bedrock`, `everruns-fireworks`, `everruns-mai`, `everruns-meta`, `everruns-openai`, `everruns-openrouter`) 0.18.1, and every `everruns-integrations-*` crate (`bashkit`, `brave-search`, `browserless`, `cursor`, `daytona`, `deno`, `docker`, `duckduckgo`, `e2b`, `filesystem`, `github`, `lua`, `openai-image`, `openrouter-workspace`, `parallel`, `sprites`, `web-fetch`) 0.18.0 → 0.18.1.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "base64 0.23.1",


### PR DESCRIPTION
## What changed

Bump the `everruns` facade crate `0.18.3 → 0.18.4` (identical code) so the Crate Release workflow can publish it.

## Why

After the integration cone was closed (#3270), every v0.21.0 library crate is on crates.io **except the `everruns` facade**. Its publish is stuck:

- The first (partial) Crate Release run created `crate/everruns/v0.18.3` pointing at the pre-fix commit `ec9c1157`, but the facade never published (the stranded integrations broke its verification build).
- The re-run from the cone-fix commit now fails the Publish Crate tag-trust check: `Package tag crate/everruns/v0.18.3 resolves to ec9c1157, expected 8f235178`.
- The agent egress proxy does not permit deleting a crate tag (git push and REST `DELETE /git/refs` both return 403), so the stale tag cannot be cleared.

Republishing the identical facade as **0.18.4** gives it a fresh tag at the current commit — the same "republish under a fresh tag" pattern used for `everruns-host` 0.20.1 earlier this release line.

## Before / After

- **Before:** `everruns` on crates.io stuck at `0.18.2` (pins provider `^0.18`); `strand-check` red because the facade could not publish.
- **After (local):** `everruns` = `0.18.4`; `sync-publish-pin-versions.py --check` → `verified for 40 package(s)`; `cargo metadata --locked` resolves for the workspace and the `external-consumer` fixture.
- On merge, Crate Release tags `crate/everruns/v0.18.4` at the merge commit and publishes it re-pinned at `everruns-provider`/`everruns-platform` `^0.19` and integrations `^0.18.1`, turning `strand-check` green. All other crates are already published, so the run only publishes the facade.

## Risk
- Low
- Single facade version bump (no code change) plus lockfile refreshes. Nothing published depends on the facade, so the bump strands nothing.

## Security
- Threat categories reviewed: none applicable (crate-release metadata / version bump only).
- Findings and resolutions: None.

## Checklist
- [x] Tests added or updated (n/a — crate-release metadata; guarded by CI `strand-check`)
- [x] Backward compatibility considered (identical facade code republished under a fresh version)