### PR TITLE
fix(models): preserve verbosity in merged profiles

### DIFF
--- a/crates/server/src/domains/models/service.rs
+++ b/crates/server/src/domains/models/service.rs
@@ -441,7 +441,7 @@ impl ModelService {
             modalities: hardcoded.modalities.or(discovered.modalities),
             reasoning_effort: hardcoded.reasoning_effort.or(discovered.reasoning_effort),
             speed: hardcoded.speed.or(discovered.speed),
-            verbosity: None,
+            verbosity: hardcoded.verbosity.or(discovered.verbosity),
             tool_search: hardcoded.tool_search,
             supported_parameters: if hardcoded.supported_parameters.is_empty() {
                 discovered.supported_parameters
@@ -708,6 +708,26 @@ mod tests {
 
         let merged = ModelService::merge_profiles(hardcoded, discovered);
         assert_eq!(merged.limits.unwrap().context, 128_000);
+    }
+
+    #[test]
+    fn merge_preserves_hardcoded_verbosity() {
+        use everruns_provider::model::{Verbosity, VerbosityConfig, VerbosityValue};
+
+        let hardcoded = ModelProfile {
+            verbosity: Some(VerbosityConfig {
+                values: vec![VerbosityValue {
+                    value: Verbosity::Medium,
+                    name: "Medium".into(),
+                }],
+                default: Verbosity::Medium,
+            }),
+            ..base_profile()
+        };
+
+        let merged = ModelService::merge_profiles(hardcoded, base_profile());
+
+        assert_eq!(merged.verbosity.unwrap().default, Verbosity::Medium);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Merging a hardcoded model profile with provider-discovered metadata was unconditionally dropping `verbosity`, which removed the UI verbosity control for models that advertise it in hardcoded profiles. 
- The merge logic is intended to let hardcoded values take precedence and discovered metadata fill gaps, so `verbosity` must be preserved from the hardcoded profile when present.

### Description

- Preserve verbosity in `merge_profiles` by setting `verbosity: hardcoded.verbosity.or(discovered.verbosity)` in `crates/server/src/domains/models/service.rs`. 
- Add a unit test `merge_preserves_hardcoded_verbosity` to assert that hardcoded `verbosity` survives the merge path. 
- No other merge semantics were changed; discovered values still fill gaps where the hardcoded profile omits a field.

### Testing

- Ran `cargo fmt --check`, which succeeded. 
- Ran the new unit test with `cargo test -p everruns-server merge_preserves_hardcoded_verbosity`, which passed. 
- Executed `just pre-push` checks; all applicable checks completed but the migration immutability check failed due to an unresolved `origin/main` reference in the checkout (CI-relevant environment issue), not related to the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88dc8ca4e4832bbf7cfb8544b923a3)