### PR TITLE
fix(everruns): preserve Agent Plugins v1 name validation during capability validation

### DIFF
--- a/crates/everruns/src/agent.rs
+++ b/crates/everruns/src/agent.rs
@@ -1406,13 +1406,19 @@ fn validate_registered_capability_config(
 
     if everruns_core::is_declarative_capability(id) || everruns_capability::is_plugin_capability(id)
     {
-        let definition = serde_json::from_value::<everruns_core::DeclarativeCapabilityDefinition>(
-            config.clone(),
-        )
-        .map_err(|error| BuildError::InvalidCapability {
-            id: id.to_string(),
-            reason: format!("invalid declarative capability config: {error}"),
-        })?;
+        let mut definition =
+            serde_json::from_value::<everruns_core::DeclarativeCapabilityDefinition>(
+                config.clone(),
+            )
+            .map_err(|error| BuildError::InvalidCapability {
+                id: id.to_string(),
+                reason: format!("invalid declarative capability config: {error}"),
+            })?;
+        // Plugin identities have already been validated by their compiler and
+        // intentionally allow names outside the narrower declarative contract.
+        if everruns_capability::is_plugin_capability(id) {
+            definition.name = "plugin".to_string();
+        }
         everruns_core::validate_declarative_capability_definition(&definition).map_err(
             |reason| BuildError::InvalidCapability {
                 id: id.to_string(),

--- a/crates/everruns/tests/application_parity.rs
+++ b/crates/everruns/tests/application_parity.rs
@@ -57,14 +57,15 @@ async fn real_workspace_seeding_and_context_inspection_use_framework_types() {
 }
 
 #[tokio::test]
-async fn local_plugin_contributes_to_the_same_inspected_context() {
+async fn agent_plugin_with_dotted_name_contributes_to_the_inspected_context() {
     let plugin = tempfile::tempdir().expect("plugin dir");
     fs::create_dir_all(plugin.path().join(".claude-plugin")).expect("manifest dir");
     fs::create_dir_all(plugin.path().join("agents")).expect("agents dir");
     fs::write(
         plugin.path().join(".claude-plugin/plugin.json"),
         r#"{
-          "name": "offline-helper",
+          "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+          "name": "com.example.tool",
           "version": "0.1.0",
           "description": "Offline fixture",
           "agents": "./agents/"


### PR DESCRIPTION
### Motivation
- Compiled Agent Plugins v1 definitions use a different name contract (dots allowed, up to 64 bytes) than declarative capabilities (no dots, 38 bytes), and the unified build-time validation was reapplying the declarative name rules to plugin configs causing valid plugins to fail at `AgentBuilder::build()`.

### Description
- In `crates/everruns/src/agent.rs` the declarative config validation path now neutralizes the `name` when validating `plugin:` capability configs by substituting the neutral name before calling `validate_declarative_capability_definition`, preserving the plugin compiler's prior name validation.
- Added regression coverage in `crates/everruns/tests/application_parity.rs` that compiles and builds a local Agent Plugins v1 manifest named `com.example.tool` and asserts its contributed context is present.
- Kept the shared content/size checks while avoiding reapplying the narrower declarative name contract to plugin-sourced definitions.

### Testing
- Ran `cargo test -p everruns --test application_parity` and the suite passed including the new `agent_plugin_with_dotted_name_contributes_to_the_inspected_context` test. 
- Ran `cargo fmt --all -- --check` which succeeded. 
- Ran repository pre-push checks via `just pre-push`; applicable checks (format, clippy, test enumeration, and many guards) passed locally while the migration immutability check could not resolve `origin/main` in this environment and reported a non-fatal failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8f171c832b8cd26056a8336e67)