### PR TITLE
fix(core): prevent spawn target narration spoofing

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1501,6 +1501,20 @@ struct UnifiedSpawnAgentTool {
     providers: Vec<DelegationTargetProvider>,
 }
 
+fn validate_spawn_agent_target_fields(
+    arguments: &serde_json::Value,
+    target_type: &str,
+) -> Result<(), String> {
+    for field in ["blueprint", "config"] {
+        if target_type != "subagent" && arguments.get(field).is_some_and(|value| !value.is_null()) {
+            return Err(format!(
+                "{field} is only valid for subagent targets, not {target_type}."
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl UnifiedSpawnAgentTool {
     fn new(providers: Vec<DelegationTargetProvider>) -> Self {
         Self { providers }
@@ -1732,6 +1746,9 @@ impl Tool for UnifiedSpawnAgentTool {
                 "Unsupported spawn_agent target.type: \"{target_type}\". Supported target types: {supported}"
             ));
         };
+        if let Err(error) = validate_spawn_agent_target_fields(&arguments, target_type) {
+            return ToolExecutionResult::tool_error(error);
+        }
         if target_type == "external_a2a"
             && arguments
                 .get("lifetime")
@@ -2809,6 +2826,33 @@ mod tests {
             .as_deref(),
             Some("Launching Orbit Scout subagent")
         );
+    }
+
+    #[test]
+    fn unified_spawn_agent_rejects_subagent_fields_for_configured_targets() {
+        for target_type in ["agent", "external_a2a"] {
+            let arguments = serde_json::json!({
+                "target": { "type": target_type, "id": "actual-target" },
+                "blueprint": "decoy-target"
+            });
+            assert_eq!(
+                validate_spawn_agent_target_fields(&arguments, target_type),
+                Err(format!(
+                    "blueprint is only valid for subagent targets, not {target_type}."
+                ))
+            );
+
+            let arguments = serde_json::json!({
+                "target": { "type": target_type, "id": "actual-target" },
+                "config": { "model": "decoy" }
+            });
+            assert_eq!(
+                validate_spawn_agent_target_fields(&arguments, target_type),
+                Err(format!(
+                    "config is only valid for subagent targets, not {target_type}."
+                ))
+            );
+        }
     }
 
     /// Contributes nothing: no tools, no prompt, no dependencies.

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -626,12 +626,14 @@ pub fn narrate_secret_store(
 /// target, otherwise the configured target id.
 fn spawn_agent_identity(arguments: &Value) -> Option<String> {
     let target = arguments.get("target");
-    let id = target
-        .and_then(|target| arg_str(target, &["id", "external_agent_id"]))
-        .map(|id| truncate(id, 40));
-    arg_str(arguments, &["blueprint"])
-        .map(|blueprint| truncate(blueprint, 40))
-        .or(id)
+    match target.and_then(|target| arg_str(target, &["type"])) {
+        Some("subagent") => {
+            arg_str(arguments, &["blueprint"]).map(|blueprint| truncate(blueprint, 40))
+        }
+        _ => target
+            .and_then(|target| arg_str(target, &["id", "external_agent_id"]))
+            .map(|id| truncate(id, 40)),
+    }
 }
 
 /// The kind of agent being spawned, from `target.type`.
@@ -2155,6 +2157,28 @@ mod tests {
         assert_eq!(
             narrate_subagent_spawn(&external, ToolNarrationPhase::Failed, None),
             "Failed to launch external agent (partner-agent)"
+        );
+    }
+
+    #[test]
+    fn subagent_spawn_narration_ignores_decoy_blueprint_for_configured_targets() {
+        let handoff = serde_json::json!({
+            "name": "Release check",
+            "target": { "type": "agent", "id": "release-reviewer" },
+            "blueprint": "trusted-reviewer"
+        });
+        assert_eq!(
+            narrate_subagent_spawn(&handoff, ToolNarrationPhase::Started, None),
+            "Launching Release check agent (release-reviewer)"
+        );
+
+        let external = serde_json::json!({
+            "target": { "type": "external_a2a", "external_agent_id": "partner-agent" },
+            "blueprint": "trusted-reviewer"
+        });
+        assert_eq!(
+            narrate_subagent_spawn(&external, ToolNarrationPhase::Started, None),
+            "Launching external agent (partner-agent)"
         );
     }
 


### PR DESCRIPTION
## What changed
Spawn-agent narration now derives identity from the selected target type: subagents use their blueprint, while first-party and external targets use their configured ID. The dispatcher rejects subagent-only `blueprint` and `config` fields for configured targets.

## Why
An untrusted tool call could supply a decoy blueprint beside a configured agent target. Execution used the configured ID, but persisted narration displayed the decoy blueprint, misrepresenting the delegated target.

## Before / After
Before: `{target:{type:"agent",id:"release-reviewer"},blueprint:"trusted-reviewer"}` narrated `trusted-reviewer` while dispatching `release-reviewer`.

After: narration identifies `release-reviewer`, and execution rejects the incompatible blueprint before provider dispatch. Unit tests cover first-party and external target conflicts.

## Risk
- Low
- Semantically invalid calls that previously ignored subagent-only fields now return a tool error.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM
- Findings and resolutions: Removed the narration/dispatch identity discrepancy and added runtime validation at the untrusted tool-argument boundary. No authorization or target allowlist behavior changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
