### PR TITLE
fix(budgets): price retrieval embeddings

### DIFF
--- a/crates/platform/src/capabilities/knowledge_index.rs
+++ b/crates/platform/src/capabilities/knowledge_index.rs
@@ -25,6 +25,7 @@ use everruns_core::events::{
 use everruns_core::tool_context::ToolContext;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_provider::tool_types::ToolHints;
+use everruns_provider::{model::DriverId, model_profiles::estimate_cost_usd};
 
 /// Stable string id for the knowledge index capability.
 pub const KNOWLEDGE_INDEX_CAPABILITY_ID: &str = "knowledge_index";
@@ -401,6 +402,13 @@ async fn emit_embedding_usage(context: &ToolContext, usage: &[EmbeddingCallUsage
     };
 
     for call in usage {
+        let estimated_cost_usd = call
+            .provider
+            .as_deref()
+            .and_then(|provider| provider.parse::<DriverId>().ok())
+            .and_then(|provider| {
+                estimate_cost_usd(&provider, &call.model, call.total_tokens, 0, 0, 0)
+            });
         // An embedding call has no messages, tools, or generated output — only
         // billed usage. The remaining fields stay empty rather than synthesized.
         let data = LlmGenerationData::success(
@@ -416,7 +424,7 @@ async fn emit_embedding_usage(context: &ToolContext, usage: &[EmbeddingCallUsage
                 cache_read_tokens: None,
                 cache_creation_tokens: None,
                 actual_cost_usd: call.actual_cost_usd,
-                estimated_cost_usd: None,
+                estimated_cost_usd,
                 effective_cost_usd: None,
             }),
             None,
@@ -610,7 +618,8 @@ mod tests {
                         model: "text-embedding-3-small".to_string(),
                         provider: Some("openai".to_string()),
                         total_tokens: 7,
-                        actual_cost_usd: Some(0.25),
+                        // Direct OpenAI reports tokens but not an inline cost.
+                        actual_cost_usd: None,
                     }],
                 })
             }
@@ -647,6 +656,7 @@ mod tests {
         assert_eq!(data.metadata.provider.as_deref(), Some("openai"));
         let usage = data.metadata.usage.as_ref().expect("usage recorded");
         assert_eq!(usage.input_tokens, 7);
-        assert_eq!(usage.actual_cost_usd, Some(0.25));
+        assert_eq!(usage.actual_cost_usd, None);
+        assert_eq!(usage.estimated_cost_usd, Some(0.000_000_14));
     }
 }

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -328,6 +328,18 @@ const META_ONLY: &[DriverId] = &[DriverId::Meta];
 static REGISTRY: &[ModelDescriptor] = &[
     // OpenAI
     md_service(
+        &["text-embedding-3-small"],
+        ModelVendor::OpenAi,
+        OPENAI,
+        ServiceKind::Embeddings,
+    ),
+    md_service(
+        &["text-embedding-3-large"],
+        ModelVendor::OpenAi,
+        OPENAI,
+        ServiceKind::Embeddings,
+    ),
+    md_service(
         &["gpt-realtime-2"],
         ModelVendor::OpenAi,
         OPENAI,
@@ -711,8 +723,57 @@ fn meta_profile_data(model_id: &str) -> Option<ModelProfile> {
     })
 }
 
+fn openai_embedding_profile(name: &str, family: &str, input_cost: f64) -> ModelProfile {
+    ModelProfile {
+        name: name.into(),
+        family: family.into(),
+        description: None,
+        release_date: Some("2024-01-25".into()),
+        last_updated: Some("2024-01-25".into()),
+        attachment: false,
+        reasoning: false,
+        temperature: false,
+        knowledge: None,
+        tool_call: false,
+        structured_output: false,
+        open_weights: false,
+        cost: Some(ModelCost {
+            input: input_cost,
+            output: 0.0,
+            cache_read: None,
+            cost_tiers: vec![],
+        }),
+        limits: Some(ModelLimits {
+            context: 8_191,
+            input: None,
+            output: 0,
+            max_media: None,
+        }),
+        modalities: Some(ModelModalities {
+            input: vec![Modality::Text],
+            output: vec![],
+        }),
+        reasoning_effort: None,
+        speed: None,
+        verbosity: None,
+        tool_search: false,
+        supported_parameters: Vec::new(),
+        supports_phases: false,
+    }
+}
+
 fn openai_profile_data(model_id: &str) -> Option<ModelProfile> {
     match model_id {
+        "text-embedding-3-small" => Some(openai_embedding_profile(
+            "Text Embedding 3 Small",
+            "text-embedding-3-small",
+            0.02,
+        )),
+        "text-embedding-3-large" => Some(openai_embedding_profile(
+            "Text Embedding 3 Large",
+            "text-embedding-3-large",
+            0.13,
+        )),
         "gpt-realtime-2" => Some(ModelProfile {
             name: "GPT Realtime 2".into(),
             family: "gpt-realtime".into(),
@@ -4645,6 +4706,24 @@ mod tests {
     #[test]
     fn test_estimate_cost_usd_unknown_model_is_none() {
         assert!(estimate_cost_usd(&DriverId::OpenAI, "no-such-model", 100, 50, 0, 0).is_none());
+    }
+
+    #[test]
+    fn test_estimate_cost_usd_openai_embedding_model() {
+        let estimate = estimate_cost_usd(
+            &DriverId::OpenAI,
+            "text-embedding-3-small",
+            1_000_000,
+            0,
+            0,
+            0,
+        );
+
+        assert_eq!(estimate, Some(0.02));
+        assert_eq!(
+            get_model_service_kind(&DriverId::OpenAI, "text-embedding-3-small"),
+            ServiceKind::Embeddings
+        );
     }
 
     #[test]

--- a/crates/server/src/domains/budgets/tests.rs
+++ b/crates/server/src/domains/budgets/tests.rs
@@ -424,6 +424,24 @@ fn test_compute_debit_usd_with_unknown_model_falls_back_to_tokens() {
 }
 
 #[test]
+fn test_compute_debit_usd_estimates_openai_embedding_cost() {
+    let (svc, _) = make_service();
+    let debit = svc.compute_debit(
+        "usd",
+        1500,
+        1500,
+        0,
+        0,
+        0,
+        Some("text-embedding-3-small"),
+        Some("openai"),
+        None,
+    );
+
+    assert_eq!(debit, 0.000_03);
+}
+
+#[test]
 fn test_compute_debit_credits_currency() {
     let (svc, _) = make_service();
     let debit = svc.compute_debit("credits", 5000, 3000, 2000, 0, 0, None, None, None);


### PR DESCRIPTION
### Motivation
- Retrieval embedding events from Direct OpenAI lacked a provider cost and no estimated cost was attached, which allowed the USD budgeting path to fall back to charging raw token counts as USD. 
- The change ensures retrieval embedding spend is represented with a sensible USD estimate so budgets are not accidentally over-debited by token-count-as-USD fallback.

### Description
- Register `text-embedding-3-small` and `text-embedding-3-large` in the model profile registry and add an `openai_embedding_profile` helper with per-token pricing so embedding models have price-table profiles. (changes in `crates/provider/src/model_profiles.rs`)
- Compute a price-table `estimated_cost_usd` for each retrieval embedding call and attach it to the emitted `llm.generation` `TokenUsage` when providers omit `usage.cost`. (changes in `crates/platform/src/capabilities/knowledge_index.rs`)
- Add/adjust tests to cover embedding model price estimation, emitted embedding usage events carrying estimated cost, and USD debit behavior for embedding models. (changes in `crates/provider/src/model_profiles.rs` and `crates/server/src/domains/budgets/tests.rs`)

### Testing
- Ran `cargo test -p everruns-provider test_estimate_cost_usd_openai_embedding_model` and the test passed. 
- Ran `cargo test -p everruns-platform search_emits_llm_generation_events_for_embedding_usage` and the test passed. 
- Ran `cargo test -p everruns-server --lib domains::budgets::tests::test_compute_debit` (and the related budget unit tests) and they passed. 
- Ran `cargo fmt --all -- --check` and `git diff --check` as part of local validation and they reported no formatting or diff issues for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8c1954832b823692e722a92358)