### PR TITLE
fix(dev): generate private per-prefix KEK for local persisted provider keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,11 @@ variables per `docs/sre/runbooks/authentication.md`.
 `start-all` maps Doppler's `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` to
 `DEFAULT_OPENAI_API_KEY` and `DEFAULT_ANTHROPIC_API_KEY`. Analyze/Health additionally requires
 `UTILITY_OPENAI_API_KEY`; no extra setup is needed when Doppler already supplies it. If Doppler does
-not supply `SECRETS_ENCRYPTION_KEY`, startup uses the stable repository local-development key.
+not supply `SECRETS_ENCRYPTION_KEY`, startup creates a private per-prefix local-development key.
 
 PostgreSQL and NATS data persist under `.local/data/`, isolated by the derived ports. Encrypted
-database records depend on the encryption key remaining stable: the default is the public,
-non-production key from `scripts/lib/local-development-secrets.sh`. Do not change that default
+database records depend on the encryption key remaining stable: the generated key is stored with
+mode 0600 under `.local/agent-dev/`. Do not delete that key
 without migrating or explicitly resetting affected local data. Valkey is started without
 snapshots. Stop the foreground stack with Ctrl+C, or from another shell with
 `PORT_PREFIX=271 just stop-all`; that command also stops the prefix's infrastructure processes.

--- a/knowledge/security/encryption.md
+++ b/knowledge/security/encryption.md
@@ -104,12 +104,11 @@ Field descriptions:
 
 ### Local Development
 
-Local databases persist encrypted provider credentials across process and worktree restarts, so
-the default local-development KEK must remain stable. Local launchers share the public,
-non-production default defined in
-[`scripts/lib/local-development-secrets.sh`](../../scripts/lib/local-development-secrets.sh) when
-`SECRETS_ENCRYPTION_KEY` is absent. Changing the effective key requires migrating or resetting the
-corresponding local database; otherwise existing encrypted records cannot be unwrapped.
+Local databases persist encrypted provider credentials across process and worktree restarts. When
+`SECRETS_ENCRYPTION_KEY` is absent, local launchers generate a private per-prefix KEK under
+`.local/agent-dev/` and retain the former public development key as a previous key for migration.
+Changing or deleting the effective key requires migrating or resetting the corresponding local
+database; otherwise encrypted records written with it cannot be unwrapped.
 
 ### Encrypted Fields
 

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -170,6 +170,7 @@ Display:   evr_pat_<first-8-chars>...      (prefix for identification)
 | TM-CRYPTO-006 | Re-encryption job missing | Low | CLI tool `reencrypt_secrets` implemented with batch processing, dry-run mode, and key rotation detection | MITIGATED |
 | TM-CRYPTO-007 | Limited encryption scope | Medium | LLM API keys encrypted; system prompt encryption reverted (PII should not be in prompts) | **OPEN** |
 | TM-CRYPTO-008 | Machine-payment wallet key exposure | Critical | When machine payments are disabled, custody UI/navigation is hidden, payment commands are omitted from Platform/MCP discovery, and payment account/policy/attempt routes return a structured `feature_not_enabled` 404; when enabled, wallet private keys are accepted only on payment account create/update, encrypted with the server envelope encryption service, never returned from API responses, decrypted only inside `ServerPaymentAuthority` immediately before native rail signing, and never sent to workers | MITIGATED |
+| TM-CRYPTO-009 | Public local KEK exposes persisted provider credentials | Medium | Local launchers generate a private per-prefix KEK with mode 0600; the former public key is accepted only as a previous key for migration | MITIGATED |
 
 ### Mitigation Details
 

--- a/scripts/lib/local-development-secrets.sh
+++ b/scripts/lib/local-development-secrets.sh
@@ -1,14 +1,37 @@
 #!/usr/bin/env bash
 
-# This public, non-production key must stay stable so persisted local databases
-# remain decryptable across restarts and worktrees.
-DEFAULT_LOCAL_SECRETS_ENCRYPTION_KEY="kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY="
+# Kept only to decrypt records written by older local stacks. New records use a
+# private, per-prefix key stored outside source control.
+LEGACY_LOCAL_SECRETS_ENCRYPTION_KEY="kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY="
 
 configure_local_development_encryption_key() {
-  if [ -z "${SECRETS_ENCRYPTION_KEY:-}" ]; then
-    export SECRETS_ENCRYPTION_KEY="$DEFAULT_LOCAL_SECRETS_ENCRYPTION_KEY"
-    return 0
+  if [ -n "${SECRETS_ENCRYPTION_KEY:-}" ]; then
+    return 1
   fi
 
-  return 1
+  local project_root secrets_dir key_file temporary_key prefix
+  project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  secrets_dir="${LOCAL_DEVELOPMENT_SECRETS_DIR:-$project_root/.local/agent-dev}"
+  prefix="${PORT_PREFIX:-default}"
+  key_file="$secrets_dir/secrets-encryption-key-$prefix"
+
+  mkdir -p "$secrets_dir"
+  chmod 700 "$secrets_dir"
+  if [ ! -s "$key_file" ]; then
+    temporary_key="$(mktemp "$secrets_dir/.secrets-encryption-key.XXXXXX")"
+    chmod 600 "$temporary_key"
+    python3 -c \
+      'import base64, os; print("kek-local-v1:" + base64.b64encode(os.urandom(32)).decode())' \
+      > "$temporary_key"
+    # Another concurrent launcher may have won; never replace its established key.
+    ln "$temporary_key" "$key_file" 2>/dev/null || true
+    rm -f "$temporary_key"
+  fi
+  chmod 600 "$key_file"
+
+  export SECRETS_ENCRYPTION_KEY="$(<"$key_file")"
+  if [ -z "${SECRETS_ENCRYPTION_KEY_PREVIOUS:-}" ]; then
+    export SECRETS_ENCRYPTION_KEY_PREVIOUS="$LEGACY_LOCAL_SECRETS_ENCRYPTION_KEY"
+  fi
+  return 0
 }

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -304,7 +304,7 @@ case "$cmd" in
     export RUST_LOG=${RUST_LOG:-info}
 
     if configure_local_development_encryption_key; then
-      echo "   ✅ Using default encryption key"
+      echo "   ✅ Using private per-prefix encryption key"
     fi
 
     print_doppler_secret_hint

--- a/scripts/start-agent-dev.sh
+++ b/scripts/start-agent-dev.sh
@@ -73,7 +73,7 @@ if [ ! -x "$PROJECT_ROOT/apps/ui/node_modules/.bin/next" ]; then
 fi
 
 if configure_local_development_encryption_key; then
-  echo "Using the stable repository local-development encryption key."
+  echo "Using the private per-prefix local-development encryption key."
 fi
 
 cd "$PROJECT_ROOT"

--- a/scripts/test-agent-dev-startup.sh
+++ b/scripts/test-agent-dev-startup.sh
@@ -50,7 +50,7 @@ EOF
 cat > "$TEST_DIR/bin/just" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$PORT_PREFIX|$AUTH_MODE|${OPENAI_API_KEY:-}|${ANTHROPIC_API_KEY:-}|${SECRETS_ENCRYPTION_KEY:-}|$*" > "$AGENT_START_CAPTURE"
+printf '%s\n' "$PORT_PREFIX|$AUTH_MODE|${OPENAI_API_KEY:-}|${ANTHROPIC_API_KEY:-}|${SECRETS_ENCRYPTION_KEY:-}|${SECRETS_ENCRYPTION_KEY_PREVIOUS:-}|$*" > "$AGENT_START_CAPTURE"
 EOF
 
 for command_name in sqlx pnpm caddy nats-server pg_ctl valkey-server; do
@@ -76,7 +76,7 @@ PATH="$TEST_DIR/bin:$PATH" \
   AGENT_START_CAPTURE="$capture" \
   "$PROJECT_ROOT/scripts/start-agent-dev.sh"
 
-expected='271|none|injected-openai|injected-anthropic|test-only-not-a-secret|start-all --no-watch'
+expected='271|none|injected-openai|injected-anthropic|test-only-not-a-secret||start-all --no-watch'
 actual="$(<"$capture")"
 [ "$actual" = "$expected" ] || {
   echo "FAIL: expected '$expected', got '$actual'" >&2
@@ -84,23 +84,38 @@ actual="$(<"$capture")"
 }
 
 env -u SECRETS_ENCRYPTION_KEY \
+  -u SECRETS_ENCRYPTION_KEY_PREVIOUS \
   PATH="$TEST_DIR/bin:$PATH" \
+  LOCAL_DEVELOPMENT_SECRETS_DIR="$TEST_DIR/secrets" \
   PORT_PREFIX=272 \
   AUTH_MODE=none \
   AGENT_START_CAPTURE="$capture" \
   "$PROJECT_ROOT/scripts/start-agent-dev.sh"
 
-expected="272|none|injected-openai|injected-anthropic|$DEFAULT_LOCAL_SECRETS_ENCRYPTION_KEY|start-all --no-watch"
 actual="$(<"$capture")"
-[ "$actual" = "$expected" ] || {
-  echo "FAIL: expected stable local encryption key, got '$actual'" >&2
+IFS='|' read -r prefix auth openai anthropic generated previous command <<< "$actual"
+[ "$prefix|$auth|$openai|$anthropic|$previous|$command" = \
+  "272|none|injected-openai|injected-anthropic|$LEGACY_LOCAL_SECRETS_ENCRYPTION_KEY|start-all --no-watch" ] || {
+  echo "FAIL: private-key startup contract mismatch: '$actual'" >&2
+  exit 1
+}
+[ "$generated" != "$LEGACY_LOCAL_SECRETS_ENCRYPTION_KEY" ]
+[ "$(stat -c '%a' "$TEST_DIR/secrets/secrets-encryption-key-272")" = 600 ]
+
+env -u SECRETS_ENCRYPTION_KEY -u SECRETS_ENCRYPTION_KEY_PREVIOUS \
+  PATH="$TEST_DIR/bin:$PATH" LOCAL_DEVELOPMENT_SECRETS_DIR="$TEST_DIR/secrets" \
+  PORT_PREFIX=272 AUTH_MODE=none AGENT_START_CAPTURE="$capture" \
+  "$PROJECT_ROOT/scripts/start-agent-dev.sh"
+restarted="$(<"$capture")"
+[ "$restarted" = "$actual" ] || {
+  echo "FAIL: local encryption key changed across restarts" >&2
   exit 1
 }
 
-default_key_definitions="$(rg -lF "$DEFAULT_LOCAL_SECRETS_ENCRYPTION_KEY" \
+legacy_key_definitions="$(rg -lF "$LEGACY_LOCAL_SECRETS_ENCRYPTION_KEY" \
   "$PROJECT_ROOT/scripts" | wc -l | tr -d ' ')"
-[ "$default_key_definitions" = "1" ] || {
-  echo "FAIL: expected one local development encryption key definition, found $default_key_definitions" >&2
+[ "$legacy_key_definitions" = "1" ] || {
+  echo "FAIL: expected one legacy local encryption key definition, found $legacy_key_definitions" >&2
   exit 1
 }
 


### PR DESCRIPTION
### Motivation

- The canonical DB-backed local startup previously fell back to a repository-visible KEK when `SECRETS_ENCRYPTION_KEY` was absent, which allowed persisted local provider API keys to be encrypted with known source-controlled material and exposed a confidentiality regression.  
- The change preserves the ability to read existing databases by accepting the legacy public key as a previous/decryption-only key while preventing new persisted credentials from using a public KEK.

### Description

- `scripts/lib/local-development-secrets.sh` now generates a private, cryptographically-random per-prefix KEK stored outside source control under `.local/agent-dev/` (directory mode `0700`, file mode `0600`), exports it as `SECRETS_ENCRYPTION_KEY`, and sets the old public value in `SECRETS_ENCRYPTION_KEY_PREVIOUS` for migration-compatible decryption.  
- The startup helpers now surface the new contract message (updated echoes in `scripts/start-agent-dev.sh` and `scripts/lib/services.sh`) and documentation was updated in `AGENTS.md` and `knowledge/security/*` to describe the private-key contract and migration implications.  
- The startup regression test `scripts/test-agent-dev-startup.sh` was extended to validate explicit-key precedence, private-key generation, key file permissions, legacy-key migration support, and stability across restarts.  
- The threat model was updated to record the public-local KEK exposure and the mitigation (private per-prefix KEK + legacy decryption-only key).

### Testing

- Shell syntax checks for modified scripts passed (`bash -n` on changed scripts).  
- `scripts/test-agent-dev-startup.sh` ran and passed the new assertions, including verifying generated key file mode `0600`, that generated key differs from the legacy public key, and that the key is stable across restarts.  
- `just check-okf` succeeded (knowledge/architecture checks); `git diff --check` and local diff checks passed.  
- `just pre-push` aggregate pre-push was run but the environment lacked an `origin/main` remote for the migration-immutability check, which caused the pre-push recipe to fail in this checkout (CI in the normal environment should re-run and is expected to pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8e00d4832bac4c55a4f411ec7a)