### PR TITLE
fix(ci): echo live-provider skips into the job log, not just the summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1525,9 +1525,35 @@ jobs:
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
           EVERRUNS_REQUIRE_LIVE_TESTS: "1"
+          # Live tests skipped by a provider account block append one line here.
+          # Named in --preserve-env so the value survives `doppler run` whatever
+          # the vault holds.
+          EVERRUNS_LIVE_SKIP_REPORT: ${{ github.workspace }}/live-provider-skips.md
         run: >-
-          doppler run --preserve-env="DATABASE_URL,API_BASE_URL,AUTH_MODE,DEPLOYMENT_GRADE,WORKER_GRPC_AUTH_TOKEN,SECRETS_ENCRYPTION_KEY,RATE_LIMIT_API_REQUESTS_PER_MINUTE,EVERRUNS_REQUIRE_LIVE_TESTS"
+          doppler run --preserve-env="DATABASE_URL,API_BASE_URL,AUTH_MODE,DEPLOYMENT_GRADE,WORKER_GRPC_AUTH_TOKEN,SECRETS_ENCRYPTION_KEY,RATE_LIMIT_API_REQUESTS_PER_MINUTE,EVERRUNS_REQUIRE_LIVE_TESTS,EVERRUNS_LIVE_SKIP_REPORT"
           -- cargo test -p everruns-server --test workflow_test -- --test-threads=1
+
+      # libtest captures stdout for tests that pass, so a skipped live test is
+      # invisible in a green run unless it is re-emitted here. Step summaries are
+      # not readable over the Actions API, so the log is the only channel a
+      # scheduled maintenance session can check — the same reason
+      # security-alerts.yml tees its report instead of only writing the summary.
+      #
+      # `always()`: the report matters just as much when a later assertion failed.
+      - name: Report skipped live tests
+        if: always()
+        run: |
+          report="${{ github.workspace }}/live-provider-skips.md"
+          if [ -s "$report" ]; then
+            echo "::warning::Live provider tests were skipped — see the lines below; their assertions did not run."
+            cat "$report"
+            {
+              echo "### Skipped live provider tests"
+              cat "$report"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No live provider tests were skipped; live assertions ran."
+          fi
 
       - name: Stop services
         if: always()

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -222,16 +222,24 @@ fn report_provider_account_skip(code: &str) {
         .to_owned();
     println!("SKIP: {test}: live provider account unavailable ({code})");
 
-    if let Ok(path) = std::env::var("GITHUB_STEP_SUMMARY") {
-        append_skip_to_summary(std::path::Path::new(&path), &test, code);
+    // Writes one file; the `Report skipped live tests` step in ci.yml renders it
+    // into both the job log and the step summary. Deliberately not written
+    // straight to GITHUB_STEP_SUMMARY: only the log is readable back over the
+    // Actions API, which is the channel a scheduled maintenance session has —
+    // the same reasoning security-alerts.yml states for teeing its report. A
+    // skip only a human can see is how OpenAI coverage stayed dark for days
+    // (EVE-943). Routing through the workflow also keeps the rendering in one
+    // place instead of appending to the summary from two directions.
+    if let Ok(path) = std::env::var("EVERRUNS_LIVE_SKIP_REPORT") {
+        append_skip_to_report(std::path::Path::new(&path), &test, code);
     }
 }
 
-/// Appends one skip line to the step-summary file, swallowing every I/O error.
+/// Appends one skip line to the report file, swallowing every I/O error.
 ///
 /// Split out so the append is covered by a test rather than only ever running
 /// inside Actions.
-fn append_skip_to_summary(path: &std::path::Path, test: &str, code: &str) {
+fn append_skip_to_report(path: &std::path::Path, test: &str, code: &str) {
     use std::io::Write;
 
     let Ok(mut file) = std::fs::OpenOptions::new()
@@ -245,24 +253,24 @@ fn append_skip_to_summary(path: &std::path::Path, test: &str, code: &str) {
 }
 
 #[test]
-fn append_skip_to_summary_accumulates_and_never_panics() {
-    let dir = std::env::temp_dir().join(format!("everruns-skip-summary-{}", std::process::id()));
+fn append_skip_to_report_accumulates_and_never_panics() {
+    let dir = std::env::temp_dir().join(format!("everruns-skip-report-{}", std::process::id()));
     std::fs::create_dir_all(&dir).expect("temp dir");
-    let path = dir.join("summary.md");
+    let path = dir.join("live-provider-skips.md");
 
     // Appends rather than truncating: several tests can skip in one run and the
-    // summary must list every one of them.
-    append_skip_to_summary(&path, "test_one", "provider_quota_exhausted");
-    append_skip_to_summary(&path, "test_two", "provider_usage_limit_reached");
-    let written = std::fs::read_to_string(&path).expect("summary written");
+    // report must list every one of them.
+    append_skip_to_report(&path, "test_one", "provider_quota_exhausted");
+    append_skip_to_report(&path, "test_two", "provider_usage_limit_reached");
+    let written = std::fs::read_to_string(&path).expect("report written");
     assert_eq!(written.lines().count(), 2, "{written}");
     assert!(written.contains("test_one"), "{written}");
     assert!(written.contains("test_two"), "{written}");
 
     // An unwritable path is silently ignored — a skip must never become a
-    // failure because Actions moved where the summary lives.
-    append_skip_to_summary(
-        &dir.join("no-such-directory").join("summary.md"),
+    // failure because the report path changed or was never created.
+    append_skip_to_report(
+        &dir.join("no-such-directory").join("live-provider-skips.md"),
         "test_three",
         "provider_quota_exhausted",
     );


### PR DESCRIPTION
## What changed

Live tests skipped by a provider account block now append to a report file (`EVERRUNS_LIVE_SKIP_REPORT`), and a new `Report skipped live tests` step renders it into **both the job log and the step summary**, with a `::warning::` annotation so it also surfaces on the run page.

The step runs on `always()` — a skip is worth reporting even when a later assertion failed — and says so explicitly when nothing was skipped, so silence is never ambiguous.

## Why

#3300 routed skips to `GITHUB_STEP_SUMMARY`. That reaches a person reading the run page, but misses the reader that matters most here: **step summaries are not exposed over the Actions API**, so a scheduled maintenance session cannot read them back.

I confirmed this against a control rather than assuming it. The `Report Open Alerts` job demonstrably writes a step summary (`cat security-alerts.md >> "$GITHUB_STEP_SUMMARY"`), and its check run returns an empty `output` too:

```
check_run 99059329641  (Report Open Alerts)   summary: (none)   text: (none)
check_run 99081256875  (Workflow Tests)       summary: (none)   text: (none)
```

So #3300's code was fine; its *channel* was wrong.

`security-alerts.yml` already states the principle #3300 missed, in its own header — it publishes to the log because that is *"readable over the Actions API, which is the channel a scheduled session has"*, and tees rather than only writing the summary. OpenAI coverage stayed dark for days precisely because nothing a machine reads said so ([EVE-943](https://linear.app/everruns/issue/EVE-943)); a disclosure only a human can see would have let the next scheduled run miss it exactly the same way.

Writing one file and rendering it in one place also avoids the double-append that keeping the test's direct `GITHUB_STEP_SUMMARY` write alongside this step would have produced.

## Before / After

**Before** (`a49c24c`, main): green, and nothing machine-readable disclosed the gap.

```
$ grep -c "SKIP" workflow-tests.log
0
test test_agent_execution_openai_with_tool_calls ... ok
test result: ok. 39 passed; 0 failed
```

**After:** the same green run carries in its **log** (and summary):

```
::warning::Live provider tests were skipped — see the lines below; their assertions did not run.
- **Skipped `test_agent_execution_openai_with_tool_calls`** — live provider account
  unavailable (`provider_quota_exhausted`). The turn never reached the provider, so
  these live assertions did not run.
```

## Risk

- **Low**
- First change here touching `ci.yml`, so I ran the repo's own CI guards, all passing: `test-ci-job-timeouts.sh`, `test-ci-labeled-event-gate.sh`, `test-ci-provider-live-filter.sh`, `test-release-workflow-security.sh`.
- Unit tests (4) pass; `./scripts/lib/pre-push.sh` passes all 22 checks.
- Worst case if the report path is unset or unwritable: identical to today's behavior — the skip still happens, the step prints "No live provider tests were skipped". It cannot fail a test.

## Security

- **Threat categories reviewed: TM-CI.** Touches a workflow, so reviewed rather than waived.
- **Findings:** None requiring a change.
  - *No change to the secret boundary.* `DOPPLER_TOKEN` handling and the push-only gate (TM-CI-001/TM-CI-002) are untouched. The new step takes no secret and runs no PR-controlled code.
  - *`EVERRUNS_LIVE_SKIP_REPORT` is added to `--preserve-env` deliberately.* It pins the runner's value against anything the vault might define under that name; it carries a path, not a credential.
  - *Nothing sensitive is echoed.* The report holds a test name and a fixed error code — no credential, model key, or provider payload. The `cat` cannot leak more than the tests wrote.
  - *Append-only.* Both the report file and the summary are opened for append, so neither clobbers other content.
- No `THREAT` markers near the diff; no threat-model update warranted.

## Follow-ups

- [EVE-943](https://linear.app/everruns/issue/EVE-943) still stands: the OpenAI account has zero credits (re-confirmed today), so these tests remain green-because-skipped. This PR makes that legible to both humans and automation; only credits restore the coverage.
- No other follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GroFongN3eUcgJz66HtZB9)_