### PR TITLE
fix(ci): stop reporting a pass for runs that executed nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,15 @@ on:
 
 # Cancel in-progress runs for the same PR/branch on new pushes.
 # On main, let every run finish so merged commits aren't silently skipped.
+#
+# Label events get their own group. They resolve `run_ci=false` for anything
+# outside the ci:skip-* set, so all their jobs skip; sharing a group with the
+# real run let that no-op cancel it and survive as the run of record. Dependabot
+# applies its labels in the same second it opens the PR, so this was not a rare
+# race — every Dependabot PR was green having run no CI at all (EVE-939).
+# Separated, label runs can only ever cancel each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && 'label' || 'code' }}
   cancel-in-progress: true
 
 permissions:
@@ -1999,6 +2006,17 @@ jobs:
     steps:
       - name: Verify all jobs passed
         run: |
+          # A run gated off by the label event (run_ci=false) skips every job,
+          # and an all-"skipped" result set would otherwise read as a pass. That
+          # turns "nothing ran" into a green required check, which is how four
+          # Dependabot PRs became mergeable with no CI behind them (EVE-939).
+          # Refuse to speak for a run that executed nothing; the real run's own
+          # Build Check is the one that carries the verdict.
+          if [ "${{ needs.changes.outputs.run_ci }}" != "true" ]; then
+            echo "run_ci=false: this run executed no jobs, so it has nothing to attest"
+            exit 1
+          fi
+
           results='${{ toJson(needs.*.result) }}'
           echo "Job results: $results"
           if echo "$results" | grep -qE '"failure"|"cancelled"'; then

--- a/scripts/test-ci-labeled-event-gate.sh
+++ b/scripts/test-ci-labeled-event-gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Guard against CI reporting a pass for a run in which nothing executed.
+#
+# `Resolve CI event gate` sets `run_ci=false` for a `pull_request`
+# `labeled`/`unlabeled` event carrying anything outside the `ci:skip-*` set, so
+# every downstream job skips. That is the right call on its own — relabelling a
+# PR should not rebuild it — but two things turned it into a false green
+# (EVE-939):
+#
+#   1. The concurrency group was keyed only on the branch, so a label event
+#      shared a group with the real run and cancelled it. Dependabot applies its
+#      labels in the same second it opens the PR, so on #3284 six runs started
+#      within one second and the survivor was the no-op labeled run.
+#   2. `Build Check` failed only on "failure"/"cancelled". An all-skipped run
+#      therefore reported success, and a required check said "pass" when the
+#      honest reading was "nothing ran".
+#
+# All four open Dependabot PRs were mergeable and green having run no CI at all,
+# including one bumping jsonschema and sha3 across Cargo.lock.
+#
+# Both halves are needed. (1) alone still loses to ordering: label a PR after a
+# real run went red and the no-op run's newer green Build Check supersedes it.
+# (2) alone lets the no-op keep cancelling real runs. This test pins both.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$SCRIPT_DIR")"
+
+python3 - <<'PY'
+import sys
+from pathlib import Path
+
+import yaml
+
+workflow = Path(".github/workflows/ci.yml")
+doc = yaml.safe_load(workflow.read_text())
+
+errors = []
+
+# --- 1. label events must not share a concurrency group with code events -----
+group = str(doc.get("concurrency", {}).get("group", ""))
+mentions_action = "github.event.action" in group
+distinguishes_label = "labeled" in group
+if not (mentions_action and distinguishes_label):
+    errors.append(
+        f"{workflow}: concurrency.group does not separate label events from code "
+        "events, so a labeled/unlabeled run can cancel the real run and become "
+        "the surviving one (EVE-939). Current group:\n"
+        f"  {group}"
+    )
+
+# --- 2. Build Check must refuse to pass a run where run_ci was false ---------
+build_check = None
+for job in doc["jobs"].values():
+    if job.get("name") == "Build Check":
+        build_check = job
+        break
+
+if build_check is None:
+    sys.exit(f"{workflow}: no job named 'Build Check' found")
+
+verify = "\n".join(
+    step.get("run") or "" for step in build_check.get("steps") or []
+)
+
+# The gate must read run_ci and exit non-zero on it. Checking for both halves
+# keeps this honest if the guard is ever reduced to a comment.
+guards_run_ci = "run_ci" in verify and "exit 1" in verify
+if not guards_run_ci:
+    errors.append(
+        f"{workflow}: the 'Build Check' verify step does not fail on "
+        "run_ci != 'true'. A run where every job skipped would report success, "
+        "turning 'nothing ran' into a green required check (EVE-939)."
+    )
+
+if errors:
+    sys.exit("\n\n".join(errors))
+
+print("ci.yml: label-event runs cannot cancel real runs, and Build Check "
+      "refuses to pass a run that executed nothing")
+PY


### PR DESCRIPTION
## What changed

`Build Check` can no longer report success for a CI run in which nothing executed, and a `labeled`/`unlabeled` run can no longer cancel the real run.

- `concurrency.group` now distinguishes label events from code events, so label runs only ever cancel each other.
- The `Build Check` verify step exits non-zero when `needs.changes.outputs.run_ci != 'true'`.
- `scripts/test-ci-labeled-event-gate.sh` pins both.

## Why

All four open Dependabot PRs (#3281–#3284) were mergeable and **green having run no CI at all**. `Build Check` was `success` on each while ~35 jobs — `Clippy Lints`, `Unit Tests (Pure)`, `Lockfile Check`, `Format Check`, `Integration Tests (PostgreSQL)` — were `skipped`. #3284 bumps `jsonschema` 0.49.2 → 0.50.1 and `sha3` 0.11 → 0.12 across `Cargo.lock` and three crate manifests, so those jobs plainly should have run.

Two defects combine:

**The no-op run cancels the real one.** `Resolve CI event gate` sets `run_ci=false` for a `labeled`/`unlabeled` event carrying anything outside the `ci:skip-*` set — correct on its own; relabelling a PR should not rebuild it. But the concurrency group was keyed only on the branch, so that no-op run shared a group with the `opened`/`synchronize` run and cancelled it. Dependabot applies its labels in the same second it opens the PR, so this was not a rare race: on #3284, six runs were created within one second (`2026-08-25T18:46:51–52Z`) and the survivor was `EVENT_ACTION: labeled` (run `32885762797`).

**The aggregate gate treats "nothing ran" as "all passed."** `Build Check` failed only on `"failure"`/`"cancelled"`, so an all-`"skipped"` result set printed *"All CI jobs passed (or were skipped due to path filtering)"* and went green.

The result is a required status check asserting a pass on evidence that does not exist.

## Before / After

The guard, against `main` as it stood:

```
.github/workflows/ci.yml: concurrency.group does not separate label events from
code events, so a labeled/unlabeled run can cancel the real run and become the
surviving one (EVE-939). Current group:
  ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

.github/workflows/ci.yml: the 'Build Check' verify step does not fail on
run_ci != 'true'. A run where every job skipped would report success, turning
'nothing ran' into a green required check (EVE-939).
```

and after:

```
ci.yml: label-event runs cannot cancel real runs, and Build Check refuses to
pass a run that executed nothing
```

Full repo shell suite: 21/21 pass.

Evidence the bug is real rather than theoretical: updating each Dependabot branch to force a `synchronize` event produced genuine runs, and #3284 — previously green — **failed**, on `Shell Tests (Repo Scripts)`. `tests/fixtures/external-consumer/Cargo.lock` pins `jsonschema 0.49.9` and `digest 0.11.3` via path deps into `crates/`, so `cargo --locked` refuses to resolve against the bumped workspace. That failure was sitting behind the false green.

## Risk

- **Medium.** CI-configuration only, no runtime surface, but it changes merge gating for every PR.
- The visible change: a label event on a PR now produces a **red** `Build Check` for that run. This is intended — that run attests nothing — and it clears on the next code push. The concurrency split keeps it off the common path: at open time the fast all-skip label run finishes before the code run, so the code run's check is the later one and carries the verdict.
- Considered and rejected: making `build-check` conditional on `run_ci == 'true'` so the label run skips it instead. GitHub counts a skipped required check as passing, which reopens the same hole.
- Both halves are required. The concurrency split alone still loses to ordering — label a PR after a real run went red and the no-op run's newer green check supersedes the red one.

## Security

- **Threat categories reviewed: TM-CI-001, TM-CI-002.**
- Both concern exfiltration of `DOPPLER_TOKEN` and LLM provider keys via PR-controlled `cargo test`, mitigated by step-scoped secrets under `if: github.event_name == 'push'` gates. This diff adds no `env:`, references no `secrets.*`, and does not touch either push gate.
- The change is strictly in the direction of *more* validation: it removes a path by which an unvalidated PR could present as green and be merged. No new exfiltration surface.
- **Findings: none.**

## Follow-ups

- PR #3288 (open, by @chaliy) documents a sibling blind spot — CI enumerates `cargo test -p` targets by hand, so `everruns-provider`'s wire tests had never run. Different mechanism, same failure mode. It also edits `ci.yml`; the two diffs touch different regions (concurrency header and `build-check` here, a new enumeration guard there), so they should merge independently, but sequence them rather than assuming.
- Otherwise no follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Fixes EVE-939

---
_Generated by [Claude Code](https://claude.ai/code/session_012vvYZv1JNDXAzzyPJvpWbE)_