### PR TITLE
docs: lead README with framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,205 +7,146 @@
 
 > **Note:** Everruns is under active development. Expect rapid changes and experimental features.
 
-**Everruns is an open-source platform for building, deploying, and operating durable AI agents.**
+**Build capable AI agents in Rust. Run them where they belong.**
 
-Define agents and their tools, compose them into reusable harnesses, then ship them to real users through Slack, web chat, scheduled jobs, webhooks, A2A, MCP, or a plain HTTP API, backed by a Rust + PostgreSQL durable execution engine that survives restarts and scales horizontally.
+Everruns is an open-source framework for building AI agents directly in Rust
+applications. Define agents, attach models and typed tools, run multi-turn
+sessions, and observe execution through one application-facing API.
 
-## Why Everruns
+Use the framework in your application. When you need a shared runtime and
+production operations, run the Everruns platform yourself or use
+[Hosted Everruns](https://app.everruns.com).
 
-- **Durable by default**: every session is a PostgreSQL-backed workflow that survives restarts, worker crashes, and network partitions. No lost runs, no in-memory state to babysit.
-- **One agent, every channel**: define a harness once, then [publish](https://docs.everruns.com/features/apps/) it to Slack, web chat, A2A, webhooks, cron schedules, voice, or a plain HTTP/[MCP](https://docs.everruns.com/features/mcp/) API.
-- **Open and provider-neutral**: implements the [Open Responses](https://www.openresponses.org/) spec across OpenAI, Anthropic, Gemini, and Azure; register remote MCP servers as tools. MIT-licensed and self-hostable.
-- **Built for production**: multi-tenant orgs, fine-grained permissions, envelope-encrypted secrets, budgets, [observability](https://docs.everruns.com/observability/), and a control-plane / worker split that scales horizontally.
+[Build with the framework](https://docs.everruns.com/framework/quickstart/) · [Read the docs](https://docs.everruns.com/framework/) · [Use Hosted Everruns](https://app.everruns.com)
 
-## Architecture
+## Build an agent
 
-```mermaid
-graph TB
-    subgraph Public["Public surface"]
-        Clients["Clients<br/>SDK · CLI · App"]
-        Proxy["Reverse proxy<br/>TLS · /api · /mcp"]
-    end
-    subgraph CP["Control plane"]
-        Server["Server<br/>REST · gRPC"]
-    end
-    subgraph Workers["Worker pool · stateless"]
-        W1["Worker"]
-        W2["Worker"]
-        Wn["Worker N"]
-    end
-    subgraph Data["State & messaging"]
-        PG["PostgreSQL<br/>required · task queue + event log"]
-        NATS["NATS JetStream<br/>optional · event push"]
-        Valkey["Valkey<br/>optional · rate limiting"]
-    end
-
-    Clients --> Proxy --> Server
-    Server <--> W1
-    Server <--> W2
-    Server <--> Wn
-    Server --> PG
-    Server -.-> NATS
-    Server -.-> Valkey
-```
-
-Workers are stateless and hold no database credentials, they reach the control plane over gRPC only. See [Architecture](https://docs.everruns.com/explanation/architecture/) for the full picture.
-
-## What's inside
-
-### Build agents
-
-- **[Harnesses](https://docs.everruns.com/features/harnesses/), Agents, Capabilities, Skills**: modular configuration that composes into a runtime agent. [Built-in harness types](https://docs.everruns.com/built-ins/) for general chat, data analysis, and coding (sandbox or Daytona-backed).
-- **[Agent versioning](https://docs.everruns.com/features/agent-versions/), blueprints, and identities**: iterate safely on production agents and run unattended workloads under virtual principals.
-- **[Capabilities library](https://docs.everruns.com/features/capabilities/)**: web fetch, bash sandbox, session filesystem, session SQL DB, memory, knowledge bases, MCP, voice, and more.
-- **[Skills registry](https://docs.everruns.com/features/skills-registry/)**: agentskills.io-format skills with discovery, search, and usage tracking.
-- **Generative UI**: agents can return rich cards via [OpenUI](https://github.com/openuidev/openui), [A2UI](https://github.com/google/a2ui), and inline `ui://everruns/...` MCP App resources.
-
-### Connect any model and any tool
-
-- **LLM providers**: OpenAI (Responses + Chat Completions), Azure OpenAI, Anthropic, Gemini, plus `llmsim` for tests. Model resolution is layered: message → session → agent → system default.
-- **[MCP](https://docs.everruns.com/features/mcp/), both ways**: register remote MCP servers as virtual capabilities (auto-discovered and namespaced), and use every deployment's always-available authenticated MCP endpoint with OAuth 2.1 so other agents can call yours.
-- **[Integrations](https://docs.everruns.com/integrations/)**: Docker, Daytona, E2B, Deno, Browserless, Brave Search, DuckDuckGo, Parallel, Sprites, Cursor, auto-registered via the `inventory` plugin system.
-- **Client-side tools** for SDK/API consumers that want to run tools locally.
-
-### Ship agents to real channels
-
-Define an **[App](https://docs.everruns.com/features/apps/)** that binds a Harness + Agent to one or more **channels**:
-
-- `slack`, Slack app with thread/channel/user routing
-- `ag_ui`, embeddable web chat (AG-UI)
-- `a2a`, Agent2Agent inbound JSON-RPC + outbound delegation
-- `webhook`, HTTP-triggered invocations
-- `schedule`, cron-based scheduled tasks
-- Voice, realtime voice sessions with hardened tool authorization
-
-### Run reliably at scale
-
-- **[Durable execution engine](https://docs.everruns.com/explanation/durable-execution/)**: PostgreSQL-backed workflows; agent sessions survive restarts, worker crashes, and network partitions.
-- **Control-plane / worker split**: workers talk to the control-plane over gRPC only; no DB credentials on workers.
-- **[Streaming events](https://docs.everruns.com/features/events/)**: SSE with NATS JetStream (production) or in-memory broadcast (dev) for ephemeral deltas, PostgreSQL for durable events.
-- **Multi-tenant**: organizations, fine-grained permissions, audit logging, envelope encryption (AES-256-GCM) for secrets.
-- **Infinity context**: automatic compaction keeps conversations going past any model's context window.
-- **[Observability](https://docs.everruns.com/observability/)**: OpenTelemetry GenAI semantic conventions, Prometheus `/metrics`, optional Braintrust.
-- **Budgeting, usage tracking, reporting**: token meters, budgets with soft enforcement, and async analytical projections (StarRocks or DuckDB-over-object-storage).
-- **[Evals](https://docs.everruns.com/features/evals/)**: user-facing behavioral evals plus a SWE-bench Lite harness.
-
-## Quick start
-
-Deploy the full stack with Docker Compose:
+Add the application-facing crate:
 
 ```bash
-mkdir everruns && cd everruns
-curl -o docker-compose.yaml https://raw.githubusercontent.com/everruns/everruns/main/examples/docker-compose-full.yaml
-
-# Generate an encryption key for secrets-at-rest
-python3 -c "import os, base64; print('kek-v1:' + base64.b64encode(os.urandom(32)).decode())"
-
-cat > .env <<'EOF'
-SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
-WORKER_GRPC_AUTH_TOKEN=<a-random-token>
-DEFAULT_OPENAI_API_KEY=sk-...            # optional
-DEFAULT_ANTHROPIC_API_KEY=sk-ant-...     # optional
-DEFAULT_GEMINI_API_KEY=...               # optional
-EOF
-
-docker compose up -d
+cargo add everruns --features openai
+cargo add tokio --features macros,rt-multi-thread
+export OPENAI_API_KEY=sk-...
 ```
 
-Then open:
+Then define a typed tool, give it to an agent, and run a turn:
 
-- Web UI: <http://localhost:9300>
-- API: <http://localhost:9300/api/v1/...>
-- MCP endpoint: <http://localhost:9300/mcp>
-- Metrics: <http://localhost:8428/vmui> (VictoriaMetrics)
+```rust
+use std::time::{SystemTime, UNIX_EPOCH};
 
-See the [Docker Compose Quickstart](https://docs.everruns.com/getting-started/docker-compose/) for the full guide.
+use everruns::{Agent, Engine, OpenAI};
 
-Contributors and coding agents can instead run the PostgreSQL, Valkey, and NATS-backed development
-stack locally without Docker. The canonical per-worktree command, prerequisites, ports, and cleanup
-instructions live in [`AGENTS.md`](./AGENTS.md#local-dev).
+#[everruns::tool]
+async fn current_time() -> Result<String, String> {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| error.to_string())?
+        .as_secs();
+    Ok(format!("{seconds} seconds since the Unix epoch"))
+}
 
-## API example
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let agent = Agent::builder()
+        .name("assistant")
+        .instructions("Use current_time when asked about time. Be concise.")
+        .provider(OpenAI::from_env()?)
+        .model("gpt-5-mini")
+        .tool(current_time())
+        .build()?;
 
-```bash
-# Create an agent
-curl -X POST http://localhost:9300/api/v1/agents \
-  -H "Content-Type: application/json" \
-  -d '{"name": "Assistant", "system_prompt": "You are a helpful assistant."}'
-
-# Start a session
-curl -X POST http://localhost:9300/api/v1/sessions \
-  -H "Content-Type: application/json" \
-  -d '{"agent_id": "{agent_id}"}'
-
-# Send a message (returns 201 with the persisted message)
-curl -X POST http://localhost:9300/api/v1/sessions/{session_id}/messages \
-  -H "Content-Type: application/json" \
-  -d '{"message": {"content": [{"type": "text", "text": "Hello!"}]}}'
-
-# Stream the agent's response and tool calls as Server-Sent Events
-curl -N http://localhost:9300/api/v1/sessions/{session_id}/sse
+    let session = Engine::new().create(agent);
+    let turn = session.send_and_wait("What time is it?").await?;
+    println!("{}", turn.response);
+    Ok(())
+}
 ```
 
-Everruns implements the [Open Responses](https://www.openresponses.org/) spec, a vendor-neutral API for multi-provider LLM interfaces with native tool calls and semantic streaming.
+Everruns derives the tool schema from the Rust function, lets the model call it during the turn, and returns the result before producing the final response. [Continue the framework quickstart.](https://docs.everruns.com/framework/quickstart/)
 
-## Use from Claude Code, Codex, or Cursor
+## The agent framework
 
-This repository is a [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) shipping the `everruns-dev` plugin, which also supports Codex and Cursor as hosts:
+The [`everruns`](./crates/everruns) crate keeps the application-facing agent
+loop explicit and embeddable:
 
-```text
-/plugin marketplace add everruns/everruns
-/plugin install everruns-dev@everruns-dev
-```
+- **Agents and sessions** — describe an agent once, then create independent,
+  multi-turn conversations through an `Engine`.
+- **Models and providers** — start offline, use OpenAI, or attach a custom
+  provider without coupling application code to a closed provider enum.
+- **Typed tools and capabilities** — give agents function tools and opt into
+  filesystem, shell, web, Lua, and MCP boundaries deliberately.
+- **Events, cancellation, and lifecycle hooks** — observe a live turn, add
+  application behavior at execution boundaries, and stop work cooperatively.
+- **Persistence and execution choices** — begin with engine-lifetime memory,
+  add local crash-durable state, or cross deliberately into a distributed host.
 
-Run `/everruns-dev:whoami` and complete the OAuth flow on first use. See [`plugins/everruns-dev/README.md`](./plugins/everruns-dev/README.md) for Codex, Cursor, local clone, and custom deployment options.
+[Framework overview](https://docs.everruns.com/framework/)
 
-## Build with the Framework
+## Choose how you run Everruns
 
-Build agents directly inside a Rust application with the **Everruns Framework** and its
-application-facing [`everruns`](./crates/everruns) crate. The default build runs offline with a
-deterministic simulator; opt-in providers, typed tools, multi-turn sessions, events,
-cancellation, files, MCP, and context inspection all stay on the same public facade. Start with
-the [Framework quickstart](https://docs.everruns.com/framework/quickstart/).
+### Use the framework in your application
 
-Applications retain the concrete `everruns::Engine` as their session owner.
-`InMemoryEngine` is a compatibility alias; Engine keeps immutable Agent
-snapshots and owns the resources required to create and resume Sessions.
+Start here when Everruns belongs inside the Rust application you are building.
+You own the process, deployment, integrations, and data path.
 
-Typed built-ins, dynamic third-party references, and reusable packages all use
-`AgentBuilder::capability`; packages can implement the open `IntoCapability`
-contract or use the curated
-[`everruns::capability`](https://docs.everruns.com/framework/advanced-capabilities/) authoring API.
+[Framework quickstart →](https://docs.everruns.com/framework/quickstart/)
 
-Advanced execution hosts combine `everruns` with `everruns-host` and focused sibling crates,
-see [Custom backends](https://docs.everruns.com/framework/custom-backends/).
+### Run the platform yourself
 
-A CLI (`everruns-cli`) is also available for scripting against a deployment, see the [CLI](https://docs.everruns.com/features/cli/) guide.
+Use the open-source platform when you need a shared control plane, server,
+workers, UI, and durable deployment in infrastructure you manage. It exposes an
+Open Responses-compatible API for remote clients and SDKs.
+
+[Docker Compose quickstart →](https://docs.everruns.com/getting-started/docker-compose/) · [Platform architecture →](https://docs.everruns.com/explanation/architecture/)
+
+### Use Hosted Everruns
+
+Use [Hosted Everruns](https://app.everruns.com) when you want the shared runtime
+and production operations without operating the platform yourself.
+
+[Open Hosted Everruns →](https://app.everruns.com)
+
+## The Everruns platform
+
+The platform is the optional runtime and control plane for agents that need to
+run beyond one application process. It provides a server, stateless worker pool,
+web UI, remote API, and PostgreSQL-backed durable execution. Workers communicate
+with the control plane over gRPC and do not hold database credentials.
+
+It also provides the operational surfaces for publishing agents to Slack, web
+chat, A2A, webhooks, schedules, voice, HTTP, and MCP; managing organizations and
+permissions; and observing, budgeting, and evaluating production agents.
+
+[Platform capabilities](https://docs.everruns.com/features/capabilities/) · [Apps and channels](https://docs.everruns.com/features/apps/) · [Durable execution](https://docs.everruns.com/explanation/durable-execution/) · [Observability](https://docs.everruns.com/observability/)
 
 ## Documentation
 
 Full documentation lives at **[docs.everruns.com](https://docs.everruns.com)**.
 
-- [Introduction](https://docs.everruns.com/getting-started/introduction/), what Everruns is and core [concepts](https://docs.everruns.com/getting-started/concepts/)
-- [Everruns Framework](https://docs.everruns.com/framework/), build and run agents inside a Rust application
-- [Docker Compose Quickstart](https://docs.everruns.com/getting-started/docker-compose/), run the full stack
-- [How-to guides](https://docs.everruns.com/how-to/), give agents tools, stream events, publish to Slack, enforce budgets
-- [Capabilities](https://docs.everruns.com/features/capabilities/) and [Harnesses](https://docs.everruns.com/features/harnesses/), the building blocks
-- [Architecture](https://docs.everruns.com/explanation/architecture/) and [Durable execution](https://docs.everruns.com/explanation/durable-execution/), how it works under the hood
-- [API Reference](https://docs.everruns.com/api/), OpenAPI 3.0
-- [SDKs](https://docs.everruns.com/features/sdk/), Rust, Python, and TypeScript clients
+- [Everruns Framework](https://docs.everruns.com/framework/) — build and run agents inside a Rust application
+- [Framework quickstart](https://docs.everruns.com/framework/quickstart/) — install the crate and configure a provider
+- [Docker Compose quickstart](https://docs.everruns.com/getting-started/docker-compose/) — run the full platform stack
+- [How-to guides](https://docs.everruns.com/how-to/) — give agents tools, stream events, publish to Slack, and enforce budgets
+- [API reference](https://docs.everruns.com/api/) — OpenAPI 3.0
+- [SDKs](https://docs.everruns.com/features/sdk/) — Rust, Python, and TypeScript clients
 
 ## Security
 
-Everruns runs untrusted agent and tool code for multiple tenants, so security is a core design goal. Threats are tracked with stable IDs across categories, authentication, tenant isolation, permissions, tool execution, LLM integration, the bash and SQLite sandboxes, durable execution, and channel integrations, each with a documented mitigation and, where feasible, test coverage.
+Everruns runs untrusted agent and tool code for multiple tenants, so security is
+a core design goal. Threats are tracked with stable IDs across authentication,
+tenant isolation, permissions, tool execution, LLM integration, sandboxes,
+durable execution, and channel integrations, each with a documented mitigation
+and, where feasible, test coverage.
 
-- [Threat model](./knowledge/security/threat-model.md), full analysis, mitigation status, and accepted risks
-- [Security testing](./knowledge/security/security-testing.md), threat-model tests, fail-rs failure injection, DeepSec scanning, and supply-chain checks
-- [Security policy](./SECURITY.md), how to report a vulnerability
+- [Threat model](./knowledge/security/threat-model.md) — full analysis, mitigation status, and accepted risks
+- [Security testing](./knowledge/security/security-testing.md) — threat-model tests, failure injection, DeepSec scanning, and supply-chain checks
+- [Security policy](./SECURITY.md) — report a vulnerability
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup and [AGENTS.md](./AGENTS.md) for the conventions used by both human and AI contributors.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup and
+[AGENTS.md](./AGENTS.md) for the conventions used by both human and AI
+contributors.
 
 ## License
 


### PR DESCRIPTION
## Summary

- lead the repository README with Everruns as an open-source Rust agent framework
- add a maintained typed-tool and OpenAI agent example for framework adopters
- separate the framework, self-hosted platform, and Hosted Everruns adoption paths while retaining platform, security, and contributor documentation

## Validation

- `cargo check -p everruns --example hello --features openai`
- `cd apps/docs && pnpm run check`
- `git diff --check`
- `PATH="/opt/homebrew/bin:$PATH" bash scripts/test-published-crate-docs.sh`
- `PATH="/opt/homebrew/bin:$PATH" bash scripts/test-publish-crates-order.sh`
- `just pre-push` *(all relevant checks passed; the published-crate documentation guard itself requires Python 3.11+ for `tomllib`, while the default system `python3` is 3.9. Re-ran the affected guards successfully using installed Python 3.12.)*

## Security review

Documentation-only change. No code, configuration, credentials, external input handling, or runtime behavior changed.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
