### PR TITLE
fix(models): allow clearing organization default model

### DIFF
--- a/apps/ui/src/__tests__/settings-organization.test.tsx
+++ b/apps/ui/src/__tests__/settings-organization.test.tsx
@@ -207,6 +207,24 @@ describe("OrganizationPage", () => {
     jest.useRealTimers();
   });
 
+  it("clears the default model override when the selection is empty", async () => {
+    jest.useFakeTimers();
+
+    render(<OrganizationPage />);
+
+    fireEvent.change(screen.getByLabelText("Default Model"), {
+      target: { value: "" },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(700);
+      await Promise.resolve();
+    });
+
+    expect(mockUpdateOrganization).toHaveBeenLastCalledWith({ default_model_id: null });
+    jest.useRealTimers();
+  });
+
   it("keeps model errors next to Models without changing Harnesses status", async () => {
     jest.useFakeTimers();
     mockUpdateOrganization.mockRejectedValueOnce(

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -146,8 +146,8 @@ export default function ModelsPage() {
     await queryClient.invalidateQueries({ queryKey: queryKeys.providers.all });
   };
 
-  const handleSetDefaultModel = async (modelId: string) => {
-    await updateOrg.mutateAsync({ default_model_id: modelId || undefined });
+  const handleSetDefaultModel = async (modelId: string | null) => {
+    await updateOrg.mutateAsync({ default_model_id: modelId });
   };
 
   return (
@@ -310,7 +310,7 @@ export default function ModelsPage() {
                     <Select
                       value={org?.default_model_id ?? "none"}
                       onValueChange={(value) =>
-                        handleSetDefaultModel(value === "none" ? "" : value)
+                        handleSetDefaultModel(value === "none" ? null : value)
                       }
                       disabled={updateOrg.isPending}
                     >

--- a/apps/ui/src/app/(main)/settings/organization/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organization/page.tsx
@@ -183,7 +183,6 @@ export default function OrganizationPage() {
 
     if (
       (group === "identity" && !nextDraft.name.trim()) ||
-      (group === "models" && !nextDraft.defaultModelId) ||
       (group === "harnesses" && (!nextDraft.defaultHarnessId || !nextDraft.baseHarnessId))
     ) {
       return;
@@ -200,7 +199,7 @@ export default function OrganizationPage() {
         group === "identity"
           ? { name: nextDraft.name.trim() }
           : group === "models"
-            ? { default_model_id: nextDraft.defaultModelId }
+            ? { default_model_id: nextDraft.defaultModelId || null }
             : {
                 default_harness_id: nextDraft.defaultHarnessId,
                 base_harness_id: nextDraft.baseHarnessId,

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -16510,7 +16510,8 @@ export interface components {
        */
       default_harness_name?: string | null;
       /**
-       * @description Default LLM model for this organization. Must be an enabled model.
+       * @description Default LLM model for this organization. Must be enabled; pass null to use the platform
+       *     default.
        * @example model_01933b5a00007000800000000000001
        */
       default_model_id?: string | null;

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -943,7 +943,7 @@ export interface CreateOrganizationRequest {
 /** Request to update an organization */
 export interface UpdateOrganizationRequest {
   name?: string;
-  default_model_id?: string;
+  default_model_id?: string | null;
   default_harness_id?: string;
   base_harness_id?: string;
   /**

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -152,10 +152,11 @@ pub struct UpdateOrganizationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "Acme Corporation")]
     pub name: Option<String>,
-    /// Default LLM model for this organization. Must be an enabled model.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Default LLM model for this organization. Must be enabled; pass null to use the platform
+    /// default.
+    #[serde(default, deserialize_with = "double_option")]
     #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
-    pub default_model_id: Option<everruns_provider::typed_id::ModelId>,
+    pub default_model_id: Option<Option<everruns_provider::typed_id::ModelId>>,
     /// Default harness to preselect in the UI for new sessions.
     /// Mutually exclusive with `default_harness_name`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -183,6 +184,14 @@ pub struct UpdateOrganizationRequest {
             everruns_provider::typed_id::ProviderId,
         >,
     >,
+}
+
+fn double_option<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Option::<T>::deserialize(de).map(Some)
 }
 
 /// Response for organization operations
@@ -610,7 +619,7 @@ pub async fn update_organization(
     }
 
     // Validate referenced IDs exist (skip if already resolved from name)
-    if let Some(ref model_id) = default_model_id {
+    if let Some(Some(model_id)) = default_model_id.as_ref() {
         // Verify the model exists and is enabled
         let model = state
             .db
@@ -680,8 +689,11 @@ pub async fn update_organization(
             .patch_organization_settings(
                 org_row.org_id,
                 UpdateOrganizationSettings {
-                    default_model_id: default_model_id
-                        .map_or(UpdateField::Unchanged, UpdateField::Set),
+                    default_model_id: match default_model_id {
+                        None => UpdateField::Unchanged,
+                        Some(None) => UpdateField::Clear,
+                        Some(Some(model_id)) => UpdateField::Set(model_id),
+                    },
                     default_harness_id: default_harness_id
                         .map_or(UpdateField::Unchanged, UpdateField::Set),
                     base_harness_id: base_harness_id
@@ -1711,6 +1723,7 @@ mod tests {
         let json = r#"{}"#;
         let req: UpdateOrganizationRequest = serde_json::from_str(json).unwrap();
         assert!(req.name.is_none());
+        assert!(req.default_model_id.is_none());
         assert!(req.default_harness_id.is_none());
         assert!(req.base_harness_id.is_none());
 
@@ -1723,5 +1736,9 @@ mod tests {
         assert_eq!(req.name.unwrap(), "New Name");
         assert!(req.default_harness_id.is_some());
         assert!(req.base_harness_id.is_some());
+
+        let req: UpdateOrganizationRequest =
+            serde_json::from_str(r#"{"default_model_id":null}"#).unwrap();
+        assert_eq!(req.default_model_id, Some(None));
     }
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -38004,7 +38004,7 @@
               "string",
               "null"
             ],
-            "description": "Default LLM model for this organization. Must be an enabled model.",
+            "description": "Default LLM model for this organization. Must be enabled; pass null to use the platform\ndefault.",
             "example": "model_01933b5a00007000800000000000001"
           },
           "default_provider_per_service": {


### PR DESCRIPTION
### Motivation

- The UI showed a "Platform default · GPT-5.6 Terra" option but did not persist a deliberate clear, and the API treated omission and JSON `null` the same so orgs could not revert an explicit default to the platform fallback.

### Description

- Change the Models UI to submit `default_model_id: null` when the platform-default option is selected and adjust the select value mapping to use `null` instead of an empty string. 
- Change the Organization Settings autosave to allow an empty model selection and include `default_model_id: null` in the PATCH payload. 
- Update the API `UpdateOrganizationRequest.default_model_id` to `Option<Option<ModelId>>` with a `double_option` deserializer so the server can distinguish field omission from an explicit `null`, and map `Some(None)` to `UpdateField::Clear` while retaining validation for concrete IDs. 
- Update UI API types and add a focused UI test and a Rust serde unit test to cover omitted, concrete, and explicit-null cases.

### Testing

- Ran the focused Rust unit test `cargo test -p everruns-server api::organizations::tests::test_update_request_partial`, which passed. 
- Ran the updated UI test file with Jest (`pnpm exec jest src/__tests__/settings-organization.test.tsx --runInBand`), which passed (13 tests). 
- Ran TypeScript typecheck and formatting (`pnpm run typecheck`, `pnpm run format:check`) and linter (`pnpm run lint`) for the UI changes, which completed without errors. 
- Ran Rust format check (`cargo fmt --all -- --check`) which passed; `just pre-push` was exercised (Rust formatting passed) during validation but the full workspace pre-push was started in a checkout without an `origin` remote so the run was scoped by the environment rather than being a failing result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8d8490832b918acd3277dc9a08)