### PR TITLE
fix(ui): stop losing the first message of a fresh chat thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,9 +1176,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/apps/ui/src/__tests__/use-events.test.tsx
+++ b/apps/ui/src/__tests__/use-events.test.tsx
@@ -25,6 +25,10 @@ jest.mock("@/lib/api/events", () => ({
   DEFAULT_EXCLUDED_EVENTS: [],
 }));
 
+const { getSseUrl } = jest.requireMock("@/lib/api/events") as {
+  getSseUrl: jest.Mock;
+};
+
 jest.mock("@/providers/org-provider", () => ({
   useOrg: () => ({ currentOrg: { public_id: "org-1" } }),
 }));
@@ -45,6 +49,7 @@ describe("useEvents SSE handling", () => {
   beforeEach(() => {
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     for (const key of Object.keys(mockSseListeners)) delete mockSseListeners[key];
+    getSseUrl.mockClear();
   });
 
   async function mountAndConnect() {
@@ -53,6 +58,33 @@ describe("useEvents SSE handling", () => {
     await waitFor(() => expect(mockSseListeners["input.message"]?.length).toBeGreaterThan(0));
     return view;
   }
+
+  // Regression: an empty snapshot used to open the stream with no cursor, so
+  // events written before the subscription (the first message of a fresh chat)
+  // were never delivered and the optimistic bubble for them stayed pinned at the
+  // bottom of the transcript.
+  it("asks for a full replay when the initial snapshot is empty", async () => {
+    await mountAndConnect();
+
+    expect(getSseUrl).toHaveBeenCalledWith("session-1", { afterSequence: 0 });
+  });
+
+  it("resumes from the last received event once one is known", async () => {
+    await mountAndConnect();
+    act(() => {
+      fireSse({ id: "e1" });
+    });
+
+    // Reconnecting now must resume from e1, not replay the session again.
+    getSseUrl.mockClear();
+    act(() => {
+      for (const handler of mockSseListeners["disconnecting"] ?? []) {
+        handler({ data: JSON.stringify({ retry_ms: 0 }) } as MessageEvent);
+      }
+    });
+
+    await waitFor(() => expect(getSseUrl).toHaveBeenCalledWith("session-1", { sinceId: "e1" }));
+  });
 
   it("deduplicates events with the same id", async () => {
     const { result } = await mountAndConnect();

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -593,7 +593,13 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
     const connectSSE = () => {
       cleanup();
 
-      const sseUrl = getSseUrl(sessionId, lastEventIdRef.current ?? undefined);
+      // No event id yet means the REST snapshot was empty (a fresh session) or
+      // failed: resume from sequence 0 so the server replays everything written
+      // before this subscription instead of starting live and dropping it.
+      const sseUrl = getSseUrl(
+        sessionId,
+        lastEventIdRef.current ? { sinceId: lastEventIdRef.current } : { afterSequence: 0 },
+      );
       const eventSource = createEventStream(sseUrl, { withCredentials: true });
       eventSourceRef.current = eventSource;
 

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -81,15 +81,33 @@ export async function listEventsPaginated(
   };
 }
 
+/**
+ * Cursor the SSE stream resumes from.
+ *
+ * `sinceId` is the normal case: everything after that event is replayed, then the
+ * stream goes live. A client that holds no events at all cannot express that with
+ * an id, so it sends `afterSequence: 0` — replay the session from its first event.
+ * Without a cursor the server starts live, and anything written between the
+ * client's REST snapshot and the subscription is dropped for good.
+ */
+export interface SseCursor {
+  sinceId?: string;
+  afterSequence?: number;
+}
+
 // Get SSE URL for real-time event streaming
-// Uses since_id for incremental updates (resolved to sequence for reliable ordering)
-// Optional exclude parameter to filter out event types (e.g., delta events)
+// Takes the cursor to resume from (see SseCursor) and an optional exclude list
+// filtering out event types (e.g. delta events)
 // Note: Org is sent via everruns_org cookie (EventSource sends cookies automatically)
-export function getSseUrl(sessionId: string, sinceId?: string, exclude?: string[]): string {
+export function getSseUrl(sessionId: string, cursor?: SseCursor, exclude?: string[]): string {
   const baseUrl = getApiBaseUrl();
   const params = new URLSearchParams();
+  const { sinceId, afterSequence } = cursor ?? {};
   if (sinceId) {
     params.set("since_id", sinceId);
+  } else if (afterSequence !== undefined) {
+    // Mutually exclusive with since_id on the server.
+    params.set("after_sequence", String(afterSequence));
   }
   if (exclude) {
     for (const type of exclude) {

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -29184,6 +29184,14 @@ export interface operations {
         /** @description Filter events with ID greater than this event ID (prefixed format: event_{32-hex}) */
         since_id?: null | components["schemas"]["eventId"];
         /**
+         * @description Forward cursor: replay durable events with `sequence` greater than this
+         *     value before switching to live streaming. `after_sequence=0` replays the
+         *     session from its first event — that is what a client with an empty
+         *     snapshot must send, otherwise events written between its snapshot and
+         *     this subscription are never delivered. Mutually exclusive with `since_id`.
+         */
+        after_sequence?: number | null;
+        /**
          * @description Positive type filter: only return events matching these types (can be specified multiple times).
          *     When empty, all types are returned. Example: ?types=turn.started&types=turn.completed
          */

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -51,6 +51,12 @@ use utoipa::{IntoParams, ToSchema};
 pub struct EventsQuery {
     /// Filter events with ID greater than this event ID (prefixed format: event_{32-hex})
     pub since_id: Option<EventId>,
+    /// Forward cursor: replay durable events with `sequence` greater than this
+    /// value before switching to live streaming. `after_sequence=0` replays the
+    /// session from its first event — that is what a client with an empty
+    /// snapshot must send, otherwise events written between its snapshot and
+    /// this subscription are never delivered. Mutually exclusive with `since_id`.
+    pub after_sequence: Option<i32>,
     /// Positive type filter: only return events matching these types (can be specified multiple times).
     /// When empty, all types are returned. Example: ?types=turn.started&types=turn.completed
     #[serde(default)]
@@ -69,6 +75,18 @@ impl EventsQuery {
     fn validate(&self) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
         validate_event_type_list(&self.types, "types")?;
         validate_event_type_list(&self.exclude, "exclude")?;
+        if self.since_id.is_some() && self.after_sequence.is_some() {
+            return Err(ErrorResponse::new(
+                "since_id and after_sequence are mutually exclusive".to_string(),
+            )
+            .into_response(StatusCode::BAD_REQUEST));
+        }
+        if self.after_sequence.is_some_and(|seq| seq < 0) {
+            return Err(
+                ErrorResponse::new("after_sequence must be >= 0".to_string())
+                    .into_response(StatusCode::BAD_REQUEST),
+            );
+        }
         Ok(())
     }
 }
@@ -344,6 +362,11 @@ pub async fn stream_sse(
 
     let event_service = state.event_service.clone();
     let initial_since_id = query.since_id.map(|id| id.uuid());
+    // A client that holds no events sends `after_sequence=0` instead of a
+    // `since_id`; without it the stream would start live and silently drop
+    // everything written before the subscription (EVE: first message of a fresh
+    // chat landed nowhere in the transcript).
+    let initial_after_sequence = query.after_sequence;
     let filter_types = query.types;
     let exclude_types = query.exclude;
 
@@ -450,6 +473,9 @@ pub async fn stream_sse(
     struct StreamState {
         phase: StreamPhase,
         last_id: Option<Uuid>,
+        /// Forward sequence cursor for the one-time PG replay. Only set when the
+        /// client has no `since_id` (empty snapshot); cleared once replayed.
+        last_sequence: Option<i32>,
         backoff_ms: u64,
         config: SseStreamConfig,
         filter_types: Vec<String>,
@@ -462,6 +488,7 @@ pub async fn stream_sse(
     let initial_state = StreamState {
         phase: StreamPhase::SendConnected,
         last_id: initial_since_id,
+        last_sequence: initial_after_sequence,
         backoff_ms: config.min_backoff_ms,
         max_duration,
         config,
@@ -517,9 +544,10 @@ pub async fn stream_sse(
                         .data(r#"{"status":"connected"}"#)
                         .retry(state.config.retry_hint(state.backoff_ms)));
 
-                    // If reconnecting (since_id set), replay from PG first.
-                    // Otherwise go straight to streaming.
-                    let next_phase = if state.last_id.is_some() {
+                    // If the client gave a cursor (reconnect `since_id`, or
+                    // `after_sequence` from an empty snapshot), replay from PG
+                    // first. Otherwise go straight to streaming.
+                    let next_phase = if state.last_id.is_some() || state.last_sequence.is_some() {
                         StreamPhase::ReplayFromPg
                     } else if use_push {
                         StreamPhase::Streaming
@@ -538,8 +566,8 @@ pub async fn stream_sse(
                     // One-time PG query to catch up on missed durable events.
                     // Ephemeral events (deltas) that were missed during disconnection
                     // are gone — the completed event has the full content.
-                    tracing::debug!(session_id = %session_id, last_id = ?state.last_id, "SSE: replaying missed durable events from PG");
-                    match event_service.list(session_id, None, state.last_id, &state.filter_types, &state.exclude_types, None, None).await {
+                    tracing::debug!(session_id = %session_id, last_id = ?state.last_id, after_sequence = ?state.last_sequence, "SSE: replaying missed durable events from PG");
+                    match event_service.list(session_id, state.last_sequence, state.last_id, &state.filter_types, &state.exclude_types, None, None).await {
                         Ok(events) => {
                             let new_last_id = events.last().map(|e| e.id.uuid()).or(state.last_id);
                             let retry_duration = state.config.retry_hint(state.config.min_backoff_ms);
@@ -565,6 +593,15 @@ pub async fn stream_sse(
                             let new_state = StreamState {
                                 phase: next_phase,
                                 last_id: new_last_id,
+                                // Replay is one-time. Keep the sequence cursor only
+                                // while no event id is known yet, so the polling
+                                // fallback still filters instead of re-listing the
+                                // whole session on every poll.
+                                last_sequence: if new_last_id.is_some() {
+                                    None
+                                } else {
+                                    state.last_sequence
+                                },
                                 backoff_ms: state.config.min_backoff_ms,
                                 ..state
                             };
@@ -637,7 +674,7 @@ pub async fn stream_sse(
                         }));
                     }
 
-                    match event_service.list(session_id, None, state.last_id, &state.filter_types, &state.exclude_types, None, None).await {
+                    match event_service.list(session_id, state.last_sequence, state.last_id, &state.filter_types, &state.exclude_types, None, None).await {
                         Ok(events) if !events.is_empty() => {
                             let new_last_id = Some(events.last().unwrap().id.uuid());
                             let retry_duration = state.config.retry_hint(state.config.min_backoff_ms);
@@ -649,6 +686,7 @@ pub async fn stream_sse(
                             Some((stream::iter(sse_events), StreamState {
                                 phase: StreamPhase::PollingFallback,
                                 last_id: new_last_id,
+                                last_sequence: None,
                                 backoff_ms: state.config.min_backoff_ms,
                                 ..state
                             }))

--- a/crates/server/tests/sse_replay_test.rs
+++ b/crates/server/tests/sse_replay_test.rs
@@ -1,0 +1,120 @@
+//! SSE cursor coverage: a client that holds no events must still receive
+//! everything written before it subscribed.
+//!
+//! Regression: the chat UI opened the stream without a cursor when its initial
+//! REST snapshot was empty (a brand-new thread). The server then started the
+//! stream live, so the first user message — written between the snapshot and the
+//! subscription — never reached the transcript, and the optimistic bubble for it
+//! stayed pinned below every later message.
+//!
+//! Run with: cargo test -p everruns-server --test sse_replay_test
+
+mod test_harness;
+
+use std::time::Duration;
+
+use axum::http::StatusCode;
+use everruns_platform::Session;
+use serde_json::{Value, json};
+use test_harness::TestServer;
+
+const IDLE: Duration = Duration::from_secs(2);
+const MAX_BYTES: usize = 64 * 1024;
+
+async fn session_with_message(server: &TestServer, text: &str) -> Session {
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({ "harness_id": server.seed_base_harness_id }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let _: Value = server
+        .post(
+            &format!("/v1/sessions/{}/messages", session.id),
+            json!({
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": text}]
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    session
+}
+
+#[tokio::test]
+async fn sse_after_sequence_zero_replays_events_written_before_subscribing() {
+    let server = TestServer::in_memory().await;
+    let session = session_with_message(&server, "replay me").await;
+
+    let stream = server
+        .get_stream_prefix(
+            &format!("/v1/sessions/{}/sse?after_sequence=0", session.id),
+            MAX_BYTES,
+            IDLE,
+        )
+        .await;
+
+    assert!(
+        stream.contains("event: input.message"),
+        "expected the earlier input.message to be replayed, got: {stream}"
+    );
+    assert!(
+        stream.contains("replay me"),
+        "expected the replayed message text, got: {stream}"
+    );
+}
+
+#[tokio::test]
+async fn sse_without_a_cursor_still_starts_live() {
+    let server = TestServer::in_memory().await;
+    let session = session_with_message(&server, "not replayed").await;
+
+    let stream = server
+        .get_stream_prefix(&format!("/v1/sessions/{}/sse", session.id), MAX_BYTES, IDLE)
+        .await;
+
+    assert!(
+        stream.contains("event: connected"),
+        "expected the connected frame, got: {stream}"
+    );
+    assert!(
+        !stream.contains("not replayed"),
+        "no cursor means no replay, got: {stream}"
+    );
+}
+
+#[tokio::test]
+async fn sse_rejects_since_id_combined_with_after_sequence() {
+    let server = TestServer::in_memory().await;
+    let session = session_with_message(&server, "hello").await;
+
+    let events: Value = server
+        .get(&format!("/v1/sessions/{}/events", session.id))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let first_id = events["data"][0]["id"].as_str().expect("event id");
+
+    server
+        .get(&format!(
+            "/v1/sessions/{}/sse?since_id={first_id}&after_sequence=0",
+            session.id
+        ))
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+
+    server
+        .get(&format!(
+            "/v1/sessions/{}/sse?after_sequence=-1",
+            session.id
+        ))
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -849,6 +849,50 @@ impl TestServer {
         }
     }
 
+    /// GET a streaming endpoint (SSE) and return the text received until the
+    /// stream falls quiet for `idle` or `max_bytes` have arrived. SSE streams
+    /// never end on their own, so a normal request would hang here.
+    pub async fn get_stream_prefix(
+        &self,
+        uri: &str,
+        max_bytes: usize,
+        idle: std::time::Duration,
+    ) -> String {
+        let normalized_uri = Self::normalize_uri(uri);
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri(&normalized_uri)
+            .body(Body::empty())
+            .expect("Failed to build request");
+
+        let response = self
+            .router
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("Request failed");
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "streaming request {normalized_uri} failed"
+        );
+
+        let mut body = response.into_body();
+        let mut text = String::new();
+        while text.len() < max_bytes {
+            match tokio::time::timeout(idle, body.frame()).await {
+                Ok(Some(Ok(frame))) => {
+                    if let Some(chunk) = frame.data_ref() {
+                        text.push_str(&String::from_utf8_lossy(chunk));
+                    }
+                }
+                // Stream ended, errored, or went idle — return what arrived.
+                Ok(_) | Err(_) => break,
+            }
+        }
+        text
+    }
+
     /// Make a request with custom method and optional body
     async fn request<T: Serialize>(
         &self,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -13197,6 +13197,19 @@
             }
           },
           {
+            "name": "after_sequence",
+            "in": "query",
+            "description": "Forward cursor: replay durable events with `sequence` greater than this\nvalue before switching to live streaming. `after_sequence=0` replays the\nsession from its first event — that is what a client with an empty\nsnapshot must send, otherwise events written between its snapshot and\nthis subscription are never delivered. Mutually exclusive with `since_id`.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            }
+          },
+          {
             "name": "types",
             "in": "query",
             "description": "Positive type filter: only return events matching these types (can be specified multiple times).\nWhen empty, all types are returned. Example: ?types=turn.started&types=turn.completed",

--- a/knowledge/execution/api-streaming.md
+++ b/knowledge/execution/api-streaming.md
@@ -41,6 +41,12 @@ data: <json>
 * `id:`, event id cursor (`event_{32-hex}` format). Reconnecting
   clients pass it back as the `since_id` query parameter to resume
   without missing events.
+  A client that holds **no** events cannot name a cursor by id: it passes
+  `after_sequence=0` instead, and the server replays the session from its
+  first event before going live. Subscribing with neither cursor starts the
+  stream live, so anything written between the client's snapshot and the
+  subscription is never delivered. The two parameters are mutually
+  exclusive (400).
 * `retry:`, server-suggested reconnect delay in milliseconds; see
   the per-endpoint description for the cycling policy.
 * `data:`, the per-event JSON body. The shape depends on the


### PR DESCRIPTION
## What changed

A chat thread no longer drops its opening user message. The SSE stream now takes a cursor a client with an empty snapshot can express — `after_sequence` (0 = replay from the session's first event) — and the stream handler replays from PostgreSQL for either cursor. `since_id` still covers every reconnect; the two are mutually exclusive (400), matching the list endpoint.

`698700f` additionally moves the lockfile off the yanked `chacha20 0.10.1` (transitive via `rand 0.10.2`), which is what turned `Check Dependency Licenses` red for every Rust PR — see the comment below.

## Why

A new thread has no events, so the UI's initial REST snapshot came back empty and it opened the stream with no cursor at all. The handler skips its replay phase in that case and starts live, so every event written between the snapshot and the subscription is dropped for good — for a new thread that is exactly the user's first message.

The transcript then kept the optimistic bubble for that message, and optimistic events sort to the end of the transcript by design. Net effect for the user: the first message of a chat is missing from the top of the thread and shows up under every later message, which reads as a message-ordering bug.

## Before / After

Reproduced against the SSE contract itself (`crates/server/tests/sse_replay_test.rs`): create a session, post a message, then subscribe.

Before — subscribing with no cursor after the message was written:

```
event: connected
data: {"status":"connected"}
```
(the `input.message` never arrives; still the case, deliberately, for a cursorless subscribe)

After — same session, subscribing with `?after_sequence=0`:

```
event: connected
data: {"status":"connected"}

event: input.message
id: event_...
data: {"type":"input.message", ... "text":"replay me" ...}
```

Client side, `useEvents` now asks for that replay whenever it holds no events (`use-events.test.tsx`), and still resumes from `since_id` once one is known. Full UI suite: 180 suites / 1486 tests green; `sse_replay_test` 3/3; `cargo clippy -p everruns-server --all-targets --all-features -D warnings` clean.

## Risk

- Low
- A client whose REST snapshot fails on a large session now replays up to the forward safety limit (10 000 events) instead of showing an empty transcript — more data over that one connection, and the right outcome for the user. Normal reconnects are unchanged: they carry `since_id` and never take the new path.

## Security

- Threat categories reviewed: TM-API (query surface), TM-DOS (stream cost). The new parameter is a bounded forward cursor on a session the caller is already authorized to stream; it is validated (non-negative, not combined with `since_id`) and the replay query keeps the existing 10 000-row safety limit. No auth or data-scoping change.
- Findings and resolutions: none.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)