### PR TITLE
fix(cli): use versioned /v1/ API paths for plugins, skills, and knowledge-bases

### DIFF
--- a/crates/cli/src/commands/knowledge_bases.rs
+++ b/crates/cli/src/commands/knowledge_bases.rs
@@ -25,7 +25,7 @@ pub enum KnowledgeBasesCommands {
 }
 
 const KNOWLEDGE_BASES: Resource = Resource {
-    path: "/knowledge-bases",
+    path: "/v1/knowledge-bases",
     collection_key: "knowledge_bases",
     empty_message: "No knowledge bases found.",
     columns: &[
@@ -68,14 +68,14 @@ pub async fn run(
         } => {
             let body = create_request(name, description, embedding_model_id);
             let response = ApiClient::new(api_url, api_key, org_id)
-                .post("/knowledge-bases", Some(&body))
+                .post(KNOWLEDGE_BASES.path, Some(&body))
                 .await?;
             format.print_value(&response);
             Ok(())
         }
         KnowledgeBasesCommands::Delete { id } => {
             let response = ApiClient::new(api_url, api_key, org_id)
-                .delete(&super::discovery::resource_path("/knowledge-bases", &id))
+                .delete(&super::discovery::resource_path(KNOWLEDGE_BASES.path, &id))
                 .await?;
             format.print_value(&response);
             Ok(())
@@ -107,7 +107,8 @@ fn create_request(
 
 #[cfg(test)]
 mod tests {
-    use super::create_request;
+    use super::{KNOWLEDGE_BASES, create_request};
+    use crate::commands::discovery::resource_path;
     use serde_json::json;
 
     #[test]
@@ -131,6 +132,15 @@ mod tests {
                 "description": null,
                 "embedding_model_id": null
             })
+        );
+    }
+
+    #[test]
+    fn request_paths_match_versioned_server_routes() {
+        assert_eq!(KNOWLEDGE_BASES.path, "/v1/knowledge-bases");
+        assert_eq!(
+            resource_path(KNOWLEDGE_BASES.path, "kb/id"),
+            "/v1/knowledge-bases/kb%2Fid"
         );
     }
 }

--- a/crates/cli/src/commands/plugins.rs
+++ b/crates/cli/src/commands/plugins.rs
@@ -22,7 +22,7 @@ pub enum PluginsCommands {
 }
 
 const PLUGINS: Resource = Resource {
-    path: "/plugins",
+    path: "/v1/plugins",
     collection_key: "plugins",
     empty_message: "No plugins found.",
     columns: &[
@@ -65,14 +65,14 @@ pub async fn run(
         } => {
             let body = install_request(&marketplace_id, &plugin_name);
             let response = ApiClient::new(api_url, api_key, org_id)
-                .post("/plugins", Some(&body))
+                .post(PLUGINS.path, Some(&body))
                 .await?;
             format.print_value(&response);
             Ok(())
         }
         PluginsCommands::Uninstall { id } => {
             let response = ApiClient::new(api_url, api_key, org_id)
-                .delete(&super::discovery::resource_path("/plugins", &id))
+                .delete(&super::discovery::resource_path(PLUGINS.path, &id))
                 .await?;
             format.print_value(&response);
             Ok(())
@@ -96,7 +96,8 @@ fn install_request(marketplace_id: &str, plugin_name: &str) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::install_request;
+    use super::{PLUGINS, install_request};
+    use crate::commands::discovery::resource_path;
     use serde_json::json;
 
     #[test]
@@ -107,6 +108,15 @@ mod tests {
                 "marketplace_id": "marketplace-id",
                 "plugin_name": "plugin-name"
             })
+        );
+    }
+
+    #[test]
+    fn request_paths_match_versioned_server_routes() {
+        assert_eq!(PLUGINS.path, "/v1/plugins");
+        assert_eq!(
+            resource_path(PLUGINS.path, "plugin/id"),
+            "/v1/plugins/plugin%2Fid"
         );
     }
 }

--- a/crates/cli/src/commands/skills.rs
+++ b/crates/cli/src/commands/skills.rs
@@ -21,7 +21,7 @@ pub enum SkillsCommands {
 }
 
 const SKILLS: Resource = Resource {
-    path: "/skills",
+    path: "/v1/skills",
     collection_key: "skills",
     empty_message: "No skills found.",
     columns: &[
@@ -63,14 +63,14 @@ pub async fn run(
                 .with_context(|| format!("Failed to read SKILL.md at {}", path.display()))?;
             let body = create_request(&skill_md);
             let response = ApiClient::new(api_url, api_key, org_id)
-                .post("/skills", Some(&body))
+                .post(SKILLS.path, Some(&body))
                 .await?;
             format.print_value(&response);
             Ok(())
         }
         SkillsCommands::Delete { id } => {
             let response = ApiClient::new(api_url, api_key, org_id)
-                .delete(&super::discovery::resource_path("/skills", &id))
+                .delete(&super::discovery::resource_path(SKILLS.path, &id))
                 .await?;
             format.print_value(&response);
             Ok(())
@@ -94,12 +94,22 @@ fn create_request(skill_md: &str) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::create_request;
+    use super::{SKILLS, create_request};
+    use crate::commands::discovery::resource_path;
     use serde_json::json;
 
     #[test]
     fn create_request_preserves_exact_skill_md_content() {
         let content = "---\nname: example\n---\n\n# Example\n";
         assert_eq!(create_request(content), json!({ "skill_md": content }));
+    }
+
+    #[test]
+    fn request_paths_match_versioned_server_routes() {
+        assert_eq!(SKILLS.path, "/v1/skills");
+        assert_eq!(
+            resource_path(SKILLS.path, "skill/id"),
+            "/v1/skills/skill%2Fid"
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Newly added composition CLI commands were constructing unversioned paths (`/plugins`, `/skills`, `/knowledge-bases`) while the server exposes these resources under `/v1/...`, causing 404s and a functional regression. 
- The `ApiClient` concatenates the base `api_url` and the provided path verbatim, so callers must supply the `/v1` prefix.

### Description

- Updated the CLI resource constants to include the API version prefix (`/v1/plugins`, `/v1/skills`, `/v1/knowledge-bases`) in `crates/cli/src/commands/plugins.rs`, `crates/cli/src/commands/skills.rs`, and `crates/cli/src/commands/knowledge_bases.rs`.
- Replaced literal path strings in POST/DELETE calls with the resource `path` constants (e.g. `.post(PLUGINS.path, ...)` and `resource_path(PLUGINS.path, &id)`) to ensure collection and detail endpoints are versioned consistently.
- Added unit tests that assert the collection paths and the percent-encoded detail request paths match the versioned server routes for each resource type.

### Testing

- Ran `cargo test -p everruns-cli`, and the CLI unit and integration suites passed (all tests succeeded).
- Ran `cargo fmt --all -- --check` (formatting check passed, auto-format applied where needed before tests).
- Ran `just pre-push`; all applicable pre-push checks completed successfully except the migration immutability check which failed only because this checkout has no `origin/main` reference (the remaining checks — formatting, clippy, lockfile, and test enumeration — passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8dfa70832bacff7154d0ec45da)