### PR TITLE
fix(evals): surface event stream lag

### DIFF
--- a/evals/generic/src/subject.rs
+++ b/evals/generic/src/subject.rs
@@ -23,8 +23,9 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Instant;
 
 use everruns::{
-    Agent, CapabilityRef, ContentPart, Controls, ImageContentPart, InMemoryEngine, InputMessage,
-    Provider, ReasoningConfig, ReasoningEffort, Session, SessionEvent, SessionEventKind,
+    Agent, CapabilityRef, ContentPart, Controls, EventStreamError, ImageContentPart,
+    InMemoryEngine, InputMessage, Provider, ReasoningConfig, ReasoningEffort, Session,
+    SessionEvent, SessionEventKind,
 };
 
 use mira::subject::summarize_events;
@@ -146,8 +147,16 @@ impl Subject for GenericRuntimeSubject {
         }
 
         // Normalize the Framework event stream: usage + ordered tool-call names.
-        while let Ok(Some(event)) = events.try_recv() {
-            transcript.events.push(event_value(event));
+        loop {
+            match events.try_recv() {
+                Ok(Some(event)) => transcript.events.push(event_value(event)),
+                Ok(None) => break,
+                Err(error) => {
+                    mark_event_stream_error(&mut transcript, error);
+                    transcript.timing.duration_ms = started.elapsed().as_millis() as u64;
+                    return transcript;
+                }
+            }
         }
         let (usage, _) = summarize_events(&transcript.events);
         transcript.usage = usage;
@@ -168,6 +177,11 @@ impl Subject for GenericRuntimeSubject {
         transcript.timing.duration_ms = started.elapsed().as_millis() as u64;
         transcript
     }
+}
+
+fn mark_event_stream_error(transcript: &mut Transcript, error: EventStreamError) {
+    transcript.error_kind = ErrorKind::Infra;
+    transcript.error = Some(format!("Framework event stream incomplete: {error}"));
 }
 
 fn event_value(event: SessionEvent) -> serde_json::Value {
@@ -467,6 +481,19 @@ mod tests {
             let t = subject.run(&sample, &cx).await;
             assert!(t.errored_infra(), "{axis}={value} should be infra");
         }
+    }
+
+    #[test]
+    fn event_stream_lag_is_an_infra_error() {
+        let mut transcript = Transcript::default();
+
+        mark_event_stream_error(&mut transcript, EventStreamError::Lagged { missed: 12 });
+
+        assert!(transcript.errored_infra());
+        assert_eq!(
+            transcript.error.as_deref(),
+            Some("Framework event stream incomplete: event stream lagged by 12 events")
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The event drain in `evals/generic/src/subject.rs` treated `Err` from `EventStream::try_recv()` as end-of-stream and silently dropped the lag condition, allowing incomplete transcripts to reach safety/efficiency scorers.
- The change ensures stream lag is treated as an infrastructure problem so scorers do not falsely pass when events were evicted from the bounded buffer.

### Description
- Replace the previous `while let Ok(Some(...)) = events.try_recv()` drain with an explicit `match` loop that `Ok(Some)` collects events, `Ok(None)` breaks, and `Err` calls a handler and returns the transcript early.
- Import `EventStreamError` and add `fn mark_event_stream_error(transcript: &mut Transcript, error: EventStreamError)` which sets `transcript.error_kind = ErrorKind::Infra` and records a diagnostic message.
- Add a regression test `event_stream_lag_is_an_infra_error` to verify an `EventStreamError::Lagged` is classified as infra and that the diagnostic contains the missed event count.
- Changes are limited to `evals/generic/src/subject.rs` and preserve existing behavior for normal event collection and other error classification paths.

### Testing
- Ran `cargo test --manifest-path evals/generic/Cargo.toml`, all tests passed including the new `event_stream_lag_is_an_infra_error` (22 tests passed).
- Ran the repository pre-push checks via `just pre-push`; formatting, Clippy, lockfile, and the scoped Rust checks that apply to this change passed, with the full `pre-push` command reporting a non-related migration immutability failure due to the local checkout lacking a resolvable `origin/main` reference.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8dae6c832b92a73d2be4531032)