### PR TITLE
fix(ui): lock the chat composer when no model is available

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -414,6 +414,18 @@ describe("ChatPanel placeholder", () => {
     expect(screen.getByText(/Choose a model/)).toBeInTheDocument();
   });
 
+  it("locks the composer while no model is available", () => {
+    mockSessionContext.llmModel = null;
+    mockSessionContext.llmModelLoading = false;
+
+    render(<ChatPanel />);
+
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Attach images (PNG, JPEG, GIF, WebP)" }),
+    ).toBeDisabled();
+  });
+
   it("waits for default model resolution before enabling submission", () => {
     mockSessionContext.llmModel = null;
     mockSessionContext.llmModelLoading = true;
@@ -424,6 +436,15 @@ describe("ChatPanel placeholder", () => {
 
     expect(screen.getByText("Checking model availability…")).toBeInTheDocument();
     expect(container.querySelector('button[type="submit"]')).toBeDisabled();
+  });
+
+  it("keeps the composer usable while model availability is still loading", () => {
+    mockSessionContext.llmModel = null;
+    mockSessionContext.llmModelLoading = true;
+
+    render(<ChatPanel />);
+
+    expect(screen.getByRole("combobox")).not.toBeDisabled();
   });
 
   it("sends an explicit model when no default is available", async () => {

--- a/apps/ui/src/components/chat/chat-composer.tsx
+++ b/apps/ui/src/components/chat/chat-composer.tsx
@@ -3,6 +3,9 @@
  * - Keep submit/readiness logic in one component so the parent only coordinates network state.
  * - Preserve slash-command UX: autocomplete owns keyboard navigation whenever visible.
  * - Image upload affordances stay next to text entry because they share send readiness.
+ * - When no model resolves, lock the whole composer (text, attachments, voice, drop zone) instead
+ *   of only the send button: typing a message that can never be sent is a dead end. The model menu
+ *   stays enabled because it is how the user recovers.
  */
 "use client";
 
@@ -139,6 +142,9 @@ export function ChatComposer({
   const hasCommands = commands.length > 0;
   const inputPlaceholder =
     placeholder ?? (hasCommands ? t("type_message_or_commands") : t("type_message"));
+  // No usable model means nothing can be sent, so the whole entry surface is locked. While the
+  // lookup is still in flight the composer stays open so opening a session never flashes disabled.
+  const composerDisabled = !modelReady && !modelLoading;
 
   useEffect(() => {
     setShowCommands(hasCommands && shouldShowCommandAutocomplete(inputValue));
@@ -225,9 +231,12 @@ export function ChatComposer({
         <div
           className={cn(
             chatSurfaceStyles.composerInputShell,
-            isDraggingOver && "bg-[hsl(var(--accent)/0.07)] ring-1 ring-accent/60",
+            !composerDisabled &&
+              isDraggingOver &&
+              "bg-[hsl(var(--accent)/0.07)] ring-1 ring-accent/60",
+            composerDisabled && "opacity-60",
           )}
-          {...dropZoneProps}
+          {...(composerDisabled ? {} : dropZoneProps)}
         >
           <ParticipantMentionAutocomplete
             options={mentionOptions}
@@ -282,6 +291,7 @@ export function ChatComposer({
             onPaste={handlePaste}
             role="combobox"
             tabIndex={0}
+            disabled={composerDisabled}
             placeholder={inputPlaceholder}
             className={chatSurfaceStyles.composerTextarea}
             aria-autocomplete="list"
@@ -299,6 +309,7 @@ export function ChatComposer({
               variant="outline"
               size="icon-lg"
               className={chatSurfaceStyles.composerIconButton}
+              disabled={composerDisabled}
               onClick={() => fileInputRef.current?.click()}
               title={t("attach_images")}
             >
@@ -337,7 +348,7 @@ export function ChatComposer({
                   chatSurfaceStyles.composerIconButton,
                   voiceActive && "border-emerald-500/50 text-emerald-600",
                 )}
-                disabled={voicePending}
+                disabled={voicePending || composerDisabled}
                 onClick={onToggleVoice}
                 title={voiceActive ? "End voice session" : "Start voice session"}
               >

--- a/test_cases/ui/chats/TC014_model_resolution_guard.md
+++ b/test_cases/ui/chats/TC014_model_resolution_guard.md
@@ -23,8 +23,10 @@ an explicit model becomes available.
 
 1. Open the existing chat thread with no resolvable model.
 2. Confirm the composer explains that a model must be chosen or configured.
-3. Enter the no-model message and press Enter.
-4. Confirm the message remains in the composer, Send stays disabled, and no turn event is created.
+3. Confirm the message box, the attachment button, and voice (when enabled) are all disabled, while
+   the model menu stays usable.
+4. Attempt to type the no-model message and press Enter; confirm nothing is entered, Send stays
+   disabled, and no turn event is created.
 5. Enable a valid chat model and select it explicitly in the composer.
 6. Send the explicit-model message in the same thread.
 7. Wait for the response and inspect the session lifecycle.
@@ -34,9 +36,11 @@ an explicit model becomes available.
 | Check | Expected |
 |-------|----------|
 | Missing-model guidance | The composer identifies the default model as unavailable and explains how to resolve it |
+| Locked composer | Message box, attachment button, and voice are disabled while no model is resolvable |
+| Escape hatch | The model menu stays enabled so a model can still be chosen |
 | Keyboard submit | Enter does not submit while no model is resolvable |
 | Send control | Send remains disabled while no model is resolvable |
 | No dead turn | No input, `turn.started`, or active-session lifecycle is created by the blocked attempt |
-| Explicit model | Selecting a valid model enables submission |
+| Explicit model | Selecting a valid model re-enables the composer and submission |
 | Follow-up | The later message completes normally in the same thread |
 | Terminal lifecycle | The valid turn emits `turn.completed` and `session.idled`; the session ends idle |


### PR DESCRIPTION
## What changed

When neither an explicit nor a default chat model resolves, the composer is now locked as a whole: the message box, the attachment button, the voice button, and the image drop zone are all disabled. The model menu stays enabled — it is how the user recovers — and the existing "Choose a model, or configure a default model, before sending." notice is unchanged.

While the model lookup is still in flight the composer stays open, so opening a session never flashes a disabled input.

## Why

Only the send button was gated on model readiness. Everything else stayed live, so a user facing `Default · Unavailable` could type a full message, attach images, or start a voice session and only discover at send time that none of it could go anywhere.

## Before / After

Verified in Chromium against `/dev/chat-components`, which renders the production `ChatComposer`. The script selects "Default model" (no model resolves), then types into the message box:

Before (`origin/main`):
```
[before] model selected -> textarea disabled: false
[before] no model -> textarea disabled: false | attach disabled: false
[before] no model -> typed text landed: "/ship tighten the tool transcript UItyping while no model is available"
```

After (this branch):
```
[after] model selected -> textarea disabled: false
[after] no model -> textarea disabled: true | attach disabled: true
[after] no model -> typed text landed: "/ship tighten the tool transcript UI"
```

The typed text lands on `main` and is rejected here; the model menu remains clickable in both, and reselecting a model restores the composer. Screenshots were captured for both states but could not be attached: this session's GitHub proxy rejects `uploads.github.com/user-attachments` (`sessions are bound to their configured repositories`), and no Crabbox publishing path is available in the container. The console output above is the reproducible substitute.

Unit coverage added in `apps/ui/src/__tests__/chat-panel.test.tsx`: the composer is locked when no model resolves, and stays usable while availability is still loading.

## Risk

- Low
- Blast radius is the chat composer's enabled state. The regression to watch for is over-disabling: a session whose model resolves slowly would be unusable if the loading state were treated as unavailable. That is why `composerDisabled` requires `!modelLoading`, covered by a dedicated test. Send behavior, submit gating, and the notice text are unchanged.

## Security

- Threat categories reviewed: TM-WEB
- Findings and resolutions: No new surface. The change only adds `disabled` attributes to existing client-side controls and skips drop-zone handlers; it introduces no new input handling, URL rendering, or network path. Client-side disabling is a UX guard, not a security control — the server-side rejection of a turn with no resolvable model (`runtime_error_model_not_configured`) is untouched and remains the enforcement point. No `THREAT` markers are near the diff and the threat model needs no update.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwjgYgaVddRW1mzLsoHP2e)_