### PR TITLE
fix(host): secure local event log opening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "everruns-test-support",
  "futures",
  "ignore",
+ "libc",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -52,6 +52,9 @@ opentelemetry-otlp = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 default = []
 direct-egress = ["dep:reqwest"]

--- a/crates/host/src/events.rs
+++ b/crates/host/src/events.rs
@@ -1,6 +1,8 @@
 //! Canonical host event persistence, bounded replay, and message projection.
 
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
@@ -891,28 +893,33 @@ impl JsonlEventLog {
         {
             tokio::fs::create_dir_all(parent).await?;
         }
+        let mut options = tokio::fs::OpenOptions::new();
+        options.create(true).read(true).append(true);
+        #[cfg(unix)]
+        {
+            // THREAT[TM-FS-014]: open and validate the log through one handle
+            // so canonical envelopes cannot be redirected through a symlink.
+            options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        }
+        let mut file = options.open(&path).await?;
+        ensure_private_event_log(&file, &path).await?;
+
         // THREAT[TM-DOS-035]: local state is not assumed trustworthy after a
         // crash or operator edit. Read through `take` so a concurrently growing
         // file cannot force an unbounded allocation during index recovery.
-        let bytes = match tokio::fs::File::open(&path).await {
-            Ok(file) => {
-                let mut bytes = Vec::new();
-                file.take(max_bytes as u64 + 1)
-                    .read_to_end(&mut bytes)
-                    .await?;
-                if bytes.len() > max_bytes {
-                    return Err(EventLogError::RecoveryLimitExceeded {
-                        detail: format!(
-                            "{} exceeds the {max_bytes}-byte local recovery limit",
-                            path.display()
-                        ),
-                    });
-                }
-                bytes
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
-            Err(error) => return Err(error.into()),
-        };
+        let mut bytes = Vec::new();
+        (&mut file)
+            .take(max_bytes as u64 + 1)
+            .read_to_end(&mut bytes)
+            .await?;
+        if bytes.len() > max_bytes {
+            return Err(EventLogError::RecoveryLimitExceeded {
+                detail: format!(
+                    "{} exceeds the {max_bytes}-byte local recovery limit",
+                    path.display()
+                ),
+            });
+        }
         let committed_len = bytes
             .iter()
             .rposition(|byte| *byte == b'\n')
@@ -937,15 +944,6 @@ impl JsonlEventLog {
                 })?;
             index.insert_existing(event)?;
         }
-        let mut options = tokio::fs::OpenOptions::new();
-        options.create(true).read(true).append(true);
-        #[cfg(unix)]
-        {
-            // THREAT[TM-FS-014]: canonical envelopes can contain prompts,
-            // tool results, and metadata; newly created logs are owner-only.
-            options.mode(0o600);
-        }
-        let file = options.open(&path).await?;
         if bytes.len() != committed_len {
             file.set_len(committed_len as u64).await?;
             file.sync_data().await?;
@@ -964,6 +962,37 @@ impl JsonlEventLog {
     pub fn path(&self) -> &Path {
         &self.path
     }
+}
+
+#[cfg(unix)]
+async fn ensure_private_event_log(file: &tokio::fs::File, path: &Path) -> std::io::Result<()> {
+    let metadata = file.metadata().await?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("event log path is not a regular file: {}", path.display()),
+        ));
+    }
+    // SAFETY: getuid has no preconditions and cannot fail.
+    if metadata.uid() != unsafe { libc::getuid() } {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "event log is not owned by the current user: {}",
+                path.display()
+            ),
+        ));
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .await?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn ensure_private_event_log(_file: &tokio::fs::File, _path: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 #[async_trait]
@@ -1452,6 +1481,46 @@ mod tests {
         EventContext, InputMessageData, OutputMessageDeltaData, SessionStartedData,
     };
     use everruns_provider::typed_id::{HarnessId, TurnId};
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn jsonl_open_rejects_symlinks_without_touching_the_target() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("tempdir");
+        let target = root.path().join("target");
+        let path = root.path().join("events.jsonl");
+        tokio::fs::write(&target, b"unchanged")
+            .await
+            .expect("write target");
+        symlink(&target, &path).expect("create symlink");
+
+        let error = JsonlEventLog::open(&path)
+            .await
+            .err()
+            .expect("symlink is rejected");
+
+        assert!(matches!(error, EventLogError::Backend { .. }));
+        assert_eq!(tokio::fs::read(&target).await.unwrap(), b"unchanged");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn jsonl_open_hardens_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().expect("tempdir");
+        let path = root.path().join("events.jsonl");
+        tokio::fs::write(&path, b"").await.expect("write fixture");
+        tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .await
+            .expect("set fixture permissions");
+
+        let _log = JsonlEventLog::open(&path).await.expect("open event log");
+
+        let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
 
     #[tokio::test]
     async fn jsonl_recovery_rejects_oversize_files_before_indexing() {

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "everruns-provider",
  "futures",
  "ignore",
+ "libc",
  "regex",
  "serde",
  "serde_json",


### PR DESCRIPTION
### Motivation
- The JSONL event log path used by `LocalConfig` followed pre-existing symlinks and opened files without validating type/ownership/permissions, which could leak sensitive conversation history or corrupt attacker-controlled targets. 
- The change ensures event-log opening is atomic and rejects symlink/unsafe files to remove a TOCTOU/ symlink-following attack surface. 

### Description
- Open the event log once and operate through the returned file handle so reads/recovery/truncation/appends cannot be redirected via a symlink, using `O_NOFOLLOW` on Unix via `OpenOptions::custom_flags`. 
- Validate the opened handle with `ensure_private_event_log(...)` to reject non-regular files, require ownership by the current user, and harden permissions to `0600` when too-permissive. 
- Replace the separate open/read/open sequence with a single `OpenOptions` open and use the opened handle for bounded recovery reads and later truncation/append work. 
- Add Unix-only regression tests `jsonl_open_rejects_symlinks_without_touching_the_target` and `jsonl_open_hardens_existing_file_permissions`, and add the Unix `libc` dependency to enable `O_NOFOLLOW` and `getuid()` checks. 

### Testing
- Ran `cargo test -p everruns-host jsonl_open --lib` which executed the new tests and reported `2 passed`. 
- Ran formatting and lint checks via `cargo fmt --all -- --check` which succeeded. 
- Executed repository pre-push checks (`just pre-push`); all applicable formatting, Clippy, lockfile, and isolation checks passed, and the suite reported a failure only because the checkout lacked an `origin/main` ref used by the migration immutability check (environment-related, not the change itself).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8c9a24832b9162a8c2e5ccec61)