### PR TITLE
fix(ci): gate postgres integration on all provider crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,14 @@ jobs:
             # surface, durable engine stores, and provider live tests that
             # currently run inside the same CI job. Keep this narrower than the
             # general Rust filter so unrelated crates do not start PostgreSQL.
+            #
+            # The provider entries are directory-wide on purpose. They used to
+            # enumerate openai/anthropic/gemini, so every driver added later
+            # fell outside the gate and `crates/provider` — which owns the wire
+            # protocols the live matrix exists to validate — was never listed at
+            # all. PR #3280 fixed an openresponses_protocol.rs regression and
+            # the live matrix was skipped on that very PR (EVE-936).
+            # scripts/test-ci-postgres-integration-filter.sh pins the invariant.
             postgres_integration:
               - 'crates/server/**'
               - 'crates/durable/**'
@@ -233,9 +241,8 @@ jobs:
               - 'crates/config/**'
               - 'crates/session-sqldb/**'
               - 'crates/llm-tests/**'
-              - 'crates/drivers/openai/**'
-              - 'crates/drivers/anthropic/**'
-              - 'crates/drivers/gemini/**'
+              - 'crates/provider/**'
+              - 'crates/drivers/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'

--- a/scripts/test-ci-postgres-integration-filter.sh
+++ b/scripts/test-ci-postgres-integration-filter.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Guard the `postgres_integration` path filter against losing the crates that own
+# provider wire behaviour.
+#
+# `Integration Tests (PostgreSQL)` is where the live provider matrix
+# (`crates/llm-tests`) runs. Its gate is the `postgres_integration` filter in
+# ci.yml. That filter used to enumerate drivers one by one — openai, anthropic,
+# gemini — so every driver added afterwards (openrouter, bedrock, meta,
+# fireworks, mai, llmsim) silently fell outside it, and `crates/provider` was
+# never listed at all.
+#
+# The cost was not theoretical: the fix for the `main` regression in
+# openresponses_protocol.rs (PR #3280) touched only `crates/provider`, so the
+# live matrix that exists to validate wire serialization was skipped on the
+# fix's own PR and the break surfaced on the merge commit instead (EVE-936).
+#
+# An enumeration cannot notice a crate that was never added to it, so the filter
+# now uses directory-wide globs and this test pins that: every crate owning
+# provider wire behaviour must be matched by some `postgres_integration` glob.
+# Re-narrowing the filter to a hand-kept list turns this red instead of silently
+# dropping a driver from live coverage.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$SCRIPT_DIR")"
+
+python3 - <<'PY'
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+workflow = Path(".github/workflows/ci.yml")
+jobs = yaml.safe_load(workflow.read_text())["jobs"]
+
+# `filters` is a YAML document embedded as a block string in the step's `with`.
+filters_raw = None
+for step in jobs["changes"]["steps"]:
+    if step.get("id") == "core_filter":
+        filters_raw = step["with"]["filters"]
+        break
+
+if filters_raw is None:
+    sys.exit(f"{workflow}: no `core_filter` paths-filter step found")
+
+patterns = yaml.safe_load(filters_raw).get("postgres_integration")
+if not patterns:
+    sys.exit(f"{workflow}: `postgres_integration` filter is missing or empty")
+
+
+def matches(pattern: str, path: str) -> bool:
+    """Approximate micromatch: `**` crosses directories, `*` does not."""
+    regex = ""
+    i = 0
+    while i < len(pattern):
+        if pattern.startswith("**", i):
+            regex += ".*"
+            i += 2
+        elif pattern[i] == "*":
+            regex += "[^/]*"
+            i += 1
+        else:
+            regex += re.escape(pattern[i])
+            i += 1
+    return re.fullmatch(regex, path) is not None
+
+
+# Crates whose source decides what goes on the wire to a provider. `provider`
+# owns the shared protocols; each `drivers/*` owns one provider's binding.
+required = [Path("crates/provider")]
+required += sorted(p for p in Path("crates/drivers").iterdir() if p.is_dir())
+
+uncovered = []
+for crate in required:
+    if not (crate / "Cargo.toml").is_file():
+        continue
+    # A representative source path: coverage of the crate means coverage of the
+    # files that can change its wire behaviour.
+    probe = f"{crate.as_posix()}/src/lib.rs"
+    if not any(matches(pattern, probe) for pattern in patterns):
+        uncovered.append(crate.as_posix())
+
+if uncovered:
+    sys.exit(
+        f"{workflow}: `postgres_integration` does not cover crates that own "
+        "provider wire behaviour, so a change to them skips the live provider "
+        "matrix (EVE-936): " + ", ".join(uncovered)
+    )
+
+print(f"postgres_integration covers all {len(required)} provider-owning crates")
+PY


### PR DESCRIPTION
## What changed

`Integration Tests (PostgreSQL)` — the job that runs the live provider matrix (`crates/llm-tests`) — now runs when any provider-owning crate changes. Its `postgres_integration` path filter trades an enumeration of three drivers for directory-wide globs:

- added `crates/provider/**` (owns the wire protocols the matrix exists to validate)
- `crates/drivers/**` replaces `crates/drivers/{openai,anthropic,gemini}/**`

A new shell test, `scripts/test-ci-postgres-integration-filter.sh`, fails when a provider-owning crate falls outside the filter.

## Why

The filter enumerated drivers one by one, so every driver added afterwards — `openrouter`, `bedrock`, `meta`, `fireworks`, `mai`, `llmsim` — fell outside the gate, and `crates/provider` was never listed at all.

That is not theoretical. PR #3280 fixed a `main` regression in `crates/provider/src/openresponses_protocol.rs`:

```
OpenAI Responses API error (400 Bad Request):
  `input[1]` missing required field `summary`
```

It touched only that one file, so the live matrix was skipped on the PR **and on the merge commit to main** (`1f17936`, `Integration Tests (PostgreSQL) :: skipped`). A wire-protocol change received zero live validation anywhere, and the break surfaced only once an unrelated PR happened to touch a covered crate.

An enumeration cannot notice a crate that was never added to it, hence the globs plus a test that pins the invariant rather than a longer hand-kept list.

## Before / After

Replaying PR #3280's diff (`crates/provider/src/openresponses_protocol.rs`) through the filter:

```
BEFORE: postgres_integration = False   → live provider matrix skipped
AFTER:  postgres_integration = True    → live provider matrix runs
```

The filter stays narrower than the general `rust` filter — unrelated crates still do not start PostgreSQL:

```
AFTER, crates/cli/src/main.rs:      False
AFTER, crates/mcp/src/lib.rs:       False
AFTER, apps/ui/src/app/page.tsx:    False
```

The new guard, run against the filter as it stood before this change:

```
.github/workflows/ci.yml: `postgres_integration` does not cover crates that own
provider wire behaviour, so a change to them skips the live provider matrix
(EVE-936): crates/provider, crates/drivers/bedrock, crates/drivers/fireworks,
crates/drivers/llmsim, crates/drivers/mai, crates/drivers/meta,
crates/drivers/openrouter
```

and after:

```
postgres_integration covers all 10 provider-owning crates
```

Full repo shell suite: 20/20 pass.

## Risk

- **Low**
- CI-configuration only; no runtime or product surface changes.
- The practical effect is more CI: provider and driver changes now start PostgreSQL and run the integration job. That is the intended cost — it is what makes the live matrix mean anything for provider changes. Scope is bounded to `crates/provider` plus 10 driver crates.
- If the new guard is wrong about which crates matter, it fails closed (red shell test), not silently.

## Security

- **Threat categories reviewed: TM-CI-001, TM-CI-002.**
- Both concern exfiltration of `DOPPLER_TOKEN` and LLM provider keys from `integration-test` via PR-controlled `cargo test`. Both are mitigated by secret *scoping*, not by which PRs run the job: no `DOPPLER_TOKEN` and no provider keys exist at workflow or job scope, and the two steps that inject `DOPPLER_TOKEN` (`Run Slack integration tests`, `Run LLM integration tests`) are each step-scoped and guarded by `if: github.event_name == 'push'`.
- This change touches only the path filter that decides *whether the job runs*. It adds no `env:`, no `secrets.*` reference, and does not alter either push gate — verified against the diff. Widening the filter means the job runs PR-controlled `cargo test` on more PRs, which is unchanged in kind from the drivers already covered, and reaches no secret because none is in scope on `pull_request`.
- **Findings: none.** No new exfiltration surface.

## Follow-ups

- The live provider matrix runs only on `push` (TM-CI-001/002 gate it away from fork PRs), so a provider change is still validated live on the merge commit rather than on the PR itself. Closing that would need a different secret model — e.g. a GitHub Environment with required approval — which is a security-design decision, not a path-filter fix. Filed as **EVE-937**.
- `crates/llm-tests` never reads `DATABASE_URL`, so the live matrix does not need PostgreSQL and is coupled to this job only by history — which is why its gate was shaped around server persistence in the first place. Splitting it into its own provider-gated job would change a required-check name, so it does not belong in this PR. Filed as **EVE-938**.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Fixes EVE-936

---
_Generated by [Claude Code](https://claude.ai/code/session_012vvYZv1JNDXAzzyPJvpWbE)_