### PR TITLE
chore(models): retire Claude Sonnet 4

### DIFF
--- a/apps/ui/src/app/dev/session-card/page.tsx
+++ b/apps/ui/src/app/dev/session-card/page.tsx
@@ -173,8 +173,8 @@ const sampleModels = {
   anthropic: {
     id: "model-uuid-anthropic",
     provider_id: "provider-anthropic",
-    model_id: "claude-sonnet-4-20250514",
-    display_name: "Claude Sonnet 4",
+    model_id: "claude-sonnet-4-6",
+    display_name: "Claude Sonnet 4.6",
     capabilities: ["chat", "tools"],
     enabled: true,
     is_favorite: true,

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -389,7 +389,6 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["claude-sonnet-4-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-haiku-4-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4"], ModelVendor::Anthropic, ANTHROPIC),
-    md(&["claude-sonnet-4"], ModelVendor::Anthropic, ANTHROPIC),
     // Google Gemini
     md(&["gemini-3.1-pro-preview"], ModelVendor::Google, GEMINI),
     md(&["gemini-3.5-flash"], ModelVendor::Google, GEMINI),
@@ -2389,7 +2388,6 @@ fn anthropic_family_supports_tool_search(family: &str) -> bool {
             | "claude-sonnet-5"
             | "claude-sonnet-4-6"
             | "claude-sonnet-4-5"
-            | "claude-sonnet-4"
             | "claude-haiku-4-5"
     )
 }
@@ -2836,43 +2834,6 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
         }),
 
         // Claude 4 series
-        "claude-sonnet-4" => Some(ModelProfile {
-            name: "Claude Sonnet 4".into(),
-            family: "claude-sonnet-4".into(),
-            description: None,
-            release_date: Some("2025-05-14".into()),
-            last_updated: Some("2025-05-14".into()),
-            attachment: true,
-            reasoning: true,
-            temperature: true,
-            knowledge: Some("2025-03-01".into()),
-            tool_call: true,
-            structured_output: true,
-            open_weights: false,
-            cost: Some(ModelCost {
-                input: 3.00,
-                output: 15.00,
-                cache_read: Some(0.30),
-                cost_tiers: vec![],
-            }),
-            limits: Some(ModelLimits {
-                context: 200_000,
-                input: None,
-                output: 64_000,
-                max_media: None,
-            }),
-            modalities: Some(ModelModalities {
-                input: vec![Modality::Text, Modality::Image],
-                output: vec![Modality::Text],
-            }),
-            reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
-            speed: None,
-            verbosity: None,
-            tool_search: false,
-            supported_parameters: Vec::new(),
-            supports_phases: false,
-        }),
-
         "claude-opus-4" => Some(ModelProfile {
             name: "Claude Opus 4".into(),
             family: "claude-opus-4".into(),
@@ -3311,7 +3272,6 @@ mod tests {
         (DriverId::Anthropic, "claude-opus-4-5"),
         (DriverId::Anthropic, "claude-sonnet-4-5"),
         (DriverId::Anthropic, "claude-haiku-4-5"),
-        (DriverId::Anthropic, "claude-sonnet-4"),
         (DriverId::Anthropic, "claude-opus-4"),
         // Gemini
         (DriverId::Gemini, "gemini-3.1-pro-preview"),
@@ -3506,10 +3466,6 @@ mod tests {
         assert_eq!(
             normalize_anthropic_model_id("claude-sonnet-5-latest"),
             "claude-sonnet-5"
-        );
-        assert_eq!(
-            normalize_anthropic_model_id("claude-sonnet-4-20250514"),
-            "claude-sonnet-4"
         );
     }
 
@@ -4538,7 +4494,6 @@ mod tests {
             "claude-opus-4",
             "claude-sonnet-4-6",
             "claude-sonnet-4-5",
-            "claude-sonnet-4",
             "claude-haiku-4-5",
         ] {
             let p = get_model_profile(&DriverId::Anthropic, id)

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -131,7 +131,6 @@ mod seed_ids {
     pub const CLAUDE_SONNET_4_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000302);
     pub const CLAUDE_HAIKU_4_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000303);
     pub const CLAUDE_OPUS_4: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000304);
-    pub const CLAUDE_SONNET_4: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000305);
     // 1M-context variants (`[1m]` model ids), 0x3a0+ sub-range.
     pub const CLAUDE_OPUS_5_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a8);
     pub const CLAUDE_OPUS_4_7_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a7);
@@ -1949,14 +1948,6 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::ANTHROPIC_PROVIDER,
         model_id: "claude-opus-4",
         display_name: "Claude Opus 4",
-        enabled: false,
-        is_favorite: false,
-    },
-    SeedModel {
-        id: seed_ids::CLAUDE_SONNET_4,
-        provider_id: seed_ids::ANTHROPIC_PROVIDER,
-        model_id: "claude-sonnet-4",
-        display_name: "Claude Sonnet 4",
         enabled: false,
         is_favorite: false,
     },

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -4581,7 +4581,7 @@ async fn test_anthropic_extended_thinking() {
         .expect("Failed to parse provider");
     println!("Created Anthropic provider: {}", provider.id);
 
-    // Create model (claude-sonnet-4 supports extended thinking)
+    // Create model (the live thinking model supports extended thinking)
     let model_response = client
         .post(format!(
             "{}/v1/providers/{}/models",
@@ -4945,7 +4945,7 @@ async fn test_anthropic_extended_thinking_with_tools() {
         .expect("Failed to parse provider");
     println!("Created Anthropic provider: {}", provider.id);
 
-    // Create model (claude-sonnet-4 supports extended thinking)
+    // Create model (the live thinking model supports extended thinking)
     let model_response = client
         .post(format!(
             "{}/v1/providers/{}/models",

--- a/docs/capabilities/auto-tool-search.md
+++ b/docs/capabilities/auto-tool-search.md
@@ -21,7 +21,7 @@ This is the recommended default for harnesses that may run on different models. 
 `auto_tool_search` resolves to one of three underlying mechanisms based on the model:
 
 - **Models with native OpenAI tool search** (GPT-5.4 and newer) → the hosted mechanism described in [OpenAI Tool Search](/capabilities/openai-tool-search/): namespaces + `defer_loading` + a `{"type": "tool_search"}` activator. No extra tool is added; the provider handles search server-side.
-- **Models with native Claude tool search** (Sonnet 4, Opus 4, Haiku 4.5, and Fable 5 and newer) → the hosted mechanism described in [Claude Tool Search](/capabilities/claude-tool-search/): per-tool `defer_loading` + a `tool_search_tool_bm25_20251119` server tool. No extra tool is added; the provider handles search server-side.
+- **Models with native Claude tool search** (Opus 4, Sonnet 4.5, Haiku 4.5, and Fable 5 and newer) → the hosted mechanism described in [Claude Tool Search](/capabilities/claude-tool-search/): per-tool `defer_loading` + a `tool_search_tool_bm25_20251119` server tool. No extra tool is added; the provider handles search server-side.
 - **All other models** (Gemini, OpenAI Completions, Claude/GPT reached via a gateway that doesn't implement the hosted format, …) → the client-side mechanism described in [Tool Search](/capabilities/tool-search/): schemas are stripped to stubs and a `tool_search` tool loads them back on demand.
 
 The choice is made when the agent's capabilities are assembled, once the model is known. You don't have to know in advance which provider an agent will use.

--- a/docs/capabilities/claude-tool-search.md
+++ b/docs/capabilities/claude-tool-search.md
@@ -48,7 +48,7 @@ Tool search requires model-level support. Per Anthropic, it is available on:
 | Model family | Supported |
 |---|---|
 | Opus 4.x (`claude-opus-4*`) | Yes |
-| Sonnet 4.x (`claude-sonnet-4*`) | Yes |
+| Sonnet 4.5 / 4.6 (`claude-sonnet-4-5`, `claude-sonnet-4-6`) | Yes |
 | Haiku 4.5 (`claude-haiku-4-5`) | Yes |
 | Fable 5 (`claude-fable-5`) | Yes |
 | Retired pre-4 Claude models | No (capability is silently ignored) |

--- a/knowledge/execution/tool-search.md
+++ b/knowledge/execution/tool-search.md
@@ -73,7 +73,7 @@ There are four capabilities, two mechanisms (hosted vs client-side). The two hos
 `auto_tool_search` is a runtime dispatcher, not a separate mechanism. `AutoToolSearchCapability` owns an `OpenAiToolSearchCapability`, a `ClaudeToolSearchCapability`, and a `ToolSearchCapability`, and implements `Capability::resolve_for_model`. The agent's model is carried on `SystemPromptContext::model`, so capability collection knows it and delegates to exactly one inner capability, collecting *its* contributions in place of the dispatcher's:
 
 - **Model has native OpenAI support** (`openai_tool_search::model_supports_native_tool_search`, GPT-5.4+): resolves to `openai_tool_search`.
-- **Model has native Anthropic support** (`claude_tool_search::model_supports_native_tool_search`, Claude Sonnet 4 / Opus 4 / Haiku 4.5 / Fable 5 and newer): resolves to `claude_tool_search`.
+- **Model has native Anthropic support** (`claude_tool_search::model_supports_native_tool_search`, Claude Opus 4 / Sonnet 4.5 / Haiku 4.5 / Fable 5 and newer): resolves to `claude_tool_search`.
 - Either hosted branch makes collection set the hosted `ToolSearchConfig` (keyed on the resolved `effective.id()`, which is one of the two hosted ids); no client-side tool or hook is contributed.
 - **Model lacks native support, or model is unknown:** resolves to the generic `tool_search`. Collection contributes its `DeferSchemaHook` + `tool_search` tool + system-prompt note and sets no hosted config.
 


### PR DESCRIPTION
## What changed

Claude Sonnet 4 (the original `claude-sonnet-4`) is retired. New orgs no longer get it in their seeded model catalog, and the model no longer resolves in the profile registry, so it carries no name, cost, limits, or native tool-search support. Sonnet 4.5 and 4.6 are untouched — only the bare Sonnet 4 goes.

Concretely: the `SeedModel` and its `seed_ids::CLAUDE_SONNET_4` UUID, the registry descriptor and profile arm, and the entry in the Anthropic native tool-search family list. Every test that named the model went with it, along with two `workflow_test` comments that claimed the extended-thinking tests use `claude-sonnet-4` — they use `LIVE_ANTHROPIC_THINKING_MODEL` (Sonnet 4.5) and now say so. Docs and knowledge that listed Sonnet 4 among the natively tool-search-capable Claude families now name 4.5/4.6, and the session-card dev preview mocks Sonnet 4.6 instead of a retired model.

## Why

Sonnet 4 is superseded twice over (4.5, 4.6) and Sonnet 5 is the enabled default. Keeping it in the seed catalog puts a dead model in every new org's picker; keeping it in the registry keeps a profile nothing seeds or tests. This follows the same retirement pattern as #3294.

## Before / After

Dev-mode server (`DEV_MODE=true AUTH_MODE=none`), `GET /api/v1/models` after seeding — the Anthropic catalog on this branch:

```
claude-haiku-4-5                   enabled=False fav=True
claude-haiku-4-6-20260301          enabled=True  fav=True
claude-opus-4                      enabled=False fav=False
claude-opus-4-5                    enabled=False fav=True
claude-opus-4-7                    enabled=True  fav=True
claude-opus-4-7[1m]                enabled=True  fav=True
claude-opus-4-8                    enabled=True  fav=True
claude-opus-5                      enabled=True  fav=True
claude-opus-5[1m]                  enabled=True  fav=True
claude-sonnet-4-5                  enabled=False fav=True
claude-sonnet-4-6                  enabled=False fav=True
claude-sonnet-5                    enabled=True  fav=True
claude-sonnet-5[1m]                enabled=True  fav=True
global.anthropic.claude-opus-5     enabled=False fav=False
global.anthropic.claude-sonnet-5   enabled=False fav=False

claude-sonnet-4 present: False
```

Before, that list carried an additional `claude-sonnet-4  enabled=False fav=False` row. Every other model is unchanged, and `claude-sonnet-4-5` / `claude-sonnet-4-6` still resolve.

Local checks before pushing: `scripts/lib/pre-push.sh` 22/22, `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings` on the two touched crates, 3,331 tests across `everruns-server --lib` / `everruns-provider` / `everruns-builtins`, and the UI format/lint checks.

## Risk

- Low
- An org that already has a `claude-sonnet-4` model row keeps the row (seeding does not delete rows) but loses its profile: no display name, cost, or limits in the UI, and `claude_tool_search` is silently skipped on it. Requests still route to Anthropic, which continues to serve the model. Anyone still on Sonnet 4 should move to 4.5 or newer; re-adding the profile is a one-block revert if that turns out to be too abrupt.

## Security

- Threat categories reviewed: TM-LLM, TM-API, TM-TENANT.
- Findings and resolutions: none. The diff only removes entries from two compile-time constant tables (`SEED_MODELS`, the model profile registry) plus tests and prose. No auth, authorization, request handling, SQL, filesystem, or process-execution path is touched; no new input reaches a trust boundary; no credential or key handling changes. The removed profile carried no secrets — only a display name, prices, and context limits. Seeding remains org-scoped exactly as before. No `THREAT` markers are near the diff, and no new surface was opened, so `knowledge/security/threat-model.md` needs no update.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — all 55 checks complete, green or skipped, on `380a4c1`; no `ci:skip-*` labels are set
- [x] All review comments addressed (code change or written reasoning) — no reviews or review threads; the only comment is the Cloudflare Pages deploy bot reporting a successful docs preview