### PR TITLE
fix(ui): gate skills server prefetch

### DIFF
--- a/apps/ui/src/__tests__/skills-server-prefetch.test.tsx
+++ b/apps/ui/src/__tests__/skills-server-prefetch.test.tsx
@@ -1,0 +1,58 @@
+import SkillsPage from "@/app/(main)/skills/page";
+
+const mockServerGet = jest.fn();
+const mockServerGetList = jest.fn();
+const mockSeedQueryData = jest.fn(
+  async (_queryClient: unknown, _queryKey: unknown, load: () => Promise<unknown>) => load(),
+);
+
+jest.mock("@tanstack/react-query", () => ({
+  HydrationBoundary: ({ children }: { children: React.ReactNode }) => children,
+  dehydrate: jest.fn(() => ({})),
+}));
+
+jest.mock("@/app/(main)/skills/skills-page-client", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/lib/server-query", () => ({
+  createServerQueryClient: () => ({}),
+  getServerRequestContext: async () => ({ apiBaseUrl: "", cookieHeader: "", orgCookieId: null }),
+  prefetchAuthBootstrap: async () => ({ currentOrgId: "org_1" }),
+  seedQueryData: (queryClient: unknown, queryKey: unknown, load: () => Promise<unknown>) =>
+    mockSeedQueryData(queryClient, queryKey, load),
+  serverGet: (...args: unknown[]) => mockServerGet(...args),
+  serverGetList: (...args: unknown[]) => mockServerGetList(...args),
+}));
+
+describe("SkillsPage server prefetch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServerGetList.mockResolvedValue([]);
+  });
+
+  it("does not fetch or dehydrate skill data when skills are disabled", async () => {
+    mockServerGet.mockResolvedValue({ skills: false });
+
+    await SkillsPage();
+
+    expect(mockServerGet).toHaveBeenCalledTimes(1);
+    expect(mockServerGet).toHaveBeenCalledWith(expect.anything(), "/v1/orgs/org_1/feature-flags");
+    expect(mockServerGetList).not.toHaveBeenCalled();
+    expect(mockSeedQueryData).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves skill and policy prefetching when skills are enabled", async () => {
+    mockServerGet.mockImplementation(async (_context, endpoint) => {
+      if (endpoint === "/v1/orgs/org_1/feature-flags") return { skills: true };
+      return {};
+    });
+
+    await SkillsPage();
+
+    expect(mockServerGetList).toHaveBeenCalledWith(expect.anything(), "/v1/skills");
+    expect(mockServerGet).toHaveBeenCalledWith(expect.anything(), "/v1/skills/config");
+    expect(mockSeedQueryData).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/ui/src/__tests__/skills-server-prefetch.test.tsx
+++ b/apps/ui/src/__tests__/skills-server-prefetch.test.tsx
@@ -41,6 +41,12 @@ describe("SkillsPage server prefetch", () => {
     expect(mockServerGet).toHaveBeenCalledWith(expect.anything(), "/v1/orgs/org_1/feature-flags");
     expect(mockServerGetList).not.toHaveBeenCalled();
     expect(mockSeedQueryData).toHaveBeenCalledTimes(1);
+    // Must match `useOrgFeatureFlags`, or the client refetches what it was handed.
+    expect(mockSeedQueryData).toHaveBeenCalledWith(
+      expect.anything(),
+      ["org-feature-flags", "org_1"],
+      expect.any(Function),
+    );
   });
 
   it("preserves skill and policy prefetching when skills are enabled", async () => {

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -23,7 +23,9 @@ export default async function SkillsPage() {
   const { currentOrgId } = await prefetchAuthBootstrap(queryClient, requestContext);
 
   if (currentOrgId) {
-    const flags = await seedQueryData(queryClient, ["feature-flags", "org", currentOrgId], () =>
+    // Same key `useOrgFeatureFlags` reads, so the client reuses this instead of
+    // refetching the flags it was just handed.
+    const flags = await seedQueryData(queryClient, ["org-feature-flags", currentOrgId], () =>
       serverGet<FeatureFlags>(requestContext, `/v1/orgs/${currentOrgId}/feature-flags`),
     );
 

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -14,7 +14,7 @@ import {
   serverGet,
   serverGetList,
 } from "@/lib/server-query";
-import type { ResourceConfigResponse, Skill } from "@/lib/api/types";
+import type { FeatureFlags, ResourceConfigResponse, Skill } from "@/lib/api/types";
 import SkillsPageClient from "./skills-page-client";
 
 export default async function SkillsPage() {
@@ -23,14 +23,20 @@ export default async function SkillsPage() {
   const { currentOrgId } = await prefetchAuthBootstrap(queryClient, requestContext);
 
   if (currentOrgId) {
-    await Promise.all([
-      seedQueryData(queryClient, [...queryKeys.skills.list(false), currentOrgId], () =>
-        serverGetList<Skill>(requestContext, "/v1/skills"),
-      ),
-      seedQueryData(queryClient, [...queryKeys.policies.config("skills"), currentOrgId], () =>
-        serverGet<ResourceConfigResponse>(requestContext, "/v1/skills/config"),
-      ),
-    ]);
+    const flags = await seedQueryData(queryClient, ["feature-flags", "org", currentOrgId], () =>
+      serverGet<FeatureFlags>(requestContext, `/v1/orgs/${currentOrgId}/feature-flags`),
+    );
+
+    if (flags?.skills) {
+      await Promise.all([
+        seedQueryData(queryClient, [...queryKeys.skills.list(false), currentOrgId], () =>
+          serverGetList<Skill>(requestContext, "/v1/skills"),
+        ),
+        seedQueryData(queryClient, [...queryKeys.policies.config("skills"), currentOrgId], () =>
+          serverGet<ResourceConfigResponse>(requestContext, "/v1/skills/config"),
+        ),
+      ]);
+    }
   }
 
   return (


### PR DESCRIPTION
### Motivation
- A client-only `FeatureFlagPageGate` allowed server components underneath to still fetch and serialize Skills data, defeating the intended no-fetch/no-reveal behavior when the `skills` feature is disabled.

### Description
- Add a server-side lookup of the organization-effective feature flags using the existing server helpers and React Query key, and only prefetch `/v1/skills` and `/v1/skills/config` when the effective `skills` flag is enabled (file: `apps/ui/src/app/(main)/skills/page.tsx`).
- Use `seedQueryData` to hydrate the same `feature-flags` query key so the client provider retains the normal flag state without extra client calls.
- Add a regression test `apps/ui/src/__tests__/skills-server-prefetch.test.tsx` that asserts disabled orgs do not fetch skills metadata and enabled orgs preserve prefetch behavior.
- Keep existing UI and hydration behavior unchanged when the flag is enabled.

### Testing
- Ran the new unit tests with `pnpm exec jest -- --runInBand src/__tests__/skills-server-prefetch.test.tsx` and the suite passed (2 tests, 2 passed).
- Type-checking with `pnpm typecheck` succeeded.
- UI linting/format checks with `pnpm lint` / `oxfmt` passed.
- Ran the repository pre-push checks with `just pre-push`; all executable checks that run in this worktree passed, and the run failed only due to migration immutability being unable to resolve `origin/main` in this environment (no code regressions introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8c5138832b9cfc870dc82beab5)