### PR TITLE
fix(builtins): hide redundant output recovery paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ futures-util = "0.3"
 # Everruns SDK
 everruns-sdk = "0.2.0"
 everruns-capability = { path = "crates/capability", version = "0.18.0", default-features = false }
-everruns-builtins = { path = "crates/builtins", version = "0.18.2" }
+everruns-builtins = { path = "crates/builtins", version = "0.18.3" }
 everruns-core = { path = "crates/core", version = "0.18.1" }
 everruns-engine = { path = "crates/engine", version = "0.18.1" }
 everruns-host = { path = "crates/host", version = "0.20.2" }

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-builtins"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/builtins/src/tool_output_persistence.rs
+++ b/crates/builtins/src/tool_output_persistence.rs
@@ -1,9 +1,9 @@
 // Tool Output Persistence Capability (EVE-222, EVE-245, EVE-562)
 //
 // Persists full exec tool output to session VFS before truncation,
-// enabling lossless retrieval via read_file/grep. The LLM gets a
-// truncated summary with `full_output` path and `output_files`
-// array pointing to the persisted files.
+// enabling lossless retrieval via read_file/grep. Persisted files stay
+// internal when the model-facing result is complete; limited results get a
+// `full_output` path and `output_files` array pointing to the missing content.
 //
 // Design decisions:
 // - Implemented as PostToolExecHook, not baked into each tool — VFS
@@ -11,7 +11,8 @@
 // - Reads `persist_output` hint from ToolDefinition to decide what to persist
 // - Writes stdout to /outputs/{safe_id}.stdout, stderr to
 //   /outputs/{safe_id}.stderr when stderr is persisted (session-scoped)
-// - Injects `output_files` array into result for agent to read selectively
+// - Injects recovery pointers only for streams whose persisted content is not
+//   fully present in the model-facing result
 // - Graceful degradation: skip silently if file_store is unavailable
 // - Runs as an always-on final hook before EVE-225 hard-limit truncation
 // - EVE-245: annotates truncated stdout with file reference so agent knows
@@ -160,8 +161,8 @@ pub fn annotate_truncated_output(truncated: &str, file_path: &str, full_size: us
 /// outcome. Default `auto` uses the compact success window or normal failure
 /// window; explicit modes retain their documented fixed budgets.
 ///
-/// The same budget applies to both `stdout`/`output` and `stderr`. Full content
-/// is always recoverable from the persisted `/outputs/` files.
+/// The same budget applies to both `stdout`/`output` and `stderr`. A recovery
+/// annotation is included only when stdout is actually limited.
 pub fn compact_persisted_result_for_model(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     stdout_path: &str,
@@ -170,12 +171,39 @@ pub fn compact_persisted_result_for_model(
 ) {
     let exit_code = result_exit_code(obj);
     let budget = output_verbosity_budget(resolve_auto_mode(output_mode, exit_code));
+    let stdout_needs_recovery =
+        model_stream_needs_recovery(obj, &["stdout", "output"], stdout_full_size, budget);
 
-    // Compact stdout (or output fallback field) and append file pointer.
+    compact_persisted_result_for_model_with_recovery(
+        obj,
+        stdout_path,
+        stdout_full_size,
+        budget,
+        stdout_needs_recovery,
+    );
+}
+
+fn compact_persisted_result_for_model_with_recovery(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    stdout_path: &str,
+    stdout_full_size: usize,
+    budget: Option<usize>,
+    stdout_needs_recovery: bool,
+) {
+    let exit_code = result_exit_code(obj);
+
+    // Compact stdout (or output fallback field), appending a pointer only when
+    // the persisted stream contains content absent from the inline result.
     for field in ["stdout", "output"] {
         if let Some(text) = obj.get(field).and_then(|v| v.as_str()) {
-            let compacted =
-                compact_with_annotation(text, budget, exit_code, stdout_path, stdout_full_size);
+            let compacted = compact_with_optional_annotation(
+                text,
+                budget,
+                exit_code,
+                stdout_path,
+                stdout_full_size,
+                stdout_needs_recovery,
+            );
             obj.insert(field.to_string(), json!(compacted));
             break; // only one of stdout/output is expected
         }
@@ -183,6 +211,33 @@ pub fn compact_persisted_result_for_model(
 
     // Compact stderr inline if present (no separate file pointer needed — already in output_files).
     compact_stderr_inline(obj, budget);
+}
+
+fn model_stream_needs_recovery(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    fields: &[&str],
+    full_size: usize,
+    budget: Option<usize>,
+) -> bool {
+    let Some(text) = fields
+        .iter()
+        .find_map(|field| obj.get(*field).and_then(|value| value.as_str()))
+    else {
+        return full_size > 0;
+    };
+
+    text.len() < full_size || budget.is_some_and(|budget| text.len() > budget)
+}
+
+fn model_stream_differs_from_full(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    fields: &[&str],
+    full_text: &str,
+) -> bool {
+    fields
+        .iter()
+        .find_map(|field| obj.get(*field).and_then(|value| value.as_str()))
+        .is_none_or(|text| text != full_text)
 }
 
 /// Compact the inline `stderr` field to `budget` bytes using outcome-aware truncation.
@@ -215,19 +270,25 @@ fn result_exit_code(obj: &serde_json::Map<String, serde_json::Value>) -> i32 {
     0
 }
 
-/// Compact `text` to `budget` bytes and append a file-reference annotation.
-fn compact_with_annotation(
+/// Compact `text` to `budget` bytes and append a file-reference annotation
+/// only when persisted content is absent from the inline result.
+fn compact_with_optional_annotation(
     text: &str,
     budget: Option<usize>,
     exit_code: i32,
     file_path: &str,
     full_size: usize,
+    needs_recovery: bool,
 ) -> String {
     let compacted = budget.filter(|budget| text.len() > *budget).map_or_else(
         || text.to_string(),
         |budget| truncate_exec_stream(text, budget, exit_code),
     );
-    annotate_truncated_output(&compacted, file_path, full_size)
+    if needs_recovery {
+        annotate_truncated_output(&compacted, file_path, full_size)
+    } else {
+        compacted
+    }
 }
 
 pub const TOOL_OUTPUT_PERSISTENCE_CAPABILITY_ID: &str = "tool_output_persistence";
@@ -331,39 +392,50 @@ impl PostToolExecHook for PersistOutputHook {
                 .get("output")
                 .and_then(|value| value.as_str())
                 .unwrap_or("auto");
-            // Enrich result JSON with file references and compact inline output (EVE-562).
+            // Compact model-facing output. Persistence is unconditional, but
+            // recovery affordances are reserved for content absent inline.
             if let Some(ref mut json_val) = result.result
                 && let Some(obj) = json_val.as_object_mut()
             {
                 let mut output_files = Vec::new();
+                let exit_code = result_exit_code(obj);
+                let budget = output_verbosity_budget(resolve_auto_mode(output_mode, exit_code));
+                let stdout_needs_recovery =
+                    model_stream_needs_recovery(obj, &["stdout", "output"], stdout.len(), budget)
+                        || model_stream_differs_from_full(obj, &["stdout", "output"], stdout);
+                let stderr_needs_recovery =
+                    model_stream_needs_recovery(obj, &["stderr"], stderr.len(), budget)
+                        || model_stream_differs_from_full(obj, &["stderr"], stderr);
 
                 if let Some(ref path) = persist_result.stdout_path {
                     let display_path = file_store.display_path(path);
-                    compact_persisted_result_for_model(
+                    compact_persisted_result_for_model_with_recovery(
                         obj,
                         &display_path,
                         stdout.len(),
-                        output_mode,
+                        budget,
+                        stdout_needs_recovery,
                     );
 
-                    output_files.push(display_path.clone());
-                    // full_output points to the stdout file only; stderr (if persisted)
-                    // is available via the output_files array
-                    obj.insert("full_output".to_string(), json!(display_path));
-                    obj.insert(
-                        "total_lines".to_string(),
-                        json!(persist_result.stdout_total_lines),
-                    );
+                    if stdout_needs_recovery {
+                        output_files.push(display_path.clone());
+                        // full_output points to the stdout file only; stderr (if
+                        // limited) is available via the output_files array.
+                        obj.insert("full_output".to_string(), json!(display_path));
+                        obj.insert(
+                            "total_lines".to_string(),
+                            json!(persist_result.stdout_total_lines),
+                        );
+                    }
                 }
 
                 if let Some(ref path) = persist_result.stderr_path {
-                    output_files.push(file_store.display_path(path));
+                    if stderr_needs_recovery {
+                        output_files.push(file_store.display_path(path));
+                    }
                     // Compact stderr inline when stdout was not persisted (if stdout was
                     // persisted, compact_persisted_result_for_model already handled this).
                     if persist_result.stdout_path.is_none() {
-                        let exit_code = result_exit_code(obj);
-                        let budget =
-                            output_verbosity_budget(resolve_auto_mode(output_mode, exit_code));
                         compact_stderr_inline(obj, budget);
                     }
                 }
@@ -663,6 +735,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_hook_retains_complete_output_without_advertising_recovery() {
+        let complete = "build finished successfully\nall checks passed";
+        let store = Arc::new(MockFileStore::default());
+        let mut context = ToolContext::new(test_session_id());
+        context.file_store = Some(store.clone());
+        let tool_call = ToolCall {
+            id: "call-complete".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({"command": "cargo test", "output": "normal"}),
+        };
+        let mut result = ToolResult {
+            tool_call_id: tool_call.id.clone(),
+            result: Some(json!({
+                "stdout": complete,
+                "stderr": "",
+                "exit_code": 0,
+                "success": true,
+                "truncated": false,
+                "output_limited": false,
+            })),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: Some(complete.to_string()),
+        };
+
+        PersistOutputHook
+            .after_exec(&tool_call, &persistence_tool_def(), &mut result, &context)
+            .await;
+
+        let value = result.result.as_ref().unwrap();
+        assert_eq!(value["stdout"], json!(complete));
+        assert!(value.get("full_output").is_none());
+        assert!(value.get("output_files").is_none());
+        assert_eq!(
+            store.content("/outputs/call-complete.stdout").as_deref(),
+            Some(complete)
+        );
+    }
+
+    #[tokio::test]
     async fn test_hook_honors_explicit_normal_and_persists_losslessly() {
         let mut lines = vec!["src/runtime.rs:10: first relevant match".to_string()];
         lines.extend((0..1200).map(|i| format!("src/module_{i}.rs: ordinary source line")));
@@ -700,6 +813,12 @@ mod tests {
         assert!(inline.len() > AUTO_SUCCESS_BUDGET + 200);
         assert!(inline.len() <= NORMAL_BUDGET + 200);
         assert!(inline.contains("first relevant match"));
+        let value = result.result.as_ref().unwrap();
+        assert_eq!(value["output_files"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            value["full_output"],
+            json!("/workspace/outputs/call-normal.stdout")
+        );
         assert_eq!(
             store.content("/outputs/call-normal.stdout").as_deref(),
             Some(full_output.as_str())
@@ -873,7 +992,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compact_small_stdout_unchanged_except_annotation() {
+    fn test_compact_small_stdout_stays_complete_without_annotation() {
         let small = "hello world";
         let mut obj = serde_json::Map::new();
         obj.insert("stdout".to_string(), json!(small));
@@ -881,19 +1000,11 @@ mod tests {
 
         compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", small.len(), "auto");
 
-        let inline = obj["stdout"].as_str().unwrap();
-        assert!(
-            inline.starts_with("hello world"),
-            "small content must be preserved"
-        );
-        assert!(
-            inline.contains("full output saved to"),
-            "must have file pointer"
-        );
+        assert_eq!(obj["stdout"], json!(small));
     }
 
     #[test]
-    fn test_compact_oversized_full_mode_stays_full() {
+    fn test_compact_full_mode_stays_complete_without_annotation() {
         let large = "z".repeat(NORMAL_BUDGET * 3);
         let large_len = large.len();
         let mut obj = serde_json::Map::new();
@@ -902,9 +1013,7 @@ mod tests {
 
         compact_persisted_result_for_model(&mut obj, "/outputs/call.stdout", large_len, "full");
 
-        let inline = obj["stdout"].as_str().unwrap();
-        assert!(inline.starts_with(&large));
-        assert!(inline.contains("full output saved to"));
+        assert_eq!(obj["stdout"], json!(large));
     }
 
     #[test]

--- a/crates/host/tests/model_visible_path_identity_test.rs
+++ b/crates/host/tests/model_visible_path_identity_test.rs
@@ -236,14 +236,16 @@ async fn assert_persistence_identity(store: Arc<dyn SessionFileSystem>, wrap_mou
     let mut persist_result = ToolResult {
         tool_call_id: "call_identity".to_string(),
         result: Some(json!({
-            "stdout": "stdout body",
-            "stderr": "stderr body",
+            "stdout": "stdout preview",
+            "stderr": "stderr preview",
             "exit_code": 0,
         })),
         images: None,
         error: None,
         connection_required: None,
-        raw_output: Some("stdout body\n--- stderr ---\nstderr body".to_string()),
+        raw_output: Some(
+            "stdout body beyond preview\n--- stderr ---\nstderr body beyond preview".to_string(),
+        ),
     };
     PersistOutputHook
         .after_exec(

--- a/crates/host/tests/workspace_paths_conformance_test.rs
+++ b/crates/host/tests/workspace_paths_conformance_test.rs
@@ -78,14 +78,16 @@ async fn assert_output_pointers_follow_store(store: Arc<dyn SessionFileSystem>) 
     let mut result = ToolResult {
         tool_call_id: "call_paths".to_string(),
         result: Some(json!({
-            "stdout": "stdout body",
-            "stderr": "stderr body",
+            "stdout": "stdout preview",
+            "stderr": "stderr preview",
             "exit_code": 0,
         })),
         images: None,
         error: None,
         connection_required: None,
-        raw_output: Some("stdout body\n--- stderr ---\nstderr body".to_string()),
+        raw_output: Some(
+            "stdout body beyond preview\n--- stderr ---\nstderr body beyond preview".to_string(),
+        ),
     };
 
     PersistOutputHook

--- a/docs/advanced/tool-output-pipeline.md
+++ b/docs/advanced/tool-output-pipeline.md
@@ -68,7 +68,7 @@ Distillation is on by default in the **generic harness**. Every transform is det
 
 Two infrastructure hooks always run last, in order:
 
-1. **Persist Output**: for tools that declare the `persist_output` hint (exec/sandbox), writes the full `raw_output` to the session VFS and annotates the inline result with a pointer. It **skips** if a result already carries `output_files` (e.g. distillation already persisted it), so the two never double-write.
+1. **Persist Output**: for tools that declare the `persist_output` hint (exec/sandbox), writes the full `raw_output` to the session VFS. When content is absent from the inline result, it adds a recovery pointer; complete inline results keep the retained file internal and do not invite a redundant read. It **skips** if a result already carries `output_files` (e.g. distillation already persisted it), so the two never double-write.
 2. **Output Hard Limit**: a final, unremovable 64 KiB ceiling. By the time it runs, the result has usually already been budgeted or distilled, so it rarely fires; it's a backstop against pathological cases.
 
 ## The destination, where full output lives
@@ -80,7 +80,7 @@ Everything the pipeline elides is recoverable from the **session filesystem**:
 <display-root>/outputs/{tool_call_id}.stderr    ← full standard error (when present)
 ```
 
-The inline result carries the pointer in `output_files` and `full_output`, plus a human-readable note telling the model to use `read_file` (with `offset`/`limit`) when it needs detail it can't see inline. Persisted streams are capped at 1 MiB each. Deleting the session cascades and removes them.
+When the inline result omits persisted content, it carries the recovery pointer in `output_files` and `full_output`, plus a human-readable note telling the model to use `read_file` (with `offset`/`limit`) for the missing detail. Complete inline output has no model-facing pointer. Persisted streams are capped at 1 MiB each. Deleting the session cascades and removes them.
 
 This is the key to aggressive shrinking: because the original is one `read_file` away, the inline view can be small without the agent losing the ability to drill in.
 

--- a/knowledge/execution/tool-execution.md
+++ b/knowledge/execution/tool-execution.md
@@ -181,7 +181,7 @@ All exec tools accept an `output` parameter controlling how much output is retur
 | `verbose` | ~16 KiB | Test failures, error investigation |
 | `full` | unlimited | Raw output, no truncation, when the LLM needs every line |
 
-Default is `auto`. In `auto` mode, the resolved budget depends on the process exit code: successful runs (`exit_code == 0`) collapse to `AUTO_SUCCESS_BUDGET` so the model relies on the persisted log; non-zero exits resolve to `normal` (~8 KiB) so failures stay debuggable in-loop. `AUTO_SUCCESS_BUDGET` is intentionally sized so the inline `stdout` field, including the `[full output saved to ... — use read_file ...]` pointer that `PersistOutputHook` appends, stays around 512 bytes total. The pointer uses the session filesystem's display identity. `raw_output` always carries the full cleaned output for persistence hooks, regardless of mode. The persistence hook reads the original tool-call argument and does not re-resolve explicit `silent`/`concise`/`normal`/`verbose`/`full` modes to `auto`; those modes retain their fixed inline window and ignore exit code.
+Default is `auto`. In `auto` mode, the resolved budget depends on the process exit code: successful runs (`exit_code == 0`) collapse to `AUTO_SUCCESS_BUDGET`; non-zero exits resolve to `normal` (~8 KiB) so failures stay debuggable in-loop. When that budget omits content, `PersistOutputHook` adds a recovery pointer and keeps the inline `stdout` field around 512 bytes total. When all content fits inline, persistence remains internal and no recovery affordance is exposed. Model-visible pointers use the session filesystem's display identity. `raw_output` always carries the full cleaned output for persistence hooks, regardless of mode. The persistence hook reads the original tool-call argument and does not re-resolve explicit `silent`/`concise`/`normal`/`verbose`/`full` modes to `auto`; those modes retain their fixed inline window and ignore exit code.
 
 Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Tools that set the `persist_output` hint persist non-empty full output to `/outputs/` via `tool_output_persistence`, stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr`, and the files are readable with `read_file`. The persisted files are the source of truth for full logs; the inline payload is sized for next-step reasoning. See `crates/core/src/tool_output_sanitizer.rs` for budget constants, `output_verbosity_budget()`, and `resolve_auto_mode()`.
 
@@ -210,8 +210,8 @@ Human-facing exec tools should return a structured result instead of a single co
 | `hint` | string | Short diagnostic hint for signal exits or common recovery advice |
 | `truncated` | boolean | Whether stdout or stderr was truncated for the inline result |
 | `total_lines` | integer | Total stdout line count before truncation |
-| `output_files` | string[] | Model-visible, file-tool-readable paths containing full persisted output |
-| `full_output` | string | Model-visible, file-tool-readable stdout path when persisted |
+| `output_files` | string[] | Model-visible, file-tool-readable paths for persisted content absent inline |
+| `full_output` | string | Model-visible, file-tool-readable stdout path when stdout is limited inline |
 
 **Legacy compatibility:** Tools may continue to carry a combined pre-truncation string in `ToolResult.raw_output` for persistence hooks and logging, but the user-visible JSON contract should use `stdout`/`stderr`.
 
@@ -353,7 +353,7 @@ Two hook slots run in sequence:
 2. **Final hooks** (`final_post_tool_hooks`), always-on infrastructure (e.g. EVE-225 hard limit)
 
 Current hooks:
-- **PersistOutputHook** (`tool_output_persistence` capability; also installed as an always-on final hook): When a tool declares `persist_output: true` in hints, writes stdout to `/outputs/{tool_call_id}.stdout` and stderr to `/outputs/{tool_call_id}.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. It skips cleanly if no session file store is present, and skips if another hook already injected `output_files`. See `crates/builtins/src/tool_output_persistence.rs`.
+- **PersistOutputHook** (`tool_output_persistence` capability; also installed as an always-on final hook): When a tool declares `persist_output: true` in hints, writes stdout to `/outputs/{tool_call_id}.stdout` and stderr to `/outputs/{tool_call_id}.stderr` in session VFS. It injects `full_output`, `total_lines`, and `output_files` only for persisted content absent from the inline result, keeping complete-output retention internal. It skips cleanly if no session file store is present, and skips if another hook already injected `output_files`. See `crates/builtins/src/tool_output_persistence.rs`.
 - **DistillOutputHook** (`tool_output_distillation` capability): For tools that do *not* declare `persist_output` (notably MCP and `web_fetch`), produces a content-aware compact inline view of large results (array sampling, string head+tail, unified-diff summary) while self-persisting the full original to `/outputs/{tool_call_id}.stdout` and injecting the same `output_files` pointer. Runs as a capability hook (before the final hooks); the `output_files` guard above prevents double-writes with PersistOutputHook. Restores the verbatim original if persistence fails. See `crates/builtins/src/tool_output_distillation.rs` and `knowledge/execution/tool-output-distillation.md`.
 
 Current final hooks (always-on, cannot be removed):

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,12 @@
 # Everruns Knowledge Update Log
 
+## 2026-08-24
+
+* **Output retention is not a recovery affordance.** Persistence-enabled tools
+  retain non-empty output in the session filesystem, but expose model-facing
+  recovery paths only for content absent from the inline result. Complete output
+  must not induce a redundant file-tool round.
+
 ## 2026-08-22
 
 * **A scheduled session's GitHub identity is not negotiable, so "try another

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",


### PR DESCRIPTION
## What changed
Persistence-enabled tools still retain non-empty stdout and stderr in the session filesystem, but complete model-facing output no longer exposes `full_output`, `output_files`, or a read-file annotation. Limited output keeps one readable recovery path, its bounded inline window, and leading evidence.

This also releases `everruns-builtins` 0.18.3 and updates the public and durable output-pipeline contracts.

## Why
The persistence hook previously treated retention as an instruction to recover. Even when every byte was already inline, the result advertised a saved path and told the model to call `read_file`, inducing a redundant model and tool round.

## Before / After
Before, the focused regression observed:

```text
left:  "build finished successfully\nall checks passed\n\n[full output saved to /workspace/outputs/call-complete.stdout (0 KiB) — use read_file with offset/limit]"
right: "build finished successfully\nall checks passed"
```

After, the same hook-level test proves the stdout is unchanged, `full_output` and `output_files` are absent, and `/outputs/call-complete.stdout` still contains the complete retained bytes. The limited-output control proves exactly one output path remains and the leading `first relevant match` survives inline compaction.

Validation:

- `cargo test -p everruns-builtins`, 539 unit tests, 4 integration tests, and doctests pass
- `cargo clippy -p everruns-builtins --all-targets --all-features -- -D warnings`
- host filesystem identity suite, 6 tests pass
- host Act-loop persistence-before-hard-limit test passes
- external-consumer shell suite passes with its release lockfile refreshed
- `cargo semver-checks --package everruns-builtins --baseline-version 0.18.2`, 196 checks pass, no semver update required
- `just check-okf`, 150 concepts conformant
- `just pre-push` passes every non-lint guard; its workspace-wide macOS clippy reaches an unchanged `origin/main` error in `crates/durable/src/sysstat.rs` where Linux-only `USER_HZ` is referenced outside a cfg gate. The affected builtins clippy command above is green.
- final GitHub CI is green, including the pure, PostgreSQL, S3, shell, clippy, release-build, SDK compatibility, docs, and isolation jobs

## Risk
- Low
- Callers that incorrectly assumed every persisted stream is model-visible will no longer see paths for already-complete output. Retention itself, session scoping, path identity, the 1 MiB storage cap, limited-output recovery, and the 64 KiB hard result cap are unchanged.

## Security
- Threat categories reviewed: TM-FS, TM-TOOL, TM-AGENT, TM-DOS
- Findings and resolutions: session-scoped writes, safe tool-call ID filtering, and persisted-stream caps are unchanged. The new comparisons are linear in already-bounded output. Complete results expose less filesystem metadata and tool-result steering; limited results retain the existing static annotation and readable display path. No new threat or mitigation change requires a threat-model entry.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
