### PR TITLE
fix(host): prevent concurrent JSONL writer corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "everruns-mcp",
  "everruns-provider",
  "everruns-test-support",
+ "fs2",
  "futures",
  "ignore",
  "libc",
@@ -3523,6 +3524,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ repository = "https://github.com/everruns/everruns"
 tokio = { version = "1.50", features = ["full"] }
 tokio-stream = "0.1"
 futures = "0.3"
+fs2 = "0.4"
 
 # Global allocator for binaries (sharded, low-fragmentation; MIT-licensed)
 mimalloc = "0.1"

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -23,6 +23,7 @@ categories = ["development-tools", "asynchronous"]
 async-trait.workspace = true
 chrono.workspace = true
 futures.workspace = true
+fs2.workspace = true
 ignore.workspace = true
 reqwest = { workspace = true, optional = true, features = ["json", "stream", "rustls", "blocking"] }
 regex.workspace = true

--- a/crates/host/src/events.rs
+++ b/crates/host/src/events.rs
@@ -861,8 +861,17 @@ impl EventLog for InMemoryEventLog {
 
 struct JsonlState {
     file: tokio::fs::File,
+    lock_file: std::fs::File,
     committed_len: u64,
     index: EventIndex,
+}
+
+struct FileLockGuard(std::fs::File);
+
+impl Drop for FileLockGuard {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
 }
 
 /// Crash-durable JSONL log containing complete canonical [`Event`] envelopes.
@@ -903,6 +912,10 @@ impl JsonlEventLog {
         }
         let mut file = options.open(&path).await?;
         ensure_private_event_log(&file, &path).await?;
+        // Cloned from the validated handle so the advisory lock guards the same
+        // file the symlink check just accepted, not whatever the path resolves
+        // to later.
+        let lock_file = file.try_clone().await?.into_std().await;
 
         // THREAT[TM-DOS-035]: local state is not assumed trustworthy after a
         // crash or operator edit. Read through `take` so a concurrently growing
@@ -952,6 +965,7 @@ impl JsonlEventLog {
             path,
             state: Mutex::new(JsonlState {
                 file,
+                lock_file,
                 committed_len: committed_len as u64,
                 index,
             }),
@@ -1014,6 +1028,21 @@ impl EventLog for JsonlEventLog {
             });
         }
         let mut state = self.state.lock().await;
+        let lock_file = state.lock_file.try_clone()?;
+        fs2::FileExt::try_lock_exclusive(&lock_file).map_err(|error| EventLogError::Backend {
+            detail: format!("cannot lock {} for append: {error}", self.path.display()),
+        })?;
+        let _file_lock = FileLockGuard(lock_file);
+        let actual_len = state.file.metadata().await?.len();
+        if actual_len != state.committed_len {
+            return Err(EventLogError::Backend {
+                detail: format!(
+                    "{} was modified by another writer (expected {} bytes, found {actual_len})",
+                    self.path.display(),
+                    state.committed_len
+                ),
+            });
+        }
         let sequence = state.index.next_sequence(request.session_id)?;
         let event = request.into_event(EventId::new(), sequence);
         let mut encoded =

--- a/crates/host/tests/event_log_contract.rs
+++ b/crates/host/tests/event_log_contract.rs
@@ -629,3 +629,26 @@ async fn jsonl_collapses_exact_duplicates_and_rejects_id_or_sequence_conflicts()
         Err(EventLogError::Corruption { .. })
     ));
 }
+
+#[tokio::test]
+async fn jsonl_rejects_append_from_stale_second_writer_without_corrupting_log() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("events.jsonl");
+    let session = SessionId::new();
+    let first = JsonlEventLog::open(&path).await.unwrap();
+    let stale = JsonlEventLog::open(&path).await.unwrap();
+
+    let accepted = first.append(input(session, "first")).await.unwrap();
+    assert_eq!(accepted.sequence, Some(1));
+    assert!(matches!(
+        stale.append(input(session, "conflict")).await,
+        Err(EventLogError::Backend { .. })
+    ));
+
+    drop(first);
+    drop(stale);
+    let reopened = JsonlEventLog::open(&path).await.unwrap();
+    let events = read_all(&reopened, session).await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].id, accepted.id);
+}

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -553,8 +553,10 @@ dependencies = [
  "everruns-engine",
  "everruns-integrations-filesystem",
  "everruns-provider",
+ "fs2",
  "futures",
  "ignore",
+ "libc",
  "regex",
  "serde",
  "serde_json",
@@ -713,6 +715,16 @@ checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
 dependencies = [
  "num",
  "num-bigint",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2746,6 +2758,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2781,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -432,8 +432,10 @@ dependencies = [
  "everruns-engine",
  "everruns-integrations-filesystem",
  "everruns-provider",
+ "fs2",
  "futures",
  "ignore",
+ "libc",
  "regex",
  "serde",
  "serde_json",
@@ -555,6 +557,16 @@ checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
 dependencies = [
  "num",
  "num-bigint",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1886,6 +1898,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,6 +1921,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "everruns-engine",
  "everruns-integrations-filesystem",
  "everruns-provider",
+ "fs2",
  "futures",
  "ignore",
  "libc",
@@ -721,6 +722,16 @@ checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
 dependencies = [
  "num",
  "num-bigint",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2695,6 +2706,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,6 +2729,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"


### PR DESCRIPTION
### Motivation

- JsonlEventLog rebuilt an instance-local index on open and accepted appends from that stale state, allowing two processes/instances to assign the same per-session sequence and durably write conflicting records.

### Description

- Add cross-process advisory locking using `fs2` and expose it in the host crate by adding `fs2` to `Cargo.toml` and `Cargo.lock` and enabling `fs2.workspace` in `crates/host/Cargo.toml`.
- Preserve a cloned std `File` alongside the async `tokio::fs::File` in `JsonlState` so `fs2` can lock the OS handle, and introduce a `FileLockGuard` RAII type to ensure the lock is released on every return path.
- During `JsonlEventLog::append` acquire an exclusive lock via `fs2::FileExt::try_lock_exclusive`, check the actual on-disk length (`metadata().len()`) against the instance's `committed_len`, and reject appends from stale writers with an `EventLogError::Backend` before assigning a sequence or writing bytes.
- Add a regression test `jsonl_rejects_append_from_stale_second_writer_without_corrupting_log` in `crates/host/tests/event_log_contract.rs` that verifies the first append is accepted, a concurrently opened stale writer is rejected, and reopening the file shows no corruption.

### Testing

- Ran `cargo fmt --all -- --check` which passed.
- Ran `cargo clippy -p everruns-host --all-targets --all-features -- -D warnings` which passed.
- Ran the focused event-log tests with `cargo test -p everruns-host --test event_log_contract jsonl_` and the JSONL contract tests (including the new dual-open regression) passed (3 passed, 0 failed).
- Ran `cargo test -p everruns-host --all-features`; the JSONL tests passed, while 7 unrelated HTTP/mocking-dependent tests failed due to environmental/mock HTTP 403 responses and are not related to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8ded34832ba88d55366d886970)