### PR TITLE
fix(engine): guard retained reasoning output

### DIFF
--- a/crates/engine/src/execution/reason.rs
+++ b/crates/engine/src/execution/reason.rs
@@ -78,13 +78,40 @@ use output_hooks::collect_output_hooks;
 use request_controls::resolve_request_controls;
 use stream_state::{
     StreamReplayState, StreamTermination, advances_stall_deadline, append_guarded_thinking_delta,
-    merge_retry_metadata,
+    inspect_guarded_reasoning_item, merge_retry_metadata,
 };
 use transcript::repair_dangling_tool_calls;
 
 // ============================================================================
 // Helper Functions
 // ============================================================================
+
+fn client_visible_guardrail_text(
+    text: &str,
+    streamed_reasoning: &str,
+    reasoning: &[ReasoningContentPart],
+    citation_annotations: &[crate::message::TextAnnotation],
+) -> String {
+    let mut guarded = streamed_reasoning.to_string();
+    if guarded.is_empty() {
+        for item_text in reasoning
+            .iter()
+            .filter_map(ReasoningContentPart::display_text)
+        {
+            if !guarded.is_empty() {
+                guarded.push_str("\n\n");
+            }
+            guarded.push_str(&item_text);
+        }
+    }
+
+    let prose = post_generation_guardrail_text(text, citation_annotations);
+    if !guarded.is_empty() && !prose.is_empty() {
+        guarded.push_str("\n\n");
+    }
+    guarded.push_str(&prose);
+    guarded
+}
 
 /// Apply capability-owned transforms to the finalized model tool-call batch.
 /// The reason atom owns timing and context; each implementation owns its policy.
@@ -1294,10 +1321,6 @@ impl ReasonAtom {
             pending_delta,
             mut tripped,
         ) = 'stream_attempt: loop {
-            // Provider id for reasoning artifacts synthesized after the stream.
-            // Model name for reasoning events emitted from inside the stream,
-            // where `model_with_provider` is no longer borrowable.
-            let stream_model_name = llm_config.model.clone();
             let stream_result = if let Some(remaining) =
                 remaining_retry_time(&retry_config, retry_started_at)
             {
@@ -1660,6 +1683,20 @@ impl ReasonAtom {
                         }
                     }
                     LlmStreamEvent::ReasoningItem(item) => {
+                        if let Some(t) = inspect_guarded_reasoning_item(
+                            &mut armed_guardrails,
+                            &mut thinking,
+                            &item,
+                        ) {
+                            tracing::warn!(
+                                session_id = %session_id,
+                                guardrail_capability_id = %t.capability_id,
+                                guardrail_id = %t.guardrail_id,
+                                "ReasonAtom: output guardrail tripped on completed reasoning item, replacing assistant message"
+                            );
+                            termination = StreamTermination::GuardrailBlocked(t);
+                            break;
+                        }
                         // One durable artifact per provider block, appended in
                         // order. Replay walks these; nothing is collapsed into
                         // a single per-message slot.
@@ -1671,37 +1708,6 @@ impl ReasonAtom {
                             has_encrypted = item.encrypted.is_some(),
                             "ReasonAtom: captured reasoning artifact"
                         );
-                        if let Err(e) = self
-                            .event_emitter
-                            .emit(EventRequest::new(
-                                session_id,
-                                streaming_event_context.clone(),
-                                ReasonItemData {
-                                    turn_id: context.turn_id,
-                                    provider: item.provider.clone(),
-                                    model: Some(stream_model_name.clone()),
-                                    // Opaque payloads are replay state, never
-                                    // event data: `reason.item` carries
-                                    // identity and safe summary only.
-                                    item_id: item.item_id.clone().unwrap_or_default(),
-                                    summary: item
-                                        .display_text()
-                                        .filter(|_| {
-                                            !matches!(item.text, Some(ReasoningText::Plain { .. }))
-                                        })
-                                        .into_iter()
-                                        .collect(),
-                                    token_count: item.tokens,
-                                },
-                            ))
-                            .await
-                        {
-                            tracing::warn!(
-                                session_id = %session_id,
-                                error = %e,
-                                "ReasonAtom: failed to emit reason.item event"
-                            );
-                        }
                         reasoning.push(item);
                     }
                     LlmStreamEvent::ToolCalls(calls) => {
@@ -1953,7 +1959,12 @@ impl ReasonAtom {
             // Post-generation guardrails must inspect citation metadata as well
             // as prose because annotations are persisted and rendered to clients.
             if !citation_annotations.is_empty() && !post_output_providers.is_empty() {
-                let guarded_output = post_generation_guardrail_text(&text, &citation_annotations);
+                let guarded_output = client_visible_guardrail_text(
+                    &text,
+                    &thinking,
+                    &reasoning,
+                    &citation_annotations,
+                );
                 let ctx = PostGenerationOutputContext {
                     system_prompt: &runtime_agent.system_prompt,
                     message_text: &guarded_output,
@@ -1983,11 +1994,12 @@ impl ReasonAtom {
         if tripped.is_none()
             && citation_annotations.is_empty()
             && !post_output_providers.is_empty()
-            && !text.is_empty()
+            && (!text.is_empty() || !thinking.is_empty() || !reasoning.is_empty())
         {
+            let guarded_output = client_visible_guardrail_text(&text, &thinking, &reasoning, &[]);
             let ctx = PostGenerationOutputContext {
                 system_prompt: &runtime_agent.system_prompt,
-                message_text: &text,
+                message_text: &guarded_output,
                 utility_llm_service: self.utility_llm_service.as_ref(),
             };
             tripped = evaluate_post_generation_guardrails(&post_output_providers, &ctx).await;
@@ -1995,6 +2007,40 @@ impl ReasonAtom {
 
         if tripped.is_some() {
             citation_annotations.clear();
+        }
+
+        // Completed reasoning metadata is withheld until every output
+        // guardrail has allowed the message. Otherwise a summary could escape
+        // through `reason.item` before a later assistant-text block trips.
+        if tripped.is_none() {
+            for item in &reasoning {
+                if let Err(e) = self
+                    .event_emitter
+                    .emit(EventRequest::new(
+                        session_id,
+                        streaming_event_context.clone(),
+                        ReasonItemData {
+                            turn_id: context.turn_id,
+                            provider: item.provider.clone(),
+                            model: Some(llm_config.model.clone()),
+                            item_id: item.item_id.clone().unwrap_or_default(),
+                            summary: item
+                                .display_text()
+                                .filter(|_| !matches!(item.text, Some(ReasoningText::Plain { .. })))
+                                .into_iter()
+                                .collect(),
+                            token_count: item.tokens,
+                        },
+                    ))
+                    .await
+                {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %e,
+                        "ReasonAtom: failed to emit reason.item event"
+                    );
+                }
+            }
         }
 
         // Release buffered text only after post-generation guardrails allow it.
@@ -2060,6 +2106,7 @@ impl ReasonAtom {
             text = t.block.replacement.clone();
             tool_calls.clear();
             thinking.clear();
+            reasoning.clear();
         }
 
         // Finalized tool-call policy seam. This is the smallest provider-neutral

--- a/crates/engine/src/execution/reason/stream_state.rs
+++ b/crates/engine/src/execution/reason/stream_state.rs
@@ -1,6 +1,7 @@
 use crate::driver_registry::{LlmCompletionMetadata, LlmStreamError, LlmStreamEvent};
 use crate::llm_retry::{RetryMetadata, is_transient_stream_error};
 use crate::output_guardrail::{ArmedGuardrail, TrippedGuardrail, evaluate_guardrails};
+use everruns_provider::reasoning::ReasoningContentPart;
 
 /// Whether replaying the current provider attempt can duplicate externally
 /// visible output or tool side effects.
@@ -116,6 +117,25 @@ pub(super) fn append_guarded_thinking_delta(
         pending_thinking_delta.push_str(delta);
         None
     }
+}
+
+/// Inspect readable completed reasoning without feeding a provider's streamed
+/// copy through stateful guardrails twice.
+pub(super) fn inspect_guarded_reasoning_item(
+    armed_guardrails: &mut [ArmedGuardrail],
+    inspected_reasoning: &mut String,
+    item: &ReasoningContentPart,
+) -> Option<TrippedGuardrail> {
+    let display_text = item.display_text()?;
+
+    // Anthropic emits the completed signed block after streaming the same text
+    // as deltas. Gemini signed thoughts arrive only as completed items.
+    if inspected_reasoning.ends_with(&display_text) {
+        return None;
+    }
+
+    inspected_reasoning.push_str(&display_text);
+    evaluate_guardrails(armed_guardrails, inspected_reasoning, &display_text)
 }
 
 #[cfg(test)]

--- a/crates/engine/src/execution/reason/tests.rs
+++ b/crates/engine/src/execution/reason/tests.rs
@@ -86,6 +86,50 @@ fn test_append_guarded_thinking_delta_allows_safe_pending_emit() {
 }
 
 #[test]
+fn test_completed_reasoning_item_is_guarded() {
+    let mut guardrails = vec![test_armed_guardrail()];
+    let mut inspected = String::new();
+    let item = ReasoningContentPart::opaque("google")
+        .with_signature("signed")
+        .with_text(ReasoningText::Plain {
+            text: "secret instructions".to_string(),
+        });
+
+    let tripped = inspect_guarded_reasoning_item(&mut guardrails, &mut inspected, &item)
+        .expect("completed reasoning should trip guardrail");
+
+    assert_eq!(tripped.block.reason_code, "test_leak");
+    assert_eq!(inspected, "secret instructions");
+}
+
+#[test]
+fn test_completed_reasoning_item_is_not_double_counted_after_deltas() {
+    let mut guardrails = vec![test_armed_guardrail()];
+    let mut inspected = "already streamed".to_string();
+    let item = ReasoningContentPart::opaque("anthropic").with_text(ReasoningText::Plain {
+        text: "already streamed".to_string(),
+    });
+
+    assert!(inspect_guarded_reasoning_item(&mut guardrails, &mut inspected, &item).is_none());
+    assert_eq!(inspected, "already streamed");
+}
+
+#[test]
+fn test_post_generation_guardrail_text_includes_reasoning_and_prose() {
+    let reasoning =
+        vec![
+            ReasoningContentPart::opaque("google").with_text(ReasoningText::Summary {
+                parts: vec!["reasoning canary".to_string()],
+            }),
+        ];
+
+    let guarded = client_visible_guardrail_text("answer", "", &reasoning, &[]);
+
+    assert!(guarded.contains("reasoning canary"));
+    assert!(guarded.contains("answer"));
+}
+
+#[test]
 fn test_reason_result_default() {
     let result = ReasonResult::default();
     assert!(!result.success);


### PR DESCRIPTION
## What changed
Output guardrails now inspect readable completed reasoning items as well as streamed reasoning deltas, without evaluating providers' duplicated completed blocks twice. Post-generation checks receive the complete client-visible reasoning and answer. Reasoning events are withheld until checks pass, and every retained/replayable reasoning artifact is cleared when output is replaced.

## Why
Signed Gemini thought blocks and other completed reasoning artifacts could bypass output guardrails. A later guardrail replacement also left retained reasoning in the completed message, REST/event projections, exports, and provider replay.

## Before / After
Before: a signed reasoning item containing `secret instructions` was retained without tripping the test guardrail, and prior reasoning survived a later replacement.

After: `cargo test -p everruns-engine execution::reason::tests --lib` proves completed reasoning trips before retention, duplicate streamed/completed provider blocks are not double-counted, and post-generation input includes reasoning plus answer text.

## Risk
- Medium
- Reasoning metadata events are now emitted after output guardrails complete instead of immediately when the provider block arrives. Opaque replay behavior is otherwise preserved for allowed messages.

## Security
- Threat categories reviewed: TM-LLM, TM-API
- Findings and resolutions: closed the reasoning guardrail bypass by applying streaming and post-generation controls to every readable representation; blocked messages clear plaintext and opaque replay artifacts before event persistence or future provider requests. No new injection, authorization, tenancy, logging, or unbounded-allocation surface was introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
