### PR TITLE
fix(ci): skip live workflow tests when the provider account is blocked

### DIFF
--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -43,6 +43,115 @@ const LIVE_ANTHROPIC_FAST_MODEL: &str = "claude-haiku-4-5-20251001";
 /// Extended thinking requires a model that supports it; Haiku does not.
 const LIVE_ANTHROPIC_THINKING_MODEL: &str = "claude-sonnet-4-5-20250929";
 
+/// Returns the error code when a turn was blocked by a live provider *account*
+/// condition — the account is out of credits, or a subscription usage limit was
+/// reached — rather than by a defect in the code under test.
+///
+/// The live provider matrix already skips on this signal (`skip_if_quota!` in
+/// `crates/llm-tests/tests/llm_test_matrix/mod.rs`, and the comment on the
+/// `live-provider-matrix` CI job). The live tests in this file drive the same
+/// shared provider accounts through the worker, so they skip on it too: a turn
+/// that never reached the provider proves nothing about tool-call serialization
+/// or reasoning projection, and failing on it reports a code regression that
+/// does not exist. Main went red exactly this way on 2026-08-29.
+///
+/// Deliberately narrow. A missing or invalid credential
+/// (`provider_misconfigured`) and every genuine API or contract break still
+/// fail loudly — see `EVERRUNS_REQUIRE_LIVE_TESTS` in the CI workflow, which
+/// exists so a silently absent key cannot report a vacuous pass.
+fn provider_account_block(message: &Value) -> Option<&str> {
+    use everruns_provider::user_facing_error::codes;
+
+    let code = message["metadata"]["error_code"].as_str()?;
+    (code == codes::PROVIDER_QUOTA_EXHAUSTED || code == codes::PROVIDER_USAGE_LIMIT_REACHED)
+        .then_some(code)
+}
+
+#[test]
+fn provider_account_block_matches_only_billing_codes() {
+    use everruns_provider::user_facing_error::codes;
+
+    let with_code = |code: &str| json!({"metadata": {"error_code": code}});
+
+    assert_eq!(
+        provider_account_block(&with_code(codes::PROVIDER_QUOTA_EXHAUSTED)),
+        Some(codes::PROVIDER_QUOTA_EXHAUSTED)
+    );
+    assert_eq!(
+        provider_account_block(&with_code(codes::PROVIDER_USAGE_LIMIT_REACHED)),
+        Some(codes::PROVIDER_USAGE_LIMIT_REACHED)
+    );
+
+    // A bad or absent credential is an operator error in the CI setup, not a
+    // billing condition — it must keep failing loudly.
+    assert_eq!(
+        provider_account_block(&with_code(codes::PROVIDER_MISCONFIGURED)),
+        None
+    );
+    // Genuine regressions the live tests exist to catch.
+    for code in [
+        codes::INVALID_TOOL_SCHEMA,
+        codes::PROCESSING_ERROR,
+        codes::MODEL_UNAVAILABLE,
+        codes::PROVIDER_RATE_LIMITED,
+    ] {
+        assert_eq!(provider_account_block(&with_code(code)), None, "{code}");
+    }
+
+    // A healthy turn carries no error code at all.
+    assert_eq!(provider_account_block(&json!({"metadata": {}})), None);
+    assert_eq!(provider_account_block(&json!({})), None);
+}
+
+/// Polls a session's messages once and reports the first provider account block
+/// found on an agent message.
+///
+/// Returns the code so the caller can name it in the skip line. Any transport
+/// or decode failure reports `None`: an unreachable API is a real failure and
+/// must not be laundered into a skip.
+async fn session_provider_account_block(
+    client: &reqwest::Client,
+    session_id: impl std::fmt::Display,
+) -> Option<String> {
+    let response = client
+        .get(format!(
+            "{}/v1/sessions/{}/messages",
+            API_BASE_URL, session_id
+        ))
+        .send()
+        .await
+        .ok()?;
+    if response.status() != 200 {
+        return None;
+    }
+    let data: Value = response.json().await.ok()?;
+    data["data"]
+        .as_array()?
+        .iter()
+        .find_map(|message| provider_account_block(message).map(str::to_owned))
+}
+
+/// Skips the current test when a previously captured
+/// `session_provider_account_block` says the live provider account is unusable.
+///
+/// Takes an already-captured value rather than polling itself, so callers can
+/// read the block while the session is still intact and act on it after they
+/// have torn their fixtures down.
+///
+/// Loud on purpose: the run log names the code, so an operator reading a green
+/// build can still see that the live assertions did not execute.
+macro_rules! skip_on_provider_account_block {
+    ($block:expr) => {
+        if let Some(code) = $block {
+            println!(
+                "SKIP: live provider account unavailable ({code}); \
+                 the turn never reached the provider, so nothing is verifiable here"
+            );
+            return;
+        }
+    };
+}
+
 #[tokio::test]
 async fn test_full_agent_session_workflow() {
     let client = reqwest::Client::new();
@@ -1214,6 +1323,8 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
         }
     }
 
+    skip_on_provider_account_block!(session_provider_account_block(&client, &session.id).await);
+
     assert!(
         write_file_called,
         "Agent should have called write_file tool"
@@ -1955,6 +2066,8 @@ async fn test_no_duplicate_tool_calls() {
             println!("  Still waiting... ({}s)", i);
         }
     }
+
+    skip_on_provider_account_block!(session_provider_account_block(&client, &session.id).await);
 
     // Step 7: Get all messages and check for duplicates
     println!("\nStep 7: Checking for duplicate tool calls...");
@@ -3581,6 +3694,10 @@ async fn test_agent_execution_openai_with_tool_calls() {
     let is_error_response = final_response_text.contains("encountered an error")
         || final_response_text.contains("try again later");
 
+    // Read the account block while the session is still intact; act on it once
+    // the fixtures below are torn down.
+    let account_block = session_provider_account_block(&client, &session.id).await;
+
     // Cleanup first before assertions
     println!("\nCleaning up...");
     client
@@ -3601,6 +3718,8 @@ async fn test_agent_execution_openai_with_tool_calls() {
         .send()
         .await
         .expect("Failed to delete provider");
+
+    skip_on_provider_account_block!(account_block);
 
     // If we got an error response, skip the test (transient API issue)
     if is_error_response {
@@ -3831,6 +3950,10 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     let is_error_response = final_response_text.contains("encountered an error")
         || final_response_text.contains("try again later");
 
+    // Read the account block while the session is still intact; act on it once
+    // the fixtures below are torn down.
+    let account_block = session_provider_account_block(&client, &session.id).await;
+
     // Cleanup first before assertions
     println!("\nCleaning up...");
     client
@@ -3851,6 +3974,8 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
         .send()
         .await
         .expect("Failed to delete provider");
+
+    skip_on_provider_account_block!(account_block);
 
     // If we got an error response, skip the test (transient API issue)
     if is_error_response {
@@ -4842,6 +4967,10 @@ async fn test_anthropic_extended_thinking() {
         followup_complete
     );
 
+    // Read the account block while the session is still intact; act on it once
+    // the fixtures below are torn down.
+    let account_block = session_provider_account_block(&client, &session.id).await;
+
     // Cleanup
     println!("\nCleaning up...");
     client
@@ -4862,6 +4991,8 @@ async fn test_anthropic_extended_thinking() {
         .send()
         .await
         .expect("Failed to delete provider");
+
+    skip_on_provider_account_block!(account_block);
 
     // Assertions
     assert!(response_complete, "First turn should complete");
@@ -5186,11 +5317,20 @@ async fn test_anthropic_extended_thinking_with_tools() {
                 followup_complete = true;
                 break;
             } else if status == "failed" {
+                // A turn the provider account blocked never exercised the
+                // thinking+tools path, so it is a skip rather than a failure.
+                skip_on_provider_account_block!(
+                    session_provider_account_block(&client, &session.id).await
+                );
                 let error = session_data["error"].as_str().unwrap_or("unknown");
                 panic!("Follow-up failed with error: {}", error);
             }
         }
     }
+
+    // Read the account block while the session is still intact; act on it once
+    // the fixtures below are torn down.
+    let account_block = session_provider_account_block(&client, &session.id).await;
 
     println!("\nResults:");
     println!("  First turn complete: {}", response_complete);
@@ -5220,6 +5360,8 @@ async fn test_anthropic_extended_thinking_with_tools() {
         .send()
         .await
         .expect("Failed to delete provider");
+
+    skip_on_provider_account_block!(account_block);
 
     // Assertions
     // Note: With interleaved thinking, the model may hit max iterations (tool loop).
@@ -5970,6 +6112,10 @@ async fn test_reasoning_reaches_api_sanitized_and_classified() {
         "agent message: {}",
         serde_json::to_string_pretty(&agent_message).unwrap_or_default()
     );
+
+    // An unusable provider account is a billing condition, not a regression in
+    // the reasoning projection this test covers.
+    skip_on_provider_account_block!(provider_account_block(&agent_message));
 
     // A provider error message would carry no reasoning and no phase, and would
     // make every assertion below vacuous.

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -103,6 +103,69 @@ fn provider_account_block_matches_only_billing_codes() {
     assert_eq!(provider_account_block(&json!({})), None);
 }
 
+/// Finds the first provider account block in a `GET /v1/sessions/{id}/messages`
+/// response body.
+///
+/// Split from the request so the extraction can be tested against a real
+/// captured response rather than first exercised during the incident it exists
+/// to report — the same approach `scripts/test-provider-credits.sh` takes for
+/// the credit-health classifier (EVE-935).
+fn messages_provider_account_block(body: &Value) -> Option<&str> {
+    body["data"]
+        .as_array()?
+        .iter()
+        .find_map(provider_account_block)
+}
+
+#[test]
+fn messages_provider_account_block_reads_a_real_quota_response() {
+    // Captured verbatim from the agent message printed by
+    // `test_reasoning_reaches_api_sanitized_and_classified` in CI run
+    // 33227749538, the run this guard exists to stop misreporting.
+    let body = json!({"data": [
+        {
+            "content": [{"text": "Think about this, then answer.", "type": "text"}],
+            "id": "message_2f1c9a4e6b7d4f0e8a1c3d5e7f902468",
+            "role": "user",
+            "sequence": 1,
+            "session_id": "session_01a04b5180217dd1a2665373ba3447ad"
+        },
+        {
+            "content": [{
+                "text": "The AI provider account is out of credits or quota. Add credits \
+                         or raise the provider account limits to continue.",
+                "type": "text"
+            }],
+            "created_at": "2026-08-29T02:20:30.955249511Z",
+            "id": "message_572957841c0f4ee995c3e70e426d70e3",
+            "metadata": {
+                "error_code": "provider_quota_exhausted",
+                "error_disclosure": "standard",
+                "error_fields": {"model_id": "gpt-5.6-terra", "provider": "openai"},
+                "source_error_code": "provider_quota_exhausted"
+            },
+            "role": "agent",
+            "sequence": 8,
+            "session_id": "session_01a04b5180217dd1a2665373ba3447ad"
+        }
+    ]});
+    assert_eq!(
+        messages_provider_account_block(&body),
+        Some("provider_quota_exhausted")
+    );
+
+    // A healthy transcript yields no block, so assertions still run.
+    let healthy = json!({"data": [
+        {"role": "user", "content": [{"text": "hi", "type": "text"}]},
+        {"role": "agent", "content": [{"text": "hello", "type": "text"}], "metadata": {}}
+    ]});
+    assert_eq!(messages_provider_account_block(&healthy), None);
+
+    // Shapes that must not panic or be mistaken for a block.
+    assert_eq!(messages_provider_account_block(&json!({"data": []})), None);
+    assert_eq!(messages_provider_account_block(&json!({})), None);
+}
+
 /// Polls a session's messages once and reports the first provider account block
 /// found on an agent message.
 ///
@@ -124,11 +187,8 @@ async fn session_provider_account_block(
     if response.status() != 200 {
         return None;
     }
-    let data: Value = response.json().await.ok()?;
-    data["data"]
-        .as_array()?
-        .iter()
-        .find_map(|message| provider_account_block(message).map(str::to_owned))
+    let body: Value = response.json().await.ok()?;
+    messages_provider_account_block(&body).map(str::to_owned)
 }
 
 /// Skips the current test when a previously captured


### PR DESCRIPTION
## What changed

The live-provider tests in `crates/server/tests/workflow_test.rs` now skip — loudly, naming the code — when a turn comes back blocked by a provider **account** condition (`provider_quota_exhausted` or `provider_usage_limit_reached`) instead of asserting on it as a code regression.

Matching is deliberately narrow. A missing or invalid credential (`provider_misconfigured`) still fails loudly, as `EVERRUNS_REQUIRE_LIVE_TESTS` intends, and so does every genuine API or contract break (`invalid_tool_schema`, `processing_error`, `model_unavailable`, `provider_rate_limited`). Transport or decode failures while reading the block report "no block", so an unreachable API stays a hard failure and is never laundered into a skip.

Applied to all seven live tests in the file, not just the two that broke today — they all share the same latent failure. Two of them tore fixtures down before asserting, so the block is captured while the session is still intact and acted on after cleanup; one also panicked on a `failed` session status before it could reach the check, and that path is covered too.

## Why

**Main is red on `68d61c0`** ([run 33227749538](https://github.com/everruns/everruns/actions/runs/33227749538)). Two failures in `Workflow Tests (Server + Worker)`:

- `test_agent_execution_openai_with_tool_calls`
- `test_reasoning_reaches_api_sanitized_and_classified`

Both are billing, not code. The shared OpenAI account is out of credits, so every turn returns a `provider_quota_exhausted` message and the assertions fire on an error string. Confirmed directly against the account — auth is healthy, the balance is not:

```
GET /v1/models                    -> 200
POST /v1/chat/completions         -> {"type": "insufficient_quota",
                                      "code": "credit_balance_exhausted",
                                      "message": "You have no credits remaining."}
```

Anthropic's account is healthy, which is exactly why only the OpenAI-driven tests failed. This is the same account condition as the EVE-662 → EVE-934 recurrence chain, now tracked for its CI impact as [EVE-943](https://linear.app/everruns/issue/EVE-943).

The repo already treats this as a skip one job over. The `live-provider-matrix` job's own step is named "skips providers without API keys **or out of quota**", backed by `skip_if_quota!` / `is_quota_exhausted` in `crates/llm-tests/tests/llm_test_matrix/mod.rs`, and its comment calls quota "a live billing condition, not a code regression". The workflow tests drive the same shared accounts through the worker but never got the same treatment. A turn that never reached the provider proves nothing about tool-call serialization or reasoning projection — there is no signal in it to keep.

## Before / After

**Before** — `main` red, the failure indistinguishable from a real regression:

```
Response preview: The AI provider account is out of credits or quota. Add credits...
panicked at crates/server/tests/workflow_test.rs:3611:5:
OpenAI agent should have called get_current_time tool

test result: FAILED. 33 passed; 2 failed
```

**After** — the same condition reports as a skip that names itself, so a green run still shows which live assertions did not execute:

```
SKIP: live provider account unavailable (provider_quota_exhausted); the turn
never reached the provider, so nothing is verifiable here
```

**Evidence.** `workflow-test` is `github.event_name == 'push'` only, so this file gets no PR-time coverage — the runtime path would otherwise first execute on the merge commit. Both halves of the guard are therefore pinned by unit tests that need no live server or credentials, the second against the agent message captured verbatim from failing run 33227749538:

```
running 2 tests
test messages_provider_account_block_reads_a_real_quota_response ... ok
test provider_account_block_matches_only_billing_codes ... ok
test result: ok. 2 passed; 0 failed
```

This mirrors how the credit-health classifier is covered against captured provider bodies in `scripts/test-provider-credits.sh` (EVE-935) — the branch that only executes against a live dead account is tested from a recorded payload rather than first exercised during the incident.

Also run locally: `just pre-push` — all 22 checks pass (`cargo fmt`, `clippy`, migration ordering/immutability, test enumeration, the 9 architecture isolation guards, knowledge conformance).

## Risk

- **Low**
- The real risk is over-matching — a genuine regression silently skipped. Contained by matching two exact structured error codes from `everruns_provider::user_facing_error::codes` rather than error prose, and the tests pin both directions: the two billing codes skip; `provider_misconfigured`, `invalid_tool_schema`, `processing_error`, `model_unavailable`, `provider_rate_limited`, a healthy transcript, an empty list and a malformed body all yield no skip. `provider_rate_limited` is deliberately excluded — a short transient throttle is not an account condition.
- Test-only change; no production code path is touched.

## Security

- **Threat categories reviewed: TM-CI, TM-LLM.** No production code changed — the diff is confined to a test file — but the change interacts with CI trust boundaries, so it was reviewed rather than waived.
- **Findings:** None requiring a change.
  - *Credential handling unchanged.* No new secret is read, logged, or moved. The push-only `DOPPLER_TOKEN` gate (TM-CI-001/TM-CI-002) is untouched; this PR does not alter who can reach the vault.
  - *No credential-failure masking.* The skip cannot hide a broken or absent key: `provider_misconfigured` is not in the matched set and is asserted excluded. This preserves what `EVERRUNS_REQUIRE_LIVE_TESTS` exists to guarantee — that a silently missing key cannot report a vacuous pass.
  - *Skip signal is server-classified, not attacker-supplied.* `metadata.error_code` is written by the server's own classifier in `crates/provider/src/user_facing_error.rs`, not copied from a provider payload, and the providers are first-party. Nothing PR-controlled selects the skip.
  - *Skips are not silent.* Each prints the code to the run log, so a green build still discloses reduced coverage. This matters given the follow-up below.
  - *No secret in the captured fixture.* The recorded payload carries only a model id, provider name and error code — checked before committing.
- No `THREAT` markers are near the diff; no threat-model update warranted.

## Follow-ups

- **The OpenAI account has no credits — someone needs to add them.** This PR stops that from reporting as a false regression; it does not restore the coverage. Until the balance is topped up, the OpenAI live paths in this file and in the `live-provider-matrix` job verify nothing and will report as skips. Anthropic coverage is unaffected. Tracked as **[EVE-943](https://linear.app/everruns/issue/EVE-943)** (recurrence #7), since it needs a billing action rather than a code change.
- `EVE-937` (live matrix validates on the merge commit, never on the PR) is left in Backlog untouched — it is an open security-design decision needing repo-admin setup, already analyzed there. Commented with today's incident as a data point; the decision remains the maintainer's.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)