### PR TITLE
fix(provider): reject semantic model suffix fallbacks

### DIFF
--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -469,14 +469,16 @@ fn resolve_descriptor(
     for descriptor in REGISTRY {
         for alias in descriptor.ids {
             let alias = alias.as_bytes();
-            // Exact (case-insensitive) match, or an `"<alias>-"` prefix (which
-            // covers dated and `-latest` suffixes).
+            // Exact (case-insensitive) match, or a recognized version suffix.
+            // Do not treat semantic variants such as `o3-mini` as versions of
+            // a shorter registered model.
             let id_matches = if id.len() == alias.len() {
                 id.eq_ignore_ascii_case(alias)
             } else {
                 id.len() > alias.len()
                     && id[alias.len()] == b'-'
                     && id[..alias.len()].eq_ignore_ascii_case(alias)
+                    && is_version_suffix(&id[alias.len() + 1..])
             };
             if !id_matches {
                 continue;
@@ -499,6 +501,27 @@ fn resolve_descriptor(
         }
     }
     best_for_surface
+}
+
+fn is_version_suffix(suffix: &[u8]) -> bool {
+    suffix.eq_ignore_ascii_case(b"latest")
+        || (suffix.len() == 8 && suffix.iter().all(u8::is_ascii_digit))
+        || (suffix.len() == 5
+            && suffix[2] == b'-'
+            && suffix[..2].iter().all(u8::is_ascii_digit)
+            && suffix[3..].iter().all(u8::is_ascii_digit))
+        || (suffix.len() == 10
+            && suffix[4] == b'-'
+            && suffix[7] == b'-'
+            && suffix
+                .iter()
+                .enumerate()
+                .all(|(index, byte)| matches!(index, 4 | 7) || byte.is_ascii_digit()))
+        || (suffix.len() == 13
+            && suffix[..8].eq_ignore_ascii_case(b"preview-")
+            && suffix[10] == b'-'
+            && suffix[8..10].iter().all(u8::is_ascii_digit)
+            && suffix[11..].iter().all(u8::is_ascii_digit))
 }
 
 /// Get a model profile by matching provider_type and model_id.
@@ -3437,6 +3460,12 @@ mod tests {
     fn test_get_profile_unknown_model() {
         let profile = get_model_profile(&DriverId::OpenAI, "unknown-model");
         assert!(profile.is_none());
+    }
+
+    #[test]
+    fn test_retired_semantic_variants_do_not_resolve_to_parent_profiles() {
+        assert!(get_model_profile(&DriverId::OpenAI, "o3-mini").is_none());
+        assert!(get_model_profile(&DriverId::Anthropic, "claude-opus-4-1").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What changed
Model profile resolution now accepts only recognized version suffixes: `latest`, compact or hyphenated dates, month-day dates, and Gemini preview dates. Retired semantic variants such as `o3-mini` and `claude-opus-4-1` no longer inherit incompatible parent profiles.

## Why
The permissive `alias-*` matcher reclassified retired child models as versions of shorter retained aliases. That exposed incorrect capabilities, request controls, stable keys, and static pricing.

## Before / After
Before: `get_model_profile(OpenAI, "o3-mini")` returned the `o3` profile, and `get_model_profile(Anthropic, "claude-opus-4-1")` returned the `claude-opus-4` profile.

After: regression tests show both lookups return `None`, while the existing versioned OpenAI, Anthropic, and Gemini profile tests continue to pass.

## Risk
- Low
- A provider version suffix outside the recognized date/latest formats will no longer inherit a profile. Exact registered model IDs remain unchanged.

## Security
- Threat categories reviewed: TM-API, TM-LLM, TM-DOS
- Findings and resolutions: Restricted untrusted model identifier matching at the profile lookup boundary. The change adds bounded byte-slice checks only, introduces no allocation or external I/O, and prevents unsupported controls and incorrect static cost metadata from reaching provider and budget paths. No threat-model update is needed because this narrows an existing validation behavior rather than adding a new surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
