### PR TITLE
fix(release): republish everruns facade as 0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",


### PR DESCRIPTION
## What changed
Bumps the `everruns` facade `0.19.0 → 0.19.1` so it can finally publish to crates.io.

## Why
The `everruns 0.19.0` facade never landed on crates.io. Two blockers, now both cleared except the tag:

1. Its first publish attempt (in the v0.22.0 release) failed on the stranded crate cone — `everruns-host` had moved to `everruns-core ^0.19` while the integration crates still pinned `^0.18`. Fixed in #3286 (17 integration crates cascade-bumped, all republished).
2. That failed attempt left the `crate/everruns/v0.19.0` tag stuck on the old release commit `943076410`. The post-fix republish was then rejected by the Publish Crate tag-guard:

```
::error::Package tag crate/everruns/v0.19.0 resolves to 943076410…, expected 0b97c64…
```

Crate tags can't be deleted (the agent egress proxy blocks it), so `0.19.0` is permanently unpublishable. Same situation the repo resolved for the v0.21.0 facade in #3271 (republished as 0.18.4).

## Before / After
- **Before:** crates.io `everruns` max version `0.18.4`; `0.19.0` tag stuck on the wrong commit; Publish Crate run #156 fails in 16s on the tag/sha guard.
- **After:** Crate Release cuts a fresh `crate/everruns/v0.19.1` tag on this commit and publishes against the now-consistent cone (core 0.19.0, provider 0.20.0, host 0.20.3, all 17 integration crates at their re-pinned versions).

Validation: `cargo fetch --locked` clean; `sync-publish-pin-versions.py --check`, `check-publish-cone.py --pre-merge` and `--self-test`, `test-publish-crates-order.sh`, `test-release-workflow-security.sh` all pass.

## Risk
- Low
- Facade-only version bump plus lockfile refreshes; no source behavior change. Nothing in the workspace depends on the facade, so there is no further cascade.

## Security
- Threat categories reviewed: No security-relevant code changes (version/lockfile only).
- Findings and resolutions: none.

## Follow-ups
No follow-ups. Once this merges and Crate Release publishes `everruns 0.19.1`, the v0.22.0 crate cone is fully on crates.io.

## Checklist
- [x] Tests added or updated (release guards pass; no code change to test)
- [x] Backward compatibility considered (patch bump of an unconsumed facade)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdBCCnTJjjovgNHq2Ciu7Y)_