### PR TITLE
chore(models): retire sunset models and seed Bedrock Claude 5

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -153,8 +153,8 @@ const mockModels: ModelWithProvider[] = [
   {
     id: "model-2",
     provider_id: "provider-2",
-    model_id: "claude-3-5-sonnet",
-    display_name: "Claude 3.5 Sonnet",
+    model_id: "claude-sonnet-5",
+    display_name: "Claude Sonnet 5",
     capabilities: ["chat"],
     enabled: false,
     healthy: true,
@@ -330,7 +330,7 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
 
     // Model badges should not be visible
     expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
-    expect(screen.queryByText("Claude 3.5 Sonnet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Claude Sonnet 5")).not.toBeInTheDocument();
   });
 
   it("does not display model badge when model_id has no matching model", async () => {
@@ -428,7 +428,7 @@ describe("AgentDetailPage - Default Model Display in Configuration", () => {
     await renderWithSuspense({ agentId: "agent-1" });
 
     expect(screen.getByText("Default Model")).toBeInTheDocument();
-    expect(screen.getAllByText("Claude 3.5 Sonnet").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Claude Sonnet 5").length).toBeGreaterThan(0);
     expect(screen.getByTestId("provider-icon-anthropic")).toBeInTheDocument();
   });
 

--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -139,7 +139,7 @@ const mockModels: ModelWithProvider[] = [
   {
     id: "model-1",
     provider_id: "provider-1",
-    model_id: "gpt-4o",
+    model_id: "gpt-5.2",
     display_name: "GPT-4o",
     capabilities: ["chat"],
     enabled: false,

--- a/apps/ui/src/__tests__/session-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-model.test.tsx
@@ -32,7 +32,7 @@ const mockSession: Session = {
 const mockModel: ModelWithProvider = {
   id: "model-1",
   provider_id: "provider-1",
-  model_id: "gpt-4o",
+  model_id: "gpt-5.2",
   display_name: "GPT-4o",
   capabilities: ["chat"],
   enabled: false,

--- a/apps/ui/src/__tests__/session-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-model.test.tsx
@@ -69,14 +69,14 @@ describe("SessionCard - LLM Model Display", () => {
     const claudeModel: ModelWithProvider = {
       ...mockModel,
       id: "model-2",
-      display_name: "Claude 3.5 Sonnet",
+      display_name: "Claude Sonnet 5",
       provider_name: "Anthropic",
       provider_type: "anthropic",
     };
 
     render(<SessionCard session={mockSession} model={claudeModel} />);
 
-    expect(screen.getByText("Claude 3.5 Sonnet")).toBeInTheDocument();
+    expect(screen.getByText("Claude Sonnet 5")).toBeInTheDocument();
   });
 
   it("links to org-level session URL", async () => {

--- a/apps/ui/src/app/dev/file-previews/page.tsx
+++ b/apps/ui/src/app/dev/file-previews/page.tsx
@@ -226,7 +226,7 @@ const sampleJSON = {
     status: "active",
     capabilities: ["code_execution", "file_operations", "web_search"],
     config: {
-      model: "claude-3-sonnet",
+      model: "claude-sonnet-5",
       temperature: 0.7,
       maxTokens: 4096,
     },

--- a/apps/ui/src/app/dev/session-card/page.tsx
+++ b/apps/ui/src/app/dev/session-card/page.tsx
@@ -187,7 +187,7 @@ const sampleModels = {
   openai: {
     id: "model-uuid-openai",
     provider_id: "provider-openai",
-    model_id: "gpt-4o",
+    model_id: "gpt-5.2",
     display_name: "GPT-4o",
     capabilities: ["chat", "tools"],
     enabled: false,

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -6232,7 +6232,7 @@ export interface components {
       is_favorite?: boolean;
       /**
        * @description The model identifier used by the provider's API (e.g., "gpt-5.6-sol", "claude-opus-5").
-       * @example gpt-4o
+       * @example gpt-5.2
        */
       model_id: string;
     };
@@ -10386,7 +10386,7 @@ export interface components {
         id: string;
         /** @description Whether this model is starred in the UI for quick access. */
         is_favorite: boolean;
-        /** @description Provider-side model identifier as sent on the wire (e.g. `gpt-4o`, `claude-sonnet-4`). */
+        /** @description Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`, `claude-sonnet-5`). */
         model_id: string;
         /**
          * @description Owning provider's prefixed public identifier.
@@ -10467,7 +10467,7 @@ export interface components {
          */
         is_favorite: boolean;
         /**
-         * @description Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).
+         * @description Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`).
          * @example claude-sonnet-4-5
          */
         model_id: string;
@@ -11550,7 +11550,7 @@ export interface components {
       id: string;
       /** @description Whether this model is starred in the UI for quick access. */
       is_favorite: boolean;
-      /** @description Provider-side model identifier as sent on the wire (e.g. `gpt-4o`, `claude-sonnet-4`). */
+      /** @description Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`, `claude-sonnet-5`). */
       model_id: string;
       /**
        * @description Owning provider's prefixed public identifier.
@@ -11757,7 +11757,7 @@ export interface components {
        */
       is_favorite: boolean;
       /**
-       * @description Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).
+       * @description Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`).
        * @example claude-sonnet-4-5
        */
       model_id: string;
@@ -16470,7 +16470,7 @@ export interface components {
       is_favorite?: boolean | null;
       /**
        * @description The model identifier used by the provider's API.
-       * @example gpt-4o-mini
+       * @example gpt-5.4-mini
        */
       model_id?: string | null;
       /**
@@ -17830,7 +17830,7 @@ export interface components {
       id: string;
       /** @description Whether this model is starred in the UI for quick access. */
       is_favorite: boolean;
-      /** @description Provider-side model identifier as sent on the wire (e.g. `gpt-4o`, `claude-sonnet-4`). */
+      /** @description Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`, `claude-sonnet-5`). */
       model_id: string;
       /**
        * @description Owning provider's prefixed public identifier.
@@ -17913,7 +17913,7 @@ export interface components {
        */
       is_favorite: boolean;
       /**
-       * @description Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).
+       * @description Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`).
        * @example claude-sonnet-4-5
        */
       model_id: string;

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -6231,7 +6231,7 @@ export interface components {
        */
       is_favorite?: boolean;
       /**
-       * @description The model identifier used by the provider's API (e.g., "gpt-4", "claude-3-opus").
+       * @description The model identifier used by the provider's API (e.g., "gpt-5.6-sol", "claude-opus-5").
        * @example gpt-4o
        */
       model_id: string;
@@ -11614,7 +11614,7 @@ export interface components {
     };
     /** @description Metadata about the model used for generation */
     ModelMetadata: {
-      /** @description Model name (e.g., "gpt-4o", "claude-3-sonnet") */
+      /** @description Model name (e.g., "gpt-5.6-sol", "claude-sonnet-5") */
       model: string;
       /**
        * Format: uuid
@@ -11638,11 +11638,8 @@ export interface components {
      * @description LLM Model Profile describing model capabilities
      *     Based on models.dev structure (<https://models.dev/api.json>)
      *
-     *     NOTE: Currently only includes profiles for:
-     *     - OpenAI: gpt-4o, gpt-4o-mini, o1, o1-mini, o1-pro, o3-mini
-     *     - Anthropic: claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-sonnet-4, claude-opus-4
-     *
-     *     Additional model profiles can be added as needed.
+     *     The registry of profiles lives in `model_profiles.rs`; retired models are
+     *     dropped from it as vendors sunset them.
      */
     ModelProfile: {
       /** @description Whether the model supports file/image attachments */
@@ -11650,7 +11647,7 @@ export interface components {
       cost?: null | components["schemas"]["ModelCost"];
       /** @description Short human-readable description of the model's strengths and intended use */
       description?: string | null;
-      /** @description Model family (e.g., "gpt-4o", "claude-3-5-sonnet") */
+      /** @description Model family (e.g., "gpt-5.6-sol", "claude-sonnet-5") */
       family: string;
       /** @description Knowledge cutoff date (YYYY-MM-DD format) */
       knowledge?: string | null;

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -3603,7 +3603,7 @@ export interface VerbosityConfig {
 export interface ModelProfile {
   /** Display name of the model */
   name: string;
-  /** Model family (e.g., "gpt-4o", "claude-3-5-sonnet") */
+  /** Model family (e.g., "gpt-5.6-sol", "claude-sonnet-5") */
   family: string;
   /** Short human-readable description of the model's strengths and intended use */
   description?: string;

--- a/crates/builtins/src/auto_tool_search.rs
+++ b/crates/builtins/src/auto_tool_search.rs
@@ -158,7 +158,8 @@ mod tests {
     #[test]
     fn test_resolves_to_generic_on_non_native_model() {
         // A model with no hosted tool_search support on either provider (here a
-        // pre-4 Claude) falls back to the safe client-side mechanism.
+        // retired pre-4 Claude, no longer in the profile registry) falls back to
+        // the safe client-side mechanism.
         let cap = AutoToolSearchCapability::new();
         let resolved = cap
             .resolve_for_model(Some("claude-3-5-haiku"))

--- a/crates/builtins/src/claude_tool_search.rs
+++ b/crates/builtins/src/claude_tool_search.rs
@@ -150,7 +150,8 @@ mod tests {
 
     #[test]
     fn test_native_support_lookup() {
-        // Claude 4-family models support hosted tool_search; 3.x do not.
+        // Claude 4-family models support hosted tool_search; retired pre-4
+        // models are no longer in the registry and resolve to false.
         assert!(model_supports_native_tool_search("claude-opus-4-8"));
         assert!(model_supports_native_tool_search("claude-sonnet-5"));
         assert!(model_supports_native_tool_search("claude-sonnet-4-6"));

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -529,7 +529,7 @@ use everruns_provider::execution_phase::ExecutionPhase;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ModelMetadata {
-    /// Model name (e.g., "gpt-4o", "claude-3-sonnet")
+    /// Model name (e.g., "gpt-5.6-sol", "claude-sonnet-5")
     pub model: String,
 
     /// Model ID (internal identifier)
@@ -3499,7 +3499,7 @@ mod tests {
             vec![],
             Some("Hi!".to_string()),
             vec![],
-            "claude-3-opus".to_string(),
+            "claude-opus-5".to_string(),
             Some("anthropic".to_string()),
             Some(TokenUsage {
                 input_tokens: 5,
@@ -3517,7 +3517,7 @@ mod tests {
         );
 
         assert!(data.metadata.success);
-        assert_eq!(data.metadata.model, "claude-3-opus");
+        assert_eq!(data.metadata.model, "claude-opus-5");
         assert_eq!(data.metadata.provider, Some("anthropic".to_string()));
         assert_eq!(data.metadata.time_to_first_token_ms, Some(25));
         assert_eq!(
@@ -3930,7 +3930,7 @@ mod tests {
         let data = OutputMessageStartedData {
             turn_id,
             message_id: MessageId::new(),
-            model: Some("claude-3".to_string()),
+            model: Some("claude-opus-5".to_string()),
             iteration: None,
             phase: None,
         };
@@ -3945,7 +3945,7 @@ mod tests {
         match deserialized {
             EventData::OutputMessageStarted(at) => {
                 assert_eq!(at.turn_id, turn_id);
-                assert_eq!(at.model, Some("claude-3".to_string()));
+                assert_eq!(at.model, Some("claude-opus-5".to_string()));
             }
             _ => panic!("Expected OutputMessageStarted, got different variant"),
         }
@@ -3960,7 +3960,7 @@ mod tests {
         let turn_id = TurnId::from_uuid(Uuid::now_v7());
         let data = ReasonThinkingStartedData {
             turn_id,
-            model: Some("claude-3".to_string()),
+            model: Some("claude-opus-5".to_string()),
         };
 
         // Serialize to JSON
@@ -3973,7 +3973,7 @@ mod tests {
         match deserialized {
             EventData::ReasonThinkingStarted(at) => {
                 assert_eq!(at.turn_id, turn_id);
-                assert_eq!(at.model, Some("claude-3".to_string()));
+                assert_eq!(at.model, Some("claude-opus-5".to_string()));
             }
             other => panic!("Expected ReasonThinkingStarted, got {}", other.event_type()),
         }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -3378,7 +3378,7 @@ mod tests {
                 harness_id: HarnessId::from_seed(1),
                 agent_id: Some(AgentId::new()),
                 metadata: Some(ModelMetadata {
-                    model: "gpt-4o".to_string(),
+                    model: "gpt-5.2".to_string(),
                     model_id: None,
                     provider_id: None,
                 }),
@@ -3462,7 +3462,7 @@ mod tests {
             tools,
             Some("Hi there!".to_string()),
             tool_calls,
-            "gpt-4o".to_string(),
+            "gpt-5.2".to_string(),
             Some("openai".to_string()),
             Some(TokenUsage {
                 input_tokens: 10,
@@ -3483,7 +3483,7 @@ mod tests {
         assert_eq!(data.output.text, Some("Hi there!".to_string()));
         assert!(data.output.tool_calls.is_empty());
         assert!(data.metadata.success);
-        assert_eq!(data.metadata.model, "gpt-4o");
+        assert_eq!(data.metadata.model, "gpt-5.2");
         assert_eq!(data.metadata.provider, Some("openai".to_string()));
         assert!(data.metadata.error.is_none());
         // New fields for gen-ai semantic conventions
@@ -3533,7 +3533,7 @@ mod tests {
         let data = LlmGenerationData::failure(
             messages,
             vec![],
-            "gpt-4o".to_string(),
+            "gpt-5.2".to_string(),
             Some("openai".to_string()),
             "Rate limit exceeded".to_string(),
             Some(50),
@@ -3987,7 +3987,7 @@ mod tests {
             vec![],
             Some("Hi!".to_string()),
             vec![],
-            "gpt-4o".to_string(),
+            "gpt-5.2".to_string(),
             Some("openai".to_string()),
             Some(TokenUsage {
                 input_tokens: 10,
@@ -4335,7 +4335,7 @@ mod contract_tests {
         let data = OutputMessageStartedData {
             turn_id: test_turn_id(),
             message_id: test_message_id(),
-            model: Some("gpt-4o".to_string()),
+            model: Some("gpt-5.2".to_string()),
             iteration: None,
             phase: None,
         };
@@ -4448,7 +4448,7 @@ mod contract_tests {
             harness_id: test_harness_id(),
             agent_id: Some(test_agent_id()),
             metadata: Some(ModelMetadata {
-                model: "gpt-4o".to_string(),
+                model: "gpt-5.2".to_string(),
                 model_id: None,
                 provider_id: None,
             }),
@@ -4559,7 +4559,7 @@ mod contract_tests {
             }],
             Some("Hi there!".to_string()),
             vec![],
-            "gpt-4o".to_string(),
+            "gpt-5.2".to_string(),
             Some("openai".to_string()),
             Some(TokenUsage::new(10, 5)),
             Some(100),

--- a/crates/core/src/llm_conversions.rs
+++ b/crates/core/src/llm_conversions.rs
@@ -313,13 +313,13 @@ mod tests {
     fn test_llm_call_config_builder_with_all_options() {
         let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-4o");
         let llm_config = llm_call_config_builder_from_agent(&runtime_agent)
-            .model("claude-3-opus")
+            .model("claude-opus-5")
             .reasoning_effort(ReasoningEffort::Medium)
             .temperature(0.7)
             .max_tokens(1000)
             .build();
 
-        assert_eq!(llm_config.model, "claude-3-opus");
+        assert_eq!(llm_config.model, "claude-opus-5");
         assert_eq!(llm_config.reasoning_effort, Some(ReasoningEffort::Medium));
         assert_eq!(llm_config.temperature, Some(0.7));
         assert_eq!(llm_config.max_tokens, Some(1000));

--- a/crates/core/src/llm_conversions.rs
+++ b/crates/core/src/llm_conversions.rs
@@ -229,10 +229,10 @@ mod tests {
 
     #[test]
     fn test_llm_call_config_builder_from_runtime_agent() {
-        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-4o");
+        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-5.2");
         let llm_config = llm_call_config_builder_from_agent(&runtime_agent).build();
 
-        assert_eq!(llm_config.model, "gpt-4o");
+        assert_eq!(llm_config.model, "gpt-5.2");
         assert!(llm_config.reasoning_effort.is_none());
         assert!(llm_config.temperature.is_none());
         assert!(llm_config.max_tokens.is_none());
@@ -268,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_llm_call_config_builder_with_metadata() {
-        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-4o");
+        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-5.2");
         let llm_config = llm_call_config_builder_from_agent(&runtime_agent)
             .with_metadata("session_id", "session_abc123")
             .with_metadata("agent_id", "agent_xyz789")
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn test_llm_call_config_builder_with_metadata_hashmap() {
-        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-4o");
+        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-5.2");
         let mut metadata = HashMap::new();
         metadata.insert("key1".to_string(), "value1".to_string());
         metadata.insert("key2".to_string(), "value2".to_string());
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_llm_call_config_builder_with_reasoning_effort() {
-        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-4o");
+        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-5.2");
         let llm_config = llm_call_config_builder_from_agent(&runtime_agent)
             .reasoning_effort(ReasoningEffort::High)
             .build();
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn test_llm_call_config_builder_with_all_options() {
-        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-4o");
+        let runtime_agent = RuntimeAgent::new("You are helpful", "gpt-5.2");
         let llm_config = llm_call_config_builder_from_agent(&runtime_agent)
             .model("claude-opus-5")
             .reasoning_effort(ReasoningEffort::Medium)

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -32,7 +32,7 @@ pub struct RuntimeAgent {
     /// System prompt that defines the agent's behavior
     pub system_prompt: String,
 
-    /// Model identifier (e.g., "gpt-5.2", "claude-3-opus")
+    /// Model identifier (e.g., "gpt-5.2", "claude-opus-5")
     pub model: String,
 
     /// Available tools for the agent
@@ -630,11 +630,11 @@ mod tests {
     fn test_builder_basic() {
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Custom prompt")
-            .model("claude-3-opus")
+            .model("claude-opus-5")
             .build();
 
         assert_eq!(runtime_agent.system_prompt, "Custom prompt");
-        assert_eq!(runtime_agent.model, "claude-3-opus");
+        assert_eq!(runtime_agent.model, "claude-opus-5");
     }
 
     #[test]
@@ -1120,8 +1120,9 @@ mod tests {
 
     #[test]
     fn test_build_clears_tool_search_for_non_native_model() {
-        // A pre-4 Claude model has no hosted tool_search support on either
-        // provider, so a hosted config is cleared (full schemas sent).
+        // A retired pre-4 Claude model has no profile (and no hosted
+        // tool_search support on either provider), so a hosted config is
+        // cleared (full schemas sent).
         let agent = RuntimeAgentBuilder::new()
             .model("claude-3-5-haiku")
             .tool_search(ToolSearchConfig {

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -231,7 +231,7 @@ impl RuntimeAgentBuilder {
     ///     .with_harness(&harness, &registry, &ctx).await
     ///     .with_agent(&agent, &registry, &ctx).await
     ///     .with_capabilities(&session_caps, &registry, &ctx).await
-    ///     .model("gpt-4o")
+    ///     .model("gpt-5.2")
     ///     .build();
     /// ```
     pub async fn with_agent(

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -1243,13 +1243,13 @@ Lint instructions.
         let content = r#"---
 name: my-skill
 description: A skill.
-model: gpt-4o
+model: gpt-5.2
 ---
 
 Body.
 "#;
         let parsed = parse_skill_md(content).unwrap();
-        assert_eq!(parsed.model.as_deref(), Some("gpt-4o"));
+        assert_eq!(parsed.model.as_deref(), Some("gpt-5.2"));
         assert_eq!(parsed.context, SkillContext::Inline);
     }
 
@@ -1271,7 +1271,7 @@ Body.
         let content = r#"---
 name: my-skill
 description: A skill.
-model: gpt-4o
+model: gpt-5.2
 ---
 
 Body.

--- a/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_llm_generation.snap
+++ b/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_llm_generation.snap
@@ -26,7 +26,7 @@ expression: data
     "text": "Hi there!"
   },
   "metadata": {
-    "model": "gpt-4o",
+    "model": "gpt-5.2",
     "provider": "openai",
     "usage": {
       "input_tokens": 10,

--- a/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_output_message_started.snap
+++ b/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_output_message_started.snap
@@ -5,5 +5,5 @@ expression: data
 {
   "turn_id": "turn_00000000000000000000000000000002",
   "message_id": "message_00000000000000000000000000000003",
-  "model": "gpt-4o"
+  "model": "gpt-5.2"
 }

--- a/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_reason_started.snap
+++ b/crates/core/src/snapshots/everruns_core__events__contract_tests__event_data_reason_started.snap
@@ -6,6 +6,6 @@ expression: data
   "harness_id": "harness_00000000000000000000000000000005",
   "agent_id": "agent_00000000000000000000000000000004",
   "metadata": {
-    "model": "gpt-4o"
+    "model": "gpt-5.2"
   }
 }

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn test_chat_span_name() {
         assert_eq!(chat_span_name("gpt-4"), "chat gpt-4");
-        assert_eq!(chat_span_name("claude-3-opus"), "chat claude-3-opus");
+        assert_eq!(chat_span_name("claude-opus-5"), "chat claude-opus-5");
     }
 
     #[test]

--- a/crates/drivers/anthropic/src/driver.rs
+++ b/crates/drivers/anthropic/src/driver.rs
@@ -1587,7 +1587,7 @@ const MILLION_CONTEXT_FAMILIES: &[&str] = &[
 /// The suffix is honored only when the bare id belongs to a family that
 /// actually supports the 1M window (`MILLION_CONTEXT_FAMILIES`). A
 /// manually-configured id that merely ends in `[1m]` but is not 1M-capable —
-/// e.g. `claude-3-haiku[1m]` or `claude-sonnet-4-5[1m]` — is left untouched. We
+/// e.g. `claude-haiku-4-5[1m]` or `claude-sonnet-4-5[1m]` — is left untouched. We
 /// must never rewrite an arbitrary configured id or send the `context-1m` beta
 /// header to a model that does not support the 1M window (it can 400 or
 /// silently truncate on models where the header was retired). Date-suffixed 1M
@@ -3195,8 +3195,8 @@ mod tests {
     fn test_normalize_anthropic_id_preserves_base_ids() {
         assert_eq!(normalize_anthropic_id("claude-opus-4-5"), "claude-opus-4-5");
         assert_eq!(
-            normalize_anthropic_id("claude-3-5-sonnet"),
-            "claude-3-5-sonnet"
+            normalize_anthropic_id("claude-sonnet-4-6"),
+            "claude-sonnet-4-6"
         );
     }
 
@@ -3256,8 +3256,8 @@ mod tests {
         // untouched — never strip them or send `context-1m` (it can 400 or
         // silently truncate, e.g. on sonnet-4-5 where the header was retired).
         for not_1m in [
-            "claude-3-haiku[1m]",
-            "claude-3-haiku-20240307[1m]",
+            "claude-haiku-4-5[1m]",
+            "claude-haiku-4-5-20251001[1m]",
             "claude-sonnet-4-5[1m]",
             "totally-made-up[1m]",
         ] {

--- a/crates/drivers/gemini/src/driver.rs
+++ b/crates/drivers/gemini/src/driver.rs
@@ -1810,9 +1810,12 @@ mod tests {
         // Known Gemini models should resolve max_tokens from profile
         let profile = everruns_provider::get_model_profile(
             &everruns_provider::DriverId::Gemini,
-            "gemini-1.5-pro",
+            "gemini-3.1-pro-preview",
         );
-        assert!(profile.is_some(), "gemini-1.5-pro should have a profile");
+        assert!(
+            profile.is_some(),
+            "gemini-3.1-pro-preview should have a profile"
+        );
         let limits = profile.unwrap().limits.expect("profile should have limits");
         assert!(limits.output > 0, "output limit should be positive");
     }

--- a/crates/drivers/openai/src/types.rs
+++ b/crates/drivers/openai/src/types.rs
@@ -204,7 +204,7 @@ pub struct OpenAiModelsResponse {
 /// Individual model info from OpenAI's models API
 #[derive(Debug, Clone, Deserialize)]
 pub struct OpenAiModelInfo {
-    /// Model identifier (e.g., "gpt-5.2", "gpt-4o")
+    /// Model identifier (e.g., "gpt-5.2", "gpt-5.4-mini")
     pub id: String,
     /// Unix timestamp of model creation
     pub created: i64,

--- a/crates/host/src/observability/otel.rs
+++ b/crates/host/src/observability/otel.rs
@@ -1187,7 +1187,7 @@ mod tests {
 
         let started = ReasonThinkingStartedData {
             turn_id,
-            model: Some("claude-3-opus".to_string()),
+            model: Some("claude-opus-5".to_string()),
         };
         let event = event_with_context(
             session_id,
@@ -1494,7 +1494,7 @@ mod tests {
                 tool_calls: vec![],
             },
             metadata: LlmGenerationMetadata {
-                model: "claude-3".to_string(),
+                model: "claude-opus-5".to_string(),
                 provider: None,
                 usage: None,
                 duration_ms: None,
@@ -1530,7 +1530,7 @@ mod tests {
                 tool_calls: vec![],
             },
             metadata: LlmGenerationMetadata {
-                model: "claude-3-5-sonnet".to_string(),
+                model: "claude-sonnet-5".to_string(),
                 provider: Some("anthropic".to_string()),
                 usage: Some(TokenUsage {
                     input_tokens: 100,

--- a/crates/host/src/observability/otel.rs
+++ b/crates/host/src/observability/otel.rs
@@ -1458,7 +1458,7 @@ mod tests {
                 }],
             },
             metadata: LlmGenerationMetadata {
-                model: "gpt-4o".to_string(),
+                model: "gpt-5.2".to_string(),
                 provider: Some("openai".to_string()),
                 usage: Some(TokenUsage::new(20, 15)),
                 duration_ms: Some(200),
@@ -2039,7 +2039,7 @@ mod tests {
                 }],
             },
             metadata: LlmGenerationMetadata {
-                model: "gpt-4o".to_string(),
+                model: "gpt-5.2".to_string(),
                 provider: Some("openai".to_string()),
                 usage: Some(TokenUsage::new(50, 20)),
                 duration_ms: Some(300),
@@ -2184,7 +2184,7 @@ mod tests {
                 tool_calls: vec![],
             },
             metadata: LlmGenerationMetadata {
-                model: "gpt-4o".to_string(),
+                model: "gpt-5.2".to_string(),
                 provider: Some("openai".to_string()),
                 usage: Some(TokenUsage::new(100, 80)),
                 duration_ms: Some(400),

--- a/crates/provider/src/model.rs
+++ b/crates/provider/src/model.rs
@@ -403,17 +403,14 @@ impl ModelVendor {
 /// LLM Model Profile describing model capabilities
 /// Based on models.dev structure (<https://models.dev/api.json>)
 ///
-/// NOTE: Currently only includes profiles for:
-/// - OpenAI: gpt-4o, gpt-4o-mini, o1, o1-mini, o1-pro, o3-mini
-/// - Anthropic: claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-sonnet-4, claude-opus-4
-///
-/// Additional model profiles can be added as needed.
+/// The registry of profiles lives in `model_profiles.rs`; retired models are
+/// dropped from it as vendors sunset them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ModelProfile {
     /// Display name of the model
     pub name: String,
-    /// Model family (e.g., "gpt-4o", "claude-3-5-sonnet")
+    /// Model family (e.g., "gpt-5.6-sol", "claude-sonnet-5")
     pub family: String,
     /// Short human-readable description of the model's strengths and intended use
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/provider/src/model.rs
+++ b/crates/provider/src/model.rs
@@ -67,7 +67,7 @@ pub struct Model {
     /// Owning provider's prefixed public identifier.
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "provider_01933b5a00007000800000000000001"))]
     pub provider_id: ProviderId,
-    /// Provider-side model identifier as sent on the wire (e.g. `gpt-4o`, `claude-sonnet-4`).
+    /// Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`, `claude-sonnet-5`).
     pub model_id: String,
     /// Human-readable display name. Safe to render in user-facing messages.
     pub display_name: String,
@@ -95,7 +95,7 @@ pub struct ModelWithProvider {
     /// Owning provider's prefixed public identifier.
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "provider_01933b5a00007000800000000000001"))]
     pub provider_id: ProviderId,
-    /// Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).
+    /// Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`).
     #[cfg_attr(feature = "openapi", schema(example = "claude-sonnet-4-5"))]
     pub model_id: String,
     /// Human-readable display name.

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -30,7 +30,7 @@ fn effort(value: ReasoningEffort, name: &str) -> ReasoningEffortValue {
     }
 }
 
-/// Standard reasoning efforts for pre-gpt-5.1 models (o1, o1-mini, o3-mini)
+/// Standard reasoning efforts for pre-gpt-5.1 reasoning models (o3, o4-mini)
 /// Default: medium, supports: low, medium, high
 fn reasoning_effort_standard() -> ReasoningEffortConfig {
     ReasoningEffortConfig {
@@ -43,7 +43,7 @@ fn reasoning_effort_standard() -> ReasoningEffortConfig {
     }
 }
 
-/// Reasoning effort for o1-pro (only high)
+/// Reasoning effort for pro-tier reasoning models (only high)
 fn reasoning_effort_high_only() -> ReasoningEffortConfig {
     ReasoningEffortConfig {
         values: vec![effort(ReasoningEffort::High, "High")],

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -207,7 +207,7 @@ fn speed_flex_only() -> SpeedConfig {
 }
 
 /// Speed for models with only a priority pricing row
-/// (gpt-4o, gpt-4o-mini, gpt-4.1 family, gpt-5/gpt-5-mini,
+/// (gpt-4.1 family, gpt-5/gpt-5-mini,
 /// gpt-5-codex, gpt-5.1/gpt-5.1-codex, gpt-5.2, gpt-5.3-codex,
 /// o3, o4-mini).
 fn speed_priority_only() -> SpeedConfig {
@@ -333,14 +333,7 @@ static REGISTRY: &[ModelDescriptor] = &[
         OPENAI,
         ServiceKind::Realtime,
     ),
-    md(&["gpt-4o"], ModelVendor::OpenAi, OPENAI),
-    md(&["gpt-4o-mini"], ModelVendor::OpenAi, OPENAI),
-    md(&["o1"], ModelVendor::OpenAi, OPENAI),
-    md(&["o1-mini"], ModelVendor::OpenAi, OPENAI),
-    md(&["o1-pro"], ModelVendor::OpenAi, OPENAI),
-    md(&["o1-preview"], ModelVendor::OpenAi, OPENAI),
     md(&["o3"], ModelVendor::OpenAi, OPENAI),
-    md(&["o3-mini"], ModelVendor::OpenAi, OPENAI),
     md(&["o3-pro"], ModelVendor::OpenAi, OPENAI),
     md(&["o3-deep-research"], ModelVendor::OpenAi, OPENAI),
     md(&["o4-mini"], ModelVendor::OpenAi, OPENAI),
@@ -465,7 +458,7 @@ static REGISTRY: &[ModelDescriptor] = &[
 /// Resolve the registry descriptor for a model id under a provider type.
 /// Matching is provider-filtered (the `surfaces` predicate) and picks the
 /// longest matching id so specific variants win over their prefixes (e.g.
-/// `gpt-4o-mini` over `gpt-4o`).
+/// `gpt-5.4-mini` over `gpt-5.4`).
 fn resolve_descriptor(
     provider_type: &DriverId,
     model_id: &str,
@@ -746,228 +739,6 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
             tool_search: false,
             supported_parameters: Vec::new(),
             supports_phases: true,
-        }),
-
-        "gpt-4o" => Some(ModelProfile {
-            name: "GPT-4o".into(),
-            family: "gpt-4o".into(),
-            description: None,
-            release_date: Some("2024-05-13".into()),
-            last_updated: Some("2024-11-20".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2023-10-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 2.50,
-                output: 10.00,
-                cache_read: Some(1.25),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 128_000,
-                input: None,
-                output: 16_384,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image, Modality::Audio],
-                output: vec![Modality::Text, Modality::Audio],
-            }),
-            reasoning_effort: None,
-            speed: Some(speed_priority_only()),
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "gpt-4o-mini" => Some(ModelProfile {
-            name: "GPT-4o mini".into(),
-            family: "gpt-4o-mini".into(),
-            description: None,
-            release_date: Some("2024-07-18".into()),
-            last_updated: Some("2024-07-18".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2023-10-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 0.15,
-                output: 0.60,
-                cache_read: Some(0.075),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 128_000,
-                input: None,
-                output: 16_384,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: None,
-            speed: Some(speed_priority_only()),
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "o1" => Some(ModelProfile {
-            name: "o1".into(),
-            family: "o1".into(),
-            description: None,
-            release_date: Some("2024-12-17".into()),
-            last_updated: Some("2024-12-17".into()),
-            attachment: true,
-            reasoning: true,
-            temperature: true,
-            knowledge: Some("2023-10-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 15.00,
-                output: 60.00,
-                cache_read: Some(7.50),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 100_000,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: Some(reasoning_effort_standard()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "o1-mini" => Some(ModelProfile {
-            name: "o1-mini".into(),
-            family: "o1-mini".into(),
-            description: None,
-            release_date: Some("2024-09-12".into()),
-            last_updated: Some("2024-09-12".into()),
-            attachment: false,
-            reasoning: true,
-            temperature: true,
-            knowledge: Some("2023-10-01".into()),
-            tool_call: false,
-            structured_output: false,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 3.00,
-                output: 12.00,
-                cache_read: Some(1.50),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 128_000,
-                input: None,
-                output: 65_536,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: Some(reasoning_effort_standard()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "o1-pro" => Some(ModelProfile {
-            name: "o1-pro".into(),
-            family: "o1-pro".into(),
-            description: None,
-            release_date: Some("2025-03-19".into()),
-            last_updated: Some("2025-03-19".into()),
-            attachment: true,
-            reasoning: true,
-            temperature: true,
-            knowledge: Some("2023-10-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 150.00,
-                output: 600.00,
-                cache_read: None,
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 100_000,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: Some(reasoning_effort_high_only()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "o3-mini" => Some(ModelProfile {
-            name: "o3-mini".into(),
-            family: "o3-mini".into(),
-            description: None,
-            release_date: Some("2025-01-31".into()),
-            last_updated: Some("2025-01-31".into()),
-            attachment: false,
-            reasoning: true,
-            temperature: true,
-            knowledge: Some("2023-10-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 1.10,
-                output: 4.40,
-                cache_read: Some(0.55),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 100_000,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: Some(reasoning_effort_standard()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
         }),
 
         "o3" => Some(ModelProfile {
@@ -2243,43 +2014,6 @@ fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
             supports_phases: false,
         }),
 
-        "o1-preview" => Some(ModelProfile {
-            name: "o1 Preview".into(),
-            family: "o1".into(),
-            description: None,
-            release_date: Some("2024-09-12".into()),
-            last_updated: Some("2024-09-12".into()),
-            attachment: false,
-            reasoning: true,
-            temperature: true,
-            knowledge: Some("2023-10-01".into()),
-            tool_call: false,
-            structured_output: false,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 15.00,
-                output: 60.00,
-                cache_read: Some(7.50),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 128_000,
-                input: None,
-                output: 32_768,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: Some(reasoning_effort_standard()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
         _ => None,
     }
 }
@@ -3533,13 +3267,6 @@ mod tests {
     const REGISTERED_MODELS: &[(DriverId, &str)] = &[
         // OpenAI
         (DriverId::OpenAI, "gpt-realtime-2"),
-        (DriverId::OpenAI, "gpt-4o"),
-        (DriverId::OpenAI, "gpt-4o-mini"),
-        (DriverId::OpenAI, "o1"),
-        (DriverId::OpenAI, "o1-mini"),
-        (DriverId::OpenAI, "o1-pro"),
-        (DriverId::OpenAI, "o1-preview"),
-        (DriverId::OpenAI, "o3-mini"),
         (DriverId::OpenAI, "o3"),
         (DriverId::OpenAI, "o3-pro"),
         (DriverId::OpenAI, "o4-mini"),
@@ -3739,11 +3466,11 @@ mod tests {
     // Per-model name/family/cost/limits constants covered by registered_model_profiles_are_structurally_consistent.
 
     #[test]
-    fn test_get_profile_openai_gpt4o_versioned() {
-        let profile = get_model_profile(&DriverId::OpenAI, "gpt-4o-2024-11-20");
+    fn test_get_profile_openai_versioned() {
+        let profile = get_model_profile(&DriverId::OpenAI, "gpt-5.2-2025-12-11");
         assert!(profile.is_some());
         let profile = profile.unwrap();
-        assert_eq!(profile.name, "GPT-4o");
+        assert_eq!(profile.name, "GPT-5.2");
     }
 
     #[test]
@@ -3755,7 +3482,7 @@ mod tests {
     #[test]
     fn test_get_profile_wrong_provider() {
         // Try to get an OpenAI model with Anthropic provider
-        let profile = get_model_profile(&DriverId::Anthropic, "gpt-4o");
+        let profile = get_model_profile(&DriverId::Anthropic, "gpt-5.2");
         assert!(profile.is_none());
     }
 
@@ -3763,11 +3490,11 @@ mod tests {
 
     #[test]
     fn test_normalize_openai_model_id() {
-        assert_eq!(normalize_model_id("gpt-4o"), "gpt-4o");
-        assert_eq!(normalize_model_id("gpt-4o-2024-11-20"), "gpt-4o");
-        assert_eq!(normalize_model_id("gpt-4o-mini"), "gpt-4o-mini");
-        assert_eq!(normalize_model_id("o1-2024-12-17"), "o1");
-        assert_eq!(normalize_model_id("o1-mini"), "o1-mini");
+        assert_eq!(normalize_model_id("gpt-5.2"), "gpt-5.2");
+        assert_eq!(normalize_model_id("gpt-5.2-2025-12-11"), "gpt-5.2");
+        assert_eq!(normalize_model_id("gpt-5.4-mini"), "gpt-5.4-mini");
+        assert_eq!(normalize_model_id("o3-2025-04-16"), "o3");
+        assert_eq!(normalize_model_id("o4-mini"), "o4-mini");
     }
 
     #[test]
@@ -3788,16 +3515,16 @@ mod tests {
 
     #[test]
     fn test_openai_completions_uses_openai_profiles() {
-        let profile = get_model_profile(&DriverId::OpenAICompletions, "gpt-4o");
+        let profile = get_model_profile(&DriverId::OpenAICompletions, "gpt-5.2");
         assert!(profile.is_some());
-        assert_eq!(profile.unwrap().name, "GPT-4o");
+        assert_eq!(profile.unwrap().name, "GPT-5.2");
     }
 
     #[test]
     fn test_azure_openai_uses_openai_profiles() {
-        let profile = get_model_profile(&DriverId::AzureOpenAI, "gpt-4o");
+        let profile = get_model_profile(&DriverId::AzureOpenAI, "gpt-5.2");
         assert!(profile.is_some());
-        assert_eq!(profile.unwrap().name, "GPT-4o");
+        assert_eq!(profile.unwrap().name, "GPT-5.2");
     }
 
     // Speed (service tier) availability follows OpenAI's official tier tables;
@@ -3830,8 +3557,6 @@ mod tests {
         }
         // Priority-only pricing rows.
         for model in [
-            "gpt-4o",
-            "gpt-4o-mini",
             "gpt-4.1",
             "gpt-4.1-mini",
             "gpt-4.1-nano",
@@ -3847,7 +3572,7 @@ mod tests {
         ] {
             assert_eq!(speeds(model), vec![Default, Priority], "{model}");
         }
-        // No tier rows: unlisted variants, chat-latest, deep research, and o1.
+        // No tier rows: unlisted variants, chat-latest, and deep research.
         for model in [
             "gpt-5-nano",
             "gpt-5-pro",
@@ -3857,7 +3582,6 @@ mod tests {
             "gpt-5.2-codex",
             "gpt-5-chat-latest",
             "o3-deep-research",
-            "o1",
         ] {
             assert_eq!(speeds(model), vec![], "{model}");
         }
@@ -4785,8 +4509,8 @@ mod tests {
         assert!(!grok_completions.tool_search);
 
         // Genuine OpenAI models still resolve under all OpenAI-family types.
-        assert!(get_model_profile(&DriverId::OpenAI, "gpt-4o").is_some());
-        assert!(get_model_profile(&DriverId::AzureOpenAI, "gpt-4o").is_some());
+        assert!(get_model_profile(&DriverId::OpenAI, "gpt-5.2").is_some());
+        assert!(get_model_profile(&DriverId::AzureOpenAI, "gpt-5.2").is_some());
     }
 
     #[test]
@@ -4956,11 +4680,11 @@ mod tests {
 
     #[test]
     fn test_estimate_cost_usd_known_model() {
-        // gpt-4o profile: input $2.50/M, output $10.00/M.
-        let est = estimate_cost_usd(&DriverId::OpenAI, "gpt-4o", 1_000_000, 500_000, 0, 0)
+        // gpt-5.2 profile: input $1.75/M, output $14.00/M.
+        let est = estimate_cost_usd(&DriverId::OpenAI, "gpt-5.2", 1_000_000, 500_000, 0, 0)
             .expect("known model should yield an estimate");
-        // 1M input * 2.50 + 0.5M output * 10.00 = 2.50 + 5.00 = 7.50
-        assert!((est - 7.50).abs() < 1e-9, "got {est}");
+        // 1M input * 1.75 + 0.5M output * 14.00 = 1.75 + 7.00 = 8.75
+        assert!((est - 8.75).abs() < 1e-9, "got {est}");
     }
 
     #[test]
@@ -4971,12 +4695,12 @@ mod tests {
     #[test]
     fn test_estimate_cost_usd_bills_disjoint_buckets() {
         // Disjoint convention: `input_tokens` is non-cached, `cache_read_tokens`
-        // additive. gpt-4o: input $2.50/M, cache_read $1.25/M. 200K non-cached
+        // additive. gpt-5.2: input $1.75/M, cache_read $0.175/M. 200K non-cached
         // input + 800K cache reads each bill at their own rate.
-        let est = estimate_cost_usd(&DriverId::OpenAI, "gpt-4o", 200_000, 0, 800_000, 0)
+        let est = estimate_cost_usd(&DriverId::OpenAI, "gpt-5.2", 200_000, 0, 800_000, 0)
             .expect("known model should yield an estimate");
-        // 200K * 2.50 + 800K * 1.25 = 0.50 + 1.00 = 1.50.
-        assert!((est - 1.50).abs() < 1e-9, "got {est}");
+        // 200K * 1.75 + 800K * 0.175 = 0.35 + 0.14 = 0.49.
+        assert!((est - 0.49).abs() < 1e-9, "got {est}");
     }
 
     #[test]

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -395,15 +395,8 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["claude-opus-4-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-sonnet-4-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-haiku-4-5"], ModelVendor::Anthropic, ANTHROPIC),
-    md(&["claude-opus-4-1"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-sonnet-4"], ModelVendor::Anthropic, ANTHROPIC),
-    md(&["claude-3-7-sonnet"], ModelVendor::Anthropic, ANTHROPIC),
-    md(&["claude-3-5-sonnet"], ModelVendor::Anthropic, ANTHROPIC),
-    md(&["claude-3-5-haiku"], ModelVendor::Anthropic, ANTHROPIC),
-    md(&["claude-3-opus"], ModelVendor::Anthropic, ANTHROPIC),
-    md(&["claude-3-sonnet"], ModelVendor::Anthropic, ANTHROPIC),
-    md(&["claude-3-haiku"], ModelVendor::Anthropic, ANTHROPIC),
     // Google Gemini
     md(&["gemini-3.1-pro-preview"], ModelVendor::Google, GEMINI),
     md(&["gemini-3.5-flash"], ModelVendor::Google, GEMINI),
@@ -411,8 +404,6 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["gemini-2.5-pro"], ModelVendor::Google, GEMINI),
     md(&["gemini-2.5-flash"], ModelVendor::Google, GEMINI),
     md(&["gemini-2.0-flash"], ModelVendor::Google, GEMINI),
-    md(&["gemini-1.5-pro"], ModelVendor::Google, GEMINI),
-    md(&["gemini-1.5-flash"], ModelVendor::Google, GEMINI),
     // Third-party, OpenAI-compatible
     md(
         &[
@@ -2660,7 +2651,6 @@ fn anthropic_family_supports_tool_search(family: &str) -> bool {
             | "claude-opus-4-7"
             | "claude-opus-4-6"
             | "claude-opus-4-5"
-            | "claude-opus-4-1"
             | "claude-opus-4"
             | "claude-sonnet-5"
             | "claude-sonnet-4-6"
@@ -3111,44 +3101,6 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
             supports_phases: false,
         }),
 
-        // Claude 4.1 series
-        "claude-opus-4-1" => Some(ModelProfile {
-            name: "Claude Opus 4.1".into(),
-            family: "claude-opus-4-1".into(),
-            description: None,
-            release_date: Some("2025-08-05".into()),
-            last_updated: Some("2025-08-05".into()),
-            attachment: true,
-            reasoning: true,
-            temperature: true,
-            knowledge: Some("2025-03-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 15.00,
-                output: 75.00,
-                cache_read: Some(1.50),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 32_000,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
         // Claude 4 series
         "claude-sonnet-4" => Some(ModelProfile {
             name: "Claude Sonnet 4".into(),
@@ -3217,230 +3169,6 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        // Claude 3.7 series
-        "claude-3-7-sonnet" => Some(ModelProfile {
-            name: "Claude 3.7 Sonnet".into(),
-            family: "claude-3-7-sonnet".into(),
-            description: None,
-            release_date: Some("2025-02-19".into()),
-            last_updated: Some("2025-02-19".into()),
-            attachment: true,
-            reasoning: true, // Extended thinking mode
-            temperature: true,
-            knowledge: Some("2024-11-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 3.00,
-                output: 15.00,
-                cache_read: Some(0.30),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 64_000, // Extended output with thinking
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        // Claude 3.5 series
-        "claude-3-5-sonnet" => Some(ModelProfile {
-            name: "Claude 3.5 Sonnet".into(),
-            family: "claude-3-5-sonnet".into(),
-            description: None,
-            release_date: Some("2024-06-20".into()),
-            last_updated: Some("2024-10-22".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2024-04-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 3.00,
-                output: 15.00,
-                cache_read: Some(0.30),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 8_192,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: None,
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "claude-3-5-haiku" => Some(ModelProfile {
-            name: "Claude 3.5 Haiku".into(),
-            family: "claude-3-5-haiku".into(),
-            description: None,
-            release_date: Some("2024-10-22".into()),
-            last_updated: Some("2024-10-22".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2024-07-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 1.00,
-                output: 5.00,
-                cache_read: Some(0.10),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 8_192,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: None,
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "claude-3-opus" => Some(ModelProfile {
-            name: "Claude 3 Opus".into(),
-            family: "claude-3-opus".into(),
-            description: None,
-            release_date: Some("2024-02-29".into()),
-            last_updated: Some("2024-02-29".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2023-08-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 15.00,
-                output: 75.00,
-                cache_read: Some(1.50),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 4_096,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: None,
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "claude-3-sonnet" => Some(ModelProfile {
-            name: "Claude 3 Sonnet".into(),
-            family: "claude-3-sonnet".into(),
-            description: None,
-            release_date: Some("2024-02-29".into()),
-            last_updated: Some("2024-02-29".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2023-08-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 3.00,
-                output: 15.00,
-                cache_read: Some(0.30),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 4_096,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: None,
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "claude-3-haiku" => Some(ModelProfile {
-            name: "Claude 3 Haiku".into(),
-            family: "claude-3-haiku".into(),
-            description: None,
-            release_date: Some("2024-03-07".into()),
-            last_updated: Some("2024-03-07".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2023-08-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 0.25,
-                output: 1.25,
-                cache_read: Some(0.03),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 4_096,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: None,
             speed: None,
             verbosity: None,
             tool_search: false,
@@ -3726,90 +3454,6 @@ fn gemini_profile_data(model_id: &str) -> Option<ModelProfile> {
             supports_phases: false,
         }),
 
-        "gemini-1.5-pro" => Some(ModelProfile {
-            name: "Gemini 1.5 Pro".into(),
-            family: "gemini-1.5-pro".into(),
-            description: None,
-            release_date: Some("2024-02-15".into()),
-            last_updated: Some("2024-09-24".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2024-04-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 1.25,
-                output: 5.00,
-                cache_read: Some(0.31),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 2_097_152,
-                input: None,
-                output: 8_192,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![
-                    Modality::Text,
-                    Modality::Image,
-                    Modality::Audio,
-                    Modality::Video,
-                ],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: None,
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
-        "gemini-1.5-flash" => Some(ModelProfile {
-            name: "Gemini 1.5 Flash".into(),
-            family: "gemini-1.5-flash".into(),
-            description: None,
-            release_date: Some("2024-05-24".into()),
-            last_updated: Some("2024-09-24".into()),
-            attachment: true,
-            reasoning: false,
-            temperature: true,
-            knowledge: Some("2024-04-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 0.075,
-                output: 0.30,
-                cache_read: Some(0.01875),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 1_048_576,
-                input: None,
-                output: 8_192,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![
-                    Modality::Text,
-                    Modality::Image,
-                    Modality::Audio,
-                    Modality::Video,
-                ],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: None,
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
         _ => None,
     }
 }
@@ -3940,15 +3584,8 @@ mod tests {
         (DriverId::Anthropic, "claude-opus-4-5"),
         (DriverId::Anthropic, "claude-sonnet-4-5"),
         (DriverId::Anthropic, "claude-haiku-4-5"),
-        (DriverId::Anthropic, "claude-opus-4-1"),
         (DriverId::Anthropic, "claude-sonnet-4"),
         (DriverId::Anthropic, "claude-opus-4"),
-        (DriverId::Anthropic, "claude-3-7-sonnet"),
-        (DriverId::Anthropic, "claude-3-5-sonnet"),
-        (DriverId::Anthropic, "claude-3-5-haiku"),
-        (DriverId::Anthropic, "claude-3-opus"),
-        (DriverId::Anthropic, "claude-3-sonnet"),
-        (DriverId::Anthropic, "claude-3-haiku"),
         // Gemini
         (DriverId::Gemini, "gemini-3.1-pro-preview"),
         (DriverId::Gemini, "gemini-3.5-flash"),
@@ -3956,8 +3593,6 @@ mod tests {
         (DriverId::Gemini, "gemini-2.5-pro"),
         (DriverId::Gemini, "gemini-2.5-flash"),
         (DriverId::Gemini, "gemini-2.0-flash"),
-        (DriverId::Gemini, "gemini-1.5-flash"),
-        (DriverId::Gemini, "gemini-1.5-pro"),
     ];
 
     /// Structural invariants that must hold for every registered profile. This
@@ -4138,16 +3773,12 @@ mod tests {
     #[test]
     fn test_normalize_anthropic_model_id() {
         assert_eq!(
-            normalize_anthropic_model_id("claude-3-5-sonnet"),
-            "claude-3-5-sonnet"
+            normalize_anthropic_model_id("claude-sonnet-5"),
+            "claude-sonnet-5"
         );
         assert_eq!(
-            normalize_anthropic_model_id("claude-3-5-sonnet-20241022"),
-            "claude-3-5-sonnet"
-        );
-        assert_eq!(
-            normalize_anthropic_model_id("claude-3-5-sonnet-latest"),
-            "claude-3-5-sonnet"
+            normalize_anthropic_model_id("claude-sonnet-5-latest"),
+            "claude-sonnet-5"
         );
         assert_eq!(
             normalize_anthropic_model_id("claude-sonnet-4-20250514"),
@@ -4912,18 +4543,6 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_claude_41_model_ids() {
-        assert_eq!(
-            normalize_anthropic_model_id("claude-opus-4-1"),
-            "claude-opus-4-1"
-        );
-        assert_eq!(
-            normalize_anthropic_model_id("claude-opus-4-1-20250805"),
-            "claude-opus-4-1"
-        );
-    }
-
-    #[test]
     fn test_normalize_claude_45_model_ids() {
         assert_eq!(
             normalize_anthropic_model_id("claude-opus-4-5-20251101"),
@@ -4936,18 +4555,6 @@ mod tests {
         assert_eq!(
             normalize_anthropic_model_id("claude-haiku-4-5-20251001"),
             "claude-haiku-4-5"
-        );
-    }
-
-    #[test]
-    fn test_normalize_claude_37_model_ids() {
-        assert_eq!(
-            normalize_anthropic_model_id("claude-3-7-sonnet"),
-            "claude-3-7-sonnet"
-        );
-        assert_eq!(
-            normalize_anthropic_model_id("claude-3-7-sonnet-20250219"),
-            "claude-3-7-sonnet"
         );
     }
 
@@ -5204,7 +4811,6 @@ mod tests {
             "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-opus-4-5",
-            "claude-opus-4-1",
             "claude-opus-4",
             "claude-sonnet-4-6",
             "claude-sonnet-4-5",
@@ -5221,12 +4827,8 @@ mod tests {
                 .unwrap()
                 .tool_search
         );
-        // Pre-4 Claude does not support it.
-        assert!(
-            !get_model_profile(&DriverId::Anthropic, "claude-3-5-haiku")
-                .map(|p| p.tool_search)
-                .unwrap_or(false)
-        );
+        // Retired pre-4 Claude models are no longer in the registry at all.
+        assert!(get_model_profile(&DriverId::Anthropic, "claude-3-5-haiku").is_none());
         // Reached via a non-first-party transport (Bedrock ConverseStream lacks
         // server-side tool search; OpenRouter's stateless shim doesn't implement
         // it), the same model must not advertise hosted tool_search — it falls

--- a/crates/provider/src/openai_protocol.rs
+++ b/crates/provider/src/openai_protocol.rs
@@ -1123,7 +1123,7 @@ mod tests {
         let request = OpenAiRequest {
             verbosity: None,
             service_tier: None,
-            model: "gpt-4o".to_string(),
+            model: "gpt-5.2".to_string(),
             messages: vec![OpenAiMessage {
                 role: "user".to_string(),
                 content: Some(OpenAiContent::Text("Hello".to_string())),
@@ -1157,7 +1157,7 @@ mod tests {
         let request = OpenAiRequest {
             verbosity: None,
             service_tier: None,
-            model: "gpt-4o".to_string(),
+            model: "gpt-5.2".to_string(),
             messages: vec![OpenAiMessage {
                 role: "user".to_string(),
                 content: Some(OpenAiContent::Text("Hello".to_string())),
@@ -1187,7 +1187,7 @@ mod tests {
             "id": "chatcmpl-123",
             "object": "chat.completion.chunk",
             "created": 1234567890,
-            "model": "gpt-4o",
+            "model": "gpt-5.2",
             "choices": [],
             "usage": {
                 "prompt_tokens": 150,
@@ -1459,7 +1459,7 @@ mod tests {
         let request = OpenAiRequest {
             verbosity: None,
             service_tier: None,
-            model: "gpt-4o-mini".to_string(),
+            model: "gpt-5.4-mini".to_string(),
             messages: vec![OpenAiMessage {
                 role: "user".to_string(),
                 content: Some(OpenAiContent::Text("Hello".to_string())),
@@ -1490,7 +1490,7 @@ mod tests {
         let request = OpenAiRequest {
             verbosity: None,
             service_tier: None,
-            model: "o3-mini".to_string(),
+            model: "o4-mini".to_string(),
             messages: vec![OpenAiMessage {
                 role: "user".to_string(),
                 content: Some(OpenAiContent::Text("Hello".to_string())),
@@ -1522,7 +1522,7 @@ mod tests {
             let request = OpenAiRequest {
                 verbosity: None,
                 service_tier: None,
-                model: "gpt-4o-mini".to_string(),
+                model: "gpt-5.4-mini".to_string(),
                 messages: vec![OpenAiMessage {
                     role: "user".to_string(),
                     content: Some(OpenAiContent::Text("Hello".to_string())),
@@ -1556,7 +1556,7 @@ mod tests {
             let request = OpenAiRequest {
                 service_tier: tier.map(str::to_string),
                 verbosity: None,
-                model: "gpt-4o-mini".to_string(),
+                model: "gpt-5.4-mini".to_string(),
                 messages: vec![OpenAiMessage {
                     role: "user".to_string(),
                     content: Some(OpenAiContent::Text("Hello".to_string())),

--- a/crates/provider/src/openresponses_protocol.rs
+++ b/crates/provider/src/openresponses_protocol.rs
@@ -587,7 +587,7 @@ impl OpenResponsesProtocolChatDriver {
     /// let driver = OpenResponsesProtocolChatDriver::new();
     ///
     /// let request = CompactRequest {
-    ///     model: "gpt-4o".to_string(),
+    ///     model: "gpt-5.2".to_string(),
     ///     input: vec![
     ///         CompactInputItem::Message {
     ///             role: "user".to_string(),
@@ -2108,7 +2108,7 @@ mod tests {
             include: None,
             text: None,
             service_tier: None,
-            model: "gpt-4o".to_string(),
+            model: "gpt-5.2".to_string(),
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
                 role: "user".to_string(),
@@ -2128,7 +2128,7 @@ mod tests {
         };
 
         let json = serde_json::to_value(&request).unwrap();
-        assert_eq!(json["model"], "gpt-4o");
+        assert_eq!(json["model"], "gpt-5.2");
         assert_eq!(json["stream"], true);
         assert_eq!(json["instructions"], "You are helpful");
         assert!(json["input"].is_array());
@@ -2177,7 +2177,7 @@ mod tests {
             include: None,
             text: None,
             service_tier: None,
-            model: "gpt-4o".to_string(),
+            model: "gpt-5.2".to_string(),
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
                 role: "user".to_string(),
@@ -3844,7 +3844,7 @@ mod tests {
     #[test]
     fn test_compact_request_serialization() {
         let request = CompactRequest {
-            model: "gpt-4o".to_string(),
+            model: "gpt-5.2".to_string(),
             input: vec![
                 CompactInputItem::Message {
                     role: "user".to_string(),
@@ -3860,7 +3860,7 @@ mod tests {
         };
 
         let json = serde_json::to_value(&request).unwrap();
-        assert_eq!(json["model"], "gpt-4o");
+        assert_eq!(json["model"], "gpt-5.2");
         assert_eq!(json["instructions"], "Be helpful");
         assert!(json["input"].is_array());
         assert_eq!(json["input"].as_array().unwrap().len(), 2);

--- a/crates/provider/tests/openai_protocol_wire.rs
+++ b/crates/provider/tests/openai_protocol_wire.rs
@@ -152,7 +152,7 @@ async fn text_stream_golden_events() {
     let stream = driver(&server)
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "hi")],
-            &config("gpt-4o"),
+            &config("gpt-5.2"),
         )
         .await
         .expect("stream should start");
@@ -201,7 +201,7 @@ async fn fragmented_tool_call_golden_events() {
     let stream = driver(&server)
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "weather?")],
-            &config("gpt-4o"),
+            &config("gpt-5.2"),
         )
         .await
         .expect("stream should start");
@@ -248,7 +248,7 @@ async fn empty_content_with_tool_calls_finish_golden_events() {
     let stream = driver(&server)
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "ping")],
-            &config("gpt-4o"),
+            &config("gpt-5.2"),
         )
         .await
         .expect("stream should start");

--- a/crates/provider/tests/openai_reconnect_wire.rs
+++ b/crates/provider/tests/openai_reconnect_wire.rs
@@ -154,7 +154,7 @@ async fn driver_reconnects_on_truncated_first_response() {
     let stream = driver
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "hi")],
-            &config("gpt-4o"),
+            &config("gpt-5.2"),
         )
         .await
         .expect("stream should start (reconnect happens before first event)");
@@ -186,7 +186,7 @@ async fn driver_surfaces_error_after_exhausting_reconnects() {
     let result = driver
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "hi")],
-            &config("gpt-4o"),
+            &config("gpt-5.2"),
         )
         .await;
     let error = match result {

--- a/crates/provider/tests/openresponses_protocol_wire.rs
+++ b/crates/provider/tests/openresponses_protocol_wire.rs
@@ -354,7 +354,7 @@ async fn non_reasoning_request_omits_include() {
     let stream = driver(&server)
         .chat_completion_stream(
             vec![LlmMessage::text(LlmMessageRole::User, "hi")],
-            &config("gpt-4o"),
+            &config("gpt-5.2"),
         )
         .await
         .expect("stream should start");

--- a/crates/server/src/api/models.rs
+++ b/crates/server/src/api/models.rs
@@ -71,7 +71,7 @@ impl_dispatchable!(AppState);
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateModelRequest {
     /// The model identifier used by the provider's API (e.g., "gpt-5.6-sol", "claude-opus-5").
-    #[schema(example = "gpt-4o")]
+    #[schema(example = "gpt-5.2")]
     pub model_id: String,
     /// Human-readable display name for the model.
     #[schema(example = "GPT-4o")]
@@ -116,7 +116,7 @@ pub struct UpdateModelRequest {
     pub provider_id: Option<String>,
     /// The model identifier used by the provider's API.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "gpt-4o-mini")]
+    #[schema(example = "gpt-5.4-mini")]
     pub model_id: Option<String>,
     /// Human-readable display name for the model.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/server/src/api/models.rs
+++ b/crates/server/src/api/models.rs
@@ -70,7 +70,7 @@ impl_dispatchable!(AppState);
 /// Request to create a new LLM model for a provider
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateModelRequest {
-    /// The model identifier used by the provider's API (e.g., "gpt-4", "claude-3-opus").
+    /// The model identifier used by the provider's API (e.g., "gpt-5.6-sol", "claude-opus-5").
     #[schema(example = "gpt-4o")]
     pub model_id: String,
     /// Human-readable display name for the model.

--- a/crates/server/src/domains/budgets/tests.rs
+++ b/crates/server/src/domains/budgets/tests.rs
@@ -276,7 +276,7 @@ fn test_compute_debit_tokens_currency() {
         500,
         0,
         0,
-        Some("gpt-4o"),
+        Some("gpt-5.2"),
         Some("openai"),
         None,
     );
@@ -293,7 +293,7 @@ fn test_compute_debit_usd_with_known_model() {
         500_000,
         0,
         0,
-        Some("gpt-4o"),
+        Some("gpt-5.2"),
         Some("openai"),
         None,
     );
@@ -313,7 +313,7 @@ fn test_compute_debit_usd_prefers_provider_cost() {
         500_000,
         0,
         0,
-        Some("gpt-4o"),
+        Some("gpt-5.2"),
         Some("openai"),
         Some(0.0123),
     );
@@ -448,7 +448,7 @@ fn test_compute_debit_zero_tokens() {
 fn test_compute_debit_usd_discounts_cached_tokens() {
     let (svc, _) = make_service();
     // Disjoint buckets: `input_tokens` is non-cached, `cache_read_tokens`
-    // additive. gpt-4o: input $2.50/M, cache_read $1.25/M. A 1M-token prompt
+    // additive. gpt-5.2: input $1.75/M, cache_read $0.175/M. A 1M-token prompt
     // split as 200K non-cached + 800K cache reads.
     let cached = svc.compute_debit(
         "usd",
@@ -457,7 +457,7 @@ fn test_compute_debit_usd_discounts_cached_tokens() {
         0,
         800_000,
         0,
-        Some("gpt-4o"),
+        Some("gpt-5.2"),
         Some("openai"),
         None,
     );
@@ -469,13 +469,13 @@ fn test_compute_debit_usd_discounts_cached_tokens() {
         0,
         0,
         0,
-        Some("gpt-4o"),
+        Some("gpt-5.2"),
         Some("openai"),
         None,
     );
-    // 200K * 2.50 + 800K * 1.25 = 0.50 + 1.00 = 1.50, well below the cache-blind 2.50.
-    assert!((cached - 1.50).abs() < 1e-9, "cached debit {cached}");
-    assert!((naive - 2.50).abs() < 1e-9, "naive debit {naive}");
+    // 200K * 1.75 + 800K * 0.175 = 0.35 + 0.14 = 0.49, well below the cache-blind 1.75.
+    assert!((cached - 0.49).abs() < 1e-9, "cached debit {cached}");
+    assert!((naive - 1.75).abs() < 1e-9, "naive debit {naive}");
 }
 
 // ========================================================================

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -139,9 +139,6 @@ mod seed_ids {
     pub const CLAUDE_HAIKU_4_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000303);
     pub const CLAUDE_OPUS_4: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000304);
     pub const CLAUDE_SONNET_4: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000305);
-    pub const CLAUDE_3_7_SONNET: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000306);
-    pub const CLAUDE_3_5_SONNET: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000307);
-    pub const CLAUDE_3_5_HAIKU: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000308);
     // 1M-context variants (`[1m]` model ids), 0x3a0+ sub-range.
     pub const CLAUDE_OPUS_5_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a8);
     pub const CLAUDE_OPUS_4_7_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a7);
@@ -158,12 +155,6 @@ mod seed_ids {
     pub const GEMINI_25_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
     pub const GEMINI_25_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000602);
     pub const GEMINI_20_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000603);
-
-    // Bedrock Models (0x700-0x7FF)
-    pub const BEDROCK_CLAUDE_HAIKU_35: Uuid =
-        Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000701);
-    pub const BEDROCK_CLAUDE_SONNET_35: Uuid =
-        Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000702);
 }
 
 // ============================================
@@ -2028,32 +2019,6 @@ const SEED_MODELS: &[SeedModel] = &[
         enabled: false,
         is_favorite: false,
     },
-    // Anthropic Claude 3.7
-    SeedModel {
-        id: seed_ids::CLAUDE_3_7_SONNET,
-        provider_id: seed_ids::ANTHROPIC_PROVIDER,
-        model_id: "claude-3-7-sonnet-latest",
-        display_name: "Claude 3.7 Sonnet",
-        enabled: false,
-        is_favorite: false,
-    },
-    // Anthropic Claude 3.5
-    SeedModel {
-        id: seed_ids::CLAUDE_3_5_SONNET,
-        provider_id: seed_ids::ANTHROPIC_PROVIDER,
-        model_id: "claude-3-5-sonnet-latest",
-        display_name: "Claude 3.5 Sonnet",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
-        id: seed_ids::CLAUDE_3_5_HAIKU,
-        provider_id: seed_ids::ANTHROPIC_PROVIDER,
-        model_id: "claude-3-5-haiku-latest",
-        display_name: "Claude 3.5 Haiku",
-        enabled: false,
-        is_favorite: false,
-    },
     // Google Gemini 3.x series (current gen)
     SeedModel {
         id: seed_ids::GEMINI_31_PRO_PREVIEW,
@@ -2101,23 +2066,6 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::GEMINI_PROVIDER,
         model_id: "gemini-2.0-flash",
         display_name: "Gemini 2.0 Flash",
-        enabled: false,
-        is_favorite: false,
-    },
-    // AWS Bedrock (ConverseStream API)
-    SeedModel {
-        id: seed_ids::BEDROCK_CLAUDE_HAIKU_35,
-        provider_id: seed_ids::BEDROCK_PROVIDER,
-        model_id: "anthropic.claude-3-5-haiku-20241022-v1:0",
-        display_name: "Claude 3.5 Haiku (Bedrock)",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
-        id: seed_ids::BEDROCK_CLAUDE_SONNET_35,
-        provider_id: seed_ids::BEDROCK_PROVIDER,
-        model_id: "anthropic.claude-3-5-sonnet-20241022-v2:0",
-        display_name: "Claude 3.5 Sonnet v2 (Bedrock)",
         enabled: false,
         is_favorite: false,
     },

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -102,17 +102,11 @@ mod seed_ids {
     pub const GPT_4_1: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000210);
     pub const GPT_4_1_MINI: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000211);
     pub const GPT_4_1_NANO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000212);
-    pub const GPT_4O: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000213);
-    pub const GPT_4O_MINI: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000214);
     pub const O4_MINI: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000215);
     pub const O4_MINI_DEEP_RESEARCH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000216);
     pub const O3: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000217);
-    pub const O3_MINI: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000218);
     pub const O3_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000219);
     pub const O3_DEEP_RESEARCH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021a);
-    pub const O1: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021b);
-    pub const O1_MINI: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021c);
-    pub const O1_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021d);
     pub const GPT_5_4: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021f);
     pub const GPT_5_4_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000220);
     pub const GPT_5_4_MINI: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000221);
@@ -125,7 +119,6 @@ mod seed_ids {
     pub const GPT_5_6_LUNA: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000228);
     pub const TEXT_EMBEDDING_3_SMALL: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000229);
-    pub const O1_PREVIEW: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021e);
 
     // Anthropic Models (0x300-0x3FF)
     pub const CLAUDE_OPUS_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030e);
@@ -155,6 +148,11 @@ mod seed_ids {
     pub const GEMINI_25_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
     pub const GEMINI_25_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000602);
     pub const GEMINI_20_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000603);
+
+    // Bedrock Models (0x700-0x7FF)
+    pub const BEDROCK_CLAUDE_OPUS_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000703);
+    pub const BEDROCK_CLAUDE_SONNET_5: Uuid =
+        Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000704);
 }
 
 // ============================================
@@ -1795,23 +1793,6 @@ const SEED_MODELS: &[SeedModel] = &[
         enabled: false,
         is_favorite: false,
     },
-    // OpenAI GPT-4 series
-    SeedModel {
-        id: seed_ids::GPT_4O,
-        provider_id: seed_ids::OPENAI_PROVIDER,
-        model_id: "gpt-4o",
-        display_name: "GPT-4o",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
-        id: seed_ids::GPT_4O_MINI,
-        provider_id: seed_ids::OPENAI_PROVIDER,
-        model_id: "gpt-4o-mini",
-        display_name: "GPT-4o mini",
-        enabled: false,
-        is_favorite: false,
-    },
     // OpenAI Reasoning models (o-series)
     SeedModel {
         id: seed_ids::O4_MINI,
@@ -1838,14 +1819,6 @@ const SEED_MODELS: &[SeedModel] = &[
         is_favorite: false,
     },
     SeedModel {
-        id: seed_ids::O3_MINI,
-        provider_id: seed_ids::OPENAI_PROVIDER,
-        model_id: "o3-mini",
-        display_name: "o3 mini",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
         id: seed_ids::O3_PRO,
         provider_id: seed_ids::OPENAI_PROVIDER,
         model_id: "o3-pro",
@@ -1858,38 +1831,6 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::OPENAI_PROVIDER,
         model_id: "o3-deep-research",
         display_name: "o3 Deep Research",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
-        id: seed_ids::O1,
-        provider_id: seed_ids::OPENAI_PROVIDER,
-        model_id: "o1",
-        display_name: "o1",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
-        id: seed_ids::O1_MINI,
-        provider_id: seed_ids::OPENAI_PROVIDER,
-        model_id: "o1-mini",
-        display_name: "o1 mini",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
-        id: seed_ids::O1_PRO,
-        provider_id: seed_ids::OPENAI_PROVIDER,
-        model_id: "o1-pro",
-        display_name: "o1 Pro",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
-        id: seed_ids::O1_PREVIEW,
-        provider_id: seed_ids::OPENAI_PROVIDER,
-        model_id: "o1-preview",
-        display_name: "o1 Preview",
         enabled: false,
         is_favorite: false,
     },
@@ -2066,6 +2007,31 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::GEMINI_PROVIDER,
         model_id: "gemini-2.0-flash",
         display_name: "Gemini 2.0 Flash",
+        enabled: false,
+        is_favorite: false,
+    },
+    // AWS Bedrock (ConverseStream API).
+    //
+    // Current Claude models have no in-region Bedrock availability at all — only
+    // the geo (`us.`/`eu.`/`au.`) and global cross-region inference profiles — so
+    // the bare `anthropic.claude-*` ids would fail everywhere. `global.` is the
+    // one prefix offered in every commercial region, which makes it the only
+    // sound default for a seed. Accounts with data-residency requirements (or on
+    // GovCloud, where global is unavailable) should add the matching geo id
+    // instead.
+    SeedModel {
+        id: seed_ids::BEDROCK_CLAUDE_OPUS_5,
+        provider_id: seed_ids::BEDROCK_PROVIDER,
+        model_id: "global.anthropic.claude-opus-5",
+        display_name: "Claude Opus 5 (Bedrock)",
+        enabled: false,
+        is_favorite: false,
+    },
+    SeedModel {
+        id: seed_ids::BEDROCK_CLAUDE_SONNET_5,
+        provider_id: seed_ids::BEDROCK_PROVIDER,
+        model_id: "global.anthropic.claude-sonnet-5",
+        display_name: "Claude Sonnet 5 (Bedrock)",
         enabled: false,
         is_favorite: false,
     },

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -703,7 +703,7 @@ mod tests {
                 CreateModelRow {
                     provider_id: provider_row.id,
                     model_id: "gpt-5.2".to_string(),
-                    display_name: "GPT-4o".to_string(),
+                    display_name: "GPT-5.2".to_string(),
                     capabilities: vec!["chat".to_string()],
                     // Resolver paths require `enabled = TRUE`; these tests
                     // exercise successful resolution, so create as enabled.
@@ -893,7 +893,7 @@ mod tests {
                 CreateModelRow {
                     provider_id: provider_row.id,
                     model_id: "gpt-5.2".to_string(),
-                    display_name: "GPT-4o".to_string(),
+                    display_name: "GPT-5.2".to_string(),
                     capabilities: vec![],
                     enabled: true,
                     is_favorite: false,
@@ -1183,7 +1183,7 @@ mod tests {
                 CreateModelRow {
                     provider_id: provider_row.id,
                     model_id: "gpt-5.2".to_string(),
-                    display_name: "GPT-4o".to_string(),
+                    display_name: "GPT-5.2".to_string(),
                     capabilities: vec![],
                     enabled: true,
                     is_favorite: false,

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -702,7 +702,7 @@ mod tests {
                 org_id,
                 CreateModelRow {
                     provider_id: provider_row.id,
-                    model_id: "gpt-4o".to_string(),
+                    model_id: "gpt-5.2".to_string(),
                     display_name: "GPT-4o".to_string(),
                     capabilities: vec!["chat".to_string()],
                     // Resolver paths require `enabled = TRUE`; these tests
@@ -733,7 +733,7 @@ mod tests {
             .unwrap();
         assert!(result.is_some());
         let resolved = result.unwrap();
-        assert_eq!(resolved.model_id, "gpt-4o");
+        assert_eq!(resolved.model_id, "gpt-5.2");
         assert_eq!(resolved.provider_type, "openai");
 
         // Run pending moka tasks so entry_count updates
@@ -746,7 +746,7 @@ mod tests {
             .await
             .unwrap();
         assert!(result2.is_some());
-        assert_eq!(result2.unwrap().model_id, "gpt-4o");
+        assert_eq!(result2.unwrap().model_id, "gpt-5.2");
 
         // Still one entry
         assert_eq!(resolver.cache_entry_count(), 1);
@@ -892,7 +892,7 @@ mod tests {
                 org_id,
                 CreateModelRow {
                     provider_id: provider_row.id,
-                    model_id: "gpt-4o".to_string(),
+                    model_id: "gpt-5.2".to_string(),
                     display_name: "GPT-4o".to_string(),
                     capabilities: vec![],
                     enabled: true,
@@ -915,7 +915,7 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_some());
-        assert_eq!(result.unwrap().model_id, "gpt-4o");
+        assert_eq!(result.unwrap().model_id, "gpt-5.2");
 
         resolver.cache.run_pending_tasks().await;
         assert_eq!(resolver.cache_entry_count(), 1);
@@ -926,7 +926,7 @@ mod tests {
             .await
             .unwrap();
         assert!(result2.is_some());
-        assert_eq!(result2.unwrap().model_id, "gpt-4o");
+        assert_eq!(result2.unwrap().model_id, "gpt-5.2");
     }
 
     #[tokio::test]
@@ -1182,7 +1182,7 @@ mod tests {
                 org_id,
                 CreateModelRow {
                     provider_id: provider_row.id,
-                    model_id: "gpt-4o".to_string(),
+                    model_id: "gpt-5.2".to_string(),
                     display_name: "GPT-4o".to_string(),
                     capabilities: vec![],
                     enabled: true,

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -142,7 +142,7 @@ pub fn provider_request_options(
 /// Credential-free resolved model identity.
 #[derive(Debug, Clone)]
 pub struct ResolvedModel {
-    /// The model identifier (e.g., "gpt-4", "claude-3-opus")
+    /// The model identifier (e.g., "gpt-5.6-sol", "claude-opus-5")
     pub model_id: String,
     /// Provider type (e.g., "openai", "anthropic")
     pub provider_type: String,
@@ -820,8 +820,8 @@ mod tests {
                 org_id,
                 CreateModelRow {
                     provider_id: provider_row.id,
-                    model_id: "claude-3-opus".to_string(),
-                    display_name: "Claude 3 Opus".to_string(),
+                    model_id: "claude-opus-5".to_string(),
+                    display_name: "Claude Opus 5".to_string(),
                     capabilities: vec![],
                     // Resolver paths require `enabled = TRUE`.
                     enabled: true,
@@ -838,8 +838,8 @@ mod tests {
                 org_id,
                 CreateModelRow {
                     provider_id: provider_row.id,
-                    model_id: "claude-3-sonnet".to_string(),
-                    display_name: "Claude 3 Sonnet".to_string(),
+                    model_id: "claude-sonnet-5".to_string(),
+                    display_name: "Claude Sonnet 5".to_string(),
                     capabilities: vec![],
                     enabled: true,
                     is_favorite: false,
@@ -860,8 +860,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(ra.unwrap().model_id, "claude-3-opus");
-        assert_eq!(rb.unwrap().model_id, "claude-3-sonnet");
+        assert_eq!(ra.unwrap().model_id, "claude-opus-5");
+        assert_eq!(rb.unwrap().model_id, "claude-sonnet-5");
 
         resolver.cache.run_pending_tasks().await;
         assert_eq!(resolver.cache_entry_count(), 2);

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -665,8 +665,8 @@ async fn test_multi_org_full_isolation() {
             org2,
             CreateModelRow {
                 provider_id: org2_provider.id,
-                model_id: "claude-3".to_string(),
-                display_name: "Claude 3".to_string(),
+                model_id: "claude-opus-5".to_string(),
+                display_name: "Claude Opus 5".to_string(),
                 capabilities: vec![],
                 enabled: true,
                 is_favorite: false,
@@ -717,7 +717,7 @@ async fn test_multi_org_full_isolation() {
 
     let org2_models = db.list_all_models(org2).await.unwrap();
     assert_eq!(org2_models.len(), 1);
-    assert_eq!(org2_models[0].model_id, "claude-3");
+    assert_eq!(org2_models[0].model_id, "claude-opus-5");
 
     let org2_servers = db.list_mcp_servers(org2, None, false).await.unwrap();
     assert_eq!(org2_servers.len(), 1);

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -370,8 +370,8 @@ async fn test_model_profile() {
 
     println!("Created provider: {} ({})", provider.name, provider.id);
 
-    // Step 2: Create a known model (gpt-4o) that has a profile
-    println!("\nStep 2: Creating gpt-4o model...");
+    // Step 2: Create a known model (gpt-5.2) that has a profile
+    println!("\nStep 2: Creating gpt-5.2 model...");
     let create_model_response = client
         .post(format!(
             "{}/v1/providers/{}/models",
@@ -379,7 +379,7 @@ async fn test_model_profile() {
         ))
         .json(&json!({
             "model_id": "gpt-5.2",
-            "display_name": "GPT-4o",
+            "display_name": "GPT-5.2",
             "capabilities": ["chat", "vision"],
             "enabled": false
         }))
@@ -412,26 +412,26 @@ async fn test_model_profile() {
         .as_array()
         .expect("Response should have data array");
 
-    let gpt4o_model = models
+    let gpt52_model = models
         .iter()
         .find(|m| m["model_id"] == "gpt-5.2")
-        .expect("Should find gpt-4o in model list");
+        .expect("Should find gpt-5.2 in model list");
 
     // Verify profile exists and has expected fields
-    let profile = &gpt4o_model["profile"];
+    let profile = &gpt52_model["profile"];
     println!("Profile: {:?}", profile);
 
     // Profile may be null if the model profile lookup isn't working
     // For now, just verify we can list models - profile lookup is optional
     if !profile.is_null() {
-        assert_eq!(profile["name"], "GPT-4o", "Profile name should be GPT-4o");
+        assert_eq!(profile["name"], "GPT-5.2", "Profile name should be GPT-5.2");
         assert_eq!(
             profile["family"], "gpt-5.2",
-            "Profile family should be gpt-4o"
+            "Profile family should be gpt-5.2"
         );
         assert!(
             profile["tool_call"].as_bool().unwrap_or(false),
-            "GPT-4o should support tool calls"
+            "GPT-5.2 should support tool calls"
         );
         println!("Profile verified successfully");
     } else {
@@ -1834,7 +1834,7 @@ async fn test_no_duplicate_tool_calls() {
         ))
         .json(&json!({
             "model_id": "gpt-5.4-mini",
-            "display_name": "GPT-4o Mini Test",
+            "display_name": "GPT-5.4 Mini Test",
             "enabled": true
         }))
         .send()
@@ -3438,7 +3438,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
         ))
         .json(&json!({
             "model_id": "gpt-5.4-mini",
-            "display_name": "GPT-4o Mini (Tool Test)",
+            "display_name": "GPT-5.4 Mini (Tool Test)",
             "enabled": true
         }))
         .send()

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -378,7 +378,7 @@ async fn test_model_profile() {
             API_BASE_URL, provider.id
         ))
         .json(&json!({
-            "model_id": "gpt-4o",
+            "model_id": "gpt-5.2",
             "display_name": "GPT-4o",
             "capabilities": ["chat", "vision"],
             "enabled": false
@@ -414,7 +414,7 @@ async fn test_model_profile() {
 
     let gpt4o_model = models
         .iter()
-        .find(|m| m["model_id"] == "gpt-4o")
+        .find(|m| m["model_id"] == "gpt-5.2")
         .expect("Should find gpt-4o in model list");
 
     // Verify profile exists and has expected fields
@@ -426,7 +426,7 @@ async fn test_model_profile() {
     if !profile.is_null() {
         assert_eq!(profile["name"], "GPT-4o", "Profile name should be GPT-4o");
         assert_eq!(
-            profile["family"], "gpt-4o",
+            profile["family"], "gpt-5.2",
             "Profile family should be gpt-4o"
         );
         assert!(
@@ -1833,7 +1833,7 @@ async fn test_no_duplicate_tool_calls() {
             API_BASE_URL, provider.id
         ))
         .json(&json!({
-            "model_id": "gpt-4o-mini",
+            "model_id": "gpt-5.4-mini",
             "display_name": "GPT-4o Mini Test",
             "enabled": true
         }))
@@ -3430,14 +3430,14 @@ async fn test_agent_execution_openai_with_tool_calls() {
         .expect("Failed to parse provider");
     println!("Created OpenAI provider: {}", provider.id);
 
-    // Create model (gpt-4o-mini for cost-effectiveness)
+    // Create model (gpt-5.4-mini for cost-effectiveness)
     let model_response = client
         .post(format!(
             "{}/v1/providers/{}/models",
             API_BASE_URL, provider.id
         ))
         .json(&json!({
-            "model_id": "gpt-4o-mini",
+            "model_id": "gpt-5.4-mini",
             "display_name": "GPT-4o Mini (Tool Test)",
             "enabled": true
         }))

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -1070,7 +1070,7 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
         .expect("Failed to parse provider");
     println!("Created Anthropic provider: {}", provider.id);
 
-    // Create model (claude-3-5-haiku for cost-effectiveness)
+    // Create model (claude-haiku-4-5 for cost-effectiveness)
     let model_response = client
         .post(format!(
             "{}/v1/providers/{}/models",
@@ -3680,7 +3680,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
         .expect("Failed to parse provider");
     println!("Created Anthropic provider: {}", provider.id);
 
-    // Create model (claude-3-5-haiku for cost-effectiveness)
+    // Create model (claude-haiku-4-5 for cost-effectiveness)
     let model_response = client
         .post(format!(
             "{}/v1/providers/{}/models",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -19906,7 +19906,7 @@
           "model_id": {
             "type": "string",
             "description": "The model identifier used by the provider's API (e.g., \"gpt-5.6-sol\", \"claude-opus-5\").",
-            "example": "gpt-4o"
+            "example": "gpt-5.2"
           }
         }
       },
@@ -27179,7 +27179,7 @@
                     },
                     "model_id": {
                       "type": "string",
-                      "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`, `claude-sonnet-4`)."
+                      "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`, `claude-sonnet-5`)."
                     },
                     "provider_id": {
                       "type": "string",
@@ -27309,7 +27309,7 @@
                     },
                     "model_id": {
                       "type": "string",
-                      "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).",
+                      "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`).",
                       "example": "claude-sonnet-4-5"
                     },
                     "model_vendor": {
@@ -29349,7 +29349,7 @@
           },
           "model_id": {
             "type": "string",
-            "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`, `claude-sonnet-4`)."
+            "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`, `claude-sonnet-5`)."
           },
           "provider_id": {
             "type": "string",
@@ -29740,7 +29740,7 @@
           },
           "model_id": {
             "type": "string",
-            "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).",
+            "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`).",
             "example": "claude-sonnet-4-5"
           },
           "model_vendor": {
@@ -37928,7 +37928,7 @@
               "null"
             ],
             "description": "The model identifier used by the provider's API.",
-            "example": "gpt-4o-mini"
+            "example": "gpt-5.4-mini"
           },
           "provider_id": {
             "type": [
@@ -40309,7 +40309,7 @@
               },
               "model_id": {
                 "type": "string",
-                "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`, `claude-sonnet-4`)."
+                "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`, `claude-sonnet-5`)."
               },
               "provider_id": {
                 "type": "string",
@@ -40426,7 +40426,7 @@
               },
               "model_id": {
                 "type": "string",
-                "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).",
+                "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-5.2`).",
                 "example": "claude-sonnet-4-5"
               },
               "model_vendor": {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -19905,7 +19905,7 @@
           },
           "model_id": {
             "type": "string",
-            "description": "The model identifier used by the provider's API (e.g., \"gpt-4\", \"claude-3-opus\").",
+            "description": "The model identifier used by the provider's API (e.g., \"gpt-5.6-sol\", \"claude-opus-5\").",
             "example": "gpt-4o"
           }
         }
@@ -29447,7 +29447,7 @@
         "properties": {
           "model": {
             "type": "string",
-            "description": "Model name (e.g., \"gpt-4o\", \"claude-3-sonnet\")"
+            "description": "Model name (e.g., \"gpt-5.6-sol\", \"claude-sonnet-5\")"
           },
           "model_id": {
             "type": [
@@ -29493,7 +29493,7 @@
       },
       "ModelProfile": {
         "type": "object",
-        "description": "LLM Model Profile describing model capabilities\nBased on models.dev structure (<https://models.dev/api.json>)\n\nNOTE: Currently only includes profiles for:\n- OpenAI: gpt-4o, gpt-4o-mini, o1, o1-mini, o1-pro, o3-mini\n- Anthropic: claude-3-5-sonnet, claude-3-5-haiku, claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-sonnet-4, claude-opus-4\n\nAdditional model profiles can be added as needed.",
+        "description": "LLM Model Profile describing model capabilities\nBased on models.dev structure (<https://models.dev/api.json>)\n\nThe registry of profiles lives in `model_profiles.rs`; retired models are\ndropped from it as vendors sunset them.",
         "required": [
           "name",
           "family",
@@ -29529,7 +29529,7 @@
           },
           "family": {
             "type": "string",
-            "description": "Model family (e.g., \"gpt-4o\", \"claude-3-5-sonnet\")"
+            "description": "Model family (e.g., \"gpt-5.6-sol\", \"claude-sonnet-5\")"
           },
           "knowledge": {
             "type": [

--- a/docs/capabilities/claude-tool-search.md
+++ b/docs/capabilities/claude-tool-search.md
@@ -51,7 +51,7 @@ Tool search requires model-level support. Per Anthropic, it is available on:
 | Sonnet 4.x (`claude-sonnet-4*`) | Yes |
 | Haiku 4.5 (`claude-haiku-4-5`) | Yes |
 | Fable 5 (`claude-fable-5`) | Yes |
-| Claude 3.x and earlier | No (capability is silently ignored) |
+| Retired pre-4 Claude models | No (capability is silently ignored) |
 
 When the capability is enabled but the model doesn't support tool search, the feature is **silently skipped, full tool schemas are sent as usual**. This standalone capability does *not* add a client-side fallback: on an unsupported model it simply does nothing (no error, no behavior change). For automatic fallback to client-side deferral, use [Auto Tool Search](/capabilities/auto-tool-search/) (or add the [Tool Search](/capabilities/tool-search/) capability explicitly).
 
@@ -90,7 +90,7 @@ Lower thresholds activate tool search with fewer tools. Set to `1` to always act
 ## Limitations
 
 - **Claude-only**: this is an Anthropic Messages API feature; other providers (OpenAI, Gemini) ignore this capability. Use [Auto Tool Search](/capabilities/auto-tool-search/) for cross-provider agents.
-- **Supported Claude models only**: Claude 3.x and earlier don't support hosted tool search.
+- **Supported Claude models only**: pre-4 Claude models don't support hosted tool search.
 - **First-party transport only**: Claude models reached via Bedrock (ConverseStream) or OpenRouter don't get hosted tool search; with this capability alone they send full schemas. Use [Auto Tool Search](/capabilities/auto-tool-search/) for client-side deferral there.
 - **No standalone fallback**: on an unsupported model/transport this capability is a no-op (full schemas), not a switch to client-side deferral. Combine with `auto_tool_search`, or add `tool_search`, if you want a fallback.
 

--- a/docs/event-reference.md
+++ b/docs/event-reference.md
@@ -48,7 +48,7 @@ Events](#reasoning-events)) and its own channel.
   "type": "output.message.started",
   "data": {
     "turn_id": "turn_...",
-    "model": "gpt-4o"
+    "model": "gpt-5.2"
   }
 }
 ```
@@ -339,7 +339,7 @@ Emitted when LLM inference begins.
   "data": {
     "agent_id": "agent_...",
     "metadata": {
-      "model": "gpt-4o"
+      "model": "gpt-5.2"
     }
   }
 }
@@ -492,7 +492,7 @@ Full visibility into LLM API calls. Emitted after each call.
       "tool_calls": []
     },
     "metadata": {
-      "model": "gpt-4o",
+      "model": "gpt-5.2",
       "provider": "openai",
       "usage": {"input_tokens": 100, "output_tokens": 50},
       "duration_ms": 1200,
@@ -600,7 +600,7 @@ Information about the model used.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `model` | string | Model name (e.g., "gpt-4o") |
+| `model` | string | Model name (e.g., "gpt-5.2") |
 | `model_id` | string? | Internal model ID |
 | `provider_id` | string? | Internal provider ID |
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -173,7 +173,7 @@ An LLM Provider is a configured API provider such as OpenAI or Anthropic. Provid
 
 ### LLM Model
 
-An LLM Model is a specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
+An LLM Model is a specific model within a provider (e.g., `gpt-5.2`, `claude-sonnet-5`).
 
 - Each model belongs to one provider
 - Sources: predefined, discovered from the provider API, or manually added

--- a/docs/how-to/migrate-providers.md
+++ b/docs/how-to/migrate-providers.md
@@ -10,7 +10,7 @@ Everruns abstracts the LLM behind a uniform interface, so the same agent can run
 Two pieces decide which model runs:
 
 - **LLM Provider**: a configured API provider with encrypted credentials (e.g., `openai`, `openrouter`, `anthropic`, `gemini`, `openai_completions`).
-- **LLM Model**: a specific model on a provider (e.g., `gpt-4o`, `claude-sonnet-4`, `gemini-1.5-pro`).
+- **LLM Model**: a specific model on a provider (e.g., `gpt-5.6-sol`, `claude-sonnet-5`, `gemini-3.5-flash`).
 
 Model resolution priority on each turn:
 

--- a/docs/observability/braintrust.md
+++ b/docs/observability/braintrust.md
@@ -82,12 +82,12 @@ Each Everruns turn creates its own trace with the following structure:
 ```
 agent turn (root span)
 ├── reason (iteration 1)
-│   └── llm.generation (gpt-4o)
+│   └── llm.generation (gpt-5.2)
 ├── act (iteration 1)
 │   ├── tool.call (search)
 │   └── tool.call (fetch)
 ├── reason (iteration 2)
-│   └── llm.generation (gpt-4o)
+│   └── llm.generation (gpt-5.2)
 └── (no more tool calls - turn complete)
 ```
 

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -216,9 +216,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.0"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.0"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "schemars",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.0"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.18.0"
+version = "0.20.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.0"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.0"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.0"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.0"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.18.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -707,12 +707,12 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
 dependencies = [
- "lazy_static",
  "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.9"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
+checksum = "29b6bb4e22283b09119c671e57ac6a185e9a0c70c31585e56b729b626d877753"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1268,18 +1268,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.9"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
+checksum = "497fbf3b1ca53b1e23a253f636e88e7a2031387388b8140199a0f240fcadf647"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.9"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
+checksum = "b84ca3f39446973a810fc90fc2645ada8c24284f6deb009c78b776813973887d"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1288,12 +1288,6 @@ dependencies = [
  "num-traits",
  "serde_json",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1765,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.9"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
+checksum = "7a0a32a2a2c2d7dd0ee54705b5fd641be73037271928f68e9b0e7205b71c9d30"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -1901,7 +1895,6 @@ checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.18.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.0"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "async-trait",
  "schemars",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.0"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.18.0"
+version = "0.20.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.0"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.0"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.18.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -549,12 +549,12 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
 dependencies = [
- "lazy_static",
  "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.9"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
+checksum = "29b6bb4e22283b09119c671e57ac6a185e9a0c70c31585e56b729b626d877753"
 dependencies = [
  "ahash",
  "bytecount",
@@ -927,18 +927,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.9"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
+checksum = "497fbf3b1ca53b1e23a253f636e88e7a2031387388b8140199a0f240fcadf647"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.9"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
+checksum = "b84ca3f39446973a810fc90fc2645ada8c24284f6deb009c78b776813973887d"
 dependencies = [
  "ahash",
  "bytecount",
@@ -947,12 +947,6 @@ dependencies = [
  "num-traits",
  "serde_json",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1291,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.9"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
+checksum = "7a0a32a2a2c2d7dd0ee54705b5fd641be73037271928f68e9b0e7205b71c9d30"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/knowledge/foundations/concepts.md
+++ b/knowledge/foundations/concepts.md
@@ -248,7 +248,7 @@ A configured API provider such as OpenAI or Anthropic. Stores encrypted API keys
 
 ### LLM Model
 
-A specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
+A specific model within a provider (e.g., `gpt-5.2`, `claude-sonnet-5`).
 
 - Each model belongs to one provider
 - Sources: predefined, discovered from the provider API, or manually added

--- a/knowledge/foundations/models.md
+++ b/knowledge/foundations/models.md
@@ -293,7 +293,7 @@ Read-only metadata describing model capabilities, costs, and limits. Computed at
 
 See `crates/provider/src/model.rs` for `ModelProfile`, `ModelCost`, `ModelLimits`, and `ReasoningEffortConfig` types.
 
-Profiles matched by provider_type + model_id with version normalization (e.g., "gpt-4o-2024-11-20" → "gpt-4o").
+Profiles matched by provider_type + model_id with version normalization (e.g., "gpt-5.2-2025-12-11" → "gpt-5.2").
 
 ### Model Discovery
 

--- a/knowledge/security/usage-tracking.md
+++ b/knowledge/security/usage-tracking.md
@@ -201,7 +201,7 @@ Usage is captured in the `llm.generation` event metadata:
   "type": "llm.generation",
   "data": {
     "metadata": {
-      "model": "gpt-4o",
+      "model": "gpt-5.2",
       "provider": "openai",
       "usage": {
         "input_tokens": 100,

--- a/research/infinity_context/src/runner.rs
+++ b/research/infinity_context/src/runner.rs
@@ -335,7 +335,7 @@ fn create_judge_config() -> Option<JudgeConfig> {
     std::env::var("ANTHROPIC_API_KEY")
         .ok()
         .map(|api_key| JudgeConfig {
-            model: "claude-3-5-haiku-20241022".to_string(),
+            model: "claude-haiku-4-5".to_string(),
             api_key,
         })
 }

--- a/research/infinity_context/src/scorer.rs
+++ b/research/infinity_context/src/scorer.rs
@@ -426,7 +426,7 @@ pub async fn check_llm_judge_health() -> HealthCheckResult {
         }
     };
 
-    let model = "claude-3-5-haiku-20241022".to_string();
+    let model = "claude-haiku-4-5".to_string();
     let config = JudgeConfig {
         model: model.clone(),
         api_key,

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -216,9 +216,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
## What changed

The model catalog no longer advertises models that vendors have retired, and AWS Bedrock now seeds current Claude models instead of ones that predate the driver.

Seed catalog and profile registry both drop 16 retired models:

- **OpenAI**: `gpt-4o`, `gpt-4o-mini`, `o1`, `o1-mini`, `o1-pro`, `o1-preview`, `o3-mini`
- **Anthropic**: `claude-3-opus`, `claude-3-sonnet`, `claude-3-haiku`, `claude-3-5-sonnet`, `claude-3-5-haiku`, `claude-3-7-sonnet`, `claude-opus-4-1`
- **Google**: `gemini-1.5-pro`, `gemini-1.5-flash`

Bedrock gains Claude Opus 5 and Sonnet 5, seeded disabled like every other non-default provider entry.

The Bedrock model-id format is the substantive detail here. Current Claude models have no in-region Bedrock availability at all — only the geo (`us.`/`eu.`/`au.`) and global cross-region inference profiles — so a bare `anthropic.claude-opus-5` would fail in every region. The seeds use the `global.` profiles, the one prefix offered in every commercial region and therefore the only sound default for a seed. A comment at the seed site points data-residency and GovCloud accounts at the matching geo ids instead. The driver passes the configured id verbatim to `converse_stream().model_id()`, so no prefix rewriting is involved.

`gpt-4o` was the codebase's default placeholder model, so it appeared across fixtures, doc examples, and event snapshots; those now use `gpt-5.2` (or `gpt-5.4-mini` where a small model was implied). Cost assertions were recomputed against gpt-5.2's real rates.

Deliberately left alone: `gpt-4o-transcribe` in the voice API (a distinct, current transcription model), the `id.starts_with("o1")` filter in OpenAI model discovery (it reflects what an account actually serves, not our catalog), and verbatim provider error strings in test fixtures.

### Unrelated CI fix folded in

crates.io yanked `chacha20 0.10.1` while this PR was in flight, turning **Check Dependency Licenses** red here and on `main`. Commit `e749684` bumps it to `0.10.2` in the three affected workspace-excluded lockfiles. This is not part of the model change; it is included at the author's request because it blocks every PR until it lands. See **Follow-ups** for what verifying that bump uncovered.

## Why

The catalog offered models that vendors have sunset, and the Bedrock seeds predated the current driver — anyone enabling them got entries that cannot serve traffic.

## Before / After

No runtime behavior changes for models that remain. The observable differences:

- A fresh seed no longer creates catalog rows for the 16 retired models, and creates two Bedrock Claude 5 rows (disabled) that it did not before.
- `get_model_profile()` returns `None` for the retired ids. Existing negative-path tests already assert this and were updated to say so explicitly — e.g. a retired pre-4 Claude now falls back to the client-side tool-search mechanism rather than the hosted one, which is the pre-existing unknown-model behavior.
- Existing database rows are untouched; seeding is additive and does not delete configured models.

### Smoke test

Ran the canonical local stack (`PORT_PREFIX=271 AUTH_MODE=none ./scripts/start-agent-dev.sh`) against a freshly seeded database:

- `/health` → `{"status":"ok","version":"0.22.0","auth_mode":"None"}`
- `GET /api/v1/models` returns 58 models; all 16 retired ids and both retired Bedrock ids are absent.
- Both new Bedrock rows are present and disabled: `global.anthropic.claude-opus-5` / `global.anthropic.claude-sonnet-5`. Their `profile` is `null`, the second follow-up below, observed rather than assumed.
- Surviving models keep profile-derived metadata: `gpt-5.2` → GPT-5.2, family `gpt-5.2`, 400K context; `claude-opus-5` → Claude Opus 5, 200K context.
- End-to-end turn on a surviving model (`claude-haiku-4-6-20260301`): created an agent and session, posted a message, and the agent replied — model resolution, provider dispatch, and turn execution all work.

Stack stopped afterward; no processes left running.

For the lockfile commit: reproduced the CI failure locally with `scripts/lib/check-nonworkspace-advisories.sh` (exit 1, `error[yanked]` on three crates), applied the bump, and confirmed the same script passes all four lockfiles (exit 0).

## Risk

- **Low**
- An operator with one of the retired models already configured keeps their row, but loses its profile-derived metadata (limits, cost, reasoning-effort options) and falls back to unknown-model defaults. That is the intended consequence of retiring a model, and those models can no longer serve traffic at the vendor anyway.
- Bedrock's new seeds are disabled by default, so nothing dispatches to them without an explicit opt-in.
- The lockfile bump also carries `jsonschema` 0.49.9 → 0.50.1 in two lockfiles. That is a correction, not a regression: `everruns-core` already requires 0.50.1, so those locks were unsatisfiable and `cargo check --locked` refused to build them at all. `examples/weekend-concierge-host` compiles cleanly on the new lockfile (verified locally); `evals/generic` does not, for a reason that predates this PR — see **Follow-ups**.

## Security

- Threat categories reviewed: **TM-LLM** (provider keys / model configuration), **TM-API** (public schema surface), **TM-TENANT** (seeded org-scoped data).
- Findings and resolutions: none. The diff changes catalog data, a static profile registry, doc comments, test fixtures, and three lockfiles. No credential handling, auth, SQL, tenancy scoping, or request-validation code is touched; the OpenAPI delta is example strings in field descriptions. No `THREAT[...]` markers exist in any touched file, and no new surface warrants one. No threat-model update needed. The dependency bump moves off a yanked crate and introduces no new advisory.

## Follow-ups

- **`evals/generic` does not compile, and this PR does not fix it.** `src/subject.rs:105` passes a `String` where the current API expects a `ReasoningEffort` enum. This is pre-existing drift, not caused by the lockfile bump: the error is in the crate's own source, path dependencies compile from the working tree regardless of the version recorded in the lock, and the original lockfile could not be built at all (`cargo check --locked` refused it). Workspace-excluded crates are compiled only by the weekly `examples-check.yml` sweep (Mondays 15:00 UTC), never per-PR, which is why this has gone unnoticed — exactly the EVE-663 failure mode that guard exists to catch. It will turn that sweep red on Monday unless fixed first. Left out because a source fix to an eval crate is unrelated to both the model change and the yank fix.
- **Bedrock models resolve no cost/limits profile.** The profile registry matches ids anchored at position 0 and its Anthropic descriptors are scoped to `DriverId::Anthropic`, so `global.anthropic.claude-opus-5` matches nothing and Bedrock spend is not token-costed. This is pre-existing (equally true of the Claude 3.5 Bedrock entries this PR removes) and widening the registry is a separate change with its own test surface.
- **The live LLM matrix still pins retired Bedrock ids.** `crates/llm-tests/tests/llm_test_matrix/mod.rs` uses `anthropic.claude-3-5-haiku-20241022-v1:0` and `anthropic.claude-3-5-sonnet-20241022-v2:0`. Those 3.5 ids do still resolve on Bedrock, so nothing is broken today, and repointing them at the Claude 5 profiles cannot be validated from this environment (no `AWS_BEDROCK_CREDENTIALS`) — changing untestable live-test ids risks turning the matrix red on main for no verified gain.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — all 53 checks green on `e749684`, no CI opt-out labels applied
- [x] All review comments addressed (code change or written reasoning) — no reviews or review threads were opened