### PR TITLE
chore(agents): drop the GitHub API token guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,19 +92,11 @@ export CARGO_INCREMENTAL=0
 # Then use the canonical command in "Local dev" above.
 ```
 
-For non-GitHub tools, failing auth means the token was not passed through, not that it expired:
+Failing auth usually means the token was not passed through, not that it expired:
 
 ```bash
 doppler run -- bash -lc 'TOKEN="$SOME_TOKEN" <command>'
 ```
-
-**The GitHub API is the exception: no token you supply reaches it.** The agent egress proxy
-rewrites the `Authorization` header for `api.github.com`, so requests authenticate as the
-session's own GitHub App installation whatever you pass — a deliberately invalid token, and no
-token at all, both answer `200` as the session user. So `doppler run -- ... GH_TOKEN=...` cannot
-widen GitHub access, and an endpoint the installation lacks scope for (Dependabot alerts, EVE-926)
-answers `403 Resource not accessible by integration` no matter which token is in hand. Fix such a
-403 by widening the App installation, never by hunting for a better token.
 
 ### Commits
 


### PR DESCRIPTION
## What changed

Removes the "The GitHub API is the exception" paragraph from `AGENTS.md` and rewords the
sentence that only existed to introduce it ("For non-GitHub tools, failing auth means…" →
"Failing auth usually means…").

No runtime behavior, tooling, or permission changes — agent instructions only.

## Why

The paragraph described the egress-proxy behavior of one specific cloud-agent harness (an
`Authorization` rewrite for `api.github.com`) as if it were a universal property of the GitHub
API. Agents run in several environments; where that proxy is not in play, or where GitHub is
reached through MCP tools rather than a raw HTTP client, the claims are simply false and the
advice ("no token you supply reaches it", "any token answers 200") misleads. Its one durable
takeaway — a `403 Resource not accessible by integration` is an installation-scope problem — was
not worth the surrounding misinformation, and the environment-specific detail belongs to the
harness, not to repo-wide agent instructions.

## Before / After

Docs-only change with no observable runtime behavior. The diff is the effect: `AGENTS.md` loses
seven lines of harness-specific claims, and the preceding sentence no longer carves out a
"non-GitHub" case that no longer exists.

`python3 scripts/check_okf.py` → `knowledge: OKF v0.2 conformant (150 concepts, 13 index files, 1 log files)`.

## Risk

- Low
- Nothing executable changes. The only downside is losing the note that a GitHub `403` is fixed
  by widening the App installation; that is harness-specific and better carried by the harness.

## Security

- Threat categories reviewed: no security-relevant code changes — the diff touches only prose in
  `AGENTS.md`. No auth, API, data-handling, or infrastructure surface is affected. Removing the
  paragraph does not change any credential path or access boundary; it only stops describing one
  harness's proxy as universal.
- Findings and resolutions: none.

## Follow-ups

No follow-ups.

## Checklist
- [ ] Tests added or updated — not applicable, docs-only.
- [x] Backward compatibility considered — agent instructions only, nothing depends on the text.
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — all non-skipped jobs green; every code job was
      skipped by `Detect Changes` because the diff touches only `AGENTS.md`. No `ci:skip-*` label
      is set.
- [x] All review comments addressed (code change or written reasoning) — no review comments.
