### PR TITLE
fix(scripts): install just without the GitHub API so cloud sessions get it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,10 @@ jobs:
               # drops a timeout-minutes must run the guard even when it touches
               # nothing under scripts/.
               - '.github/workflows/ci.yml'
+              # scripts/test-cloud-env-tooling.sh reads the cloud bootstrap, so
+              # a PR that unpins a tool there must run the guard even when it
+              # touches no scripts/test-*.sh.
+              - 'scripts/init-cloud-env.sh'
               - 'Cargo.toml'
               - 'crates/*/Cargo.toml'
               - 'integrations/*/Cargo.toml'

--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -41,8 +41,46 @@ install_just() {
 
     info "Installing just (pre-built binary)..."
 
-    # Use official installer script - downloads pre-built binary
-    curl --proto '=https' --tlsv1.2 -sSf --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 https://just.systems/install.sh | bash -s -- --to "$INSTALL_DIR"
+    # Detect architecture
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64)  JUST_ARCH="x86_64" ;;
+        aarch64) JUST_ARCH="aarch64" ;;
+        *)       error "Unsupported architecture: $ARCH" ;;
+    esac
+
+    # Pinned version — the upstream just.systems installer resolves the version
+    # through api.github.com/repos/casey/just/releases/latest, and a cloud-agent
+    # session scopes the GitHub API to this repository, so that call returns 403
+    # and the install fails. Release assets on github.com are not scoped, so
+    # pinning and fetching the asset directly is what works here — the same
+    # reason gh, caddy and doppler below are pinned.
+    JUST_VERSION="1.58.0"
+    JUST_SHA256=""
+    case "$JUST_ARCH" in
+        x86_64)  JUST_SHA256="4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d" ;;
+        aarch64) JUST_SHA256="748237128c4c40cbdabc65e841d05ceba13cc23a91eaba395495894c1d9764df" ;;
+        *)       error "Unsupported architecture for checksum verification: $JUST_ARCH" ;;
+    esac
+
+    JUST_TARBALL="just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz"
+    JUST_URL="https://github.com/casey/just/releases/download/${JUST_VERSION}/${JUST_TARBALL}"
+
+    # Download and extract
+    TEMP_DIR=$(mktemp -d)
+    trap "rm -rf $TEMP_DIR" EXIT
+
+    info "Downloading just v${JUST_VERSION}..."
+    curl -fsSL --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 "$JUST_URL" -o "$TEMP_DIR/$JUST_TARBALL"
+
+    info "Verifying just checksum..."
+    echo "${JUST_SHA256}  $TEMP_DIR/$JUST_TARBALL" | sha256sum -c - >/dev/null
+
+    tar -xzf "$TEMP_DIR/$JUST_TARBALL" -C "$TEMP_DIR"
+
+    # Install binary
+    cp "$TEMP_DIR/just" "$INSTALL_DIR/just"
+    chmod +x "$INSTALL_DIR/just"
 
     if command -v just &> /dev/null; then
         info "just installed: $(just --version)"

--- a/scripts/test-cloud-env-tooling.sh
+++ b/scripts/test-cloud-env-tooling.sh
@@ -57,7 +57,7 @@ fi
 
 # 2. No remote script piped into a shell. That hands version resolution to a
 #    vendor installer, which is how the api.github.com call got in unnoticed.
-if grep -nE 'curl[^|]*\|[[:space:]]*(ba)?sh' "$TARGET"; then
+if grep -nE 'curl[^|]*\|[[:space:]]*(ba)?sh' <<<"$CODE"; then
   echo "FAIL: $TARGET pipes a remote installer into a shell." >&2
   echo "      Vendor installers resolve versions over the GitHub API; pin the" >&2
   echo "      version and download the release asset directly." >&2

--- a/scripts/test-cloud-env-tooling.sh
+++ b/scripts/test-cloud-env-tooling.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Guard scripts/init-cloud-env.sh against resolving a tool version through the
+# GitHub API, or through a vendor installer that does it on the script's behalf.
+#
+# init-cloud-env.sh is the first thing a cloud-agent session runs, and `just` is
+# what AGENTS.md requires before every push (`just pre-push`). So a tool that
+# fails to install here does not merely degrade — it removes the pre-push gate
+# from every cloud session that follows.
+#
+# `install_just` used to pipe https://just.systems/install.sh into bash. That
+# installer resolves its version through
+# `api.github.com/repos/casey/just/releases/latest`, and a cloud-agent session
+# scopes the GitHub API to the repositories it was granted, so the call returns
+# 403 for any other repo:
+#
+#   {"message": "GitHub access to this repository is not enabled for this
+#    session. Use add_repo to request access."}
+#
+# The script then reported `One or more tool installs failed` and exited 1 with
+# `just` absent, while gh, caddy and doppler installed fine — those three pin a
+# version and fetch the release asset from github.com, which is not API-scoped.
+# The comment on `install_doppler` already stated the rule ("Pinned version —
+# skip GitHub API call"); `install_just` was the one installer that never got it.
+#
+# Checking only that `just` is pinned would not stop this recurring for the next
+# tool, so this pins the property rather than the instance: no installer may
+# reach api.github.com, and none may pipe a remote script into a shell — the two
+# shapes that put version resolution back on a network path a cloud session
+# cannot use. Both fail closed here instead of at 3am in someone's session.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$SCRIPT_DIR")"
+
+TARGET="scripts/init-cloud-env.sh"
+
+if [ ! -f "$TARGET" ]; then
+  echo "FAIL: $TARGET is missing" >&2
+  exit 1
+fi
+
+status=0
+
+# Comments are allowed to name api.github.com — the explanation of why it is
+# avoided lives in this file and in the script itself. Only code is checked.
+CODE="$(sed 's/[[:space:]]*#.*$//' "$TARGET")"
+
+# 1. No GitHub API dependency. Release assets on github.com are fine; the
+#    api.github.com host is what a session's repo scoping refuses.
+if grep -n 'api\.github\.com' <<<"$CODE"; then
+  echo "FAIL: $TARGET reaches api.github.com — a cloud-agent session scopes the" >&2
+  echo "      GitHub API to its granted repos and returns 403 for anything else." >&2
+  echo "      Pin the version and fetch the release asset from github.com instead." >&2
+  status=1
+fi
+
+# 2. No remote script piped into a shell. That hands version resolution to a
+#    vendor installer, which is how the api.github.com call got in unnoticed.
+if grep -nE 'curl[^|]*\|[[:space:]]*(ba)?sh' "$TARGET"; then
+  echo "FAIL: $TARGET pipes a remote installer into a shell." >&2
+  echo "      Vendor installers resolve versions over the GitHub API; pin the" >&2
+  echo "      version and download the release asset directly." >&2
+  status=1
+fi
+
+# 3. Every installer pins an explicit version. An unpinned tool has to ask
+#    something what the latest release is, and the only thing to ask is the API
+#    checked above.
+for tool in just gh doppler caddy; do
+  fn="install_${tool}"
+  if ! grep -q "^${fn}()" "$TARGET"; then
+    echo "FAIL: $TARGET has no ${fn} function" >&2
+    status=1
+    continue
+  fi
+
+  if ! awk "/^${fn}\\(\\)/,/^}/" "$TARGET" | grep -qE '_VERSION="[0-9]+\.[0-9]+'; then
+    echo "FAIL: ${fn} does not pin an explicit version" >&2
+    status=1
+  fi
+done
+
+# 4. Checksum ratchet. `just` and `doppler` verify what they downloaded; `gh`
+#    and `caddy` do not yet (EVE-945). This list may only grow — dropping a
+#    verified tool back to unverified fails here.
+for tool in just doppler; do
+  if ! awk "/^install_${tool}\\(\\)/,/^}/" "$TARGET" | grep -q 'sha256sum -c'; then
+    echo "FAIL: install_${tool} no longer verifies a sha256 checksum" >&2
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  exit 1
+fi
+
+echo "PASS: init-cloud-env.sh pins every tool and needs no GitHub API access"


### PR DESCRIPTION
## What changed

`scripts/init-cloud-env.sh` now installs `just` the same way it installs `gh`, `caddy` and `doppler`: a pinned version, the release asset fetched straight from `github.com`, and a sha256 check. It previously piped `https://just.systems/install.sh` into bash.

Adds `scripts/test-cloud-env-tooling.sh` as a guard, and lists `scripts/init-cloud-env.sh` in ci.yml's `shell` path filter so that guard runs when the bootstrap changes.

## Why

`just` could not be installed in a cloud-agent session at all.

The upstream installer resolves its version through `api.github.com/repos/casey/just/releases/latest`. A cloud-agent session scopes the GitHub API to the repositories it was granted, so that call returns 403 for `casey/just`:

```
{"message": "GitHub access to this repository is not enabled for this session.
  Use add_repo to request access."}
```

The other three tools were unaffected because they pin a version and fetch the release *asset*, which is served from `github.com` and is not API-scoped. `install_doppler` already carried the rule as a comment — *"Pinned version — skip GitHub API call"* — and `install_just` was the single installer that never got it.

The cost is not a slower setup. AGENTS.md requires `just pre-push` before every push, so a cloud session without `just` loses the pre-push gate entirely, silently, for everything it does afterwards.

## Before / After

**Before** — the script exits 1 and `just` is missing, while everything else succeeds:

```
[INFO] Installing just (pre-built binary)...
[INFO] Downloading gh v2.63.2...
[INFO] Downloading caddy v2.9.1...
[INFO] Downloading doppler v3.75.2...
curl: (22) The requested URL returned error: 403
[INFO] doppler installed: v3.75.2
[INFO] caddy installed: v2.9.1
[INFO] gh installed: gh version 2.63.2
[ERROR] One or more tool installs failed
$ just --version
bash: just: command not found
```

**After** — exit 0, all four present:

```
[INFO] Cloud environment ready in 3s

Installed tools:
  - just just 1.58.0
  - gh gh version 2.63.2
  - doppler v3.75.2
  - caddy v2.9.1
```

The guard fails against the pre-fix script and passes against the fixed one:

```
$ git stash push scripts/init-cloud-env.sh && bash scripts/test-cloud-env-tooling.sh
45:    curl ... https://just.systems/install.sh | bash -s -- --to "$INSTALL_DIR"
FAIL: scripts/init-cloud-env.sh pipes a remote installer into a shell.
FAIL: install_just does not pin an explicit version
FAIL: install_just no longer verifies a sha256 checksum
EXIT=1

$ git stash pop && bash scripts/test-cloud-env-tooling.sh
PASS: init-cloud-env.sh pins every tool and needs no GitHub API access
```

**Smoke test of the affected flow:** removed `just`, ran `./scripts/init-cloud-env.sh` from clean in this cloud session — exit 0, all four tools present, `just --version` → `just 1.58.0`, and `just pre-push` then ran 22/22. That end-to-end run *is* the flow this change fixes.

`./scripts/run-shell-tests.sh`: 22/22 pass. `just pre-push`: 22/22 pass.

## Risk

- Low
- Blast radius is the cloud bootstrap script only; no product code, no workspace dependency change.
- The pin means `just` no longer tracks latest. That is the tradeoff the other three installers already made deliberately, and it is what makes the install reproducible.
- A wrong checksum would fail the install closed rather than installing bad bytes. Both architectures' sums were read from the release's own `SHA256SUMS`, and the x86_64 path was executed end to end here.
- Arch coverage narrows from the vendor script's full matrix to x86_64/aarch64. No practical regression: `install_doppler` and `install_caddy` already `error` on anything else, so the script as a whole never completed on other architectures.

The guard pins the property rather than the instance — no installer may reach `api.github.com` or pipe a remote script into a shell, and every installer must pin an explicit version — so the next tool added cannot quietly reintroduce the same dependency. Checking only that `just` is pinned would not have stopped that.

## Security

**Threat categories reviewed:** `TM-CI-001`–`TM-CI-008` (the diff touches `ci.yml`) and supply-chain integrity of the bootstrap trust path. Not applicable and why: no product code, no auth/authz surface, no API/DB/filesystem/frontend surface, no new input parsing — `TM-AUTH`, `TM-AUTHZ`, `TM-API`, `TM-SQL`, `TM-FS`, `TM-WEB`, `TM-TENANT`, `TM-DOS` are untouched. No `THREAT[...]` markers exist in either touched script, and none is warranted.

**Findings and resolutions:**

- **`TM-CI-001`–`TM-CI-008`: unaffected, verified rather than assumed.** The only ci.yml change adds one glob to the `shell` paths-filter. The job it gates, `shell-test`, declares no `env:`, no `secrets.*` and no `DOPPLER_TOKEN` — it needs no credentials, which is why it is not `push`-gated. The change touches no job condition, no `env:` block and no `github.event_name` gate, and it makes that one secret-free job run *more* often, never fewer. No secret-bearing job's trigger surface moves, so every mitigation in that table still holds verbatim.
- **Supply chain: net improvement.** The change *removes* an unpinned remote script from the bootstrap trust path (`curl | bash`, whose content and resolved version could differ between two runs) and replaces it with a specific release artifact verified against a sha256 recorded in-repo. This narrows an existing trust path rather than opening a new one, so no threat-model entry is introduced or materially changed and `knowledge/security/threat-model.md` needs no update.
- **Found, not fixed here.** `install_gh` and `install_caddy` pin versions but verify no checksum, and `configure_gh_auth` runs `gh` with the Doppler token — so the one unverified binary is also the one that handles the vault. Out of scope for a bug fix; tracked as **EVE-945**. Worth noting the pattern already exists in-repo: ci.yml's own `shell-test` job installs caddy by downloading `caddy_<ver>_checksums.txt` and running `sha512sum -c`. The guard's checksum ratchet lists the two tools that *do* verify, so this cannot silently regress while that gap is open.

## Follow-ups

- **EVE-945** — `init-cloud-env.sh` installs `gh` and `caddy` without verifying a checksum. Kept out of this PR to hold it to the bug it fixes; closing it is a two-line change per installer plus adding both to the ratchet list in `scripts/test-cloud-env-tooling.sh`.

Nothing else deferred.

## Checklist

- [x] Tests added or updated — `scripts/test-cloud-env-tooling.sh`, verified failing against the pre-fix script first
- [x] Backward compatibility considered — dev-tooling script; `just` is installed at a pinned version instead of latest, and the `command -v just` early return means an existing install is still left alone
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — no `ci:skip-*` label is applied; `Shell Tests (Repo Scripts)` is the check this diff affects and it runs on the final commit
- [x] All review comments addressed (code change or written reasoning)