### PR TITLE
Preserve generation estimates when folding compaction cost (fix budgets)

### DIFF
--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -15583,8 +15583,13 @@ export interface components {
       cache_read_tokens?: number | null;
       /**
        * Format: double
-       * @description Best-effort USD cost for already-aggregated usage. Per-generation usage
-       *     leaves this unset and derives the effective cost from actual/estimated.
+       * @description Best-effort USD cost when it cannot be derived from actual/estimated
+       *     alone: already-aggregated usage, or a generation carrying a cost that
+       *     belongs to neither slot. Per-generation usage normally leaves this unset
+       *     and derives the effective cost from actual-else-estimated; the exception
+       *     is a turn whose compaction cost is folded in, where the combined total
+       *     has to live here precisely so the generation's own actual-vs-estimated
+       *     distinction survives (EVE-895).
        */
       effective_cost_usd?: number | null;
       /**

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -595,8 +595,13 @@ pub struct TokenUsage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub estimated_cost_usd: Option<f64>,
 
-    /// Best-effort USD cost for already-aggregated usage. Per-generation usage
-    /// leaves this unset and derives the effective cost from actual/estimated.
+    /// Best-effort USD cost when it cannot be derived from actual/estimated
+    /// alone: already-aggregated usage, or a generation carrying a cost that
+    /// belongs to neither slot. Per-generation usage normally leaves this unset
+    /// and derives the effective cost from actual-else-estimated; the exception
+    /// is a turn whose compaction cost is folded in, where the combined total
+    /// has to live here precisely so the generation's own actual-vs-estimated
+    /// distinction survives (EVE-895).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effective_cost_usd: Option<f64>,
 }
@@ -646,9 +651,10 @@ impl TokenUsage {
         self
     }
 
-    /// Set the precomputed best-effort USD cost for aggregate usage, returning
-    /// `self` for chaining. Generation usage should leave this unset so the
-    /// best-effort cost remains actual-else-estimated for that generation.
+    /// Set the precomputed best-effort USD cost, returning `self` for chaining.
+    /// Generation usage should leave this unset so the best-effort cost remains
+    /// actual-else-estimated for that generation, unless a cost outside those
+    /// two slots is folded in (see the field's documentation).
     pub fn with_effective_cost(mut self, effective_cost_usd: Option<f64>) -> Self {
         self.effective_cost_usd = effective_cost_usd;
         self

--- a/crates/engine/src/execution/reason.rs
+++ b/crates/engine/src/execution/reason.rs
@@ -23,6 +23,14 @@ use std::sync::Arc;
 use std::time::Instant;
 use uuid::Uuid;
 
+fn add_compaction_cost(usage: &mut TokenUsage, compaction_cost: f64) {
+    let generation_cost = usage.effective_cost_usd();
+    usage.effective_cost_usd = Some(generation_cost.unwrap_or(0.0) + compaction_cost);
+    if let Some(actual_cost) = usage.actual_cost_usd.as_mut() {
+        *actual_cost += compaction_cost;
+    }
+}
+
 use super::ExecutionContext;
 use crate::annotation_hook::{collect_annotations, verify_annotations};
 use crate::capabilities::CapabilityRegistry;
@@ -2161,17 +2169,15 @@ impl ReasonAtom {
         );
 
         // Add compaction info if compaction was performed. Compaction is a
-        // separate billable model call on the same turn, so its cost is folded
-        // into the generation's actual cost — `UsageTrackingListener` reads only
-        // `metadata.usage`, so that is the only path to budgets and
-        // `llm_generations`. `compaction.cost_usd` keeps the split visible
-        // (EVE-895).
+        // separate billable model call on the same turn. Preserve whether the
+        // generation cost was actual or estimated while recording their combined
+        // best-effort cost for budgets and usage totals. `compaction.cost_usd`
+        // keeps the split visible (EVE-895).
         if let Some(info) = compaction_info {
             if let Some(compaction_cost) = info.cost_usd {
                 match generation_data.metadata.usage.as_mut() {
                     Some(usage) => {
-                        usage.actual_cost_usd =
-                            Some(usage.actual_cost_usd.unwrap_or(0.0) + compaction_cost);
+                        add_compaction_cost(usage, compaction_cost);
                     }
                     // The generation itself reported no usage — a provider may
                     // price compaction without returning usage on the retry.

--- a/crates/engine/src/execution/reason/tests.rs
+++ b/crates/engine/src/execution/reason/tests.rs
@@ -7,6 +7,27 @@ use serde_json::json;
 use std::collections::HashMap;
 
 #[test]
+fn compaction_cost_preserves_estimated_generation_cost() {
+    let mut usage = TokenUsage::new(1_000_000, 500_000).with_cost(None, Some(7.5));
+
+    add_compaction_cost(&mut usage, 0.0125);
+
+    assert_eq!(usage.actual_cost_usd, None);
+    assert_eq!(usage.estimated_cost_usd, Some(7.5));
+    assert_eq!(usage.effective_cost_usd(), Some(7.5125));
+}
+
+#[test]
+fn compaction_cost_combines_with_actual_generation_cost() {
+    let mut usage = TokenUsage::new(10, 5).with_cost(Some(0.25), Some(0.2));
+
+    add_compaction_cost(&mut usage, 0.0125);
+
+    assert_eq!(usage.actual_cost_usd, Some(0.2625));
+    assert_eq!(usage.effective_cost_usd(), Some(0.2625));
+}
+
+#[test]
 fn material_reduction_requires_five_percent_at_normal_sizes() {
     assert!(!materially_reduced(1_000, 951));
     assert!(materially_reduced(1_000, 950));

--- a/crates/server/src/domains/budgets/service.rs
+++ b/crates/server/src/domains/budgets/service.rs
@@ -730,7 +730,7 @@ impl EventListener for BudgetService {
             output_tokens,
             cache_read_tokens,
             cache_creation_tokens,
-            usage.actual_cost_usd,
+            usage.effective_cost_usd(),
             data.metadata.finish_reasons.as_deref(),
         )
         .await;

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -36167,7 +36167,7 @@
               "null"
             ],
             "format": "double",
-            "description": "Best-effort USD cost for already-aggregated usage. Per-generation usage\nleaves this unset and derives the effective cost from actual/estimated."
+            "description": "Best-effort USD cost when it cannot be derived from actual/estimated\nalone: already-aggregated usage, or a generation carrying a cost that\nbelongs to neither slot. Per-generation usage normally leaves this unset\nand derives the effective cost from actual-else-estimated; the exception\nis a turn whose compaction cost is folded in, where the combined total\nhas to live here precisely so the generation's own actual-vs-estimated\ndistinction survives (EVE-895)."
           },
           "estimated_cost_usd": {
             "type": [


### PR DESCRIPTION
### Motivation

- Fix a logic bug where folding compaction cost into `usage.actual_cost_usd` caused a generation's token-estimated cost to be ignored, under-reporting turn spend and under-enforcing USD budgets. 

### Description

- Add `add_compaction_cost(usage, compaction_cost)` to preserve the generation's actual-vs-estimated distinction while recording a combined best-effort total in `effective_cost_usd`.
- Use the helper when folding `compaction.cost_usd` into a generation's usage so the generation estimate remains visible and the compaction split stays attributable.
- Update budget handling to pass `usage.effective_cost_usd()` (combined best-effort cost) to `process_llm_generation` instead of `usage.actual_cost_usd` so budgets debit the full combined amount.
- Add unit tests (`compaction_cost_preserves_estimated_generation_cost`, `compaction_cost_combines_with_actual_generation_cost`) to cover mixed estimated-generation/actual-compaction and fully-actual cases.

### Testing

- Ran `cargo fmt --all -- --check` and formatting passed. 
- Ran unit tests for the engine changes (`cargo test -p everruns-engine`), including the new tests, and they passed (`2 passed`).
- Ran the repository test supporting `reason_atom_test` target (`cargo test -p everruns-test-support --test reason_atom_test native_compaction_cost_reaches_generation_usage_and_stays_attributable`) and the targeted test passed (`1 passed`).
- Ran `just pre-push`; code checks (format, clippy, tests) passed locally, and the pre-push command flagged an unrelated migration immutability check failure due to missing `origin/main` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8df264832ba5f21b3b162c15ba)