### PR TITLE
chore(release): prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-25
+
+### Highlights
+
+- **Reasoning modeled as ordered artifacts** - Model reasoning is now captured as ordered artifacts with a published classification, so reasoning steps replay in the order they were produced and their kind is visible to consumers ([#3276](https://github.com/everruns/everruns/pull/3276)).
+- **Bounded batch file reads** - The filesystem capability gained bounded batch reads, letting agents fetch several files in a single guarded call instead of one round-trip per file ([#3275](https://github.com/everruns/everruns/pull/3275)).
+
+### What's Changed
+
+- feat(reasoning): model reasoning as ordered artifacts and publish the classification ([#3276](https://github.com/everruns/everruns/pull/3276)) by [@chaliy](https://github.com/chaliy)
+- feat(filesystem): add bounded batch reads ([#3275](https://github.com/everruns/everruns/pull/3275)) by [@chaliy](https://github.com/chaliy)
+- fix(events): stop publishing reasoning replay state on the events API ([#3279](https://github.com/everruns/everruns/pull/3279)) by [@chaliy](https://github.com/chaliy)
+- fix(openresponses): send the required summary on replayed reasoning items ([#3280](https://github.com/everruns/everruns/pull/3280)) by [@chaliy](https://github.com/chaliy)
+- fix(narration): name the agent that spawn_agent spawns ([#3277](https://github.com/everruns/everruns/pull/3277)) by [@chaliy](https://github.com/chaliy)
+- fix(builtins): hide redundant output recovery paths ([`5fe85ff`](https://github.com/everruns/everruns/commit/5fe85ffd67edf62f77d1d29e7fb827b8bc8ffdf1)) by [@chaliy](https://github.com/chaliy)
+- refactor(tls): standardise on aws-lc-rs and drop the second crypto backend ([#3272](https://github.com/everruns/everruns/pull/3272)) by [@chaliy](https://github.com/chaliy)
+- chore(sessions): retire the global chat singleton endpoints ([#3278](https://github.com/everruns/everruns/pull/3278)) by [@chaliy](https://github.com/chaliy)
+- chore(test-cases): retarget retired-route references at their replacements ([#3273](https://github.com/everruns/everruns/pull/3273)) by [@chaliy](https://github.com/chaliy)
+- fix(release): republish everruns facade as 0.18.4 ([#3271](https://github.com/everruns/everruns/pull/3271)) by [@chaliy](https://github.com/chaliy)
+- fix(release): cascade-bump integration crates to close the v0.21.0 cone ([#3270](https://github.com/everruns/everruns/pull/3270)) by [@chaliy](https://github.com/chaliy)
+
+### Crate Releases
+
+Two published library crates had breaking public-contract changes this cycle (the reasoning-artifact
+work in [#3276](https://github.com/everruns/everruns/pull/3276) and the aws-lc-rs TLS
+consolidation in [#3272](https://github.com/everruns/everruns/pull/3272)), classified with
+`cargo semver-checks`:
+
+- `everruns-core` 0.18.1 → 0.19.0 (breaking: reasoning content parts and reworked `ReasoningConfig`)
+- `everruns-provider` 0.19.0 → 0.20.0 (breaking: `tls-ring` feature removed, crypto-provider installer renamed, reasoning types added)
+
+The `everruns` facade takes a matching bump (0.18.4 → 0.19.0) for the new reasoning
+`SessionEventKind` variants and provider re-exports. Because core and provider took breaking `0.x`
+bumps, every other published crate that pins them receives a compatibility patch republish to close
+the cone (`strand-check`):
+
+- `everruns-ard` 0.18.1 → 0.18.2, `everruns-builtins` 0.18.4 → 0.18.5, `everruns-capability` 0.18.0 → 0.18.1, `everruns-cli` 0.18.1 → 0.18.2, `everruns-engine` 0.18.1 → 0.18.2, `everruns-host` 0.20.2 → 0.20.3, `everruns-mcp` 0.19.1 → 0.19.2, `everruns-platform` 0.19.0 → 0.19.1, `everruns-test-support` 0.18.3 → 0.18.4, `everruns-turbopuffer` 0.18.1 → 0.18.2
+- Drivers: `everruns-anthropic` 0.18.1 → 0.18.2, `everruns-bedrock` 0.18.1 → 0.18.2, `everruns-fireworks` 0.18.1 → 0.18.2, `everruns-gemini` 0.18.1 → 0.18.2, `everruns-llmsim` 0.18.3 → 0.18.4, `everruns-mai` 0.18.1 → 0.18.2, `everruns-meta` 0.18.1 → 0.18.2, `everruns-openai` 0.18.1 → 0.18.2, `everruns-openrouter` 0.18.1 → 0.18.2
+
+`everruns-macros` is unchanged and outside the cone, so it is not republished. No crate was
+deleted or absorbed this cycle.
+
 ## [0.21.0] - 2026-08-22
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.4"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "schemars",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "everruns-provider",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "everruns-capability",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-test-support"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -191,18 +191,18 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-capability = { path = "crates/capability", version = "0.18.0", default-features = false }
-everruns-builtins = { path = "crates/builtins", version = "0.18.4" }
-everruns-core = { path = "crates/core", version = "0.18.1" }
-everruns-engine = { path = "crates/engine", version = "0.18.1" }
-everruns-host = { path = "crates/host", version = "0.20.2" }
-everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.3", default-features = false }
+everruns-capability = { path = "crates/capability", version = "0.18.1", default-features = false }
+everruns-builtins = { path = "crates/builtins", version = "0.18.5" }
+everruns-core = { path = "crates/core", version = "0.19.0" }
+everruns-engine = { path = "crates/engine", version = "0.18.2" }
+everruns-host = { path = "crates/host", version = "0.20.3" }
+everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.4", default-features = false }
 everruns-test-support = { path = "crates/test-support", version = "0.18.2", default-features = false }
-everruns-platform = { path = "crates/platform", version = "0.19.0" }
-everruns-provider = { path = "crates/provider", version = "0.19.0", default-features = false }
-everruns-mcp = { path = "crates/mcp", version = "0.19.1" }
+everruns-platform = { path = "crates/platform", version = "0.19.1" }
+everruns-provider = { path = "crates/provider", version = "0.20.0", default-features = false }
+everruns-mcp = { path = "crates/mcp", version = "0.19.2" }
 everruns-ard = { path = "crates/ard", version = "0.18.0" }
-everruns-openai = { path = "crates/drivers/openai", version = "0.18.1" }
+everruns-openai = { path = "crates/drivers/openai", version = "0.18.2" }
 everruns = { path = "crates/everruns", version = "0.18.0" }
 everruns-macros = { path = "crates/macros", version = "0.18.1" }
 everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.2" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/ard/Cargo.toml
+++ b/crates/ard/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 name = "everruns-ard"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-builtins"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ categories = ["development-tools", "asynchronous"]
 # execution values. It owns no host, platform, database, network, process, or
 # interpreter implementation edge.
 everruns-capability.workspace = true
-everruns-core = { path = "../core", version = "0.18.1", default-features = false }
+everruns-core = { path = "../core", version = "0.19.0", default-features = false }
 everruns-provider.workspace = true
 
 async-trait.workspace = true

--- a/crates/capability/Cargo.toml
+++ b/crates/capability/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns-capability"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "everruns-cli"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-core"
-version = "0.18.1"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/drivers/anthropic/Cargo.toml
+++ b/crates/drivers/anthropic/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-anthropic"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -43,7 +43,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.19.0" }
+everruns-provider = { path = "../../provider", version = "0.20.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/bedrock/Cargo.toml
+++ b/crates/drivers/bedrock/Cargo.toml
@@ -8,7 +8,7 @@ name = "everruns-bedrock"
 readme = "README.md"
 keywords = ["agent", "llm", "ai", "bedrock", "aws"]
 categories = ["api-bindings", "asynchronous"]
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -39,7 +39,7 @@ base64.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.19.0" }
+everruns-provider = { path = "../../provider", version = "0.20.0" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/drivers/fireworks/Cargo.toml
+++ b/crates/drivers/fireworks/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-fireworks"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -35,7 +35,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { version = "0.19.0", path = "../../provider" }
+everruns-provider = { version = "0.20.0", path = "../../provider" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures discovery requests;

--- a/crates/drivers/gemini/Cargo.toml
+++ b/crates/drivers/gemini/Cargo.toml
@@ -7,7 +7,7 @@ name = "everruns-gemini"
 readme = "README.md"
 keywords = ["agent", "llm", "ai", "gemini", "google"]
 categories = ["api-bindings", "asynchronous"]
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -39,7 +39,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.19.0" }
+everruns-provider = { path = "../../provider", version = "0.20.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/llmsim/Cargo.toml
+++ b/crates/drivers/llmsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-llmsim"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/drivers/mai/Cargo.toml
+++ b/crates/drivers/mai/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-mai"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { version = "0.19.0", path = "../../provider" }
+everruns-provider = { version = "0.20.0", path = "../../provider" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver/token requests;

--- a/crates/drivers/meta/Cargo.toml
+++ b/crates/drivers/meta/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "everruns-meta"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -24,7 +24,7 @@ serde.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.19.0" }
+everruns-provider = { path = "../../provider", version = "0.20.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/openai/Cargo.toml
+++ b/crates/drivers/openai/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-openai"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.19.0" }
+everruns-provider = { path = "../../provider", version = "0.20.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/openrouter/Cargo.toml
+++ b/crates/drivers/openrouter/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-openrouter"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -34,7 +34,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.19.0" }
+everruns-provider = { path = "../../provider", version = "0.20.0" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "everruns-engine"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns"
-version = "0.18.4"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "everruns-host"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-mcp"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "everruns-platform"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns-provider"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "everruns-test-support"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -44,7 +44,7 @@ fixtures = ["dep:everruns-platform"]
 host = ["dep:everruns-host", "sim", "everruns-llmsim/host"]
 
 [dependencies]
-everruns-core = { path = "../core", version = "0.18.1", default-features = false }
+everruns-core = { path = "../core", version = "0.19.0", default-features = false }
 everruns-engine.workspace = true
 everruns-capability.workspace = true
 everruns-provider.workspace = true

--- a/crates/turbopuffer/Cargo.toml
+++ b/crates/turbopuffer/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-turbopuffer"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.4"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "schemars",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## What changed

Cuts the **v0.22.0** product release.

- Product version bumped to `0.22.0` (`Cargo.toml` workspace, `apps/ui/package.json`).
- `CHANGELOG.md` `0.22.0` section with highlights and the full What's Changed list (11 commits since `v0.21.0`).
- Lockfile refreshed (`cargo update --workspace`; workspace-scoped, no unrelated dependency churn).

**Highlights**
- Reasoning modeled as ordered artifacts with a published classification (#3276).
- Bounded batch file reads for the filesystem capability (#3275).

## Why

Regular release to publish the accumulated changes on `main` since `v0.21.0`, and to release the
library crates whose public contracts changed this cycle.

## Library-crate release audit (required)

Audited every published workspace crate (`publish != false`) with `cargo semver-checks` (v0.50.0,
git baselines) against the `v0.21.0` baseline. **Two crates had genuine breaking public-contract
changes:**

- `everruns-core` 0.18.1 → **0.19.0** — breaking (reasoning content parts; reworked `ReasoningConfig`).
- `everruns-provider` 0.19.0 → **0.20.0** — breaking (`tls-ring` feature removed and crypto-provider installer renamed per the aws-lc-rs consolidation; reasoning types added).

The `everruns` facade takes a matching **0.18.4 → 0.19.0** bump (new reasoning `SessionEventKind`
variants + provider re-exports). Because core and provider took breaking `0.x` bumps, every other
published crate that pins them gets a **compatibility patch republish** to close the cone that
`strand-check` enforces (18 crates: ard, builtins, capability, cli, engine, host, mcp, platform,
test-support, turbopuffer, and the anthropic/bedrock/fireworks/gemini/llmsim/mai/meta/openai/openrouter
drivers). `everruns-macros` is outside the cone and unchanged — not republished. No crate was
deleted or absorbed. Full old→new table is in the CHANGELOG `Crate Releases` section. Pins were
rewritten by `scripts/sync-publish-pin-versions.py --write`; `--check` passes for all 40 packages.

On merge, the Crate Release workflow tags and publishes each bumped crate in dependency order
(idempotent by crates.io presence).

## Before / After

Metadata-only release change (no source logic). Product version moves `0.21.0 → 0.22.0`;
the crates listed above move to their new versions on crates.io after merge. The first CI run
surfaced a stale `tests/fixtures/external-consumer/Cargo.lock` (the fixture is built `--locked`);
refreshed it for the new crate versions in the second commit and CI is green.

## Risk

- Low — version and changelog metadata plus internal pin updates; no behavior change in this PR.
- The core/provider breaking bumps are already-merged source changes being versioned now; the cone
  cascade prevents a partial (stranded) crate release.

## Security

- Threat categories reviewed: none applicable — no security-relevant code changes (version/changelog/pins only).
- Findings and resolutions: none.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated (n/a — metadata-only release)
- [x] Backward compatibility considered (crate cone closed; product internal)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)