### PR TITLE
fix(tests): assert message-history index support, not planner choice

### DIFF
--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -1709,6 +1709,26 @@ async fn test_long_message_history_reads_are_bounded_and_index_supported() {
         message_index.0
     );
 
+    // The property migration 084 established is that the query predicate is
+    // *implied by* the index predicate, which is what lets Postgres use this
+    // partial index at all. Assert that directly, with sequential scans
+    // disabled for the planning of this one statement.
+    //
+    // Asserting "the plan contains no Seq Scan" instead would test the
+    // planner's cost comparison rather than the index, and that comparison
+    // depends on how many unrelated rows other tests happen to have left in
+    // the shared `events` table: once a large enough fraction of the table
+    // matches the predicate, a sequential scan is genuinely the cheaper plan
+    // and Postgres is right to choose it. That made the old assertion fail on
+    // `main` without either this query or the index changing.
+    //
+    // `SET LOCAL` scopes the setting to this transaction, which is rolled
+    // back, so no pooled connection escapes with seqscan disabled.
+    let mut tx = pool.begin().await.expect("begin planner-assertion tx");
+    sqlx::query("SET LOCAL enable_seqscan = off")
+        .execute(&mut *tx)
+        .await
+        .expect("disable seq scans for the planner assertion");
     let plan_rows: Vec<(String,)> = sqlx::query_as(
         r#"
         EXPLAIN (ANALYZE, BUFFERS)
@@ -1725,17 +1745,25 @@ async fn test_long_message_history_reads_are_bounded_and_index_supported() {
     )
     .bind(session.id.uuid())
     .bind(everruns_server::storage::repository::MESSAGE_SAFETY_LIMIT as i64)
-    .fetch_all(pool)
+    .fetch_all(&mut *tx)
     .await
     .expect("explain bounded message history query");
+    tx.rollback().await.expect("roll back planner-assertion tx");
     let plan = plan_rows
         .into_iter()
         .map(|row| row.0)
         .collect::<Vec<_>>()
         .join("\n");
+    // Widening the query's event types beyond the index predicate, or
+    // narrowing the index back to the pre-084 pair, makes the partial index
+    // unusable and drops the planner onto `idx_events_session_sequence` --
+    // scanning every event type in the session. That is the regression this
+    // catches.
     assert!(
-        !plan.contains("Seq Scan on events"),
-        "message history query should not seq-scan events:\n{plan}"
+        plan.contains("idx_events_messages"),
+        "message history query must be servable by the idx_events_messages \
+         partial index; a plan on another index means the query predicate is \
+         no longer implied by the index predicate (see migration 084):\n{plan}"
     );
 
     println!(


### PR DESCRIPTION
## What changed

`test_long_message_history_reads_are_bounded_and_index_supported` now asserts that the bounded message-history query **can be served by** `idx_events_messages`, by planning that one statement with `enable_seqscan = off`, instead of asserting that the default plan happens to contain no `Seq Scan`. Test-only; no product code, schema, or query changes.

## Why

`Integration Tests (PostgreSQL)` is red on `main` (`f99307de`, run [33605450626](https://github.com/everruns/everruns/actions/runs/33605450626)):

```
test test_long_message_history_reads_are_bounded_and_index_supported ... FAILED
message history query should not seq-scan events
  ->  Seq Scan on events  (cost=0.00..273.16 rows=1904) (actual rows=3050)
        Rows Removed by Filter: 2015
```

Nothing in the query, the index, or the test changed — `crates/server/tests/repository_integration_test.rs` has not been touched since #3287.

The old assertion tested the planner's **cost comparison**, not the index. That comparison depends on how many unrelated rows other tests happen to have left in the shared `events` table. The failing plan matches 3,050 of 5,065 rows; at roughly 60% selectivity a sequential scan genuinely is the cheaper plan and PostgreSQL is right to choose it. So the test moved with unrelated churn elsewhere in the suite, and would keep moving.

The property that actually matters is the one migration `084_events_index_optimization.sql` was written to establish: PostgreSQL can only use a partial index when the query predicate is *implied by* the index predicate. Before 084 the index covered two event types while the query filtered three, so the planner fell back to `idx_events_session_sequence` and scanned every event type in the session. That is the regression worth guarding, and it is independent of table size.

## Before / After

Verified against PostgreSQL 16 with all 125 migrations applied.

The assertion holds for the query as written:

```
SET enable_seqscan = off; EXPLAIN <message history query>
 ->  Index Scan Backward using idx_events_messages on events
       Index Cond: (session_id = '...'::uuid)
```

And it fails when the predicate drifts — same query widened by one event type outside the index predicate, i.e. the pre-084 shape:

```
 ->  Index Scan Backward using idx_events_session_sequence on events
```

**This is stricter than what it replaces.** In that second case the old assertion still passed, because a fallback index scan is not a `Seq Scan` — the exact regression 084 fixed would have gone undetected.

Full `repository_integration_test` suite against a freshly migrated database: the target test passes. (`test_agent_crud` fails on a brand-new database from a parallel harness-seeding race in `ensure_test_harness_id` at line 57; it passes once the database is seeded, is unrelated to this change, and is green in CI.)

## Risk

- **Low**
- Test-only. The narrow risk would be leaking `enable_seqscan = off` onto a pooled connection and skewing later tests; `SET LOCAL` is scoped to a transaction that is explicitly rolled back, so it cannot outlive the statement.

## Security

- Threat categories reviewed: none applicable. No product code, authentication, authorization, API surface, schema, or dependency changes — this only rewrites an assertion inside an existing integration test.
- Findings and resolutions: none.

## Follow-ups

No follow-ups. This unblocks `main`; PR #3345 is red on the same failure and will go green once this lands.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — test-only, no public surface
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_016Ng3MqkRMEqwfFWCSZbQXG

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ng3MqkRMEqwfFWCSZbQXG)_