### PR TITLE
fix(ci): include knowledge job in aggregate Build Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2119,6 +2119,7 @@ jobs:
       - format
       - lockfile
       - msrv
+      - knowledge
       - clippy
       - unit-test
       - worker-test


### PR DESCRIPTION
### Motivation
- The repository added a `knowledge` OKF validation job but the branch-protection aggregation job `ci-success` did not list it in `needs`, so knowledge-only failures could be ignored by the aggregate `Build Check`.

### Description
- Add `knowledge` to the `ci-success.needs` list in `.github/workflows/ci.yml` so OKF validation failures and cancellations are included in the aggregate Build Check.

### Testing
- Ran `git diff --check` and inspected the workflow diff to confirm the `knowledge` entry was added (passed).
- Executed a Ruby one-liner `ruby -e 'require "yaml"; jobs = YAML.load_file(".github/workflows/ci.yml", aliases: true).fetch("jobs"); abort "knowledge job missing" unless jobs.key?("knowledge"); abort "knowledge omitted from aggregate" unless jobs.fetch("ci-success").fetch("needs").include?("knowledge")'` to assert the job exists and is included in `ci-success.needs` (passed).
- Started `just pre-push` to exercise local CI checks; the targeted YAML assertion passed and the full workspace run began but was interrupted during the long Rust lint/build stage (no failing checks observed for the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8cac6c832b870665cc5f9e998b)