### PR TITLE
fix(tools): validate arguments and enable strict schemas

### DIFF
--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -25,7 +25,7 @@ use crate::{
     tool_context::ToolContext, tool_context::ToolContextService, tool_context::ToolContextServices,
 };
 
-use crate::error::Result;
+use crate::error::{AgentLoopError, Result};
 use crate::tool_execution::ToolExecutor;
 // EVE-888: `spawn_background`, its session-task mirroring, the background
 // event sink and the reattach path moved to `everruns-platform`
@@ -687,6 +687,39 @@ impl std::fmt::Debug for ToolRegistry {
     }
 }
 
+fn validate_tool_arguments(tool: &dyn Tool, tool_call: &ToolCall) -> Result<Option<String>> {
+    let arguments = tool_call.execution_arguments();
+    let definition = tool.to_definition();
+    let validator = jsonschema::validator_for(definition.parameters()).map_err(|error| {
+        AgentLoopError::config(format!(
+            "Tool '{}' has an invalid parameters schema: {error}",
+            tool_call.name
+        ))
+    })?;
+    let issues: Vec<_> = validator
+        .iter_errors(&arguments)
+        .map(|error| {
+            serde_json::json!({
+                "instance_path": error.instance_path().to_string(),
+                "message": error.to_string(),
+                "schema_path": error.schema_path().to_string(),
+            })
+        })
+        .collect();
+    if issues.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(
+        serde_json::json!({
+            "code": "invalid_tool_arguments",
+            "tool": tool_call.name,
+            "issues": issues,
+        })
+        .to_string(),
+    ))
+}
+
 #[async_trait]
 impl ToolExecutor for ToolRegistry {
     async fn execute(
@@ -698,7 +731,12 @@ impl ToolExecutor for ToolRegistry {
             crate::error::AgentLoopError::tool(format!("Tool not found: {}", tool_call.name))
         })?;
 
-        let result = tool.execute(tool_call.arguments.clone()).await;
+        if let Some(error) = validate_tool_arguments(tool.as_ref(), tool_call)? {
+            return Ok(ToolExecutionResult::tool_error(error)
+                .into_tool_result(&tool_call.id, &tool_call.name));
+        }
+
+        let result = tool.execute(tool_call.execution_arguments()).await;
         Ok(result.into_tool_result(&tool_call.id, &tool_call.name))
     }
 
@@ -712,10 +750,14 @@ impl ToolExecutor for ToolRegistry {
             crate::error::AgentLoopError::tool(format!("Tool not found: {}", tool_call.name))
         })?;
 
-        // Use execute_with_context for all tools - context-aware tools will use it,
-        // regular tools will delegate to execute() via the default implementation
+        if let Some(error) = validate_tool_arguments(tool.as_ref(), tool_call)? {
+            return Ok(ToolExecutionResult::tool_error(error)
+                .into_tool_result(&tool_call.id, &tool_call.name));
+        }
+
+        // Context-aware tools use the supplied context; regular tools delegate to execute().
         let result = tool
-            .execute_with_context(tool_call.arguments.clone(), context)
+            .execute_with_context(tool_call.execution_arguments(), context)
             .await;
         Ok(result.into_tool_result(&tool_call.id, &tool_call.name))
     }
@@ -1153,6 +1195,100 @@ mod tests {
                 def.name()
             );
         }
+    }
+
+    fn invalid_arguments_error(result: ToolResult) -> serde_json::Value {
+        let message = result.error.expect("expected tool error");
+        serde_json::from_str(&message).expect("tool error should be valid JSON")
+    }
+
+    #[tokio::test]
+    async fn test_tool_registry_rejects_missing_required_argument() {
+        let mut registry = ToolRegistry::new();
+        registry.register(EchoTool);
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "echo".to_string(),
+            arguments: serde_json::json!({}),
+        };
+        let tool_def = registry.get("echo").unwrap().to_definition();
+
+        let error = invalid_arguments_error(registry.execute(&tool_call, &tool_def).await.unwrap());
+
+        assert_eq!(error["code"], "invalid_tool_arguments");
+        assert_eq!(error["tool"], "echo");
+        assert_eq!(error["issues"][0]["instance_path"], "");
+        assert!(
+            error["issues"][0]["message"]
+                .as_str()
+                .unwrap()
+                .contains("required")
+        );
+        assert!(
+            error["issues"][0]["schema_path"]
+                .as_str()
+                .unwrap()
+                .contains("required")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_registry_rejects_wrong_argument_type() {
+        let mut registry = ToolRegistry::new();
+        registry.register(EchoTool);
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "echo".to_string(),
+            arguments: serde_json::json!({"message": 42}),
+        };
+        let tool_def = registry.get("echo").unwrap().to_definition();
+
+        let error = invalid_arguments_error(registry.execute(&tool_call, &tool_def).await.unwrap());
+
+        assert_eq!(error["code"], "invalid_tool_arguments");
+        assert_eq!(error["tool"], "echo");
+        assert_eq!(error["issues"][0]["instance_path"], "/message");
+        assert!(
+            error["issues"][0]["message"]
+                .as_str()
+                .unwrap()
+                .contains("string")
+        );
+        assert!(
+            error["issues"][0]["schema_path"]
+                .as_str()
+                .unwrap()
+                .contains("type")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_registry_rejects_unknown_argument() {
+        let mut registry = ToolRegistry::new();
+        registry.register(EchoTool);
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "echo".to_string(),
+            arguments: serde_json::json!({"message": "test", "unexpected": true}),
+        };
+        let tool_def = registry.get("echo").unwrap().to_definition();
+
+        let error = invalid_arguments_error(registry.execute(&tool_call, &tool_def).await.unwrap());
+
+        assert_eq!(error["code"], "invalid_tool_arguments");
+        assert_eq!(error["tool"], "echo");
+        assert!(
+            error["issues"][0]["message"]
+                .as_str()
+                .unwrap()
+                .contains("unexpected")
+        );
+        assert!(
+            error["issues"][0]["schema_path"]
+                .as_str()
+                .unwrap()
+                .contains("additionalProperties")
+        );
     }
 
     #[tokio::test]

--- a/crates/provider/src/openai_protocol.rs
+++ b/crates/provider/src/openai_protocol.rs
@@ -356,15 +356,23 @@ impl OpenAIProtocolChatDriver {
     fn convert_tools(tools: &[ToolDefinition]) -> Vec<OpenAiTool> {
         tools
             .iter()
-            .map(|tool| OpenAiTool {
-                r#type: "function".to_string(),
-                function: OpenAiFunction {
-                    name: tool.name().to_string(),
-                    description: tool.description().to_string(),
-                    parameters: crate::tool_schema_compat::sanitize_openai_tool_schema(
-                        tool.parameters(),
-                    ),
-                },
+            .map(|tool| {
+                let strict_parameters =
+                    crate::tool_schema_compat::strict_openai_tool_schema(tool.parameters());
+                let strict = strict_parameters.is_some().then_some(true);
+                OpenAiTool {
+                    r#type: "function".to_string(),
+                    function: OpenAiFunction {
+                        name: tool.name().to_string(),
+                        description: tool.description().to_string(),
+                        parameters: strict_parameters.unwrap_or_else(|| {
+                            crate::tool_schema_compat::sanitize_openai_tool_schema(
+                                tool.parameters(),
+                            )
+                        }),
+                        strict,
+                    },
+                }
             })
             .collect()
     }
@@ -873,6 +881,8 @@ struct OpenAiFunction {
     name: String,
     description: String,
     parameters: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    strict: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1924,5 +1934,43 @@ mod tests {
         ];
         let filtered = drop_orphaned_tool_messages(&messages);
         assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn function_tools_serialize_strict_only_for_compatible_schemas() {
+        use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolHints, ToolPolicy};
+        let make_tool = |parameters| {
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "lookup".into(),
+                display_name: None,
+                description: "Lookup".into(),
+                parameters,
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::Never,
+                hints: ToolHints::default(),
+                full_parameters: None,
+            })
+        };
+        let compatible = OpenAIProtocolChatDriver::convert_tools(&[make_tool(json!({
+            "type": "object", "properties": {"query": {"type": "string"}}
+        }))]);
+        let serialized = serde_json::to_value(&compatible[0]).unwrap();
+        assert_eq!(serialized["function"]["strict"], true);
+        assert_eq!(
+            serialized["function"]["parameters"]["required"],
+            json!(["query"])
+        );
+        assert_eq!(
+            serialized["function"]["parameters"]["properties"]["query"]["type"],
+            json!(["string", "null"])
+        );
+
+        let incompatible = OpenAIProtocolChatDriver::convert_tools(&[make_tool(json!({
+            "type": "object", "allOf": [{"type": "object"}]
+        }))]);
+        let serialized = serde_json::to_value(&incompatible[0]).unwrap();
+        assert!(serialized["function"].get("strict").is_none());
+        assert!(serialized["function"]["parameters"].get("allOf").is_some());
     }
 }

--- a/crates/provider/src/openresponses_protocol.rs
+++ b/crates/provider/src/openresponses_protocol.rs
@@ -457,14 +457,23 @@ impl OpenResponsesProtocolChatDriver {
     fn convert_tools(tools: &[ToolDefinition]) -> Vec<ResponsesTool> {
         tools
             .iter()
-            .map(|tool| ResponsesTool::Function {
-                r#type: "function".to_string(),
-                name: tool.name().to_string(),
-                description: tool.description().to_string(),
-                parameters: Self::sanitize_parameters(tool.parameters()),
-                defer_loading: None,
-            })
+            .map(|tool| Self::function_tool(tool, None))
             .collect()
+    }
+
+    fn function_tool(tool: &ToolDefinition, defer_loading: Option<bool>) -> ResponsesTool {
+        let strict_parameters =
+            crate::tool_schema_compat::strict_openai_tool_schema(tool.parameters());
+        ResponsesTool::Function {
+            r#type: "function".to_string(),
+            name: tool.name().to_string(),
+            description: tool.description().to_string(),
+            parameters: strict_parameters
+                .clone()
+                .unwrap_or_else(|| Self::sanitize_parameters(tool.parameters())),
+            strict: strict_parameters.as_ref().map(|_| true),
+            defer_loading,
+        }
     }
 
     /// Convert tools with tool_search support: groups tools into namespaces,
@@ -488,13 +497,7 @@ impl OpenResponsesProtocolChatDriver {
                 DeferrablePolicy::Automatic | DeferrablePolicy::Always => true,
             };
 
-            let func = ResponsesTool::Function {
-                r#type: "function".to_string(),
-                name: tool.name().to_string(),
-                description: tool.description().to_string(),
-                parameters: Self::sanitize_parameters(tool.parameters()),
-                defer_loading: if should_defer { Some(true) } else { None },
-            };
+            let func = Self::function_tool(tool, if should_defer { Some(true) } else { None });
 
             if !should_defer {
                 never_defer.push(func);
@@ -2075,6 +2078,8 @@ enum ResponsesTool {
         description: String,
         parameters: Value,
         #[serde(skip_serializing_if = "Option::is_none")]
+        strict: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         defer_loading: Option<bool>,
     },
     /// Namespace grouping for tool_search (groups related deferred tools)
@@ -2563,6 +2568,7 @@ mod tests {
                 },
                 "required": ["location"]
             }),
+            strict: Some(true),
             defer_loading: None,
         };
 
@@ -3834,7 +3840,16 @@ mod tests {
         assert_eq!(tool["type"], "function");
         assert_eq!(tool["name"], "get_current_time");
         assert_eq!(tool["parameters"]["type"], "object");
-        assert_eq!(tool["parameters"]["required"], json!(["timezone"]));
+        assert_eq!(tool["strict"], true);
+        assert_eq!(
+            tool["parameters"]["required"],
+            json!(["format", "timezone"])
+        );
+        assert_eq!(
+            tool["parameters"]["properties"]["format"]["type"],
+            json!(["string", "null"])
+        );
+        assert_eq!(tool["parameters"]["additionalProperties"], false);
     }
 
     // ========================================================================
@@ -5056,6 +5071,7 @@ mod tests {
                 name: "read_file".to_string(),
                 description: "Read a file".to_string(),
                 parameters: json!({}),
+                strict: None,
                 defer_loading: Some(true),
             }],
         };
@@ -5556,5 +5572,40 @@ mod tests {
             2,
             "refreshable auth must be resolved per HTTP attempt, including retries"
         );
+    }
+
+    #[test]
+    fn function_tools_serialize_strict_only_for_compatible_schemas() {
+        let mut compatible = make_tool("lookup", None, crate::tool_types::DeferrablePolicy::Never);
+        match &mut compatible {
+            ToolDefinition::Builtin(tool) => {
+                tool.parameters = json!({
+                    "type": "object", "properties": {"query": {"type": "string"}}
+                })
+            }
+            ToolDefinition::ClientSide(_) => unreachable!(),
+        }
+        let serialized =
+            serde_json::to_value(&OpenResponsesProtocolChatDriver::convert_tools(&[compatible])[0])
+                .unwrap();
+        assert_eq!(serialized["strict"], true);
+        assert_eq!(serialized["parameters"]["required"], json!(["query"]));
+
+        let mut incompatible =
+            make_tool("lookup", None, crate::tool_types::DeferrablePolicy::Never);
+        match &mut incompatible {
+            ToolDefinition::Builtin(tool) => {
+                tool.parameters = json!({
+                    "type": "object", "allOf": [{"type": "object"}]
+                })
+            }
+            ToolDefinition::ClientSide(_) => unreachable!(),
+        }
+        let serialized = serde_json::to_value(
+            &OpenResponsesProtocolChatDriver::convert_tools(&[incompatible])[0],
+        )
+        .unwrap();
+        assert!(serialized.get("strict").is_none());
+        assert!(serialized["parameters"].get("allOf").is_some());
     }
 }

--- a/crates/provider/src/tool_schema_compat.rs
+++ b/crates/provider/src/tool_schema_compat.rs
@@ -18,6 +18,159 @@ pub fn sanitize_openai_tool_schema(schema: &Value) -> Value {
     sanitized
 }
 
+/// Normalize a tool schema for OpenAI strict structured outputs.
+///
+/// Returns `None` when the schema uses constructs whose object shape cannot be
+/// closed without risking a semantic change. Callers must then use the
+/// sanitized non-strict schema instead.
+pub fn strict_openai_tool_schema(schema: &Value) -> Option<Value> {
+    let mut normalized = sanitize_openai_tool_schema(schema);
+    if normalized.get("type").and_then(Value::as_str) != Some("object") {
+        return None;
+    }
+    normalize_strict_node(&mut normalized)?;
+    Some(normalized)
+}
+
+fn normalize_strict_node(node: &mut Value) -> Option<()> {
+    let object = node.as_object_mut()?;
+
+    // Strict structured outputs support only a JSON Schema subset. Decline
+    // unknown keywords rather than sending a request the provider may reject.
+    if object.keys().any(|key| {
+        !matches!(
+            key.as_str(),
+            "type"
+                | "properties"
+                | "required"
+                | "additionalProperties"
+                | "items"
+                | "enum"
+                | "anyOf"
+                | "description"
+                | "title"
+        )
+    }) {
+        return None;
+    }
+
+    if let Some(any_of) = object.get_mut("anyOf") {
+        let variants = any_of.as_array_mut()?;
+        if variants.is_empty() {
+            return None;
+        }
+        for variant in variants {
+            normalize_strict_node(variant)?;
+        }
+    }
+
+    let schema_type = object.get("type").cloned();
+    let types = match schema_type.as_ref() {
+        Some(Value::String(value)) => vec![value.as_str()],
+        Some(Value::Array(values)) if !values.is_empty() => values
+            .iter()
+            .map(Value::as_str)
+            .collect::<Option<Vec<_>>>()?,
+        None if object.contains_key("anyOf") || object.contains_key("enum") => Vec::new(),
+        _ => return None,
+    };
+
+    let is_object = types.contains(&"object");
+    let is_array = types.contains(&"array");
+    if (object.contains_key("properties") || object.contains_key("required")) && !is_object {
+        return None;
+    }
+    if object.contains_key("items") && !is_array {
+        return None;
+    }
+
+    if is_object {
+        // A union containing object and another non-null type has no unambiguous
+        // place for object-only strict constraints.
+        if types
+            .iter()
+            .any(|value| *value != "object" && *value != "null")
+        {
+            return None;
+        }
+        let originally_required: std::collections::HashSet<String> = object
+            .get("required")
+            .map(|required| required.as_array().map(Vec::as_slice))
+            .unwrap_or(Some(&[]))?
+            .iter()
+            .map(|value| value.as_str().map(str::to_owned))
+            .collect::<Option<_>>()?;
+        let property_names = {
+            let properties = object
+                .entry("properties")
+                .or_insert_with(|| Value::Object(serde_json::Map::new()))
+                .as_object_mut()?;
+            if originally_required
+                .iter()
+                .any(|name| !properties.contains_key(name))
+            {
+                return None;
+            }
+
+            for (name, property) in properties.iter_mut() {
+                normalize_strict_node(property)?;
+                if !originally_required.contains(name) {
+                    make_nullable(property)?;
+                }
+            }
+            properties.keys().cloned().map(Value::String).collect()
+        };
+        object.insert("required".to_string(), Value::Array(property_names));
+        object.insert("additionalProperties".to_string(), Value::Bool(false));
+    }
+
+    if is_array {
+        if types
+            .iter()
+            .any(|value| *value != "array" && *value != "null")
+        {
+            return None;
+        }
+        normalize_strict_node(object.get_mut("items")?)?;
+    }
+
+    Some(())
+}
+
+fn make_nullable(schema: &mut Value) -> Option<()> {
+    let object = schema.as_object_mut()?;
+    if let Some(schema_type) = object.get_mut("type") {
+        match schema_type {
+            Value::String(value) if value != "null" => {
+                *schema_type = Value::Array(vec![
+                    Value::String(value.clone()),
+                    Value::String("null".into()),
+                ]);
+            }
+            Value::String(_) => {}
+            Value::Array(types) => {
+                if !types.iter().all(Value::is_string) {
+                    return None;
+                }
+                if !types.iter().any(|value| value.as_str() == Some("null")) {
+                    types.push(Value::String("null".into()));
+                }
+            }
+            _ => return None,
+        }
+        return Some(());
+    }
+
+    let variants = object.get_mut("anyOf")?.as_array_mut()?;
+    if !variants
+        .iter()
+        .any(|variant| variant.get("type").and_then(Value::as_str) == Some("null"))
+    {
+        variants.push(serde_json::json!({"type": "null"}));
+    }
+    Some(())
+}
+
 fn sanitize_node(node: &mut Value) {
     match node {
         Value::Object(object) => {
@@ -154,6 +307,74 @@ mod tests {
         assert_eq!(
             sanitized["items"]["description"],
             "Tenant-scoped identifier. Validation for this value is enforced by the tool."
+        );
+    }
+}
+
+#[cfg(test)]
+mod strict_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn strict_schema_closes_nested_objects_and_makes_optional_fields_nullable() {
+        let normalized = strict_openai_tool_schema(&json!({
+            "type": "object",
+            "properties": {
+                "fixed": {"type": "string"},
+                "nested": {
+                    "type": "object",
+                    "properties": {"value": {"type": "integer"}},
+                    "required": ["value"]
+                },
+                "list": {"type": "array", "items": {
+                    "type": "object", "properties": {"flag": {"type": "boolean"}}
+                }}
+            },
+            "required": ["fixed"]
+        }))
+        .unwrap();
+
+        assert_eq!(normalized["required"], json!(["fixed", "list", "nested"]));
+        assert_eq!(normalized["additionalProperties"], false);
+        assert_eq!(normalized["properties"]["fixed"]["type"], "string");
+        assert_eq!(
+            normalized["properties"]["nested"]["type"],
+            json!(["object", "null"])
+        );
+        assert_eq!(
+            normalized["properties"]["nested"]["additionalProperties"],
+            false
+        );
+        assert_eq!(
+            normalized["properties"]["nested"]["properties"]["value"]["type"],
+            "integer"
+        );
+        assert_eq!(
+            normalized["properties"]["list"]["items"]["additionalProperties"],
+            false
+        );
+        assert_eq!(
+            normalized["properties"]["list"]["items"]["properties"]["flag"]["type"],
+            json!(["boolean", "null"])
+        );
+    }
+
+    #[test]
+    fn strict_schema_declines_ambiguous_composition() {
+        assert!(
+            strict_openai_tool_schema(&json!({
+                "type": "object",
+                "allOf": [{"type": "object", "properties": {"value": {"type": "string"}}}]
+            }))
+            .is_none()
+        );
+        assert!(
+            strict_openai_tool_schema(&json!({
+                "type": "object",
+                "properties": {"value": {"type": "string", "pattern": "^[a-z]+$"}}
+            }))
+            .is_none()
         );
     }
 }


### PR DESCRIPTION
## What

- validate every tool invocation against its registered JSON Schema before execution
- return structured, model-visible validation failures for corrective turns
- enable strict tool schemas for compatible OpenAI Chat and OpenResponses tools
- safely fall back to sanitized non-strict schemas when strict conversion is unsupported

## Why

Malformed, missing, wrong-type, and unknown tool arguments could previously reach individual tool implementations without an authoritative shared validation boundary. Provider requests also did not opt into strict structured tool outputs.

## How

- validate original tool schemas in `ToolRegistry` immediately before normal or context-aware execution
- preserve `tool_call_repair` as the pre-execution repair and reprompt layer
- normalize provider schemas recursively for strict mode, including closed objects and nullable-required optional properties
- omit `strict` for unsupported or ambiguous schemas rather than failing provider requests

## Risk

- Medium
- Strict schema normalization changes provider-facing schemas for compatible tools, while local validation continues to use the original schema
- Incompatible schemas retain the existing non-strict behavior

## Security

- Reviewed tool-boundary validation, untrusted model arguments, error disclosure, malformed registered schemas, provider schema compatibility, and recursive schema traversal
- Invalid model arguments become bounded structured tool errors; malformed registered schemas remain configuration failures
- No new secrets, network access, execution paths, or dependencies

## Validation

- `cargo test -p everruns-core --lib` — 1,059 passed
- `cargo test -p everruns-provider --lib` — 477 passed
- `cargo test -p everruns-provider strict --lib` — 8 passed
- `cargo test -p everruns-engine tool_call --lib` — 17 passed
- `cargo clippy -p everruns-core -p everruns-provider --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

`just pre-push` also passed formatting, migration, knowledge, architecture, and attribution checks. Its shared-target clippy wrapper reported a failure without diagnostics, while the equivalent targeted all-targets/all-features clippy command above passed. The published-doc check used a Python runtime without `tomllib`.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
