### PR TITLE
fix(guardrails): make secret-leak judge stage-agnostic and add test

### DIFF
--- a/crates/core/src/guardrail_gallery.rs
+++ b/crates/core/src/guardrail_gallery.rs
@@ -148,9 +148,9 @@ fn llm_judge(prompt: &str) -> GuardrailRule {
 /// Natural-language policy for the secret-leak judge. Describes the *class* of
 /// content to block (secret material rendered in cleartext) rather than any
 /// specific value, so it catches opaque secrets not known at config time.
-const SECRET_LEAK_JUDGE_POLICY: &str = "Block any tool call whose arguments would print, echo, log, \
-    diff, display, or transmit secret or credential material in cleartext — API keys, access tokens, \
-    passwords, private keys, connection strings, or values read from a secrets manager. Allow \
+const SECRET_LEAK_JUDGE_POLICY: &str = "Block any tool call, tool argument, tool result, log, diff, or \
+    other content that displays or transmits secret or credential material in cleartext — API keys, \
+    access tokens, passwords, private keys, connection strings, or values read from a secrets manager. Allow \
     comparisons that only reveal a hash, fingerprint, length, or redacted form. Allow reads or \
     writes that store or move a secret without displaying its value.";
 
@@ -389,6 +389,21 @@ mod tests {
         let shell = find_guardrail_gallery_item("block-shell-access").expect("present");
         assert_eq!(shell.check_types(), vec!["tool_pattern"]);
         assert_eq!(shell.stages(), vec!["tool_use"]);
+    }
+
+    #[test]
+    fn secret_leak_judge_policy_covers_tool_results() {
+        let item = find_guardrail_gallery_item("secret-leak-judge").expect("present");
+        let check = item
+            .config
+            .checks
+            .iter()
+            .find(|check| check.stage == GuardrailStage::ToolOutput)
+            .expect("tool-output check");
+        let GuardrailRule::LlmJudge { prompt } = &check.rule else {
+            panic!("tool-output check must use an LLM judge");
+        };
+        assert!(prompt.contains("tool result"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The shared `SECRET_LEAK_JUDGE_POLICY` was narrowly worded for tool-call arguments while the preset also applied it to `ToolOutput`, allowing a literal judge to permit secret-bearing tool results.
- The change ensures the model-backed judge policy actually covers tool results and other content the preset advertises it blocks.

### Description
- Reworded `SECRET_LEAK_JUDGE_POLICY` in `crates/core/src/guardrail_gallery.rs` to explicitly cover "tool call, tool argument, tool result, log, diff, or other content" that displays or transmits secret/credential material while preserving allowed hash/redaction exceptions.
- Added a unit test `secret_leak_judge_policy_covers_tool_results` that finds the `ToolOutput` check for the `secret-leak-judge` preset, asserts it uses an `LlmJudge`, and verifies the judge prompt references tool results.
- Kept existing behavior and exceptions unchanged; the change is purely policy wording and test coverage.

### Testing
- Ran `cargo fmt --check -- crates/core/src/guardrail_gallery.rs` which passed.
- Ran `git diff --check` which passed.
- Ran `cargo test -p everruns-core guardrail_gallery::tests --lib` and all tests passed (8 passed, 0 failed).
- Ran `just pre-push`; the scoped checks (formatting, clippy, many repository guards) passed, and the overall command failed only because `origin/main` is unavailable for the migration immutability comparison in this checkout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8d68d0832b9527f37eb0090a98)