### PR TITLE
fix(release): cascade-bump integration crates and gate the publish cone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,10 @@ jobs:
               - 'examples/coding-cli/**'
               - 'scripts/cli-e2e-test.sh'
               - 'scripts/lib/check-everruns-examples.sh'
+              # The lockfile job runs the publish-cone gate; re-run it when the
+              # gate or the pin-sync script it pairs with changes.
+              - 'scripts/check-publish-cone.py'
+              - 'scripts/sync-publish-pin-versions.py'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
@@ -326,6 +330,16 @@ jobs:
 
       - name: Check publish-pin versions match workspace
         run: python3 scripts/sync-publish-pin-versions.py --check
+
+      # Deterministic guard: a breaking bump of a foundational crate must
+      # cascade to every published dependant in the same change, or the facade
+      # publish strands on two incompatible copies of that crate (the failure
+      # that blocked the everruns 0.19.0 facade in the v0.22.0 release).
+      - name: Self-test the publish-cone gate
+        run: python3 scripts/check-publish-cone.py --self-test
+
+      - name: Check publish cone has no unhealed strands
+        run: python3 scripts/check-publish-cone.py --pre-merge
 
   msrv:
     name: Published Crate MSRV

--- a/.github/workflows/crate-release.yml
+++ b/.github/workflows/crate-release.yml
@@ -197,69 +197,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Same detection the ci.yml pre-merge gate runs, in strict mode: here,
+      # after publishing, a freshly cascaded version already counts as fixed, so
+      # any remaining strand is a genuine partial release to fail on. Uses the
+      # cargo preinstalled on the runner image, as the previous inline check did.
       - name: Detect stranded published dependants
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import json, subprocess, sys, urllib.request, urllib.error
-
-          def index_path(name: str) -> str:
-              n = name.lower()
-              if len(n) == 1: return f"1/{n}"
-              if len(n) == 2: return f"2/{n}"
-              if len(n) == 3: return f"3/{n[0]}/{n}"
-              return f"{n[0:2]}/{n[2:4]}/{n}"
-
-          def latest_published(name: str):
-              try:
-                  body = urllib.request.urlopen(
-                      f"https://index.crates.io/{index_path(name)}", timeout=30).read().decode()
-              except urllib.error.HTTPError as exc:
-                  if exc.code == 404: return None
-                  raise
-              rows = [json.loads(l) for l in body.splitlines() if l.strip() and not json.loads(l).get("yanked")]
-              return rows[-1] if rows else None
-
-          def caret_allows(req: str, ver: str) -> bool:
-              # Cargo default (caret) semantics, sufficient for this all-caret graph.
-              r = req.lstrip("^").strip()
-              try:
-                  rp = [int(x) for x in r.split("-")[0].split(".")]
-                  vp = [int(x) for x in ver.split("-")[0].split(".")]
-              except ValueError:
-                  return True  # non-caret / complex req: don't flag, avoid false positives
-              while len(rp) < 3: rp.append(0)
-              while len(vp) < 3: vp.append(0)
-              # lower bound
-              if vp < rp: return False
-              # upper bound: first non-zero component of the requirement fixes the compatible range
-              if rp[0] != 0:   return vp[0] == rp[0]
-              if rp[1] != 0:   return vp[0] == 0 and vp[1] == rp[1]
-              return vp[0] == 0 and vp[1] == 0 and vp[2] == rp[2]
-
-          meta = json.loads(subprocess.check_output(
-              ["cargo", "metadata", "--no-deps", "--format-version", "1"], text=True))
-          current = {p["name"]: p["version"] for p in meta["packages"] if p.get("publish") != []}
-
-          stranded = []
-          for name in sorted(current):
-              latest = latest_published(name)
-              if not latest:
-                  continue
-              for dep in latest.get("deps", []):
-                  dname = dep["name"]
-                  if dname in current and dep.get("kind") != "dev":
-                      if not caret_allows(dep["req"], current[dname]):
-                          stranded.append(
-                              f"{name} {latest['vers']} pins {dname} {dep['req']}, "
-                              f"but the workspace now ships {dname} {current[dname]}")
-
-          if stranded:
-              print("::error::Partial release: published crates stranded by an incompatible dependency:")
-              for s in stranded:
-                  print(f"  - {s}")
-              print("Cascade-bump and republish each stranded crate (patch is enough), or yank it "
-                    "via the Yank Crate workflow if it was absorbed/removed.")
-              sys.exit(1)
-          print(f"No stranded published dependants across {len(current)} crates.")
-          PY
+        run: python3 scripts/check-publish-cone.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-bashkit"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-lua"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openrouter-workspace"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-web-fetch"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,12 +205,12 @@ everruns-ard = { path = "crates/ard", version = "0.18.0" }
 everruns-openai = { path = "crates/drivers/openai", version = "0.18.2" }
 everruns = { path = "crates/everruns", version = "0.18.0" }
 everruns-macros = { path = "crates/macros", version = "0.18.1" }
-everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.2" }
-everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.18.1" }
-everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.18.1" }
-everruns-integrations-duckduckgo = { path = "integrations/duckduckgo", version = "0.18.1" }
-everruns-integrations-lua = { path = "integrations/lua", version = "0.18.1" }
-everruns-integrations-openrouter-workspace = { path = "integrations/openrouter-workspace", version = "0.18.1" }
+everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.3" }
+everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.18.2" }
+everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.18.2" }
+everruns-integrations-duckduckgo = { path = "integrations/duckduckgo", version = "0.18.2" }
+everruns-integrations-lua = { path = "integrations/lua", version = "0.18.2" }
+everruns-integrations-openrouter-workspace = { path = "integrations/openrouter-workspace", version = "0.18.2" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/integrations/bashkit/Cargo.toml
+++ b/integrations/bashkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-bashkit"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/brave-search/Cargo.toml
+++ b/integrations/brave-search/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "everruns-integrations-brave-search"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/browserless/Cargo.toml
+++ b/integrations/browserless/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "everruns-integrations-browserless"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/cursor/Cargo.toml
+++ b/integrations/cursor/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "everruns-integrations-cursor"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/daytona/Cargo.toml
+++ b/integrations/daytona/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "everruns-integrations-daytona"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/deno/Cargo.toml
+++ b/integrations/deno/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "everruns-integrations-deno"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/docker/Cargo.toml
+++ b/integrations/docker/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "everruns-integrations-docker"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/duckduckgo/Cargo.toml
+++ b/integrations/duckduckgo/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-e2b"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/filesystem/Cargo.toml
+++ b/integrations/filesystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-filesystem"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-integrations-github"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/lua/Cargo.toml
+++ b/integrations/lua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-lua"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/openai-image/Cargo.toml
+++ b/integrations/openai-image/Cargo.toml
@@ -7,7 +7,7 @@
 [package]
 name = "everruns-integrations-openai-image"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/openrouter-workspace/Cargo.toml
+++ b/integrations/openrouter-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-openrouter-workspace"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/parallel/Cargo.toml
+++ b/integrations/parallel/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-integrations-parallel"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/sprites/Cargo.toml
+++ b/integrations/sprites/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "everruns-integrations-sprites"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/web-fetch/Cargo.toml
+++ b/integrations/web-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-web-fetch"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/scripts/check-publish-cone.py
+++ b/scripts/check-publish-cone.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Deterministic guard against a partial (stranded) crate-publish cone.
+
+A breaking bump of a foundational crate (e.g. everruns-core 0.18 -> 0.19, or
+everruns-provider 0.19 -> 0.20) leaves every *published* dependant whose latest
+crates.io version still pins the old, now-incompatible requirement unable to
+resolve alongside the new foundational crate. A downstream consumer then pulls
+two copies of the foundational crate, and any facade that re-exports both sides
+fails to compile during `cargo publish` verification -- exactly how the
+everruns 0.19.0 facade publish broke in the v0.22.0 release.
+
+This checker compares each published crate's latest crates.io pins against the
+versions the workspace now ships, using the same crates.io sparse index and
+caret semantics as crate-release.yml's post-publish strand check. It runs in two
+modes:
+
+  (default, strict)  Flag every stranded published dependant. Intended to run
+                     *after* publishing (crate-release.yml), where a freshly
+                     cascaded version already counts as fixed.
+
+  --pre-merge        Flag a strand only when the stranded crate is NOT being
+                     bumped in this change (its workspace version already equals
+                     its latest published version). A crate whose version is
+                     bumped here will be republished by the same crate-release
+                     run and re-pinned via workspace inheritance, so it is not a
+                     permanent strand. This makes the check a deterministic
+                     pre-merge gate: a release PR that bumps a foundational
+                     crate but forgets to cascade its published dependants fails
+                     CI, while the cascade-fix PR that bumps them passes.
+
+`--self-test` exercises the pure caret/strand logic against fixtures with no
+network access, so the gate's own correctness is guarded deterministically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+
+def index_path(name: str) -> str:
+    n = name.lower()
+    if len(n) == 1:
+        return f"1/{n}"
+    if len(n) == 2:
+        return f"2/{n}"
+    if len(n) == 3:
+        return f"3/{n[0]}/{n}"
+    return f"{n[0:2]}/{n[2:4]}/{n}"
+
+
+def latest_published(name: str) -> dict | None:
+    """Latest non-yanked release row from the crates.io sparse index, or None."""
+    try:
+        body = urllib.request.urlopen(
+            f"https://index.crates.io/{index_path(name)}", timeout=30
+        ).read().decode()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+    rows = [
+        json.loads(line)
+        for line in body.splitlines()
+        if line.strip() and not json.loads(line).get("yanked")
+    ]
+    return rows[-1] if rows else None
+
+
+def caret_allows(req: str, ver: str) -> bool:
+    """Cargo default (caret) semantics, sufficient for this all-caret graph."""
+    r = req.lstrip("^").strip()
+    try:
+        rp = [int(x) for x in r.split("-")[0].split(".")]
+        vp = [int(x) for x in ver.split("-")[0].split(".")]
+    except ValueError:
+        return True  # non-caret / complex req: don't flag, avoid false positives
+    while len(rp) < 3:
+        rp.append(0)
+    while len(vp) < 3:
+        vp.append(0)
+    if vp < rp:  # lower bound
+        return False
+    # upper bound: first non-zero component of the requirement fixes the range
+    if rp[0] != 0:
+        return vp[0] == rp[0]
+    if rp[1] != 0:
+        return vp[0] == 0 and vp[1] == rp[1]
+    return vp[0] == 0 and vp[1] == 0 and vp[2] == rp[2]
+
+
+def workspace_versions() -> dict[str, str]:
+    meta = json.loads(
+        subprocess.check_output(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"], text=True
+        )
+    )
+    # Published packages are those whose manifest does not set publish = false
+    # (cargo reports publish = [] for those).
+    return {p["name"]: p["version"] for p in meta["packages"] if p.get("publish") != []}
+
+
+def find_strands(current: dict[str, str], pre_merge: bool) -> list[str]:
+    """Return human-readable strand descriptions.
+
+    A strand is a *published* crate whose latest crates.io release pins a sibling
+    workspace crate at a requirement the version now in the workspace violates.
+    In pre_merge mode a strand is ignored when the stranding crate is itself
+    being bumped in this change (workspace version != latest published), because
+    that republish heals it.
+    """
+    strands: list[str] = []
+    for name in sorted(current):
+        latest = latest_published(name)
+        if not latest:
+            continue  # never published: cannot strand a consumer yet
+        if pre_merge and current[name] != latest["vers"]:
+            continue  # bumped here -> will be republished and re-pinned; not permanent
+        for dep in latest.get("deps", []):
+            dname = dep["name"]
+            if dname in current and dep.get("kind") != "dev":
+                if not caret_allows(dep["req"], current[dname]):
+                    strands.append(
+                        f"{name} {latest['vers']} pins {dname} {dep['req']}, "
+                        f"but the workspace now ships {dname} {current[dname]}"
+                    )
+    return strands
+
+
+def run_check(pre_merge: bool) -> int:
+    current = workspace_versions()
+    strands = find_strands(current, pre_merge)
+    if strands:
+        if pre_merge:
+            print(
+                "::error::Publish cone is inconsistent: a foundational crate was "
+                "bumped incompatibly but these published dependants are not "
+                "cascade-bumped in this change and would strand on publish:"
+            )
+        else:
+            print(
+                "::error::Partial release: published crates stranded by an "
+                "incompatible dependency:"
+            )
+        for s in strands:
+            print(f"  - {s}")
+        print(
+            "Cascade-bump and republish each stranded crate (a patch bump is "
+            "enough; the pin re-syncs via workspace inheritance), or yank it via "
+            "the Yank Crate workflow if it was absorbed/removed."
+        )
+        return 1
+    scope = "unhealed" if pre_merge else "stranded"
+    print(f"No {scope} published dependants across {len(current)} crates.")
+    return 0
+
+
+def self_test() -> int:
+    """Network-free checks of the pure caret and strand logic."""
+    failures: list[str] = []
+
+    def expect(label: str, got, want) -> None:
+        if got != want:
+            failures.append(f"{label}: got {got!r}, want {want!r}")
+
+    # Caret upper/lower bounds around the release that actually broke.
+    expect("^0.18.1 allows 0.19.0", caret_allows("^0.18.1", "0.19.0"), False)
+    expect("^0.18.1 allows 0.18.4", caret_allows("^0.18.1", "0.18.4"), True)
+    expect("^0.19.0 allows 0.20.0", caret_allows("^0.19.0", "0.20.0"), False)
+    expect("^0.19.0 allows 0.19.2", caret_allows("^0.19.0", "0.19.2"), True)
+    expect("^1.2 allows 1.9", caret_allows("^1.2", "1.9.0"), True)
+    expect("^1.2 allows 2.0", caret_allows("^1.2", "2.0.0"), False)
+    expect("below lower bound", caret_allows("^0.19.0", "0.18.9"), False)
+
+    # Strand detection over a fixture cone, monkeypatching the index lookup.
+    global latest_published
+    real = latest_published
+    published = {
+        # facade re-exports host (new core) and filesystem (old core) -> conflict
+        "everruns-host": {"vers": "0.20.3", "deps": [{"name": "everruns-core", "req": "^0.19.0", "kind": "normal"}]},
+        "everruns-integrations-filesystem": {"vers": "0.18.2", "deps": [{"name": "everruns-core", "req": "^0.18.1", "kind": "normal"}]},
+        "everruns-core": {"vers": "0.18.4", "deps": []},
+    }
+    latest_published = lambda name: published.get(name)  # noqa: E731
+    try:
+        workspace = {
+            "everruns-core": "0.19.0",
+            "everruns-host": "0.20.3",
+            "everruns-integrations-filesystem": "0.18.2",  # NOT bumped -> unhealed strand
+        }
+        strict = find_strands(workspace, pre_merge=False)
+        expect("strict flags filesystem strand", any("filesystem" in s for s in strict), True)
+        pre = find_strands(workspace, pre_merge=True)
+        expect("pre-merge flags un-bumped filesystem", any("filesystem" in s for s in pre), True)
+
+        healed = dict(workspace, **{"everruns-integrations-filesystem": "0.18.3"})  # bumped
+        pre_healed = find_strands(healed, pre_merge=True)
+        expect("pre-merge ignores bumped filesystem", pre_healed, [])
+        strict_healed = find_strands(healed, pre_merge=False)
+        expect("strict still flags until republished", any("filesystem" in s for s in strict_healed), True)
+    finally:
+        latest_published = real
+
+    if failures:
+        print("check-publish-cone self-test FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("check-publish-cone self-test passed.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pre-merge",
+        action="store_true",
+        help="ignore strands healed by a version bump in this change (PR gate)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run network-free logic checks and exit",
+    )
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    return run_check(pre_merge=args.pre_merge)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## What changed
Two things:

1. **Unblocks the `everruns` 0.19.0 facade publish.** The v0.22.0 release bumped `everruns-core` (0.18→0.19) and `everruns-provider` (0.19→0.20) breakingly, but the 17 published `everruns-integrations-*` crates still pinned the old majors on crates.io. This cascade-bumps all 17 (filesystem `0.18.2→0.18.3`, the rest `0.18.1→0.18.2`) so **Crate Release** republishes them re-pinned at `everruns-core ^0.19` / `everruns-provider ^0.20` (pins re-sync automatically via workspace inheritance). Once they land, the facade `everruns 0.19.0` publish resolves a single, consistent cone.

2. **Adds a deterministic gate so this can't recur.** New `scripts/check-publish-cone.py` with a `--pre-merge` mode, wired into the `ci.yml` lockfile job. It fails a PR that bumps a foundational crate incompatibly without cascade-bumping every published dependant in the same change.

## Why
The facade publish (Publish Crate run #135) failed during `cargo publish` verification:

```
error[E0277]: the trait bound `FileSystemCapability: everruns_core::Capability` is not satisfied
note: there are multiple different versions of crate `everruns_core` in the dependency graph
      everruns-core 0.19.0  (via everruns-host 0.20.3)
      everruns-core 0.18.1  (via everruns-integrations-filesystem 0.18.2)
```

The facade re-exports both `everruns-host` (moved to core 0.19) and `everruns-integrations-filesystem` (still on core 0.18), pulling two incompatible copies of `everruns-core`. 18/19 crates published fine; only the facade — last in dependency order — stranded. The existing strand check runs **after** publish on `main`, so it detects the partial release but does not block the release PR that causes it.

## Before / After
**Publish cone gate** on this branch's workspace state:

```
$ python3 scripts/check-publish-cone.py --pre-merge   # before the bumps (main)
::error::Publish cone is inconsistent: ...
  - everruns-integrations-filesystem 0.18.2 pins everruns-core ^0.18.1, but the workspace now ships everruns-core 0.19.0
  ...17 crates...
exit 1

$ python3 scripts/check-publish-cone.py --pre-merge   # after the bumps (this PR)
No unhealed published dependants across 40 crates.
exit 0

$ python3 scripts/check-publish-cone.py --self-test
check-publish-cone self-test passed.
```

`sync-publish-pin-versions.py --check`, `test-publish-crates-order.sh`, and `test-release-workflow-security.sh` all pass. Root and external-consumer fixture lockfiles refreshed; `cargo fetch --locked` clean.

**After merge:** Crate Release republishes the 17 integration crates, then reissues `everruns 0.19.0` (currently missing from crates.io; latest is 0.18.4), and the post-publish strand check goes green.

## Risk
- Low
- Version-only manifest bumps plus lockfile/pin syncs; no source behavior change. The gate is additive. The `crate-release.yml` strand check now calls the shared script (strict mode) instead of a duplicated inline copy — same logic, guarded by the script's `--self-test`.

## Security
- Threat categories reviewed: No security-relevant code changes. Release-automation/CI only; the gate reads the public crates.io sparse index (same source the existing strand check already used) and adds no new secrets, permissions, or external actions. `test-release-workflow-security.sh` (SHA-pin / env-bound-input guard) passes.
- Findings and resolutions: none.

## Follow-ups
No follow-ups. After this merges and the crate cone is fully published, `everruns 0.19.0` will be live on crates.io.

## Checklist
- [x] Tests added or updated (network-free `--self-test` of the gate logic; existing publish-order/pin/security tests pass)
- [x] Backward compatibility considered (patch bumps; pins re-sync via workspace inheritance)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdBCCnTJjjovgNHq2Ciu7Y)_