### PR TITLE
fix(narration): name the agent that spawn_agent spawns

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1580,20 +1580,16 @@ impl Tool for UnifiedSpawnAgentTool {
         // A call still streaming its arguments, or one naming an unknown
         // target, must not fall back to "Running Spawn Agent": narrate the
         // delegation directly so the line always names the agent being spawned.
-        tool_call
+        let from_provider = tool_call
             .arguments
             .get("target")
             .and_then(|target| target.get("type"))
             .and_then(serde_json::Value::as_str)
             .and_then(|target_type| self.provider_for(target_type))
-            .and_then(|tool| tool.narrate(tool_call, phase, locale, ctx))
-            .or_else(|| {
-                Some(crate::tool_narration::narrate_subagent_spawn(
-                    &tool_call.arguments,
-                    phase,
-                    locale,
-                ))
-            })
+            .and_then(|tool| tool.narrate(tool_call, phase, locale, ctx));
+        Some(from_provider.unwrap_or_else(|| {
+            crate::tool_narration::narrate_subagent_spawn(&tool_call.arguments, phase, locale)
+        }))
     }
 
     fn name(&self) -> &str {

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1577,13 +1577,23 @@ impl Tool for UnifiedSpawnAgentTool {
         locale: Option<&str>,
         ctx: crate::tool_narration::ToolNarrationContext<'_>,
     ) -> Option<String> {
-        let target_type = tool_call
+        // A call still streaming its arguments, or one naming an unknown
+        // target, must not fall back to "Running Spawn Agent": narrate the
+        // delegation directly so the line always names the agent being spawned.
+        tool_call
             .arguments
             .get("target")
             .and_then(|target| target.get("type"))
-            .and_then(serde_json::Value::as_str)?;
-        self.provider_for(target_type)
+            .and_then(serde_json::Value::as_str)
+            .and_then(|target_type| self.provider_for(target_type))
             .and_then(|tool| tool.narrate(tool_call, phase, locale, ctx))
+            .or_else(|| {
+                Some(crate::tool_narration::narrate_subagent_spawn(
+                    &tool_call.arguments,
+                    phase,
+                    locale,
+                ))
+            })
     }
 
     fn name(&self) -> &str {
@@ -2728,6 +2738,82 @@ mod tests {
     // that contributes nothing, one that contributes plain tools, and one
     // that carries mounts plus a dependency.
     // -------------------------------------------------------------------------
+
+    struct StubSubagentSpawnTool;
+
+    #[async_trait]
+    impl Tool for StubSubagentSpawnTool {
+        fn name(&self) -> &str {
+            "spawn_agent"
+        }
+        fn description(&self) -> &str {
+            "stub subagent delegation"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object" })
+        }
+        fn narrate(
+            &self,
+            tool_call: &ToolCall,
+            phase: crate::tool_narration::ToolNarrationPhase,
+            locale: Option<&str>,
+            _ctx: crate::tool_narration::ToolNarrationContext<'_>,
+        ) -> Option<String> {
+            Some(crate::tool_narration::narrate_subagent_spawn(
+                &tool_call.arguments,
+                phase,
+                locale,
+            ))
+        }
+        async fn execute(&self, _arguments: serde_json::Value) -> crate::ToolExecutionResult {
+            crate::ToolExecutionResult::success(serde_json::json!({}))
+        }
+    }
+
+    fn spawn_agent_call(arguments: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: "call-1".to_string(),
+            name: "spawn_agent".to_string(),
+            arguments,
+        }
+    }
+
+    /// The dispatcher always names the agent being spawned, including when the
+    /// call carries no usable `target.type` yet.
+    #[test]
+    fn unified_spawn_agent_narration_names_the_agent() {
+        let tool = UnifiedSpawnAgentTool::new(vec![DelegationTargetProvider {
+            target_type: "subagent",
+            tool: Box::new(StubSubagentSpawnTool),
+        }]);
+        let ctx = crate::tool_narration::ToolNarrationContext::default();
+
+        assert_eq!(
+            tool.narrate(
+                &spawn_agent_call(serde_json::json!({
+                    "name": "Orbit Scout",
+                    "target": { "type": "subagent" },
+                    "blueprint": "github_scout"
+                })),
+                crate::tool_narration::ToolNarrationPhase::Started,
+                None,
+                ctx,
+            )
+            .as_deref(),
+            Some("Launching Orbit Scout subagent (github_scout)")
+        );
+
+        assert_eq!(
+            tool.narrate(
+                &spawn_agent_call(serde_json::json!({ "name": "Orbit Scout" })),
+                crate::tool_narration::ToolNarrationPhase::Started,
+                None,
+                ctx,
+            )
+            .as_deref(),
+            Some("Launching Orbit Scout subagent")
+        );
+    }
 
     /// Contributes nothing: no tools, no prompt, no dependencies.
     struct NoopFixture;

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -622,32 +622,64 @@ pub fn narrate_secret_store(
     }
 }
 
-/// Subagent delegation narration.
+/// Which agent a `spawn_agent` call delegates to: the blueprint for a subagent
+/// target, otherwise the configured target id.
+fn spawn_agent_identity(arguments: &Value) -> Option<String> {
+    let target = arguments.get("target");
+    let id = target
+        .and_then(|target| arg_str(target, &["id", "external_agent_id"]))
+        .map(|id| truncate(id, 40));
+    arg_str(arguments, &["blueprint"])
+        .map(|blueprint| truncate(blueprint, 40))
+        .or(id)
+}
+
+/// The kind of agent being spawned, from `target.type`.
+fn spawn_agent_kind(arguments: &Value, uk: bool) -> &'static str {
+    let target_type = arguments
+        .get("target")
+        .and_then(|target| arg_str(target, &["type"]))
+        .unwrap_or("subagent");
+    match (target_type, uk) {
+        ("agent", false) => "agent",
+        ("agent", true) => "агента",
+        ("external_a2a", false) => "external agent",
+        ("external_a2a", true) => "зовнішнього агента",
+        (_, false) => "subagent",
+        (_, true) => "субагента",
+    }
+}
+
+/// Delegation narration for `spawn_agent`: always says *which* agent is being
+/// spawned — its run name, its kind (subagent, first-party agent, external A2A
+/// agent), and the blueprint or configured target id when one is set.
+///
+/// "Launching Orbit Scout subagent (github_scout)".
 pub fn narrate_subagent_spawn(
     arguments: &Value,
     phase: ToolNarrationPhase,
     locale: Option<&str>,
 ) -> String {
+    let uk = is_uk(locale);
+    let kind = spawn_agent_kind(arguments, uk);
     let name = arg_str(arguments, &["name"]).map(|name| truncate(name, 40));
-    if is_uk(locale) {
-        let target = name
-            .map(|name| format!("субагента {name}"))
-            .unwrap_or_else(|| "субагента".to_string());
-        phrase3(
-            ("Запускаю", "Запустив", "Не вдалося запустити"),
-            Some(target),
-            phase,
-        )
-    } else {
-        let target = name
-            .map(|name| format!("{name} subagent"))
-            .unwrap_or_else(|| "subagent".to_string());
-        phrase3(
-            ("Launching", "Launched", "Failed to launch"),
-            Some(target),
-            phase,
-        )
+    let identity = spawn_agent_identity(arguments);
+
+    let mut target = match (&name, uk) {
+        (Some(name), false) => format!("{name} {kind}"),
+        (Some(name), true) => format!("{kind} {name}"),
+        (None, _) => kind.to_string(),
+    };
+    if let Some(identity) = identity.filter(|identity| Some(identity) != name.as_ref()) {
+        target.push_str(&format!(" ({identity})"));
     }
+
+    let verbs = pick(
+        locale,
+        ("Launching", "Launched", "Failed to launch"),
+        ("Запускаю", "Запустив", "Не вдалося запустити"),
+    );
+    phrase3(verbs, Some(target), phase)
 }
 
 /// `write_todos` narration.
@@ -2076,6 +2108,65 @@ mod tests {
         assert_eq!(
             summarize_group_actions(&actions, None),
             "Searched files twice, Read AGENTS.md, and 2 more actions"
+        );
+    }
+
+    #[test]
+    fn subagent_spawn_narration_names_the_spawned_agent() {
+        let call = serde_json::json!({
+            "name": "Orbit Scout",
+            "instructions": "Inspect the orbit subsystem.",
+            "target": { "type": "subagent" }
+        });
+        assert_eq!(
+            narrate_subagent_spawn(&call, ToolNarrationPhase::Started, None),
+            "Launching Orbit Scout subagent"
+        );
+        assert_eq!(
+            narrate_subagent_spawn(&call, ToolNarrationPhase::Completed, None),
+            "Launched Orbit Scout subagent"
+        );
+    }
+
+    #[test]
+    fn subagent_spawn_narration_includes_blueprint_and_target_id() {
+        let blueprint = serde_json::json!({
+            "name": "Orbit Scout",
+            "target": { "type": "subagent" },
+            "blueprint": "github_scout"
+        });
+        assert_eq!(
+            narrate_subagent_spawn(&blueprint, ToolNarrationPhase::Started, None),
+            "Launching Orbit Scout subagent (github_scout)"
+        );
+
+        let handoff = serde_json::json!({
+            "name": "Release check",
+            "target": { "type": "agent", "id": "release-reviewer" }
+        });
+        assert_eq!(
+            narrate_subagent_spawn(&handoff, ToolNarrationPhase::Started, None),
+            "Launching Release check agent (release-reviewer)"
+        );
+
+        let external = serde_json::json!({
+            "target": { "type": "external_a2a", "id": "partner-agent" }
+        });
+        assert_eq!(
+            narrate_subagent_spawn(&external, ToolNarrationPhase::Failed, None),
+            "Failed to launch external agent (partner-agent)"
+        );
+    }
+
+    #[test]
+    fn subagent_spawn_narration_is_localized() {
+        let call = serde_json::json!({
+            "name": "Orbit Scout",
+            "target": { "type": "subagent" }
+        });
+        assert_eq!(
+            narrate_subagent_spawn(&call, ToolNarrationPhase::Started, Some("uk")),
+            "Запускаю субагента Orbit Scout"
         );
     }
 }

--- a/crates/engine/src/execution/act.rs
+++ b/crates/engine/src/execution/act.rs
@@ -905,6 +905,20 @@ where
                 return narration;
             }
         }
+        // Capability hooks only reach tools a capability lists in `tools()`.
+        // Tools assembled outside any capability — the unified `spawn_agent`
+        // dispatcher built from delegation targets, registry-augmented and
+        // proxied tools — still own narration, so ask the executing tool
+        // directly before falling back to the generic display-name phrasing.
+        if let Some(narration) = self
+            .context_services
+            .tool_registry
+            .as_ref()
+            .and_then(|registry| registry.get(&tool_call.name))
+            .and_then(|tool| tool.narrate(tool_call, phase, locale, ctx))
+        {
+            return narration;
+        }
         render_tool_narration_with_locale(tool_def, tool_call, phase, locale)
     }
 
@@ -1992,6 +2006,35 @@ mod tests {
             )
             .as_deref(),
             Some("Searched files twice")
+        );
+    }
+
+    /// Tools assembled outside any capability (the unified `spawn_agent`
+    /// dispatcher, registry augmentations, MCP proxies) have no
+    /// `CapabilityNarrationHook`, so the act atom must consult the registry
+    /// before the generic "Running {display_name}" fallback.
+    #[test]
+    fn registry_owned_tool_narrates_itself_without_a_capability_hook() {
+        let mut registry = ToolRegistry::new();
+        registry.register_boxed(Box::new(NarratingGrepTool));
+        let atom = ActAtom::new(ToolRegistry::new(), NoopEventEmitter)
+            .with_tool_registry(Arc::new(registry));
+        let context = ExecutionContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let tool_call = ToolCall {
+            id: "grep-1".to_string(),
+            name: "grep_files".to_string(),
+            arguments: json!({ "pattern": "full_name" }),
+        };
+
+        assert_eq!(
+            atom.render_tool_narration(
+                &context,
+                None,
+                &tool_call,
+                ToolNarrationPhase::Started,
+                None,
+            ),
+            "Searching files for full_name"
         );
     }
 

--- a/crates/everruns/tests/local_spawn_agent_runtime_test.rs
+++ b/crates/everruns/tests/local_spawn_agent_runtime_test.rs
@@ -38,8 +38,8 @@ use everruns_core::session_task::{
 };
 use everruns_core::{CapabilityRegistry, MessageRole};
 use everruns_host::{
-    AgentBuilder, HarnessBuilder, HostBackends, InProcessRuntime, InProcessRuntimeBuilder,
-    RuntimeSessionStore, SessionBuilder,
+    AgentBuilder, EventReadLimit, EventReadRequest, HarnessBuilder, HostBackends, InProcessRuntime,
+    InProcessRuntimeBuilder, RuntimeSessionStore, SessionBuilder,
 };
 use everruns_llmsim::LlmSimRuntimeExt;
 use everruns_llmsim::{LlmSimConfig, ResponseConfig, ToolCallConfig, ToolCallPattern};
@@ -155,6 +155,35 @@ impl LocalSessionRunner for RuntimeRunner {
         // maps bare `idle` → `completed`; a foreground handoff treats `idle` as
         // terminal directly. Either way the task settles.
         Ok(Some("idle".to_string()))
+    }
+}
+
+/// Narration recorded on this session's `spawn_agent` tool events. The
+/// dispatcher is assembled by core from the active delegation targets rather
+/// than contributed by a capability, so this is what proves a real turn renders
+/// a delegation line instead of the generic "Running Spawn Agent" fallback.
+async fn spawn_agent_narrations(runtime: &InProcessRuntime, session_id: SessionId) -> Vec<String> {
+    let limit = EventReadLimit::new(200).expect("event read limit");
+    let mut request = EventReadRequest::new(session_id, limit);
+    let mut narrations = Vec::new();
+    loop {
+        let page = runtime
+            .event_log()
+            .read_page(request)
+            .await
+            .expect("read session events");
+        for event in &page.events {
+            if let everruns_core::EventData::ToolStarted(data) = &event.data
+                && data.tool_call.name == "spawn_agent"
+                && let Some(narration) = &data.narration
+            {
+                narrations.push(narration.clone());
+            }
+        }
+        let Some(cursor) = page.next_cursor else {
+            return narrations;
+        };
+        request = EventReadRequest::from_cursor(cursor, limit);
     }
 }
 
@@ -410,6 +439,15 @@ async fn spawn_agent_dispatches_subagent_and_handoff_via_llmsim() {
         "child transcript should contain its marker: {child_reply}"
     );
 
+    // The transcript line names the spawned agent (the dispatcher owns this
+    // narration; no capability hook covers `spawn_agent`).
+    let narrations = spawn_agent_narrations(&runtime, parent_subagent_session_id).await;
+    assert_eq!(
+        narrations,
+        vec!["Launching Subagent Echo subagent".to_string()],
+        "spawn_agent(subagent) narration must name the spawned agent"
+    );
+
     // ---- Target 2: agent handoff (foreground) ------------------------------
     let turn = runtime
         .run_text_turn(
@@ -451,5 +489,12 @@ async fn spawn_agent_dispatches_subagent_and_handoff_via_llmsim() {
     assert!(
         handoff_summary.contains(HANDOFF_MARKER),
         "handoff summary should carry the target agent's reply: {handoff_summary}"
+    );
+
+    let narrations = spawn_agent_narrations(&runtime, parent_handoff_session_id).await;
+    assert_eq!(
+        narrations,
+        vec![format!("Launching Handoff Run agent ({HANDOFF_TARGET_ID})")],
+        "spawn_agent(agent) narration must name the configured handoff target"
     );
 }

--- a/knowledge/execution/tool-narration.md
+++ b/knowledge/execution/tool-narration.md
@@ -77,8 +77,15 @@ During capability assembly, the framework wraps each applied capability in a
 [`ToolCallHook`](../../crates/core/src/capabilities/mod.rs) channel) and registers
 it on the act atom. These adapters are appended **after** every explicit
 tool-call hook, so model-authored narration (the `human_intent` capability)
-keeps precedence. The first hook to return `Some` wins; if none do, the act
-atom falls back to [`render_tool_narration_with_locale`](../../crates/core/src/tool_narration.rs).
+keeps precedence. The first hook to return `Some` wins.
+
+Capability hooks only reach tools a capability lists in `tools()`. Tools
+assembled outside a capability still own their narration — the unified
+`spawn_agent` dispatcher built from delegation targets, registry
+augmentations, MCP proxy tools — so when no hook answers, the act atom asks
+the executing tool in the session's tool registry for its `Tool::narrate`.
+Only then does it fall back to
+[`render_tool_narration_with_locale`](../../crates/core/src/tool_narration.rs).
 
 The default `Capability::narrate` constructs `self.tools()` per call to find the
 match; narration is low-frequency, but a capability with expensive `tools()` can


### PR DESCRIPTION
## What changed

Every `spawn_agent` call now narrates the delegation instead of the generic tool
name. The line carries the run name, the target kind (subagent, agent, external
agent), and the blueprint or configured target id when one is set:
`Launching Orbit Scout subagent (github_scout)`, `Launched Release check agent
(release-reviewer)`, `Failed to launch external agent (partner-agent)`.
Ukrainian phrasing is preserved.

Two mechanics back it:

- When no capability hook narrates a call, the act atom asks the executing tool
  in the session tool registry for its own `Tool::narrate` before falling back
  to display-name phrasing. This also restores narration for other tools that no
  capability lists in `tools()` (registry augmentations, MCP proxy tools).
- The unified dispatcher no longer returns `None` for a call whose `target.type`
  is missing or unknown, so a still-streaming call renders a spawn line rather
  than the fallback.

## Why

`spawn_agent` is assembled in core from the registered delegation targets, not
contributed by a capability. Narration reaches events through one
`CapabilityNarrationHook` per applied capability, and each hook only matches
tools that capability lists in `tools()`. Nothing lists `spawn_agent`, so the
dispatcher's own `narrate` was never asked and every delegation, in every host,
rendered as "Running Spawn Agent" — a line that says nothing about which agent
is being spawned.

## Before / After

The `local_spawn_agent_runtime_test` runtime proof (real in-process runtime,
llmsim driver, real dispatcher) now asserts the narration on the parent
sessions' `spawn_agent` tool events. With the act-atom change reverted:

```
assertion `left == right` failed: spawn_agent(subagent) narration must name the spawned agent
  left: ["Running Spawn Agent"]
 right: ["Launching Subagent Echo subagent"]
```

With the fix:

```
running 1 test
test spawn_agent_dispatches_subagent_and_handoff_via_llmsim ... ok
```

Both targets are covered: the subagent spawn reads `Launching Subagent Echo
subagent`, the handoff reads `Launching Handoff Run agent (handoff-target)`.

## Risk

- Low
- Narration text is user-visible only. Existing hook precedence is unchanged:
  explicit tool-call hooks (model-authored `human_intent`) still win, capability
  hooks still come next, and the registry lookup is a new step that only runs
  when nothing else answered. Wording for `spawn_agent` changes for clients that
  match on the old string; narration is display text, not a contract.
  `narrate_subagent_spawn` keeps its public signature (core public API guard
  passes).

## Security

- Threat categories reviewed: TM-TOOL, TM-LLM, TM-DOS.
- Findings and resolutions:
  - TM-LLM (data exposure): narration renders only `name`, `target.type`,
    `target.id`/`external_agent_id`, and `blueprint`, each bounded to 40
    characters. Instructions, `config`, `public_context`, and result/message
    schemas are never rendered, so no credential-bearing field reaches an event
    or a UI. `target.type` maps to a fixed set of literals, so no model-supplied
    text passes through as the agent kind.
  - TM-TOOL: the registry lookup resolves only tools already registered for the
    session and calls `narrate`, which is a read-only formatter; it opens no
    execution path and cannot reach an unregistered tool.
  - TM-DOS: one map lookup per narration render, on an already-bounded path; all
    rendered values are truncated. No unbounded work or allocation added.
  - No `THREAT` markers are near the diff and no new surface was opened, so
    `knowledge/security/threat-model.md` needs no update.

## Follow-ups

No follow-ups. `knowledge/execution/tool-narration.md` is updated in this PR to
record the registry step in the wiring order. Yolop carries a temporary
host-side wrapper for the same symptom because it consumes published crates; it
is retired there once this ships in a release, which is tracked in that repo, not
here.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcJrDLr9U1V1hciNaUpAko)_