### PR TITLE
fix(ci): surface live-provider skips in a green run's step summary

### DIFF
--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -191,22 +191,114 @@ async fn session_provider_account_block(
     messages_provider_account_block(&body).map(str::to_owned)
 }
 
+/// Renders one skip line for GitHub's step summary.
+///
+/// Separate from the file write so the wording is testable without touching the
+/// environment.
+fn provider_account_skip_line(test: &str, code: &str) -> String {
+    format!(
+        "- **Skipped `{test}`** — live provider account unavailable (`{code}`). \
+         The turn never reached the provider, so these live assertions did not run."
+    )
+}
+
+/// Records a skipped live test somewhere a *green* run still shows it.
+///
+/// `libtest` captures stdout for tests that pass, and the `workflow-test` job
+/// runs without `--nocapture`, so a bare `println!` here is swallowed by exactly
+/// the green run that most needs to disclose the missing coverage. That is the
+/// silent-green blind spot EVE-935 exists to close, so the skip is also appended
+/// to GitHub's step summary, which the test process writes directly and libtest
+/// does not capture. (`doppler run --preserve-env` passes `GITHUB_STEP_SUMMARY`
+/// through untouched — it only arbitrates names Doppler itself defines.)
+///
+/// Best effort by design: a missing, unset, or unwritable summary file must
+/// never turn a skip into a failure. Outside Actions the `println!` still
+/// carries the line under `--nocapture`.
+fn report_provider_account_skip(code: &str) {
+    let test = std::thread::current()
+        .name()
+        .unwrap_or("unknown test")
+        .to_owned();
+    println!("SKIP: {test}: live provider account unavailable ({code})");
+
+    if let Ok(path) = std::env::var("GITHUB_STEP_SUMMARY") {
+        append_skip_to_summary(std::path::Path::new(&path), &test, code);
+    }
+}
+
+/// Appends one skip line to the step-summary file, swallowing every I/O error.
+///
+/// Split out so the append is covered by a test rather than only ever running
+/// inside Actions.
+fn append_skip_to_summary(path: &std::path::Path, test: &str, code: &str) {
+    use std::io::Write;
+
+    let Ok(mut file) = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path)
+    else {
+        return;
+    };
+    let _ = writeln!(file, "{}", provider_account_skip_line(test, code));
+}
+
+#[test]
+fn append_skip_to_summary_accumulates_and_never_panics() {
+    let dir = std::env::temp_dir().join(format!("everruns-skip-summary-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("summary.md");
+
+    // Appends rather than truncating: several tests can skip in one run and the
+    // summary must list every one of them.
+    append_skip_to_summary(&path, "test_one", "provider_quota_exhausted");
+    append_skip_to_summary(&path, "test_two", "provider_usage_limit_reached");
+    let written = std::fs::read_to_string(&path).expect("summary written");
+    assert_eq!(written.lines().count(), 2, "{written}");
+    assert!(written.contains("test_one"), "{written}");
+    assert!(written.contains("test_two"), "{written}");
+
+    // An unwritable path is silently ignored — a skip must never become a
+    // failure because Actions moved where the summary lives.
+    append_skip_to_summary(
+        &dir.join("no-such-directory").join("summary.md"),
+        "test_three",
+        "provider_quota_exhausted",
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn provider_account_skip_line_names_the_test_and_code() {
+    let line = provider_account_skip_line(
+        "test_agent_execution_openai_with_tool_calls",
+        "provider_quota_exhausted",
+    );
+    // A reader scanning a green run's summary needs both: which test lost its
+    // coverage, and why.
+    assert!(
+        line.contains("test_agent_execution_openai_with_tool_calls"),
+        "{line}"
+    );
+    assert!(line.contains("provider_quota_exhausted"), "{line}");
+    // Markdown list item, so it renders in the step summary rather than running
+    // together with neighbouring lines.
+    assert!(line.starts_with("- "), "{line}");
+    assert!(!line.contains('\n'), "must stay one line: {line}");
+}
+
 /// Skips the current test when a previously captured
 /// `session_provider_account_block` says the live provider account is unusable.
 ///
 /// Takes an already-captured value rather than polling itself, so callers can
 /// read the block while the session is still intact and act on it after they
 /// have torn their fixtures down.
-///
-/// Loud on purpose: the run log names the code, so an operator reading a green
-/// build can still see that the live assertions did not execute.
 macro_rules! skip_on_provider_account_block {
     ($block:expr) => {
         if let Some(code) = $block {
-            println!(
-                "SKIP: live provider account unavailable ({code}); \
-                 the turn never reached the provider, so nothing is verifiable here"
-            );
+            report_provider_account_skip(&code);
             return;
         }
     };


### PR DESCRIPTION
## What changed

When a live test skips because the provider account is blocked, the skip is now appended to `GITHUB_STEP_SUMMARY` as well as stdout, so a **green** run still names which live assertions did not execute and why.

Best effort by design: an unset or unwritable summary path is ignored rather than turning a skip into a failure, and stdout still carries the line for local runs under `--nocapture`.

## Why

#3299 added the account-block guard and claimed skips were loud enough that "a green build still discloses reduced coverage". **That claim was wrong, and the merge commit proved it.**

`libtest` captures stdout for tests that *pass*, and the `workflow-test` job runs without `--nocapture`. Verified on `53ed104`: the job went green with the two OpenAI tests skipping, and not one line of their output reached the log —

```
$ grep -c "SKIP" workflow-tests.log
0
$ grep -c "Step 1: Creating" workflow-tests.log     # any test stdout at all
0

running 37 tests
test test_agent_execution_openai_with_tool_calls ... ok
test result: ok. 37 passed; 0 failed
```

So #3299 traded a false red for a silent green. That is the exact blind spot EVE-935 exists to close: OpenAI coverage has been dark since ~2026-08-25 ([EVE-943](https://linear.app/everruns/issue/EVE-943)), and CI now reports green with nothing indicating it.

The step summary is written by the test process directly and is not captured by libtest, so the disclosure survives — and Actions renders it on the run summary rather than burying it in job output. `doppler run --preserve-env` passes `GITHUB_STEP_SUMMARY` through untouched; it only arbitrates names Doppler itself defines, so no workflow change is needed.

The alternative — adding `--nocapture` to the job, as `live-provider-matrix` does — would dump every step of all 37 verbose tests into a log that was already ~3,700 lines. The summary keeps the signal and drops the noise.

## Before / After

**Before:** green run, zero indication that two live tests verified nothing.

**After:** the same green run carries, in its step summary:

```
- **Skipped `test_agent_execution_openai_with_tool_calls`** — live provider account
  unavailable (`provider_quota_exhausted`). The turn never reached the provider, so
  these live assertions did not run.
```

Both the wording and the file append are unit-tested rather than first executing inside Actions:

```
running 4 tests
test provider_account_block_matches_only_billing_codes ... ok
test messages_provider_account_block_reads_a_real_quota_response ... ok
test provider_account_skip_line_names_the_test_and_code ... ok
test append_skip_to_summary_accumulates_and_never_panics ... ok
test result: ok. 4 passed; 0 failed
```

`append_skip_to_summary_accumulates_and_never_panics` pins the two properties that matter operationally: appends accumulate (several tests can skip in one run and all must be listed), and an unwritable path is swallowed rather than failing the test.

Also run locally: `./scripts/lib/pre-push.sh` — all 22 checks pass.

## Risk

- **Low**
- Test-only; no production code path touched. The guard's skip/no-skip decision is unchanged — this only adds where the skip is recorded.
- Worst case if `GITHUB_STEP_SUMMARY` is absent or unwritable: behavior is exactly as it is today on main (skip still happens, line only on captured stdout). It cannot make a test fail.

## Security

- **Threat categories reviewed: TM-CI.** Test-only diff, but it writes a file at a path taken from the environment, so it was reviewed rather than waived.
- **Findings:** None requiring a change.
  - *Path comes from the Actions runner, not from PR content or provider output.* `GITHUB_STEP_SUMMARY` is set by the runner; the job is already push-only. Nothing PR-controlled influences it.
  - *Append-only, never truncating.* Opened with `.append(true)`, so it cannot clobber other steps' summary content.
  - *No secret in the written line.* It carries a test name and a fixed error code — no credential, model key, or provider payload.
  - *Failure is contained.* Every I/O error is swallowed deliberately, so a summary-path change in Actions degrades disclosure rather than reddening CI.
- No `THREAT` markers near the diff; no threat-model update warranted.

## Follow-ups

- [EVE-943](https://linear.app/everruns/issue/EVE-943) still stands: the OpenAI account has no credits, so those tests remain green-because-skipped. This PR makes that visible; only credits restore the coverage.
- No other follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GroFongN3eUcgJz66HtZB9)_