### PR TITLE
fix(test): repair the five tests the new credentials exposed on main

### DIFF
--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -4600,7 +4600,7 @@ async fn test_anthropic_extended_thinking() {
             API_BASE_URL, provider.id
         ))
         .json(&json!({
-            "model_id": "claude-sonnet-4-20250514",
+            "model_id": "claude-sonnet-4-6",
             "display_name": "Claude Sonnet 4 (Thinking Test)",
             "enabled": true
         }))
@@ -4752,14 +4752,25 @@ async fn test_anthropic_extended_thinking() {
                             thinking_content.len()
                         );
                     }
-                    // Check if message has thinking field
-                    "message.agent" if event["data"]["message"]["thinking"].is_string() => {
+                    // Reasoning rides on the message as ordered content parts.
+                    // The flat `message.thinking` string this used to read was
+                    // removed with the reasoning rework: one field per message
+                    // cannot express several thinking blocks, each with its own
+                    // signature and position, which is what providers require.
+                    // `message.agent` is not an event type. The message events
+                    // are `output.message.started` / `.delta` / `.completed`;
+                    // the completed one carries the finished message.
+                    "output.message.completed"
+                        if event["data"]["message"]["content"].as_array().is_some_and(
+                            |parts| parts.iter().any(|p| p["type"] == "reasoning"),
+                        ) =>
+                    {
                         message_agent_with_thinking = true;
-                        let thinking = event["data"]["message"]["thinking"].as_str().unwrap_or("");
-                        println!(
-                            "  Found message.agent with thinking field ({} chars)",
-                            thinking.len()
-                        );
+                        let parts = event["data"]["message"]["content"]
+                            .as_array()
+                            .map(|p| p.iter().filter(|x| x["type"] == "reasoning").count())
+                            .unwrap_or(0);
+                        println!("  Found message.agent with {parts} reasoning part(s)");
                     }
                     _ => {}
                 }
@@ -4875,7 +4886,7 @@ async fn test_anthropic_extended_thinking() {
     );
     assert!(
         message_agent_with_thinking,
-        "message.agent event should have thinking field populated"
+        "message.agent should carry reasoning content parts"
     );
     assert!(
         followup_complete,
@@ -4960,7 +4971,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
             API_BASE_URL, provider.id
         ))
         .json(&json!({
-            "model_id": "claude-sonnet-4-20250514",
+            "model_id": "claude-sonnet-4-6",
             "display_name": "Claude Sonnet 4 (Thinking+Tools Test)",
             "enabled": true
         }))
@@ -5106,17 +5117,20 @@ async fn test_anthropic_extended_thinking_with_tools() {
                         thinking_found = true;
                         println!("    - {}", event_type);
                     }
-                    "tool.call_started" => {
+                    // The emitted names are `tool.call_requested` and
+                    // `tool.completed`; `tool.call_started` / `tool.call_completed`
+                    // were never event types this runtime publishes.
+                    "tool.call_requested" | "tool.started" => {
                         tool_call_found = true;
                         let tool_name = event["data"]["tool_name"].as_str().unwrap_or("?");
                         println!("    - {} (tool: {})", event_type, tool_name);
                     }
-                    "tool.call_completed" => {
+                    "tool.completed" => {
                         tool_completed_found = true;
                         let success = event["data"]["success"].as_bool().unwrap_or(false);
                         println!("    - {} (success: {})", event_type, success);
                     }
-                    "message.agent" => {
+                    "output.message.completed" => {
                         final_message_found = true;
                         // Reasoning is ordered `reasoning` content parts; the
                         // opaque signature is replay state and never published.
@@ -5244,7 +5258,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     );
     assert!(
         final_message_found,
-        "Should have at least one message.agent event"
+        "Should have at least one output.message.completed event"
     );
 
     // Multi-turn test may not complete if first turn hit max iterations

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -4613,11 +4613,12 @@ async fn test_anthropic_extended_thinking() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!(
-            "{}/v1/agents/{}/sessions",
-            API_BASE_URL, agent.public_id
-        ))
-        .json(&json!({"title": "Extended Thinking Test Session"}))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
+        .json(&json!({
+            "harness_name": SEED_HARNESS_NAME,
+            "agent_id": agent.public_id,
+            "title": "Extended Thinking Test Session"
+        }))
         .send()
         .await
         .expect("Failed to create session");
@@ -4634,8 +4635,8 @@ async fn test_anthropic_extended_thinking() {
     println!("\nStep 4: Sending message with reasoning effort=low...");
     let message_response = client
         .post(format!(
-            "{}/v1/agents/{}/sessions/{}/messages",
-            API_BASE_URL, agent.public_id, session.id
+            "{}/v1/sessions/{}/messages",
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -4668,10 +4669,7 @@ async fn test_anthropic_extended_thinking() {
 
         // Check session status
         let session_response = client
-            .get(format!(
-                "{}/v1/agents/{}/sessions/{}",
-                API_BASE_URL, agent.public_id, session.id
-            ))
+            .get(format!("{}/v1/sessions/{}", API_BASE_URL, session.id))
             .send()
             .await;
 
@@ -4695,8 +4693,8 @@ async fn test_anthropic_extended_thinking() {
     // Fetch all events (requires agent_id in path)
     let events_response = client
         .get(format!(
-            "{}/v1/agents/{}/sessions/{}/events",
-            API_BASE_URL, agent.public_id, session.id
+            "{}/v1/sessions/{}/events",
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -4768,8 +4766,8 @@ async fn test_anthropic_extended_thinking() {
     println!("\nStep 6: Sending follow-up message to test multi-turn with thinking...");
     let followup_response = client
         .post(format!(
-            "{}/v1/agents/{}/sessions/{}/messages",
-            API_BASE_URL, agent.public_id, session.id
+            "{}/v1/sessions/{}/messages",
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -4794,10 +4792,7 @@ async fn test_anthropic_extended_thinking() {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         let session_response = client
-            .get(format!(
-                "{}/v1/agents/{}/sessions/{}",
-                API_BASE_URL, agent.public_id, session.id
-            ))
+            .get(format!("{}/v1/sessions/{}", API_BASE_URL, session.id))
             .send()
             .await;
 
@@ -4976,11 +4971,12 @@ async fn test_anthropic_extended_thinking_with_tools() {
     // Step 3: Create session
     println!("\nStep 3: Creating session...");
     let session_response = client
-        .post(format!(
-            "{}/v1/agents/{}/sessions",
-            API_BASE_URL, agent.public_id
-        ))
-        .json(&json!({"title": "Time Reporting with Thinking Test"}))
+        .post(format!("{}/v1/sessions", API_BASE_URL))
+        .json(&json!({
+            "harness_name": SEED_HARNESS_NAME,
+            "agent_id": agent.public_id,
+            "title": "Time Reporting with Thinking Test"
+        }))
         .send()
         .await
         .expect("Failed to create session");
@@ -4997,8 +4993,8 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("\nStep 4: Sending message (expecting thinking + tool use)...");
     let message_response = client
         .post(format!(
-            "{}/v1/agents/{}/sessions/{}/messages",
-            API_BASE_URL, agent.public_id, session.id
+            "{}/v1/sessions/{}/messages",
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -5029,10 +5025,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         let session_response = client
-            .get(format!(
-                "{}/v1/agents/{}/sessions/{}",
-                API_BASE_URL, agent.public_id, session.id
-            ))
+            .get(format!("{}/v1/sessions/{}", API_BASE_URL, session.id))
             .send()
             .await;
 
@@ -5063,8 +5056,8 @@ async fn test_anthropic_extended_thinking_with_tools() {
     // Fetch all events
     let events_response = client
         .get(format!(
-            "{}/v1/agents/{}/sessions/{}/events",
-            API_BASE_URL, agent.public_id, session.id
+            "{}/v1/sessions/{}/events",
+            API_BASE_URL, session.id
         ))
         .send()
         .await
@@ -5123,8 +5116,8 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("\nStep 6: Sending follow-up message (multi-turn with thinking+tools)...");
     let followup_response = client
         .post(format!(
-            "{}/v1/agents/{}/sessions/{}/messages",
-            API_BASE_URL, agent.public_id, session.id
+            "{}/v1/sessions/{}/messages",
+            API_BASE_URL, session.id
         ))
         .json(&json!({
             "message": {
@@ -5149,10 +5142,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         let session_response = client
-            .get(format!(
-                "{}/v1/agents/{}/sessions/{}",
-                API_BASE_URL, agent.public_id, session.id
-            ))
+            .get(format!("{}/v1/sessions/{}", API_BASE_URL, session.id))
             .send()
             .await;
 

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -5852,23 +5852,23 @@ async fn test_reasoning_reaches_api_sanitized_and_classified() {
             let v = v.trim();
             !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
         });
-    let has_provider_key = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
-        .iter()
-        .any(|k| std::env::var(k).ok().is_some_and(|v| !v.trim().is_empty()));
-    if !has_provider_key {
-        assert!(
-            !require_live,
-            "EVERRUNS_REQUIRE_LIVE_TESTS is set but neither OPENAI_API_KEY nor \
-             ANTHROPIC_API_KEY is present. This test verifies real provider \
-             reasoning end to end and cannot do that without a credential — fix \
-             the job's secrets rather than relaxing this check."
-        );
-        eprintln!(
-            "SKIP: no provider credential; set EVERRUNS_REQUIRE_LIVE_TESTS=1 to \
-             make this a failure"
-        );
-        return;
-    }
+    let api_key = match std::env::var("OPENAI_API_KEY") {
+        Ok(key) if !key.trim().is_empty() => key,
+        _ => {
+            assert!(
+                !require_live,
+                "EVERRUNS_REQUIRE_LIVE_TESTS is set but OPENAI_API_KEY is not \
+                 present. This test verifies real provider reasoning end to end \
+                 and cannot do that without a credential — fix the job's secrets \
+                 rather than relaxing this check."
+            );
+            eprintln!(
+                "SKIP: no OPENAI_API_KEY; set EVERRUNS_REQUIRE_LIVE_TESTS=1 to \
+                 make this a failure"
+            );
+            return;
+        }
+    };
 
     // Names are unique per run: the API rejects a duplicate agent name with
     // 409, so fixed names pass once against a fresh database and fail on every
@@ -5878,14 +5878,57 @@ async fn test_reasoning_reaches_api_sanitized_and_classified() {
         .expect("clock after epoch")
         .as_nanos();
 
+    // The test brings its own provider rather than relying on an org default.
+    // The server and worker in CI start outside `doppler run` and hold no
+    // provider credential of their own; creating the provider here is what puts
+    // a usable key in the database for the worker to pick up. Relying on the org
+    // default passed locally, where the stack is Doppler-fed, and failed in CI
+    // against a fresh database — the turn had no credential to run with.
+    let provider_response = client
+        .post(format!("{}/v1/providers", API_BASE_URL))
+        .json(&json!({
+            "name": format!("reasoning-projection-provider-{run_id}"),
+            "provider_type": "openai",
+            "api_key": api_key,
+            "enabled": true
+        }))
+        .send()
+        .await
+        .expect("Failed to create provider");
+    assert_eq!(provider_response.status(), 201);
+    let provider: Provider = provider_response
+        .json()
+        .await
+        .expect("Failed to parse provider");
+
+    // A reasoning-capable model: the whole point is a turn that produces
+    // reasoning artifacts.
+    let model_response = client
+        .post(format!(
+            "{}/v1/providers/{}/models",
+            API_BASE_URL, provider.id
+        ))
+        .json(&json!({
+            "model_id": "gpt-5.2",
+            "display_name": format!("Reasoning Projection Model {run_id}"),
+            "enabled": true
+        }))
+        .send()
+        .await
+        .expect("Failed to create model");
+    if model_response.status() != 201 {
+        let status = model_response.status();
+        let body = model_response.text().await.unwrap_or_default();
+        panic!("Failed to create model: status={status}, body={body}");
+    }
+    let model: Model = model_response.json().await.expect("Failed to parse model");
+
     let agent_response = client
         .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
             "name": format!("reasoning-projection-agent-{run_id}"),
             "system_prompt": "You are a helpful assistant.",
-            // No model override: the agent takes the org default, which is a
-            // real reasoning-capable provider. That is the path this test is
-            // here to verify.
+            "default_model_id": model.id,
         }))
         .send()
         .await

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -1012,6 +1012,14 @@ async fn test_session_filesystem_workspace_prefix() {
 /// Skips if no API key is available.
 #[tokio::test]
 async fn test_agent_filesystem_and_bash_workspace_integration() {
+    // Unique per run: the API rejects a duplicate name with 409, and the name
+    // stays claimed by the soft-deleted row after the test cleans up, so fixed
+    // names pass once against a given database and fail on every rerun.
+    let run_id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+
     use std::time::Duration;
 
     let client = reqwest::Client::builder()
@@ -1035,7 +1043,7 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
     let provider_response = client
         .post(format!("{}/v1/providers", API_BASE_URL))
         .json(&json!({
-            "name": "FS Bash Integration Test Provider",
+            "name": format!("fs-bash-provider-{run_id}"),
             "provider_type": "anthropic",
             "api_key": api_key,
             "enabled": false
@@ -1065,8 +1073,8 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
             API_BASE_URL, provider.id
         ))
         .json(&json!({
-            "model_id": "claude-3-5-haiku-latest",
-            "display_name": "Claude 3.5 Haiku (FS Bash Test)",
+            "model_id": "claude-haiku-4-5",
+            "display_name": "Claude Haiku 4.5 (FS Bash Test)",
             "enabled": true
         }))
         .send()
@@ -1089,7 +1097,7 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
     let agent_response = client
         .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
-            "name": "fs-bash-test-agent",
+            "name": format!("fs-bash-test-agent-{run_id}"),
             "display_name": "FS Bash Test Agent",
             "system_prompt": "You are a file system assistant. When asked to create a file, use the write_file tool to create it. Always confirm what you did.",
             "capabilities": [
@@ -3620,6 +3628,14 @@ async fn test_agent_execution_openai_with_tool_calls() {
 /// Skips if no API key is available.
 #[tokio::test]
 async fn test_agent_execution_anthropic_with_tool_calls() {
+    // Unique per run: the API rejects a duplicate name with 409, and the name
+    // stays claimed by the soft-deleted row after the test cleans up, so fixed
+    // names pass once against a given database and fail on every rerun.
+    let run_id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+
     use std::time::Duration;
 
     // Check if Anthropic API key is available
@@ -3645,7 +3661,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     let provider_response = client
         .post(format!("{}/v1/providers", API_BASE_URL))
         .json(&json!({
-            "name": "Anthropic Tool Test Provider",
+            "name": format!("anthropic-tool-provider-{run_id}"),
             "provider_type": "anthropic",
             "api_key": api_key,
             "enabled": false
@@ -3675,8 +3691,8 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
             API_BASE_URL, provider.id
         ))
         .json(&json!({
-            "model_id": "claude-3-5-haiku-latest",
-            "display_name": "Claude 3.5 Haiku (Tool Test)",
+            "model_id": "claude-haiku-4-5",
+            "display_name": "Claude Haiku 4.5 (Tool Test)",
             "enabled": true
         }))
         .send()
@@ -3696,7 +3712,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     let agent_response = client
         .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
-            "name": "anthropic-dad-jokes-agent",
+            "name": format!("anthropic-dad-jokes-agent-{run_id}"),
             "display_name": "Anthropic Dad Jokes Agent",
             "system_prompt": "You are a dad jokes comedian. When the user asks for a joke about the time, you MUST first use the get_current_time tool to get the current time, then tell a short dad joke that somehow references the time you received. Keep your response brief.",
             "capabilities": [{"ref": "current_time", "config": {}}],
@@ -4524,6 +4540,14 @@ async fn test_cancel_turn_endpoint() {
 /// Skips if no API key is available.
 #[tokio::test]
 async fn test_anthropic_extended_thinking() {
+    // Unique per run: the API rejects a duplicate name with 409, and the name
+    // stays claimed by the soft-deleted row after the test cleans up, so fixed
+    // names pass once against a given database and fail on every rerun.
+    let run_id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+
     use std::time::Duration;
 
     let client = reqwest::Client::builder()
@@ -4546,7 +4570,7 @@ async fn test_anthropic_extended_thinking() {
     let provider_response = client
         .post(format!("{}/v1/providers", API_BASE_URL))
         .json(&json!({
-            "name": "Anthropic Thinking Test Provider",
+            "name": format!("anthropic-thinking-provider-{run_id}"),
             "provider_type": "anthropic",
             "api_key": api_key,
             "enabled": false
@@ -4597,7 +4621,7 @@ async fn test_anthropic_extended_thinking() {
     let agent_response = client
         .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
-            "name": "thinking-test-agent",
+            "name": format!("thinking-test-agent-{run_id}"),
             "display_name": "Thinking Test Agent",
             "system_prompt": "You are a helpful assistant. Think through problems step by step.",
             "default_model_id": model.id
@@ -4876,6 +4900,14 @@ async fn test_anthropic_extended_thinking() {
 /// Requirements: API + Worker running, ANTHROPIC_API_KEY environment variable set.
 #[tokio::test]
 async fn test_anthropic_extended_thinking_with_tools() {
+    // Unique per run: the API rejects a duplicate name with 409, and the name
+    // stays claimed by the soft-deleted row after the test cleans up, so fixed
+    // names pass once against a given database and fail on every rerun.
+    let run_id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+
     use std::time::Duration;
 
     let client = reqwest::Client::builder()
@@ -4898,7 +4930,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     let provider_response = client
         .post(format!("{}/v1/providers", API_BASE_URL))
         .json(&json!({
-            "name": "Anthropic Thinking+Tools Test",
+            "name": format!("anthropic-thinking-tools-provider-{run_id}"),
             "provider_type": "anthropic",
             "api_key": api_key,
             "enabled": false
@@ -4949,7 +4981,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
     let agent_response = client
         .post(format!("{}/v1/agents", API_BASE_URL))
         .json(&json!({
-            "name": "time-reporter-agent",
+            "name": format!("time-reporter-agent-{run_id}"),
             "display_name": "Time Reporter Agent",
             "system_prompt": "You help users with simple requests. When asked for the time, call the current_time tool once and report the result.",
             "default_model_id": model.id,


### PR DESCRIPTION
## What changed

main is red at 8a14ea2. #3288 gave the workflow-test job Doppler credentials,
and four tests that had been skipping themselves for want of an API key started
running. They fail. A fifth, the reasoning projection test added in that PR,
fails for a different reason. This repairs all five.

Nothing here changes product code. Every failure is a test that stopped
executing at some point and never noticed the API move underneath it.

## The five failures

| Test | Cause |
|---|---|
| `test_reasoning_reaches_api_sanitized_and_classified` | took the org default model; the CI server and worker start outside `doppler run` and hold no credential, so the turn came back `provider_misconfigured` |
| `test_anthropic_extended_thinking` | `POST /v1/agents/{id}/sessions` — not a route |
| `test_anthropic_extended_thinking_with_tools` | same, plus `tool.call_started` / `tool.call_completed` — not event types |
| `test_agent_execution_anthropic_with_tool_calls` | `claude-3-5-haiku-latest` retired; the turn errored, so no tool was called |
| `test_agent_filesystem_and_bash_workspace_integration` | same retired model |

Found while fixing them, all in the same two thinking tests:

- `claude-sonnet-4-20250514` produced no thinking, so the accumulator stayed
  empty and `reason.thinking.completed` never fired.
- `message.agent` is not an event type. The message events are
  `output.message.started` / `.delta` / `.completed`.
- Names were fixed strings, and the name stays claimed by the soft-deleted row
  after each test's own cleanup. These passed once against a given database and
  409ed on every rerun — including the CI re-run someone reaches for on a
  suspected flake.

## The one that is ours

The thinking tests read a flat `message.thinking` string. That field was
removed deliberately in #3276: one field per message cannot express several
thinking blocks, each with its own signature and position, which is what
providers require. Reasoning rides as ordered `reasoning` content parts, and
the tests now read those.

That is the documented pre-1.0 break, and it is the only failure the reasoning
rework caused. The rest is drift.

## Why this is worth the noise

The reasoning event stream was never broken. It looked that way at first —
`reason.thinking.completed` was missing — and the cause was a retired model
producing no thinking, not the rework. Running these tests is also what
confirmed, independently, that `output.message.completed` carries a reasoning
part while withholding replay state, which is exactly the contract #3279
established.

Four dead tests, seven stale references between them. None of it was reachable
by adding tests; only by executing the ones that already existed.

## Risk

- **Low.** Test-only. No product code is touched.
- The credentials that exposed these stay as they are: the job is push-only,
  the same trust boundary the existing live-LLM step relies on.

## Evidence

| Check | Result |
|---|---|
| `cargo test -p everruns-server --test workflow_test` (live, `EVERRUNS_REQUIRE_LIVE_TESTS=1`) | **35 passed, 0 failed** |
| the five previously failing | all pass against real OpenAI and Anthropic |
| multi-turn replay in both thinking tests | completes — thinking is sent back correctly |
| `output.message.completed` | carries a reasoning part, no replay state |

Run against a live stack with the same flag CI uses. The push build on main is
the real confirmation, since the workflow-test job cannot run on a pull request.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDwmfuubczWiykh4g21Byw)_