### PR TITLE
fix(ci): include live provider matrix in build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2124,6 +2124,7 @@ jobs:
       - worker-test
       - shell-test
       - integration-test
+      - live-provider-matrix
       - s3-integration-test
       - build-binaries
       - workflow-test

--- a/scripts/test-ci-provider-live-filter.sh
+++ b/scripts/test-ci-provider-live-filter.sh
@@ -78,6 +78,15 @@ if jobs[JOB].get("services"):
         "provider credentials, not infrastructure (EVE-938)"
     )
 
+# Build Check is the branch-protection aggregate. Keep the standalone live job
+# in its dependency set so a provider failure cannot produce a green aggregate.
+aggregate_needs = jobs.get("ci-success", {}).get("needs", [])
+if JOB not in aggregate_needs:
+    sys.exit(
+        f"{workflow}: `ci-success` does not need `{JOB}`, so Build Check cannot "
+        "report failures from the live provider matrix"
+    )
+
 
 def matches(pattern: str, path: str) -> bool:
     """Approximate micromatch: `**` crosses directories, `*` does not."""


### PR DESCRIPTION
## What changed
Build Check now waits for and aggregates the standalone Live Provider Matrix job. The provider-live workflow guard also asserts this dependency so future job splits cannot silently drop provider failures from the aggregate.

## Why
The live provider tests were moved out of the PostgreSQL integration job, but the new job was not added to `ci-success.needs`. Build Check could therefore report success without considering a failed or still-running provider matrix.

## Before / After
Before (negative regression proof): removing the dependency makes `scripts/test-ci-provider-live-filter.sh` exit 1 with:

```
.github/workflows/ci.yml: `ci-success` does not need `live-provider-matrix`, so Build Check cannot report failures from the live provider matrix
```

After:

```
provider_live covers all 11 provider-owning crates and gates live-provider-matrix
```

## Risk
- Low
- Build Check now remains pending until the push-only live provider matrix completes when that job is eligible. Existing skipped-job handling remains unchanged.

## Security
- Threat categories reviewed: TM-CI-001 and TM-CI-002.
- Findings and resolutions: The change only strengthens CI result aggregation. The push-only job condition and step-scoped Doppler credential boundary are unchanged; no new secret or PR-controlled execution surface is introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
