### PR TITLE
fix(local): serialize reconnect with wake fallback

### DIFF
--- a/crates/everruns/src/local/wake_routing.rs
+++ b/crates/everruns/src/local/wake_routing.rs
@@ -20,13 +20,14 @@
 //! with the host, because that part is genuinely host-specific.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use everruns_core::session::ExecutionSession;
 use everruns_platform::{PlatformCreateSessionRequest, PlatformMessage};
 use everruns_provider::error::Result;
 use everruns_provider::typed_id::{AgentId, HarnessId, SessionId};
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use super::platform_store::LocalSessionRunner;
@@ -38,7 +39,7 @@ use super::platform_store::LocalSessionRunner;
 /// or closed host does not keep swallowing wakes.
 #[derive(Debug, Clone, Default)]
 pub struct WakeRoutes {
-    routes: Arc<Mutex<HashMap<SessionId, UnboundedSender<String>>>>,
+    routes: Arc<AsyncMutex<HashMap<SessionId, UnboundedSender<String>>>>,
 }
 
 impl WakeRoutes {
@@ -51,34 +52,20 @@ impl WakeRoutes {
     ///
     /// Registering a session that already has a route replaces it — the newest
     /// loop wins, which is what a reconnecting host wants.
-    pub fn register(&self, session_id: SessionId) -> UnboundedReceiver<String> {
+    pub async fn register(&self, session_id: SessionId) -> UnboundedReceiver<String> {
         let (sender, receiver) = unbounded_channel();
-        self.routes.lock().unwrap().insert(session_id, sender);
+        self.routes.lock().await.insert(session_id, sender);
         receiver
     }
 
     /// Stop routing to `session_id`.
-    pub fn unregister(&self, session_id: SessionId) {
-        self.routes.lock().unwrap().remove(&session_id);
+    pub async fn unregister(&self, session_id: SessionId) {
+        self.routes.lock().await.remove(&session_id);
     }
 
     /// Sessions currently claimed by a host loop.
-    pub fn live_sessions(&self) -> Vec<SessionId> {
-        self.routes.lock().unwrap().keys().copied().collect()
-    }
-
-    /// Deliver to a registered host, pruning a closed route atomically with
-    /// the failed send so a concurrent registration cannot be removed.
-    fn try_send(&self, session_id: SessionId, content: &str) -> bool {
-        let mut routes = self.routes.lock().unwrap();
-        let Some(sender) = routes.get(&session_id) else {
-            return false;
-        };
-        if sender.send(content.to_string()).is_err() {
-            routes.remove(&session_id);
-            return false;
-        }
-        true
+    pub async fn live_sessions(&self) -> Vec<SessionId> {
+        self.routes.lock().await.keys().copied().collect()
     }
 }
 
@@ -113,7 +100,7 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
         // Live host sessions are always routable. If the inner runner scopes
         // its own routes, union the two; if it routes everything (`None`), so
         // do we.
-        let live = self.routes.live_sessions();
+        let live = self.routes.live_sessions().await;
         match self.inner.routable_session_ids().await? {
             None => Ok(None),
             Some(mut inner) => {
@@ -128,13 +115,18 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
     }
 
     async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
-        if self.routes.try_send(session_id, content) {
-            return Ok(());
+        let mut routes = self.routes.routes.lock().await;
+        if let Some(sender) = routes.get(&session_id) {
+            if sender.send(content.to_string()).is_ok() {
+                return Ok(());
+            }
+            routes.remove(&session_id);
         }
 
         // Nobody is driving this session, or its host went away. Deliver this
         // wake synchronously now because immediate background completions are
-        // not retried.
+        // not retried. Keep registration serialized until the turn finishes so
+        // a reconnecting host cannot start driving the same session underneath it.
         self.inner.send_message(session_id, content).await
     }
 
@@ -187,6 +179,7 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
 mod tests {
     use super::*;
     use everruns_provider::error::AgentLoopError;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Default)]
@@ -248,7 +241,7 @@ mod tests {
     async fn a_live_host_session_receives_the_wake_instead_of_running_a_turn() {
         let routes = WakeRoutes::new();
         let session_id = SessionId::new_random();
-        let mut receiver = routes.register(session_id);
+        let mut receiver = routes.register(session_id).await;
         let runner = HostRoutedRunner::new(RecordingRunner::default(), routes);
 
         runner
@@ -287,7 +280,7 @@ mod tests {
     async fn a_closed_host_channel_prunes_the_route_and_delivers_synchronously() {
         let routes = WakeRoutes::new();
         let session_id = SessionId::new_random();
-        let receiver = routes.register(session_id);
+        let receiver = routes.register(session_id).await;
         drop(receiver); // the host went away
         let runner = HostRoutedRunner::new(RecordingRunner::default(), routes.clone());
 
@@ -296,7 +289,7 @@ mod tests {
             .await
             .expect("a dead receiver should fall through to the inner runner");
         assert!(
-            routes.live_sessions().is_empty(),
+            routes.live_sessions().await.is_empty(),
             "the dead route must be pruned"
         );
         assert_eq!(runner.inner().turns_run.load(Ordering::SeqCst), 1);
@@ -310,9 +303,9 @@ mod tests {
     async fn re_registering_replaces_the_route_and_a_stale_send_does_not_prune_it() {
         let routes = WakeRoutes::new();
         let session_id = SessionId::new_random();
-        let stale = routes.register(session_id);
+        let stale = routes.register(session_id).await;
         drop(stale);
-        let mut fresh = routes.register(session_id);
+        let mut fresh = routes.register(session_id).await;
         let runner = HostRoutedRunner::new(RecordingRunner::default(), routes.clone());
 
         runner
@@ -324,7 +317,104 @@ mod tests {
             fresh.try_recv().expect("fresh host receives"),
             "second wake"
         );
-        assert_eq!(routes.live_sessions(), vec![session_id]);
+        assert_eq!(routes.live_sessions().await, vec![session_id]);
+    }
+
+    #[tokio::test]
+    async fn reconnect_waits_for_a_synchronous_turn_to_finish() {
+        use tokio::sync::Notify;
+        use tokio::time::{Duration, timeout};
+
+        struct BlockingRunner {
+            entered: Arc<Notify>,
+            release: Arc<Notify>,
+        }
+
+        #[async_trait]
+        impl LocalSessionRunner for BlockingRunner {
+            async fn create_session(
+                &self,
+                _harness_id: HarnessId,
+                _agent_id: Option<AgentId>,
+                _title: Option<&str>,
+                _locale: Option<&str>,
+                _parent_session_id: Option<SessionId>,
+            ) -> Result<ExecutionSession> {
+                Err(AgentLoopError::tool("create_session unused in these tests"))
+            }
+
+            async fn send_message(&self, _session_id: SessionId, _content: &str) -> Result<()> {
+                self.entered.notify_one();
+                self.release.notified().await;
+                Ok(())
+            }
+
+            async fn list_sessions(
+                &self,
+                _limit: Option<usize>,
+                _agent_id: Option<AgentId>,
+            ) -> Result<Vec<ExecutionSession>> {
+                Ok(vec![])
+            }
+
+            async fn get_session(
+                &self,
+                _session_id: SessionId,
+            ) -> Result<Option<ExecutionSession>> {
+                Ok(None)
+            }
+
+            async fn get_messages(
+                &self,
+                _session_id: SessionId,
+                _limit: Option<usize>,
+            ) -> Result<Vec<PlatformMessage>> {
+                Ok(vec![])
+            }
+
+            async fn get_session_status(&self, _session_id: SessionId) -> Result<Option<String>> {
+                Ok(None)
+            }
+        }
+
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let routes = WakeRoutes::new();
+        let session_id = SessionId::new_random();
+        let runner = Arc::new(HostRoutedRunner::new(
+            BlockingRunner {
+                entered: entered.clone(),
+                release: release.clone(),
+            },
+            routes.clone(),
+        ));
+
+        let send = tokio::spawn({
+            let runner = runner.clone();
+            async move { runner.send_message(session_id, "first wake").await }
+        });
+        entered.notified().await;
+
+        let mut registration = tokio::spawn({
+            let routes = routes.clone();
+            async move { routes.register(session_id).await }
+        });
+        assert!(
+            timeout(Duration::from_millis(20), &mut registration)
+                .await
+                .is_err(),
+            "a reconnect must not become live while the inner turn is running"
+        );
+
+        release.notify_one();
+        send.await.expect("send task should finish").unwrap();
+        let mut receiver = registration.await.expect("registration should finish");
+
+        runner
+            .send_message(session_id, "second wake")
+            .await
+            .expect("wake should reach the reconnected host");
+        assert_eq!(receiver.try_recv().unwrap(), "second wake");
     }
 
     #[tokio::test]
@@ -378,7 +468,7 @@ mod tests {
         let child = SessionId::new_random();
         let host_session = SessionId::new_random();
         let routes = WakeRoutes::new();
-        let _receiver = routes.register(host_session);
+        let _receiver = routes.register(host_session).await;
         let runner = HostRoutedRunner::new(ScopedRunner(child), routes);
 
         let routable = runner

--- a/crates/everruns/src/local/wake_routing.rs
+++ b/crates/everruns/src/local/wake_routing.rs
@@ -20,17 +20,30 @@
 //! with the host, because that part is genuinely host-specific.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::pin::pin;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use everruns_core::session::ExecutionSession;
 use everruns_platform::{PlatformCreateSessionRequest, PlatformMessage};
 use everruns_provider::error::Result;
 use everruns_provider::typed_id::{AgentId, HarnessId, SessionId};
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::Notify;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use super::platform_store::LocalSessionRunner;
+
+#[derive(Debug, Default)]
+struct RouteState {
+    /// Sessions with a live host loop.
+    routes: HashMap<SessionId, UnboundedSender<String>>,
+    /// Sessions with a synchronous fallback turn in flight, by depth.
+    ///
+    /// A depth rather than a flag because a turn can wake its own session
+    /// again before it finishes; counting means the nested wake proceeds
+    /// instead of waiting on something it is itself inside of.
+    delivering: HashMap<SessionId, usize>,
+}
 
 /// Registry of sessions with a live host loop.
 ///
@@ -39,7 +52,9 @@ use super::platform_store::LocalSessionRunner;
 /// or closed host does not keep swallowing wakes.
 #[derive(Debug, Clone, Default)]
 pub struct WakeRoutes {
-    routes: Arc<AsyncMutex<HashMap<SessionId, UnboundedSender<String>>>>,
+    state: Arc<Mutex<RouteState>>,
+    /// Notified when a session's last in-flight fallback turn finishes.
+    idle: Arc<Notify>,
 }
 
 impl WakeRoutes {
@@ -52,20 +67,89 @@ impl WakeRoutes {
     ///
     /// Registering a session that already has a route replaces it — the newest
     /// loop wins, which is what a reconnecting host wants.
+    ///
+    /// Async because it waits out a synchronous fallback turn already running
+    /// for *this* session: becoming live underneath one is exactly the
+    /// two-loops-on-one-session state this module exists to prevent. Other
+    /// sessions' turns never block it, and no lock is held across the wait.
     pub async fn register(&self, session_id: SessionId) -> UnboundedReceiver<String> {
         let (sender, receiver) = unbounded_channel();
-        self.routes.lock().await.insert(session_id, sender);
-        receiver
+        loop {
+            // Arm the waiter *before* reading `delivering`, so a turn that
+            // finishes in the gap wakes us rather than leaving us parked.
+            let mut idle = pin!(self.idle.notified());
+            idle.as_mut().enable();
+
+            {
+                let mut state = self.state.lock().unwrap();
+                if !state.delivering.contains_key(&session_id) {
+                    state.routes.insert(session_id, sender);
+                    return receiver;
+                }
+            }
+
+            idle.await;
+        }
     }
 
     /// Stop routing to `session_id`.
-    pub async fn unregister(&self, session_id: SessionId) {
-        self.routes.lock().await.remove(&session_id);
+    pub fn unregister(&self, session_id: SessionId) {
+        self.state.lock().unwrap().routes.remove(&session_id);
     }
 
     /// Sessions currently claimed by a host loop.
-    pub async fn live_sessions(&self) -> Vec<SessionId> {
-        self.routes.lock().await.keys().copied().collect()
+    pub fn live_sessions(&self) -> Vec<SessionId> {
+        self.state.lock().unwrap().routes.keys().copied().collect()
+    }
+
+    /// Hand `content` to a live host, or claim the synchronous fallback.
+    ///
+    /// `None` means delivered. `Some(guard)` means the caller owns the fallback
+    /// turn and must hold the guard until it finishes. Both the route decision
+    /// and the claim happen under one lock, so `register` cannot slip between
+    /// them; the lock is released before the turn runs.
+    fn deliver_or_claim(&self, session_id: SessionId, content: &str) -> Option<Delivery> {
+        let mut state = self.state.lock().unwrap();
+        if let Some(sender) = state.routes.get(&session_id) {
+            if sender.send(content.to_string()).is_ok() {
+                return None;
+            }
+            // The host went away. Prune atomically with the failed send so a
+            // concurrent registration cannot be removed.
+            state.routes.remove(&session_id);
+        }
+        *state.delivering.entry(session_id).or_insert(0) += 1;
+        Some(Delivery {
+            routes: self.clone(),
+            session_id,
+        })
+    }
+}
+
+/// Marks a synchronous fallback turn as in flight for one session.
+struct Delivery {
+    routes: WakeRoutes,
+    session_id: SessionId,
+}
+
+impl Drop for Delivery {
+    fn drop(&mut self) {
+        let now_idle = {
+            let mut state = self.routes.state.lock().unwrap();
+            match state.delivering.get_mut(&self.session_id) {
+                Some(depth) if *depth > 1 => {
+                    *depth -= 1;
+                    false
+                }
+                _ => {
+                    state.delivering.remove(&self.session_id);
+                    true
+                }
+            }
+        };
+        if now_idle {
+            self.routes.idle.notify_waiters();
+        }
     }
 }
 
@@ -100,7 +184,7 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
         // Live host sessions are always routable. If the inner runner scopes
         // its own routes, union the two; if it routes everything (`None`), so
         // do we.
-        let live = self.routes.live_sessions().await;
+        let live = self.routes.live_sessions();
         match self.inner.routable_session_ids().await? {
             None => Ok(None),
             Some(mut inner) => {
@@ -115,18 +199,15 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
     }
 
     async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
-        let mut routes = self.routes.routes.lock().await;
-        if let Some(sender) = routes.get(&session_id) {
-            if sender.send(content.to_string()).is_ok() {
-                return Ok(());
-            }
-            routes.remove(&session_id);
-        }
+        let Some(_delivery) = self.routes.deliver_or_claim(session_id, content) else {
+            return Ok(());
+        };
 
         // Nobody is driving this session, or its host went away. Deliver this
         // wake synchronously now because immediate background completions are
-        // not retried. Keep registration serialized until the turn finishes so
-        // a reconnecting host cannot start driving the same session underneath it.
+        // not retried. `_delivery` lives until this call returns, which is what
+        // holds off a reconnecting host for *this* session; every other session
+        // keeps running.
         self.inner.send_message(session_id, content).await
     }
 
@@ -179,7 +260,6 @@ impl<R: LocalSessionRunner> LocalSessionRunner for HostRoutedRunner<R> {
 mod tests {
     use super::*;
     use everruns_provider::error::AgentLoopError;
-    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Default)]
@@ -289,7 +369,7 @@ mod tests {
             .await
             .expect("a dead receiver should fall through to the inner runner");
         assert!(
-            routes.live_sessions().await.is_empty(),
+            routes.live_sessions().is_empty(),
             "the dead route must be pruned"
         );
         assert_eq!(runner.inner().turns_run.load(Ordering::SeqCst), 1);
@@ -317,65 +397,64 @@ mod tests {
             fresh.try_recv().expect("fresh host receives"),
             "second wake"
         );
-        assert_eq!(routes.live_sessions().await, vec![session_id]);
+        assert_eq!(routes.live_sessions(), vec![session_id]);
+    }
+
+    /// Stands in for a runner whose turn takes real time: parks in
+    /// `send_message` until released, so a test can observe the window during
+    /// which a fallback turn is in flight.
+    struct BlockingRunner {
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl LocalSessionRunner for BlockingRunner {
+        async fn create_session(
+            &self,
+            _harness_id: HarnessId,
+            _agent_id: Option<AgentId>,
+            _title: Option<&str>,
+            _locale: Option<&str>,
+            _parent_session_id: Option<SessionId>,
+        ) -> Result<ExecutionSession> {
+            Err(AgentLoopError::tool("create_session unused in these tests"))
+        }
+
+        async fn send_message(&self, _session_id: SessionId, _content: &str) -> Result<()> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(())
+        }
+
+        async fn list_sessions(
+            &self,
+            _limit: Option<usize>,
+            _agent_id: Option<AgentId>,
+        ) -> Result<Vec<ExecutionSession>> {
+            Ok(vec![])
+        }
+
+        async fn get_session(&self, _session_id: SessionId) -> Result<Option<ExecutionSession>> {
+            Ok(None)
+        }
+
+        async fn get_messages(
+            &self,
+            _session_id: SessionId,
+            _limit: Option<usize>,
+        ) -> Result<Vec<PlatformMessage>> {
+            Ok(vec![])
+        }
+
+        async fn get_session_status(&self, _session_id: SessionId) -> Result<Option<String>> {
+            Ok(None)
+        }
     }
 
     #[tokio::test]
     async fn reconnect_waits_for_a_synchronous_turn_to_finish() {
-        use tokio::sync::Notify;
         use tokio::time::{Duration, timeout};
-
-        struct BlockingRunner {
-            entered: Arc<Notify>,
-            release: Arc<Notify>,
-        }
-
-        #[async_trait]
-        impl LocalSessionRunner for BlockingRunner {
-            async fn create_session(
-                &self,
-                _harness_id: HarnessId,
-                _agent_id: Option<AgentId>,
-                _title: Option<&str>,
-                _locale: Option<&str>,
-                _parent_session_id: Option<SessionId>,
-            ) -> Result<ExecutionSession> {
-                Err(AgentLoopError::tool("create_session unused in these tests"))
-            }
-
-            async fn send_message(&self, _session_id: SessionId, _content: &str) -> Result<()> {
-                self.entered.notify_one();
-                self.release.notified().await;
-                Ok(())
-            }
-
-            async fn list_sessions(
-                &self,
-                _limit: Option<usize>,
-                _agent_id: Option<AgentId>,
-            ) -> Result<Vec<ExecutionSession>> {
-                Ok(vec![])
-            }
-
-            async fn get_session(
-                &self,
-                _session_id: SessionId,
-            ) -> Result<Option<ExecutionSession>> {
-                Ok(None)
-            }
-
-            async fn get_messages(
-                &self,
-                _session_id: SessionId,
-                _limit: Option<usize>,
-            ) -> Result<Vec<PlatformMessage>> {
-                Ok(vec![])
-            }
-
-            async fn get_session_status(&self, _session_id: SessionId) -> Result<Option<String>> {
-                Ok(None)
-            }
-        }
 
         let entered = Arc::new(Notify::new());
         let release = Arc::new(Notify::new());
@@ -415,6 +494,79 @@ mod tests {
             .await
             .expect("wake should reach the reconnected host");
         assert_eq!(receiver.try_recv().unwrap(), "second wake");
+    }
+
+    #[tokio::test]
+    async fn a_fallback_turn_only_holds_off_its_own_sessions_reconnect() {
+        // The hold-off above is per session. A fallback turn for one session
+        // must not stall registration, unregistration, or delivery for any
+        // other — those are independent host loops.
+        use tokio::time::{Duration, timeout};
+
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let routes = WakeRoutes::new();
+        let busy = SessionId::new_random();
+        let other = SessionId::new_random();
+        let runner = Arc::new(HostRoutedRunner::new(
+            BlockingRunner {
+                entered: entered.clone(),
+                release: release.clone(),
+            },
+            routes.clone(),
+        ));
+
+        let send = tokio::spawn({
+            let runner = runner.clone();
+            async move { runner.send_message(busy, "wake for the busy session").await }
+        });
+        entered.notified().await;
+
+        let mut receiver = timeout(Duration::from_secs(5), routes.register(other))
+            .await
+            .expect("another session's reconnect must not wait on the busy turn");
+        assert_eq!(routes.live_sessions(), vec![other]);
+
+        timeout(
+            Duration::from_secs(5),
+            runner.send_message(other, "wake for the other session"),
+        )
+        .await
+        .expect("delivery to another session must not wait on the busy turn")
+        .expect("wake should be routed");
+        assert_eq!(
+            receiver.try_recv().unwrap(),
+            "wake for the other session",
+            "the other host loop keeps receiving while the busy turn runs"
+        );
+
+        release.notify_one();
+        send.await.expect("send task should finish").unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_turn_that_wakes_its_own_session_again_does_not_deadlock() {
+        // `send_message` is reachable from inside a turn. A nested wake for the
+        // same session must fall through to another turn, not park forever
+        // waiting for the turn it is already inside of to finish.
+        use tokio::time::{Duration, timeout};
+
+        let runner = HostRoutedRunner::new(RecordingRunner::default(), WakeRoutes::new());
+        let session_id = SessionId::new_random();
+
+        let outer = runner.routes().deliver_or_claim(session_id, "outer wake");
+        assert!(outer.is_some(), "no host loop, so this claims the fallback");
+
+        timeout(
+            Duration::from_secs(5),
+            runner.send_message(session_id, "nested wake"),
+        )
+        .await
+        .expect("a nested wake for the same session must not deadlock")
+        .expect("wake should be delivered");
+
+        drop(outer);
+        assert_eq!(runner.inner().turns_run.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Close a reconnect race where a stale closed route could be pruned and the synchronous fallback turn run while a fresh host route re-registered, which could cause a turn to run underneath a live host loop instead of delivering the wake to the host.

### Description
- `WakeRoutes` keeps a `std::sync::Mutex` held only for map operations, plus a per-session in-flight *depth* for synchronous fallback turns.
- `deliver_or_claim` makes the route decision (deliver to a live host, or prune a dead one) **and** claims the fallback under that single lock, then releases it. The returned `Delivery` guard lives until the inner turn returns.
- `register` waits only while *its own* session has a claim outstanding, using a `Notify` armed before the state read so a turn finishing in the gap cannot leave it parked. No lock is held across an await, so there is no lock to re-enter and no deadlock to have — including for a turn that wakes its own session again, which increments the depth and proceeds.
- Removes the old `try_send` helper; the send/prune logic now lives in `deliver_or_claim`.

### Breaking change
`WakeRoutes::register` becomes `async` (`everruns::local`, feature-gated behind `local`). An embedder calling `routes.register(id)` must `.await` it. This is inherent to the guarantee — a reconnect that must wait for an in-flight turn has to be able to suspend. `unregister` and `live_sessions` stay synchronous. There are no in-repo callers of `WakeRoutes` outside this module.

### Testing
- `reconnect_waits_for_a_synchronous_turn_to_finish` — the original guarantee: a reconnect cannot become live while a synchronous turn for that session is running.
- `a_fallback_turn_only_holds_off_its_own_sessions_reconnect` — registration and delivery for a *second* session proceed while the first is parked mid-turn.
- `a_turn_that_wakes_its_own_session_again_does_not_deadlock` — a nested same-session wake completes rather than parking on itself.
- `cargo test -p everruns --features local --lib` — 92 passed, 0 failed.
- `cargo clippy -p everruns --features local --all-targets` clean; `cargo fmt --all -- --check` clean; migration ordering clean.

------
Originally opened from [Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8dddc0832b9c6be9afb6f3576d); reworked to the narrower per-session design after review.