### PR TITLE
refactor(tls): standardise on aws-lc-rs and drop the second crypto backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83a251fa1a4c9d0fe6e816b7acd60549e473e08d14f27a1d992c2675abff05f"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "futures-util",
@@ -329,7 +330,6 @@ dependencies = [
  "portable-atomic",
  "rand 0.10.2",
  "regex",
- "ring",
  "rustls-native-certs",
  "rustls-pki-types",
  "rustls-webpki",
@@ -6901,7 +6901,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -8218,6 +8217,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "futures-core",
@@ -8225,7 +8225,6 @@ dependencies = [
  "http 1.5.0",
  "httparse",
  "rand 0.8.7",
- "ring",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ syn = { version = "3.0", features = ["full"] }
 trybuild = "1.0"
 
 # Database
-sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "migrate", "uuid", "chrono", "macros"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls-aws-lc-rs", "postgres", "migrate", "uuid", "chrono", "macros"] }
 
 # UUID and time
 uuid = { version = "1.11", features = ["v4", "v5", "v7", "serde"] }
@@ -143,10 +143,26 @@ object_store = { version = "0.14", features = ["aws"] }
 governor = "0.10"
 
 # Valkey/Redis (distributed rate limiting)
-fred = { version = "10", features = ["enable-rustls-ring", "i-scripts"] }
+fred = { version = "10", features = ["enable-rustls", "i-scripts"] }
 
 # NATS (event delivery, task queue)
-async-nats = "0.50"
+# Default features minus `ring`, plus `aws-lc-rs`: async-nats picks a rustls
+# backend through its own feature, and the workspace links exactly one (EVE-924).
+async-nats = { version = "0.50", default-features = false, features = [
+    "server_2_10",
+    "server_2_11",
+    "server_2_12",
+    "server_2_14",
+    "service",
+    "aws-lc-rs",
+    "jetstream",
+    "nkeys",
+    "crypto",
+    "object-store",
+    "kv",
+    "websockets",
+    "nuid",
+] }
 
 # Authentication
 argon2 = "0.5"
@@ -202,7 +218,7 @@ a2a-client = { package = "a2a-client-lf", version = "0.1" }
 a2a-server = { package = "a2a-server-lf", version = "0.3" }
 
 # gRPC (tonic)
-tonic = { version = "0.14", features = ["tls-ring"] }
+tonic = { version = "0.14", features = ["tls-aws-lc"] }
 tonic-prost = "0.14"
 tonic-build = "0.14"
 tonic-prost-build = "0.14"
@@ -239,7 +255,11 @@ notify-debouncer-mini = { version = "0.7", default-features = false }
 ignore = "0.4"
 
 # TLS
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
+# `aws-lc-rs` is rustls' own default backend and the one every third-party crate
+# in the graph already pins; standardising on it leaves a single crypto
+# implementation linked (EVE-924). Every other TLS-carrying dependency in this
+# file selects the same backend explicitly — keep them in sync when bumping.
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 
 # Plugin system for external integrations
 inventory = "0.3"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,7 +23,7 @@ clap.workspace = true
 
 # Everruns SDK
 everruns-sdk.workspace = true
-everruns-provider = { workspace = true, default-features = false, features = ["tls-ring"] }
+everruns-provider = { workspace = true, default-features = false, features = ["tls-aws-lc-rs"] }
 
 # HTTP client (for endpoints not yet in SDK)
 reqwest.workspace = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -171,7 +171,7 @@ pub enum CapabilitiesCommand {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    everruns_provider::install_ring_crypto_provider();
+    everruns_provider::install_default_crypto_provider();
 
     let cli = Cli::parse();
     let output_format = output::OutputFormat::from_str(&cli.output);

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -68,7 +68,7 @@ utility-openai = ["everruns-provider/http"]
 observability = [
     "direct-egress",
     "tokio/time",
-    "everruns-provider/tls-ring",
+    "everruns-provider/tls-aws-lc-rs",
     "dep:rand",
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",

--- a/crates/host/src/observability/telemetry.rs
+++ b/crates/host/src/observability/telemetry.rs
@@ -129,7 +129,7 @@ impl Drop for TelemetryGuard {
 /// }
 /// ```
 pub fn init_telemetry(config: TelemetryConfig) -> TelemetryGuard {
-    everruns_provider::install_ring_crypto_provider();
+    everruns_provider::install_default_crypto_provider();
 
     // Build resource with service info
     let mut resource_attrs = vec![KeyValue::new("service.name", config.service_name.clone())];

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -128,7 +128,7 @@ required-features = ["container-sandbox-live-tests"]
 
 [dev-dependencies]
 everruns-builtins.workspace = true
-everruns-provider = { workspace = true, features = ["tls-ring"] }
+everruns-provider = { workspace = true, features = ["tls-aws-lc-rs"] }
 a2a-server.workspace = true
 axum.workspace = true
 futures.workspace = true

--- a/crates/platform/src/capabilities/a2a_delegation.rs
+++ b/crates/platform/src/capabilities/a2a_delegation.rs
@@ -2114,7 +2114,7 @@ mod tests {
     }
 
     async fn spawn_real_a2a_agent() -> String {
-        everruns_provider::install_ring_crypto_provider();
+        everruns_provider::install_default_crypto_provider();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let base_url = format!("http://{addr}");

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -61,9 +61,10 @@ rustls = { workspace = true, optional = true }
 [features]
 default = ["http"]
 # Shared protocol drivers, request helpers, and streaming reconnect support.
-http = ["dep:reqwest", "dep:eventsource-stream", "dep:http", "dep:bytes", "tokio/net", "tls-ring"]
-# Process-wide ring selection for products that link multiple rustls providers.
-tls-ring = ["dep:rustls"]
+http = ["dep:reqwest", "dep:eventsource-stream", "dep:http", "dep:bytes", "tokio/net", "tls-aws-lc-rs"]
+# Process-wide crypto-provider install for products that build TLS clients.
+# The workspace links `aws-lc-rs` only (EVE-924).
+tls-aws-lc-rs = ["dep:rustls"]
 
 # OpenAPI schema derives (utoipa::ToSchema).
 openapi = ["dep:utoipa"]
@@ -72,7 +73,7 @@ sqlx = ["dep:sqlx"]
 
 [[test]]
 name = "tls_startup"
-required-features = ["http", "tls-ring"]
+required-features = ["http", "tls-aws-lc-rs"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/provider/README.md
+++ b/crates/provider/README.md
@@ -16,9 +16,9 @@ through `everruns`; provider implementers and low-level hosts depend here
 directly to avoid pulling in the agent-loop kernel.
 
 The default `http` feature provides the shared protocol implementations and
-selects the ring Rustls provider before constructing their clients. Contract-
+installs the Rustls crypto provider before constructing their clients. Contract-
 only consumers can use `default-features = false` to avoid HTTP and TLS
-dependencies entirely. The `tls-ring` feature exposes the idempotent startup
+dependencies entirely. The `tls-aws-lc-rs` feature exposes the idempotent startup
 initializer independently for binaries that assemble multiple TLS stacks.
 
 ## Quick Example

--- a/crates/provider/src/driver_helpers.rs
+++ b/crates/provider/src/driver_helpers.rs
@@ -125,7 +125,7 @@ pub fn shared_streaming_http_client() -> reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            crate::install_ring_crypto_provider();
+            crate::install_default_crypto_provider();
             harden_builder(
                 reqwest::Client::builder()
                     .connect_timeout(HTTP_CONNECT_TIMEOUT)
@@ -152,7 +152,7 @@ pub fn shared_request_http_client() -> reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT
         .get_or_init(|| {
-            crate::install_ring_crypto_provider();
+            crate::install_default_crypto_provider();
             harden_builder(
                 reqwest::Client::builder()
                     .connect_timeout(HTTP_CONNECT_TIMEOUT)

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -113,12 +113,15 @@ pub use user_facing_error::{
     parse_usage_limit_reset_at, trim_error_chain_prefixes,
 };
 
-/// Select ring as the process-wide rustls crypto provider.
+/// Select the workspace crypto backend as the process-wide rustls provider.
 ///
-/// Products that link more than one rustls provider call this once during
-/// startup, before constructing TLS clients. Repeated and concurrent calls are
-/// safe: rustls accepts the first installation and later calls are no-ops.
-#[cfg(feature = "tls-ring")]
-pub fn install_ring_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+/// The backend is a build-time choice — the workspace standardises on
+/// `aws-lc-rs` (EVE-924), so only one is ever linked. Products still call this
+/// once during startup, before constructing TLS clients, because rustls refuses
+/// to pick a default implicitly when a crate in the graph could install another.
+/// Repeated and concurrent calls are safe: rustls accepts the first
+/// installation and later calls are no-ops.
+#[cfg(feature = "tls-aws-lc-rs")]
+pub fn install_default_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }

--- a/crates/provider/tests/tls_startup.rs
+++ b/crates/provider/tests/tls_startup.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Barrier};
 
 #[test]
-fn concurrent_provider_clients_install_ring_without_panicking() {
+fn concurrent_provider_clients_install_crypto_provider_without_panicking() {
     const THREADS: usize = 24;
     let barrier = Arc::new(Barrier::new(THREADS));
     let mut handles = Vec::with_capacity(THREADS);
@@ -15,7 +15,7 @@ fn concurrent_provider_clients_install_ring_without_panicking() {
             } else {
                 let _ = everruns_provider::driver_helpers::shared_request_http_client();
             }
-            everruns_provider::install_ring_crypto_provider();
+            everruns_provider::install_default_crypto_provider();
         }));
     }
 
@@ -24,4 +24,30 @@ fn concurrent_provider_clients_install_ring_without_panicking() {
             .join()
             .expect("TLS client initialization must not panic");
     }
+
+    // The workspace links exactly one crypto backend (EVE-924). Naming
+    // `rustls::crypto::aws_lc_rs` at all is already a compile-time assertion
+    // that `aws-lc-rs` is the selected one — `rustls::crypto::ring` does not
+    // exist under this feature set. This checks the runtime half: that the
+    // provider the racing installers above actually won with is that backend,
+    // and not one a re-added `ring` dependency installed first.
+    let installed = rustls::crypto::CryptoProvider::get_default()
+        .expect("a crypto provider must be installed after client construction");
+    let expected = rustls::crypto::aws_lc_rs::default_provider();
+
+    let installed_suites: Vec<_> = installed
+        .cipher_suites
+        .iter()
+        .map(|suite| suite.suite())
+        .collect();
+    let expected_suites: Vec<_> = expected
+        .cipher_suites
+        .iter()
+        .map(|suite| suite.suite())
+        .collect();
+
+    assert_eq!(
+        installed_suites, expected_suites,
+        "process default crypto provider is not aws-lc-rs; a second rustls backend is linked"
+    );
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -84,7 +84,9 @@ futures-util.workspace = true
 flate2.workspace = true
 tar.workspace = true
 
-bashkit = { version = "0.17.0", features = ["scripted_tool", "jq"] }
+# `default-features = false` drops bashkit's default `ring`; the rest of its
+# default set is restored explicitly so only the crypto backend changes (EVE-924).
+bashkit = { version = "0.17.0", default-features = false, features = ["scripted_tool", "jq", "tzdata", "aws-lc-rs"] }
 
 everruns-capability = { workspace = true }
 everruns-core = { path = "../core", features = ["openapi", "tree-sitter-outlines"] }

--- a/crates/server/specs/cache.md
+++ b/crates/server/specs/cache.md
@@ -8,7 +8,7 @@ Caching and rate limiting strategy for everruns. PostgreSQL is the sole stateful
 
 Valkey is optional infrastructure for coordinating rate limits across 10+ control-plane instances.
 
-- **Crate**: `fred` v10 (`enable-rustls-ring`, `i-scripts` features)
+- **Crate**: `fred` v10 (`enable-rustls`, `i-scripts` features)
 - **Module**: `crates/server/src/valkey.rs`
 - **Env var**: `VALKEY_URL` (e.g., `redis://localhost:6379`). See `docs/sre/environment-variables.md`.
 - **Algorithm**: Sliding-window counter via atomic Lua script (sorted set per key)

--- a/docs/how-to/migrate-to-0-18.md
+++ b/docs/how-to/migrate-to-0-18.md
@@ -251,11 +251,11 @@ their effectful owners:
 | `driver_helpers`, `stream_reconnect` | `everruns_provider::` |
 | `OpenAiUtilityLlmService`, `SystemUtilityLlmConfig`, `UTILITY_OPENAI_API_KEY_ENV` | `everruns_host::` with `features = ["utility-openai"]` |
 
-Core no longer initializes Rustls. Provider HTTP clients install their ring
+Core no longer initializes Rustls. Provider HTTP clients install the workspace
 crypto provider when they are first constructed, while server, worker, and CLI
 startup owners install it eagerly. Custom binaries that combine TLS stacks can
-depend on `everruns-provider` with `features = ["tls-ring"]` and call
-`everruns_provider::install_ring_crypto_provider()` once during startup; the
+depend on `everruns-provider` with `features = ["tls-aws-lc-rs"]` and call
+`everruns_provider::install_default_crypto_provider()` once during startup; the
 call is idempotent and safe under concurrent initialization.
 
 ## Provider and typed-ID imports

--- a/integrations/bashkit/Cargo.toml
+++ b/integrations/bashkit/Cargo.toml
@@ -21,7 +21,9 @@ everruns-capability.workspace = true
 everruns-core.workspace = true
 everruns-provider.workspace = true
 async-trait.workspace = true
-bashkit = { version = "0.17.0", features = ["jq", "http_client", "bot-auth"] }
+# `default-features = false` drops bashkit's default `ring`; the rest of its
+# default set is restored explicitly so only the crypto backend changes (EVE-924).
+bashkit = { version = "0.17.0", default-features = false, features = ["jq", "http_client", "bot-auth", "bash_tool", "tzdata", "aws-lc-rs"] }
 serde_json.workspace = true
 futures.workspace = true
 tokio = { workspace = true, features = ["rt", "sync", "time"] }

--- a/integrations/browserless/src/cdp.rs
+++ b/integrations/browserless/src/cdp.rs
@@ -811,7 +811,7 @@ fn build_http11_tls_connector() -> Result<Connector, String> {
     for cert in rustls_native_certs::load_native_certs().certs {
         let _ = root_store.add(cert);
     }
-    let provider = rustls::crypto::ring::default_provider();
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
     let mut config = rustls::ClientConfig::builder_with_provider(provider.into())
         .with_safe_default_protocol_versions()
         .map_err(|e| format!("Failed to build TLS config: {e}"))?

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -811,7 +811,7 @@ fn build_http11_tls_connector() -> Result<Connector, String> {
     for cert in rustls_native_certs::load_native_certs().certs {
         let _ = root_store.add(cert);
     }
-    let provider = rustls::crypto::ring::default_provider();
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
     let mut config = rustls::ClientConfig::builder_with_provider(provider.into())
         .with_safe_default_protocol_versions()
         .map_err(|e| format!("Failed to build TLS config: {e}"))?

--- a/integrations/e2b/tests/live_api_test.rs
+++ b/integrations/e2b/tests/live_api_test.rs
@@ -59,7 +59,7 @@ impl Drop for SandboxGuard {
 async fn smoke_live_sandbox_exec_and_files() {
     // Test binary doesn't go through init_telemetry() or CLI main(),
     // so install the rustls CryptoProvider explicitly (rustls 0.23 requirement).
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let api_key = require_api_key!();
     let client = E2BClient::new(api_key.clone());

--- a/knowledge/project/dependency-surface.md
+++ b/knowledge/project/dependency-surface.md
@@ -129,6 +129,14 @@ binary carrying web-fetch, and was the only reason the workspace resolved a
 - Duplicate versions are mostly not ours to fix. `reqwest 0.12` alongside `0.13` comes
   from `everruns-sdk`, the `a2a-*-lf` crates, and `reqwest-eventsource`; `http 0.2` comes
   from the AWS SDK behind the Bedrock driver. Chase these by upgrading upstreams.
+- Exactly one rustls crypto backend is linked, and it is `aws-lc-rs` (EVE-924). A
+  duplicate backend is worse than a duplicate version: two C/assembly crypto libraries
+  mean two advisory streams, two FIPS stories, and a `CryptoProvider` that rustls cannot
+  choose on its own. Every TLS-carrying dependency in the root manifest therefore names
+  the backend explicitly — `rustls`, `sqlx`, `fred`, `tonic`, `async-nats`, `bashkit` —
+  so a bump cannot re-enable `ring` by inheriting a default. `cargo tree -i ring --target
+  all` printing nothing is the invariant; `crates/provider/tests/tls_startup.rs` asserts
+  the runtime half.
 
 ## Success Bar
 

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -1862,7 +1862,6 @@ checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",


### PR DESCRIPTION
## What changed

Every shipped binary linked two independent cryptographic implementations — `ring 0.17.14` alongside `aws-lc-rs 1.18.0` / `aws-lc-sys 0.44.0`. This drops `ring` entirely and standardises on `aws-lc-rs`, rustls' own default backend.

No behavior changes for users or callers. TLS remains enabled on every surface that had it, with the same root store and the same cipher-suite policy — only the implementation underneath changes.

Changed selections:

* workspace `rustls`, `sqlx`, `fred`, `tonic`, `async-nats`
* both `bashkit` dependencies, via `default-features = false` with the rest of its default set restored explicitly
* `everruns-provider`'s `tls-ring` feature and `install_ring_crypto_provider`, renamed to `tls-aws-lc-rs` and `install_default_crypto_provider` — the backend is a build-time choice now, so the old names were misleading
* the direct `rustls::crypto::ring::default_provider()` calls in the deno, browserless and e2b integrations

## Why

EVE-924 concluded this was not fixable from our own manifests: two third-party crates hard-coded `rustls/ring` with a fixed feature list, and Cargo unifies features across the graph. Both pinners have since cleared:

* `bashkit 0.17.1` added `ring` / `aws-lc-rs` features selecting `rustls?/<backend>` and `cfg`s its provider install on them, so `http_client` no longer implies a backend.
* `rakers` / `ureq` are no longer in the dependency graph at all.

With both gone, every remaining `ring` selection was ours. Two C/assembly crypto libraries mean two advisory streams to track, two FIPS/compliance stories, and a rustls `CryptoProvider` ambiguity that only an explicit process-wide install kept unambiguous.

## Before / After

`ring` is out of the build graph on every target:

```
$ cargo tree -i ring --target all          # before: 1193-line reverse tree
$ cargo tree -i ring --target all          # after
warning: nothing to print.
```

`aws-lc-rs` remains as the single backend. `Cargo.lock` still lists `ring`, but only as an *unselected optional* dependency of `hickory-proto`, `quinn-proto` and `rustls-webpki` — nothing builds it. That is deliberate: it keeps the RustSec gate conservative rather than blind.

Lockfile delta is exactly the three feature-driven swaps, nothing else:

```
 async-nats:       + aws-lc-rs   - ring
 rustls:                         - ring
 tokio-websockets: + aws-lc-rs   - ring
```

Real HTTPS handshakes through both shared provider clients, on the new backend:

```
streaming: HTTP 200 OK
request:   HTTP 200 OK
```

## Risk

- **Low**
- The realistic failure mode would be a feature swap that silently disables TLS or changes cert validation. Checked each one against the upstream manifests instead of assuming:
  - `sqlx`: `_tls-rustls-aws-lc-rs` = `_tls-rustls` + `rustls/aws-lc-rs` + `webpki-roots` — identical to the `_tls-rustls-ring-webpki` it replaces except for the backend, so DB TLS keeps the same webpki root store.
  - `fred`: `enable-rustls` carries the same `rustls-native-certs` / `tls12` / `logging` set as `enable-rustls-ring`.
  - `tonic`: `tls-aws-lc` mirrors `tls-ring` (`_tls-any` + `tokio-rustls/<backend>`), so gRPC mTLS is unaffected.
  - `async-nats` and `bashkit` use `default-features = false`; every non-crypto default is restored explicitly, so only the backend changed.
- The cross-compile risk EVE-924 flagged does not apply in this direction. `aws-lc-sys` was **already** linked into the release CLI on every target `cli-binaries.yml` builds (verified with `cargo tree -p everruns-cli -i aws-lc-sys` on `main`), so this removes a backend rather than adding one. No new C/assembly build surface.

## Security

- **Threat categories reviewed:** supply-chain / dependency risk; TLS transport integrity across the surfaces this touches — `TM-API-001` (database TLS via `sqlx`), `TM-DURABLE-002` (worker gRPC mTLS via `tonic`), `TM-AUTH-005` / `TM-LLM-006` (outbound HTTPS via the provider clients), and the Valkey `rediss://` path via `fred`.
- **Findings and resolutions:**
  - *Could a feature swap weaken cert validation?* No — verified per crate above; root stores and TLS versions are unchanged. This was the one finding worth chasing and it came back clean.
  - *Does removing a backend reduce security?* No. It halves the crypto advisory surface and removes the `CryptoProvider` ambiguity. `aws-lc-rs` is rustls' default and FIPS-capable; `ring` is not.
  - No `THREAT[...]` marker sits on any touched line, and no trust boundary moved, so `knowledge/security/threat-model.md` needed no update.

## Follow-ups

No follow-ups. The one durable risk — a future dependency bump silently re-enabling `ring` by inheriting a default — is closed in this PR rather than deferred: every TLS-carrying dependency now names its backend explicitly, `crates/provider/tests/tls_startup.rs` asserts the installed process default is aws-lc-rs, and the invariant plus its two checks are recorded in `knowledge/project/dependency-surface.md`.

## Validation

- `cargo check --workspace` — clean
- `just pre-push` — all 22 checks green (includes `cargo fmt`, clippy, Cargo.lock freshness, knowledge/OKF conformance)
- `cargo test -p everruns-provider --test tls_startup` — passes, now asserting the installed provider is aws-lc-rs
- Ad-hoc HTTPS smoke through both shared provider clients — 200 OK on each (temporary test, not committed)

Not run locally: the canonical `./scripts/start-agent-dev.sh` stack. This environment has no Doppler, Postgres or NATS, so the sqlx/NATS/Valkey/tonic connection paths are covered by CI's integration suite rather than a local smoke.

Fixes EVE-924


---
_Generated by [Claude Code](https://claude.ai/code/session_01BQZ1a9uSWmR22cAAjVvXw4)_