### PR TITLE
fix(scripts): verify gh and caddy checksums in the cloud bootstrap

### DIFF
--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -108,6 +108,14 @@ install_gh() {
 
     # Pinned version — skip GitHub API call to avoid rate limits and hangs
     GH_VERSION="2.63.2"
+    # From gh_${GH_VERSION}_checksums.txt in the same release.
+    GH_SHA256=""
+    case "$GH_ARCH" in
+        amd64) GH_SHA256="912fdb1ca29cb005fb746fc5d2b787a289078923a29d0f9ec19a0b00272ded00" ;;
+        arm64) GH_SHA256="0f31e2a8549c64b5c1679f0b99ce5e0dac7c91da9e86f6246adb8805b0f0b4bb" ;;
+        armv6) GH_SHA256="483c64a4502a56eee1be592e50e6a6ae41663a2f0471c2187dc550c6a3f63696" ;;
+        *)     error "Unsupported architecture for checksum verification: $GH_ARCH" ;;
+    esac
 
     GH_TARBALL="gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz"
     GH_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}"
@@ -118,6 +126,9 @@ install_gh() {
 
     info "Downloading gh v${GH_VERSION}..."
     curl -fsSL --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 "$GH_URL" -o "$TEMP_DIR/$GH_TARBALL"
+
+    info "Verifying gh checksum..."
+    echo "${GH_SHA256}  $TEMP_DIR/$GH_TARBALL" | sha256sum -c - >/dev/null
 
     tar -xzf "$TEMP_DIR/$GH_TARBALL" -C "$TEMP_DIR"
 
@@ -200,6 +211,15 @@ install_caddy() {
     esac
 
     CADDY_VERSION="2.9.1"
+    # Caddy publishes sha512, not sha256, in caddy_${CADDY_VERSION}_checksums.txt.
+    # ci.yml's shell-test job verifies the same artifact the same way.
+    CADDY_SHA512=""
+    case "$CADDY_ARCH" in
+        amd64) CADDY_SHA512="0412057ba591c33bdb66034d7f32209619ce635147dac3084c79abcbc118a761145e695199f57c6798d88fab077f2b0d9cb999f52ded904c6d464a4eba202932" ;;
+        arm64) CADDY_SHA512="80b917c2bd8aa0892f1386ff97af9e776067dd8cdc4793238869aca7e13f7280f89d1799a1fef08b49af92dbd86684c3ba7a38b9d44afc55ef2eeb33b49e1cbd" ;;
+        *)     error "Unsupported architecture for checksum verification: $CADDY_ARCH" ;;
+    esac
+
     CADDY_TARBALL="caddy_${CADDY_VERSION}_linux_${CADDY_ARCH}.tar.gz"
     CADDY_URL="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${CADDY_TARBALL}"
 
@@ -209,6 +229,9 @@ install_caddy() {
 
     info "Downloading caddy v${CADDY_VERSION}..."
     curl -fsSL --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 "$CADDY_URL" -o "$TEMP_DIR/$CADDY_TARBALL"
+
+    info "Verifying caddy checksum..."
+    echo "${CADDY_SHA512}  $TEMP_DIR/$CADDY_TARBALL" | sha512sum -c - >/dev/null
 
     tar -xzf "$TEMP_DIR/$CADDY_TARBALL" -C "$TEMP_DIR" caddy
 

--- a/scripts/test-cloud-env-tooling.sh
+++ b/scripts/test-cloud-env-tooling.sh
@@ -27,6 +27,13 @@
 # reach api.github.com, and none may pipe a remote script into a shell — the two
 # shapes that put version resolution back on a network path a cloud session
 # cannot use. Both fail closed here instead of at 3am in someone's session.
+#
+# It also requires every installer to verify what it downloaded (EVE-945).
+# Pinning the URL settles which version is fetched; it says nothing about the
+# bytes that arrive. These binaries then run with the Doppler vault reachable —
+# `configure_gh_auth` invokes `gh` under `doppler run` on every session — and
+# agent sessions fetch through an egress proxy that terminates TLS, so
+# "HTTPS was end-to-end" is not an argument available here.
 
 set -euo pipefail
 
@@ -81,12 +88,15 @@ for tool in just gh doppler caddy; do
   fi
 done
 
-# 4. Checksum ratchet. `just` and `doppler` verify what they downloaded; `gh`
-#    and `caddy` do not yet (EVE-945). This list may only grow — dropping a
-#    verified tool back to unverified fails here.
-for tool in just doppler; do
-  if ! awk "/^install_${tool}\\(\\)/,/^}/" "$TARGET" | grep -q 'sha256sum -c'; then
-    echo "FAIL: install_${tool} no longer verifies a sha256 checksum" >&2
+# 4. Checksum ratchet, now covering every installer (EVE-945). A pinned URL
+#    stops an attacker choosing the version; it does not notice the bytes at
+#    that URL changing, and these binaries then run with DOPPLER_TOKEN in the
+#    environment — `configure_gh_auth` hands the vault to `gh` on every session.
+#    Either digest is accepted because upstream decides which it publishes: gh,
+#    just and doppler publish sha256, caddy publishes sha512.
+for tool in just gh doppler caddy; do
+  if ! awk "/^install_${tool}\\(\\)/,/^}/" "$TARGET" | grep -qE 'sha(256|512)sum -c'; then
+    echo "FAIL: install_${tool} does not verify a checksum" >&2
     status=1
   fi
 done
@@ -95,4 +105,4 @@ if [ "$status" -ne 0 ]; then
   exit 1
 fi
 
-echo "PASS: init-cloud-env.sh pins every tool and needs no GitHub API access"
+echo "PASS: init-cloud-env.sh pins and verifies every tool, and needs no GitHub API access"


### PR DESCRIPTION
## What changed

`scripts/init-cloud-env.sh` now verifies a checksum for all four tools it installs, not two. Adds `GH_SHA256` (amd64/arm64/armv6) and `CADDY_SHA512` (amd64/arm64) beside the existing version pins, read from each release's own checksums file.

The guard's checksum ratchet in `scripts/test-cloud-env-tooling.sh` now covers all four installers instead of the two that happened to comply.

Fixes **EVE-945**.

## Why

The bootstrap pinned all four versions but downloaded `gh` and `caddy` on trust.

Pinning the URL settles *which* version is fetched; it says nothing about the bytes that arrive. That gap matters most for `gh` specifically: `configure_gh_auth` invokes it under `doppler run`, so the one unverified binary was also the one handed the vault on every cloud session.

Agent sessions also fetch through an egress proxy that terminates TLS, so "HTTPS was end-to-end" is not an argument available in the setting this script exists for.

This is not a new scheme — ci.yml's own `shell-test` job already installs caddy by fetching `caddy_<ver>_checksums.txt` and running `sha512sum -c`. The bootstrap was simply the surface that never got it.

## Before / After

**Before** — two of four verified:

```
[INFO] Verifying doppler checksum...
[INFO] Verifying just checksum...
[INFO] gh installed: gh version 2.63.2          ← no verification
[INFO] caddy installed: v2.9.1                  ← no verification
```

**After** — all four, from a clean state with every binary removed:

```
[INFO] Verifying just checksum...
[INFO] Verifying gh checksum...
[INFO] Verifying caddy checksum...
[INFO] Verifying doppler checksum...
[INFO] Cloud environment ready in 3s
SCRIPT_EXIT=0
```

**Negative test** — a checksum that doesn't verify must not install. Corrupting the `gh` amd64 digest to zeroes:

```
[INFO] Verifying gh checksum...
sha256sum: WARNING: 1 computed checksum did NOT match
[ERROR] One or more tool installs failed
EXIT=1
$ command -v gh
gh ABSENT (failed closed, correct)
```

The ratchet fails against the pre-fix script and passes after:

```
$ git show 365e4ef:scripts/init-cloud-env.sh > scripts/init-cloud-env.sh
FAIL: install_gh does not verify a checksum
FAIL: install_caddy does not verify a checksum
EXIT=1
```

`./scripts/run-shell-tests.sh`: 22/22 pass. `just pre-push`: 22/22 pass.

## Risk

- Low, but the failure mode deserves naming: a **wrong** checksum would break every cloud session, since the install fails closed. That is why the negative test above exists and why all four digests were exercised on real downloads rather than transcribed and trusted.
- All digests come from the upstream release's own checksums file (`gh_2.63.2_checksums.txt`, `caddy_2.9.1_checksums.txt`). The amd64 path for all four tools was executed end to end here; arm64/armv6 digests are transcribed from those same files and cannot be executed on this runner.
- caddy uses `sha512sum`, not `sha256sum`, because that is what upstream publishes. The ratchet accepts either digest for that reason rather than forcing a scheme upstream doesn't offer.
- No product code, no workspace dependency change, no CI workflow change.

## Security

**Threat categories reviewed:** supply-chain integrity of the cloud bootstrap, and `TM-APIKEY` / `TM-CI-001`–`002` by adjacency, since the tools involved handle `DOPPLER_TOKEN`. Not applicable and why: no product code, no auth/authz logic, no API, SQL, filesystem, or frontend surface, no new input parsing — `TM-AUTH`, `TM-AUTHZ`, `TM-API`, `TM-SQL`, `TM-FS`, `TM-WEB`, `TM-TENANT`, `TM-DOS` are untouched. No `THREAT[...]` markers exist in either file.

**Findings and resolutions:**

- **Closes the gap this PR is named for.** Every binary the bootstrap installs is now verified against a digest recorded in-repo before it is placed on `PATH`. The `gh` case is the material one: it is the binary `configure_gh_auth` runs under `doppler run`, so it was the unverified artifact with vault access.
- **Fails closed, demonstrated not assumed.** The negative test above confirms a mismatch aborts the install rather than warning and continuing — worth proving explicitly, since `sha256sum -c` warns on stderr and the exit code is what actually gates.
- **No new threat surface.** This only narrows an existing trust path; nothing is added. `knowledge/security/threat-model.md` needs no update, and no CI workflow, job condition, or secret gate is touched, so `TM-CI-001`–`008` hold verbatim.
- **Residual, accepted:** the digests are pinned to specific versions, so a version bump must update them together. The ratchet makes an unverified installer fail CI, but it cannot detect a *stale* digest paired with a bumped version — that combination fails loudly at install time instead, which is the safe direction.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated — ratchet extended to all four installers, verified failing against the pre-fix script first, plus an executed negative test
- [x] Backward compatibility considered — same versions, same URLs, same resulting binaries; only an added verification step
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5J2GCMyNLWheXAuUaeup2)_