### PR TITLE
fix(evals): allow generic workspace writes

### DIFF
--- a/evals/generic/src/subject.rs
+++ b/evals/generic/src/subject.rs
@@ -25,7 +25,7 @@ use std::time::Instant;
 use everruns::{
     Agent, CapabilityRef, ContentPart, Controls, EventStreamError, ImageContentPart,
     InMemoryEngine, InputMessage, Provider, ReasoningConfig, ReasoningEffort, Session,
-    SessionEvent, SessionEventKind,
+    SessionEvent, SessionEventKind, WorkspacePolicy,
 };
 
 use mira::subject::summarize_events;
@@ -323,7 +323,9 @@ fn build_session(
         builder = builder.capability(CapabilityRef::new(*capability));
     }
     if harness.capabilities.contains(&"session_file_system") {
-        builder = builder.workspace(workspace.path());
+        builder = builder
+            .workspace(workspace.path())
+            .workspace_policy(WorkspacePolicy::read_write());
     }
     if let Some(mode) = config.parallel_tool_calls_mode {
         builder = builder.capability(CapabilityRef::with_config(


### PR DESCRIPTION
### Motivation

- The generic eval subject now creates a temporary Framework workspace but inherited the Framework's default `WorkspacePolicy::read_only()`, which blocked file creation and edits required by several dataset cases.

### Description

- Import `WorkspacePolicy` and opt the eval `Agent` into a writable workspace when the harness enables `session_file_system` by calling `.workspace_policy(WorkspacePolicy::read_write())` in `evals/generic/src/subject.rs`.
- This change is scoped to the generic eval subject so the Framework's secure read-only default remains unchanged for other consumers.

### Testing

- Ran `cargo +1.94.0 test --manifest-path evals/generic/Cargo.toml`, which completed with `21 passed` tests.
- Ran repository checks via `just pre-push`; most code checks (formatting, clippy, `Cargo.lock` freshness) were exercised and passed where applicable, but the overall `pre-push` job failed due to an unavailable `origin/main` preventing the migration immutability check and UI checks being skipped in this environment.
- Verified `git diff --check` and local formatting as part of the workflow; changes are limited to `evals/generic/src/subject.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8e40f0832ba4c0a85831b9346f)