### PR TITLE
fix(host): enforce `user_prompt_submit` hooks on finalized steering

### DIFF
--- a/crates/everruns/src/session.rs
+++ b/crates/everruns/src/session.rs
@@ -588,7 +588,7 @@ impl SessionActor {
         let finalization = async {
             let remaining = steering.close_and_drain();
             runtime
-                .append_accepted_inputs(self.session_id, remaining)
+                .append_accepted_inputs(self.session_id, turn_id, remaining)
                 .await?;
             if cancelled {
                 let (_, request) = self

--- a/crates/host/src/host.rs
+++ b/crates/host/src/host.rs
@@ -1127,15 +1127,16 @@ pub async fn execute_input_activity<A: RuntimeHostAdapter>(
 /// skipped early). Errors loading specs are logged and treated as "no hooks"
 /// so a hook-collection failure never blocks a turn that wasn't asking to be
 /// hooked.
-struct UserPromptHookResult {
-    decision: everruns_core::lifecycle_hooks::UserPromptDecision,
-    original_message: String,
+pub(crate) struct UserPromptHookResult {
+    pub(crate) decision: everruns_core::lifecycle_hooks::UserPromptDecision,
+    pub(crate) original_message: String,
 }
 
-async fn run_user_prompt_submit_for_turn<A: RuntimeHostAdapter>(
+pub(crate) async fn run_user_prompt_submit_for_message<A: RuntimeHostAdapter>(
     adapter: &A,
     org_id: i64,
     input: &ReasonInput,
+    message_text: String,
 ) -> everruns_provider::error::Result<Option<UserPromptHookResult>> {
     let (specs, dispatcher) = match collect_lifecycle_hook_specs(
         adapter,
@@ -1165,15 +1166,6 @@ async fn run_user_prompt_submit_for_turn<A: RuntimeHostAdapter>(
         return Ok(None);
     }
 
-    let message_text = adapter
-        .message_store()
-        .get(input.context.session_id, input.context.input_message_id)
-        .await
-        .ok()
-        .flatten()
-        .map(|m| m.content_to_llm_string())
-        .unwrap_or_default();
-
     let ctx = everruns_core::lifecycle_hooks::TurnHookContext {
         session_id: input.context.session_id,
         turn_id: Some(input.context.turn_id),
@@ -1188,6 +1180,22 @@ async fn run_user_prompt_submit_for_turn<A: RuntimeHostAdapter>(
         decision,
         original_message,
     }))
+}
+
+async fn run_user_prompt_submit_for_turn<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    input: &ReasonInput,
+) -> everruns_provider::error::Result<Option<UserPromptHookResult>> {
+    let message_text = adapter
+        .message_store()
+        .get(input.context.session_id, input.context.input_message_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|m| m.content_to_llm_string())
+        .unwrap_or_default();
+    run_user_prompt_submit_for_message(adapter, org_id, input, message_text).await
 }
 
 pub async fn execute_reason_activity<A: RuntimeHostAdapter>(

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -13,7 +13,7 @@ use crate::builders::SingleSessionBuilder;
 use crate::events::{EventHistory, EventLog, EventReadLimit, EventReadRequest, HostEventEmitter};
 use crate::host::{
     ResolvedTurnInputs, RuntimeHostAdapter, execute_act_activity, execute_input_activity,
-    execute_reason_activity_with_prompt_messages,
+    execute_reason_activity_with_prompt_messages, run_user_prompt_submit_for_message,
 };
 use crate::in_memory::{InMemorySessionFileStore, InMemorySessionFileSystemFactory};
 use async_trait::async_trait;
@@ -31,7 +31,8 @@ use everruns_core::events::{
     Event, EventContext, EventRequest, InputMessageData, SessionStartedData,
 };
 use everruns_core::harness_definition::HarnessDefinition;
-use everruns_core::message::Message;
+use everruns_core::lifecycle_hooks::UserPromptDecision;
+use everruns_core::message::{ContentPart, Message};
 use everruns_core::plugins::{PluginFileSet, compile_plugin};
 #[cfg(feature = "mcp")]
 use everruns_core::resolve_runtime_capabilities;
@@ -1383,7 +1384,7 @@ impl InProcessRuntime {
                 // already been marked `waiting_for_tool_results` by the effect.
                 TurnPlan::WaitForToolResults { .. } => {
                     steering.close();
-                    self.inject_steering_inputs(session_id, steering.drain())
+                    self.append_accepted_inputs(session_id, turn_id, steering.drain())
                         .await?;
                     return Ok(finish_turn(
                         turn_id,
@@ -1431,11 +1432,69 @@ impl InProcessRuntime {
     pub async fn append_accepted_inputs(
         &self,
         session_id: SessionId,
+        turn_id: TurnId,
         inputs: Vec<AcceptedTurnInput>,
     ) -> Result<()> {
-        self.inject_steering_inputs(session_id, inputs)
-            .await
-            .map(|_| ())
+        if inputs.is_empty() {
+            return Ok(());
+        }
+
+        let snapshot = self.resolved_execution_snapshot(session_id).await?;
+        let org_id = in_process_internal_org_id(&snapshot.organization_id);
+        for input in inputs {
+            let mut message = input.into_message();
+            let hook_input = ReasonInput {
+                context: ExecutionContext::new(session_id, turn_id, message.id)
+                    .with_workspace_id(snapshot.workspace_id),
+                harness_id: snapshot.harness_id,
+                agent_id: snapshot.agent_id,
+                org_id,
+                mcp_tool_definitions: vec![],
+                previous_response_id: None,
+                iteration: 1,
+            };
+            if let Some(result) = run_user_prompt_submit_for_message(
+                self,
+                org_id,
+                &hook_input,
+                message.content_to_llm_string(),
+            )
+            .await?
+            {
+                let enforced = match result.decision {
+                    UserPromptDecision::Continue { message }
+                        if message != result.original_message =>
+                    {
+                        Some((message, false))
+                    }
+                    UserPromptDecision::Block {
+                        reason,
+                        user_message,
+                    } => Some((user_message.unwrap_or(reason), true)),
+                    UserPromptDecision::Continue { .. } => None,
+                };
+                if let Some((safe_text, blocked)) = enforced {
+                    // No reason boundary remains to carry a provider-only override.
+                    // Persist the enforced form so later history cannot expose raw input.
+                    if blocked {
+                        message.content.clear();
+                    } else {
+                        message
+                            .content
+                            .retain(|part| !matches!(part, ContentPart::Text(_)));
+                    }
+                    message.content.insert(0, ContentPart::text(safe_text));
+                }
+            }
+            self.event_emitter
+                .emit(EventRequest::new(
+                    session_id,
+                    EventContext::empty(),
+                    InputMessageData::new(message),
+                ))
+                .await?;
+        }
+        Ok(())
     }
 
     /// Drain any queued task wakes for `session_id` and inject them into the

--- a/crates/host/tests/in_process_runtime_test.rs
+++ b/crates/host/tests/in_process_runtime_test.rs
@@ -3,13 +3,14 @@ use everruns_builtins::InfinityContextCapability;
 use everruns_core::events::{EventContext, EventRequest, InputMessageData};
 use everruns_core::network_access::NetworkAccessList;
 use everruns_core::{
-    AgentDefinition, CapabilityRegistry, ExecutionSession, InitialFile, Message, MessageRole,
-    WorkspacePolicy, session_files::SessionFileSystem,
+    AgentDefinition, Capability, CapabilityRegistry, CapabilityStatus, ExecutionSession,
+    InitialFile, Message, MessageRole, WorkspacePolicy, session_files::SessionFileSystem,
 };
 use everruns_host::HostComposition;
 use everruns_host::{
-    AgentBuilder, HarnessBuilder, HostBackends, InProcessRuntimeBuilder, RealDiskFileStore,
-    SessionBuilder, SessionFileSystemFactory, SessionFileSystemFactoryContext, TurnStopReason,
+    AcceptedTurnInput, AgentBuilder, HarnessBuilder, HostBackends, InProcessRuntimeBuilder,
+    RealDiskFileStore, SessionBuilder, SessionFileSystemFactory, SessionFileSystemFactoryContext,
+    TurnStopReason,
 };
 use everruns_llmsim::LlmSimConfig;
 use everruns_llmsim::LlmSimRuntimeExt;
@@ -21,6 +22,76 @@ use everruns_provider::tool_types::ToolCall;
 use everruns_test_support::TestMathCapability;
 use std::path::PathBuf;
 use std::sync::Arc;
+
+#[cfg(feature = "bashkit")]
+struct BlockingPromptCapability;
+
+#[cfg(feature = "bashkit")]
+impl Capability for BlockingPromptCapability {
+    fn id(&self) -> &str {
+        "blocking_prompt"
+    }
+    fn name(&self) -> &str {
+        "Blocking prompt"
+    }
+    fn description(&self) -> &str {
+        "Blocks submitted prompts"
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn user_hooks(&self) -> Vec<everruns_core::user_hook_types::UserHookSpec> {
+        use everruns_core::user_hook_types::{
+            ExecutorSpec, HookEvent, HookMatcher, HookSource, OnError, UserHookSpec,
+        };
+        vec![UserHookSpec {
+            id: Some("block".into()),
+            event: HookEvent::UserPromptSubmit,
+            matcher: HookMatcher::default(),
+            executor: ExecutorSpec::Bash {
+                command:
+                    r#"echo '{"decision":"block","reason":"policy","user_message":"blocked"}'"#
+                        .into(),
+                env: Default::default(),
+            },
+            timeout_ms: 5000,
+            on_error: OnError::Warn,
+            description: None,
+            source: HookSource::UserConfig,
+        }]
+    }
+}
+
+#[cfg(feature = "bashkit")]
+#[tokio::test]
+async fn accepted_input_persisted_after_a_turn_ends_is_prompt_hook_enforced() {
+    let runtime = InProcessRuntimeBuilder::new()
+        .capability(BlockingPromptCapability)
+        .llm_sim_as_default(LlmSimConfig::fixed("unused"))
+        .single_session(|session| {
+            session
+                .harness("guarded", "Guard every prompt.")
+                .harness_capability("blocking_prompt")
+                .agent("guarded-agent", "Reply safely.")
+        })
+        .build()
+        .await
+        .expect("runtime builds");
+    let session_id = runtime.default_session_id().expect("default session");
+
+    runtime
+        .append_accepted_inputs(
+            session_id,
+            everruns_provider::typed_id::TurnId::new(),
+            vec![AcceptedTurnInput::new("raw unsafe prompt")],
+        )
+        .await
+        .expect("accepted input persists");
+
+    let messages = runtime.messages(session_id).await.expect("history loads");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].content_to_llm_string(), "blocked");
+}
 
 fn minimal_platform() -> HostComposition {
     let mut capabilities = CapabilityRegistry::new();


### PR DESCRIPTION
### Motivation
- Prevent persisted steered user input from bypassing provider-bound prompt guardrails by ensuring any steering that misses a reason boundary still crosses the `user_prompt_submit` hook enforcement path before reaching history.

### Description
- Add a reusable hook entry `run_user_prompt_submit_for_message` and wire it so hooks can be executed against an explicit message text (`crates/host/src/host.rs`).
- Change the finalized-steering paths to run prompt hooks before persisting accepted steering: `append_accepted_inputs` now accepts a `turn_id`, runs hooks per message, and persists either the hook-rewritten text or a blocked-safe form (clearing original text when blocked) instead of raw input (`crates/host/src/runtime.rs`).
- Ensure runtime places finalized steering through the new enforcement path from both the cancellation/finalization case and the wait-for-tool-results pause (`crates/everruns/src/session.rs`, `crates/host/src/runtime.rs`).
- Add a regression test that verifies accepted input persisted after a turn ends is subject to `user_prompt_submit` enforcement (`crates/host/tests/in_process_runtime_test.rs`).

### Testing
- Ran `cargo test -p everruns-host --features bashkit --test in_process_runtime_test accepted_input_persisted_after_a_turn_ends_is_prompt_hook_enforced -- --nocapture` and it passed.
- Ran `cargo test -p everruns --test session_events turn_handle_cancellation_emits_a_correlated_terminal_event` and it passed.
- Ran `cargo check -p everruns-host -p everruns` and it passed.
- Ran `git diff --check` and it reported no problems; `just pre-push` was started (formatting passed) but the full workspace pre-push run was interrupted so not fully completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8ea628832bbae60b8259e14174)