### PR TITLE
feat(models): add Claude Fable 5.1 profile, seed it, and cover it in the live matrix

### DIFF
--- a/crates/builtins/src/claude_tool_search.rs
+++ b/crates/builtins/src/claude_tool_search.rs
@@ -157,6 +157,7 @@ mod tests {
         assert!(model_supports_native_tool_search("claude-sonnet-4-6"));
         assert!(model_supports_native_tool_search("claude-haiku-4-5"));
         assert!(model_supports_native_tool_search("claude-fable-5"));
+        assert!(model_supports_native_tool_search("claude-fable-5-1"));
         assert!(!model_supports_native_tool_search("claude-3-5-haiku"));
         // Unknown / non-Anthropic models are not native.
         assert!(!model_supports_native_tool_search("gpt-5.5"));

--- a/crates/drivers/anthropic/src/driver.rs
+++ b/crates/drivers/anthropic/src/driver.rs
@@ -172,7 +172,7 @@ impl AnthropicChatDriver {
                     //    interleaves on its own).
                     //  - context-1m: opts the `[1m]` model ids into the 1M
                     //    context window. It is GA / silently ignored on Opus 4.6+
-                    //    and Fable 5 (the only ids we attach it to), so always
+                    //    and Fable 5.x (the only ids we attach it to), so always
                     //    sending it is safe.
                     //  - cache-diagnosis: required for the request-level
                     //    `diagnostics` object and the diagnostics payload on
@@ -783,7 +783,7 @@ impl ChatDriver for AnthropicChatDriver {
             Some(Self::convert_tools(&config.tools, prompt_cache_enabled))
         };
 
-        // Sampling parameters are removed on Fable 5 and Opus 4.8/4.7 —
+        // Sampling parameters are removed on Fable 5.x and Opus 5/4.8/4.7 —
         // sending `temperature` returns 400 ("`temperature` is deprecated for
         // this model"). The model profile's `temperature` flag is the source
         // of truth; drop the parameter for models that reject it.
@@ -800,9 +800,9 @@ impl ChatDriver for AnthropicChatDriver {
 
         // Build thinking config from reasoning effort.
         //
-        // Recent Claude models (Fable 5, Opus 4.8/4.7, and the 4.6 family) use
-        // adaptive thinking: `thinking: {type: "adaptive"}` plus
-        // `output_config.effort`. On Fable 5 and Opus 4.8/4.7 the budget-based
+        // Recent Claude models (Fable 5.x, Opus 5/4.8/4.7, and the 4.6 family)
+        // use adaptive thinking: `thinking: {type: "adaptive"}` plus
+        // `output_config.effort`. On Fable 5.x and Opus 5/4.8/4.7 the budget-based
         // `thinking: {type: "enabled", budget_tokens}` form is removed and
         // returns 400, so this split is load-bearing, not stylistic.
         let (thinking, output_config) = match config.reasoning_effort {
@@ -1511,10 +1511,10 @@ enum AnthropicSystemBlock {
 /// Thinking configuration for Claude.
 ///
 /// `Enabled` is the legacy budget-based form; `Adaptive` is required on
-/// Fable 5 and Opus 4.8/4.7 (where `budget_tokens` returns 400) and is the
+/// Fable 5.x and Opus 5/4.8/4.7 (where `budget_tokens` returns 400) and is the
 /// recommended form on the 4.6 family. "No thinking" is always expressed by
 /// omitting the field — an explicit `{type: "disabled"}` is rejected by
-/// Fable 5.
+/// Fable 5.x.
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 enum AnthropicThinking {
@@ -1523,7 +1523,7 @@ enum AnthropicThinking {
         budget_tokens: u32,
     },
     Adaptive {
-        /// Fable 5 and Opus 4.8/4.7 omit thinking text by default
+        /// Fable 5.x and Opus 5/4.8/4.7 omit thinking text by default
         /// (`display: "omitted"`); "summarized" restores it so assistant
         /// messages keep their thinking content like on budget-based models.
         display: &'static str,
@@ -1552,11 +1552,15 @@ struct AnthropicOutputConfig {
     effort: String,
 }
 
-/// Claude families that use adaptive thinking. On Fable 5, Opus 4.8/4.7, and
-/// Sonnet 5 budget-based thinking is removed (400); on Opus 4.6 / Sonnet 4.6 it
-/// is deprecated and adaptive is the recommended form. Keep in sync with the
+/// Claude families that use adaptive thinking. On Fable 5.x, Opus 5/4.8/4.7,
+/// and Sonnet 5 budget-based thinking is removed (400); on Opus 4.6 / Sonnet 4.6
+/// it is deprecated and adaptive is the recommended form. Keep in sync with the
 /// adaptive-thinking profiles in `everruns_provider::model_profiles`.
+///
+/// `claude-fable-5-1` is listed on its own: `normalize_anthropic_id` only
+/// strips 8-digit date suffixes, so the `-1` does not collapse to Fable 5.
 const ADAPTIVE_THINKING_FAMILIES: &[&str] = &[
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-5",
     "claude-opus-4-8",
@@ -1572,6 +1576,7 @@ const ADAPTIVE_THINKING_FAMILIES: &[&str] = &[
 /// capability — kept separate so a future divergence (1M without adaptive
 /// thinking, or vice versa) cannot silently mis-gate either path.
 const MILLION_CONTEXT_FAMILIES: &[&str] = &[
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-5",
     "claude-opus-4-8",
@@ -2330,6 +2335,8 @@ mod tests {
     fn test_uses_adaptive_thinking_by_family() {
         // Adaptive-only / adaptive-recommended families, with and without
         // dated suffixes.
+        assert!(uses_adaptive_thinking("claude-fable-5-1"));
+        assert!(uses_adaptive_thinking("claude-fable-5-1-20260901"));
         assert!(uses_adaptive_thinking("claude-fable-5"));
         assert!(uses_adaptive_thinking("claude-fable-5-20260601"));
         assert!(uses_adaptive_thinking("claude-opus-5"));
@@ -2347,7 +2354,7 @@ mod tests {
 
     #[test]
     fn test_thinking_config_serialization() {
-        // Adaptive must not carry budget_tokens (400 on Fable 5 / Opus 4.8 /
+        // Adaptive must not carry budget_tokens (400 on Fable 5.x / Opus 4.8 /
         // 4.7); display:"summarized" opts back into visible thinking text,
         // which those models omit by default.
         let adaptive = serde_json::to_value(AnthropicThinking::adaptive()).unwrap();
@@ -3222,6 +3229,10 @@ mod tests {
         assert_eq!(
             split_million_context("claude-opus-4-8[1m]"),
             ("claude-opus-4-8", true)
+        );
+        assert_eq!(
+            split_million_context("claude-fable-5-1[1m]"),
+            ("claude-fable-5-1", true)
         );
         assert_eq!(
             split_million_context("claude-fable-5[1m]"),

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -33,6 +33,8 @@ use everruns_test_support::in_memory_loop::{InMemoryAgenticLoop, TurnResult};
 
 #[rstest]
 #[case::anthropic_haiku(ANTHROPIC_HAIKU)]
+#[case::anthropic_sonnet5(ANTHROPIC_SONNET5)]
+#[case::anthropic_fable_5_1(ANTHROPIC_FABLE_5_1)]
 #[case::openai_gpt56_luna(OPENAI_GPT56_LUNA)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
@@ -78,6 +80,8 @@ async fn test_basic_completion(#[case] config: ProviderModelConfig) {
 
 #[rstest]
 #[case::anthropic_haiku(ANTHROPIC_HAIKU)]
+#[case::anthropic_sonnet5(ANTHROPIC_SONNET5)]
+#[case::anthropic_fable_5_1(ANTHROPIC_FABLE_5_1)]
 #[case::openai_gpt56_luna(OPENAI_GPT56_LUNA)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
@@ -131,6 +135,8 @@ async fn test_tool_call(#[case] config: ProviderModelConfig) {
 
 #[rstest]
 #[case::anthropic_haiku(ANTHROPIC_HAIKU)]
+#[case::anthropic_sonnet5(ANTHROPIC_SONNET5)]
+#[case::anthropic_fable_5_1(ANTHROPIC_FABLE_5_1)]
 #[case::openai_gpt56_luna(OPENAI_GPT56_LUNA)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::meta_muse_spark_contributor(META_MUSE_SPARK_CONTRIBUTOR)]

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -267,7 +267,12 @@ async fn test_thinking_with_tool_call(#[case] config: ProviderModelConfig) {
                 .unwrap();
             let input = InputMessage {
                 role: MessageRole::User,
-                content: vec![ContentPart::text("What's the current time in UTC?")],
+                // The user turn also asks for a tool check: with the system
+                // instruction alone, Sonnet 5 still skipped the tool on ~2/7
+                // first attempts at low effort.
+                content: vec![ContentPart::text(
+                    "What's the current time in UTC? Check it with your tool rather than guessing.",
+                )],
                 controls: Some(Controls {
                     speed: None,
                     verbosity: None,

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -29,14 +29,13 @@ use everruns_test_support::in_memory_loop::{InMemoryAgenticLoop, TurnResult};
 // ============================================================================
 
 #[rstest]
-// Uses Opus 5 rather than the `claude-opus-4-7` alias: that alias now returns
-// its reasoning as public response text with an empty private `thinking` field
-// (observed 6/6 on main), which is not what this private-field assertion checks.
-// Current Opus/Sonnet models surface reasoning on the private field.
+// Current Anthropic models only: Fable 5.1, Opus 5 and Sonnet 5 surface
+// reasoning on the private `thinking` field, which is what this assertion
+// checks. The superseded `claude-opus-4-7` alias returned its reasoning as
+// public response text with an empty private field (observed 6/6 on main).
 #[case::anthropic_fable_5_1(ANTHROPIC_FABLE_5_1)]
 #[case::anthropic_opus5(ANTHROPIC_OPUS5)]
 #[case::anthropic_sonnet5(ANTHROPIC_SONNET5)]
-#[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::meta_muse_spark_contributor(META_MUSE_SPARK_CONTRIBUTOR)]
@@ -224,9 +223,8 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
 
 #[rstest]
 #[case::anthropic_fable_5_1(ANTHROPIC_FABLE_5_1)]
-#[case::anthropic_opus(ANTHROPIC_OPUS)]
+#[case::anthropic_opus5(ANTHROPIC_OPUS5)]
 #[case::anthropic_sonnet5(ANTHROPIC_SONNET5)]
-#[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::meta_muse_spark_contributor(META_MUSE_SPARK_CONTRIBUTOR)]

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -33,7 +33,9 @@ use everruns_test_support::in_memory_loop::{InMemoryAgenticLoop, TurnResult};
 // its reasoning as public response text with an empty private `thinking` field
 // (observed 6/6 on main), which is not what this private-field assertion checks.
 // Current Opus/Sonnet models surface reasoning on the private field.
+#[case::anthropic_fable_5_1(ANTHROPIC_FABLE_5_1)]
 #[case::anthropic_opus5(ANTHROPIC_OPUS5)]
+#[case::anthropic_sonnet5(ANTHROPIC_SONNET5)]
 #[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]
 #[case::openai_gpt54(OPENAI_GPT54)]
@@ -221,7 +223,9 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
 // ============================================================================
 
 #[rstest]
+#[case::anthropic_fable_5_1(ANTHROPIC_FABLE_5_1)]
 #[case::anthropic_opus(ANTHROPIC_OPUS)]
+#[case::anthropic_sonnet5(ANTHROPIC_SONNET5)]
 #[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]
 #[case::openai_gpt54(OPENAI_GPT54)]
@@ -246,9 +250,16 @@ async fn test_thinking_with_tool_call(#[case] config: ProviderModelConfig) {
         |r: &TurnResult| r.success && r.tool_calls_count > 0,
         {
             let model = config.model().expect("model set (checked above)");
+            // Firm, tool-naming instruction: Fable 5.1 rejects forced
+            // `tool_choice`, and with adaptive thinking on, Fable 5.1 and
+            // Sonnet 5 answered the softer "use ... when asked about time"
+            // wording without calling the tool (3/3 clean sampling misses).
             let runner = InMemoryAgenticLoop::builder()
                 .agent_name("Thinking Time Agent")
-                .system_prompt("Use get_current_time tool when asked about time.")
+                .system_prompt(
+                    "You have no clock. When asked about the time, always call the \
+                     get_current_time tool first, then answer from its result.",
+                )
                 .model(model)
                 .driver_registry(all_providers_registry())
                 .capability(CurrentTimeCapability)

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -87,8 +87,12 @@ impl std::fmt::Display for ProviderModelConfig {
 
 // Not wired into the live matrix: `claude-fable-5` is listed by the Anthropic
 // `/models` endpoint but returns "Model not available" on inference from the
-// CI key. Re-add the `#[case]` entries once it's usable; Anthropic stays
-// covered via haiku/opus/sonnet below.
+// CI key, and `claude-fable-5-1` (its successor, same tier and rate-limit
+// pool) is assumed to behave the same until verified. Re-add the `#[case]`
+// entries once they're usable; Anthropic stays covered via haiku/opus/sonnet
+// below.
+pub const ANTHROPIC_FABLE_5_1: ProviderModelConfig =
+    ProviderModelConfig::new(DriverId::Anthropic, "claude-fable-5-1", "ANTHROPIC_API_KEY");
 pub const ANTHROPIC_FABLE: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::Anthropic, "claude-fable-5", "ANTHROPIC_API_KEY");
 

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -101,18 +101,10 @@ pub const ANTHROPIC_HAIKU: ProviderModelConfig = ProviderModelConfig::new(
     "ANTHROPIC_API_KEY",
 );
 
-// Bare alias — the API does not serve a dated id for Opus 4.7.
-pub const ANTHROPIC_OPUS: ProviderModelConfig =
-    ProviderModelConfig::new(DriverId::Anthropic, "claude-opus-4-7", "ANTHROPIC_API_KEY");
-
+// Current Anthropic tiers only; superseded Opus 4.7 / Sonnet 4.6 entries were
+// dropped when Opus 5 / Sonnet 5 took their matrix rows.
 pub const ANTHROPIC_OPUS5: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::Anthropic, "claude-opus-5", "ANTHROPIC_API_KEY");
-
-pub const ANTHROPIC_SONNET: ProviderModelConfig = ProviderModelConfig::new(
-    DriverId::Anthropic,
-    "claude-sonnet-4-6",
-    "ANTHROPIC_API_KEY",
-);
 
 pub const ANTHROPIC_SONNET5: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::Anthropic, "claude-sonnet-5", "ANTHROPIC_API_KEY");

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -85,12 +85,11 @@ impl std::fmt::Display for ProviderModelConfig {
 // Provider catalogue — add new providers/models here
 // ============================================================================
 
-// Not wired into the live matrix. Both `claude-fable-5-1` and `claude-fable-5`
-// serve inference on the Doppler `ANTHROPIC_API_KEY` (verified 2026-09-02 with
-// a `max_tokens: 1` request); the earlier "Model not available" dates from the
-// period when Anthropic had Fable disabled. They stay out of the `#[case]`
-// lists on cost grounds only ($10/$50 per MTok, 2x Opus 5) — Anthropic is
-// covered via haiku/opus/sonnet below. Add a `#[case]` to opt a test in.
+// Fable 5.1 is in the live matrix (top tier, $10/$50 per MTok — keep its
+// cases to the basic/thinking suites). Fable 5 stays out: same tier, same
+// surface, superseded. The earlier "Model not available" on Fable dates from
+// the period when Anthropic had it disabled; both ids serve inference on the
+// Doppler `ANTHROPIC_API_KEY` (verified 2026-09-02).
 pub const ANTHROPIC_FABLE_5_1: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::Anthropic, "claude-fable-5-1", "ANTHROPIC_API_KEY");
 pub const ANTHROPIC_FABLE: ProviderModelConfig =
@@ -114,6 +113,9 @@ pub const ANTHROPIC_SONNET: ProviderModelConfig = ProviderModelConfig::new(
     "claude-sonnet-4-6",
     "ANTHROPIC_API_KEY",
 );
+
+pub const ANTHROPIC_SONNET5: ProviderModelConfig =
+    ProviderModelConfig::new(DriverId::Anthropic, "claude-sonnet-5", "ANTHROPIC_API_KEY");
 
 pub const OPENAI_GPT56_LUNA: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::OpenAI, "gpt-5.6-luna", "OPENAI_API_KEY")

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -85,12 +85,12 @@ impl std::fmt::Display for ProviderModelConfig {
 // Provider catalogue — add new providers/models here
 // ============================================================================
 
-// Not wired into the live matrix: `claude-fable-5` is listed by the Anthropic
-// `/models` endpoint but returns "Model not available" on inference from the
-// CI key, and `claude-fable-5-1` (its successor, same tier and rate-limit
-// pool) is assumed to behave the same until verified. Re-add the `#[case]`
-// entries once they're usable; Anthropic stays covered via haiku/opus/sonnet
-// below.
+// Not wired into the live matrix. Both `claude-fable-5-1` and `claude-fable-5`
+// serve inference on the Doppler `ANTHROPIC_API_KEY` (verified 2026-09-02 with
+// a `max_tokens: 1` request); the earlier "Model not available" dates from the
+// period when Anthropic had Fable disabled. They stay out of the `#[case]`
+// lists on cost grounds only ($10/$50 per MTok, 2x Opus 5) — Anthropic is
+// covered via haiku/opus/sonnet below. Add a `#[case]` to opt a test in.
 pub const ANTHROPIC_FABLE_5_1: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::Anthropic, "claude-fable-5-1", "ANTHROPIC_API_KEY");
 pub const ANTHROPIC_FABLE: ProviderModelConfig =

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -150,7 +150,7 @@ fn reasoning_effort_anthropic_extended_thinking() -> ReasoningEffortConfig {
 }
 
 /// Adaptive thinking config for recent Claude reasoning models
-/// (Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6)
+/// (Fable 5.1, Fable 5, Opus 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6)
 /// Uses thinking.type="adaptive" with effort parameter instead of budget_tokens
 /// Default: high, supports: low, medium, high, max (mapped to xhigh)
 fn reasoning_effort_anthropic_adaptive_thinking() -> ReasoningEffortConfig {
@@ -380,6 +380,7 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["gpt-5.6-terra"], ModelVendor::OpenAi, OPENAI),
     md(&["gpt-5.6-luna"], ModelVendor::OpenAi, OPENAI),
     // Anthropic
+    md(&["claude-fable-5-1"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-fable-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-8"], ModelVendor::Anthropic, ANTHROPIC),
@@ -389,6 +390,7 @@ static REGISTRY: &[ModelDescriptor] = &[
     // 200K base models (e.g. "Opus 4.8" vs "Opus 4.8 (1M)" in the picker); the
     // driver sends the `context-1m` beta header for them. See
     // `anthropic_1m_variant` for how their profiles are derived.
+    md(&["claude-fable-5-1[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-fable-5[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-5[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-8[1m]"], ModelVendor::Anthropic, ANTHROPIC),
@@ -2450,7 +2452,7 @@ fn anthropic_1m_variant(mut profile: ModelProfile) -> ModelProfile {
 
 /// Whether a Claude model `family` supports Anthropic's hosted tool_search
 /// (the `tool_search_tool_*_20251119` server tools). Per docs.claude.com, this
-/// is Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, and Fable 5 — the 3.x families do not
+/// is Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, and Fable 5.x — the 3.x families do not
 /// support it. Centralized here (rather than per-literal) because the rule is a
 /// clean family cutoff; contrast the OpenAI profiles, which set `tool_search`
 /// per model literal.
@@ -2462,7 +2464,8 @@ fn anthropic_1m_variant(mut profile: ModelProfile) -> ModelProfile {
 fn anthropic_family_supports_tool_search(family: &str) -> bool {
     matches!(
         family,
-        "claude-fable-5"
+        "claude-fable-5-1"
+            | "claude-fable-5"
             | "claude-opus-5"
             | "claude-opus-4-8"
             | "claude-opus-4-7"
@@ -2487,7 +2490,57 @@ fn anthropic_profile_data(model_id: &str) -> Option<ModelProfile> {
 
 fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
     match model_id {
-        // Claude Fable 5 (newest — top tier above Opus)
+        // Claude Fable 5.1 (newest — top tier above Opus; successor to Fable 5)
+        // Source: Anthropic model card (claude-api skill `shared/models.md`) and
+        // docs.claude.com — Fable 5.1 is not yet in models.dev. Same tier, limits
+        // and per-token price as Fable 5 ($10/$50); cache reads drop to $0.25/MTok
+        // (a quarter of Fable 5's $1.00). Same request surface as Fable 5:
+        // adaptive thinking only (an explicit `thinking: {type: "disabled"}`
+        // returns 400, so the param is omitted when no effort is set), sampling
+        // parameters removed (`temperature: false`). Fable 5.1 additionally
+        // rejects forced tool use (`tool_choice` `any`/`tool` return 400); the
+        // Anthropic driver only ever sends `auto`, so no driver change is needed.
+        // Release/knowledge dates are not published in the model card; the
+        // Models API exposes them at runtime.
+        "claude-fable-5-1" => Some(ModelProfile {
+            name: "Claude Fable 5.1".into(),
+            family: "claude-fable-5-1".into(),
+            description: None,
+            release_date: None,
+            last_updated: None,
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: None,
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(ModelCost {
+                input: 10.00,
+                output: 50.00,
+                cache_read: Some(0.25),
+                cost_tiers: vec![],
+            }),
+            limits: Some(ModelLimits {
+                // Bare id is the 200K profile; `claude-fable-5-1[1m]` is the 1M twin.
+                context: 200_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(ModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Pdf],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            speed: None,
+            verbosity: None,
+            tool_search: false,
+            supported_parameters: Vec::new(),
+            supports_phases: false,
+        }),
+
+        // Claude Fable 5 (previous Fable release; still served, below Fable 5.1)
         // Source: Anthropic model card (claude-api skill `shared/models.md`) and
         // docs.claude.com — Fable 5 is not yet in models.dev. Same API surface as
         // Opus 4.8: adaptive thinking only, sampling parameters removed (temperature
@@ -2534,7 +2587,7 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
             supports_phases: false,
         }),
 
-        // Claude Opus 5 (current Opus; below Fable 5, above Opus 4.8)
+        // Claude Opus 5 (current Opus; below Fable 5.1, above Opus 4.8)
         // Source: Anthropic model card (claude-api skill `shared/models.md`) and
         // docs.claude.com — Opus 5 is not yet in models.dev. A drop-in upgrade at
         // Opus 4.8's pricing ($5/$25, cache-read $0.50) with the same 200K/1M-twin
@@ -2707,6 +2760,9 @@ fn anthropic_profile_data_inner(model_id: &str) -> Option<ModelProfile> {
 
         // 1M-context twins of the base profiles above. Same pricing and
         // capabilities; only the context limit and display name differ.
+        "claude-fable-5-1[1m]" => {
+            anthropic_profile_data("claude-fable-5-1").map(anthropic_1m_variant)
+        }
         "claude-fable-5[1m]" => anthropic_profile_data("claude-fable-5").map(anthropic_1m_variant),
         "claude-opus-5[1m]" => anthropic_profile_data("claude-opus-5").map(anthropic_1m_variant),
         "claude-opus-4-8[1m]" => {
@@ -3346,6 +3402,7 @@ mod tests {
         (DriverId::OpenAI, "gpt-5.6-terra"),
         (DriverId::OpenAI, "gpt-5.6-luna"),
         // Anthropic
+        (DriverId::Anthropic, "claude-fable-5-1"),
         (DriverId::Anthropic, "claude-fable-5"),
         (DriverId::Anthropic, "claude-opus-5"),
         (DriverId::Anthropic, "claude-opus-4-8"),
@@ -4413,6 +4470,34 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_fable_5_1_profile_and_1m_variant() {
+        // `claude-fable-5-1` is its own family: the `-1` is not a version
+        // suffix, so it must not fall back to the Fable 5 descriptor.
+        let base = get_model_profile(&DriverId::Anthropic, "claude-fable-5-1").unwrap();
+        assert_eq!(base.name, "Claude Fable 5.1");
+        assert_eq!(base.family, "claude-fable-5-1");
+        assert_eq!(base.limits.as_ref().unwrap().context, 200_000);
+        assert!(base.reasoning);
+        assert!(!base.temperature);
+        assert!(base.tool_search);
+        let base_cost = base.cost.as_ref().unwrap();
+        let fable_5_cost = get_model_profile(&DriverId::Anthropic, "claude-fable-5")
+            .unwrap()
+            .cost
+            .unwrap();
+        // Same per-token price as Fable 5; cache reads are a quarter of it.
+        assert_eq!(base_cost.input, fable_5_cost.input);
+        assert_eq!(base_cost.output, fable_5_cost.output);
+        assert_eq!(base_cost.cache_read, Some(0.25));
+
+        let m1 = get_model_profile(&DriverId::Anthropic, "claude-fable-5-1[1m]").unwrap();
+        assert_eq!(m1.name, "Claude Fable 5.1 (1M)");
+        assert_eq!(m1.family, "claude-fable-5-1");
+        assert_eq!(m1.limits.as_ref().unwrap().context, 1_000_000);
+        assert_eq!(m1.cost.unwrap().input, base_cost.input);
+    }
+
+    #[test]
     fn test_claude_opus_4_7_and_4_6_have_1m_variants() {
         for id in ["claude-opus-4-7[1m]", "claude-opus-4-6[1m]"] {
             let m1 = get_model_profile(&DriverId::Anthropic, id).unwrap();
@@ -4575,6 +4660,7 @@ mod tests {
     fn test_anthropic_native_tool_search_by_family() {
         // Claude 4-family + Fable advertise Anthropic's hosted tool_search.
         for id in [
+            "claude-fable-5-1",
             "claude-fable-5",
             "claude-opus-5",
             "claude-opus-4-8",

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -121,6 +121,7 @@ mod seed_ids {
         Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000229);
 
     // Anthropic Models (0x300-0x3FF)
+    pub const CLAUDE_FABLE_5_1: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030f);
     pub const CLAUDE_OPUS_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030e);
     pub const CLAUDE_SONNET_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030c);
     pub const CLAUDE_OPUS_4_8: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030d);
@@ -132,6 +133,7 @@ mod seed_ids {
     pub const CLAUDE_HAIKU_4_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000303);
     pub const CLAUDE_OPUS_4: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000304);
     // 1M-context variants (`[1m]` model ids), 0x3a0+ sub-range.
+    pub const CLAUDE_FABLE_5_1_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a9);
     pub const CLAUDE_OPUS_5_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a8);
     pub const CLAUDE_OPUS_4_7_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a7);
     pub const CLAUDE_SONNET_5_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a5);
@@ -1837,7 +1839,29 @@ const SEED_MODELS: &[SeedModel] = &[
         enabled: false,
         is_favorite: false,
     },
-    // Anthropic current-gen (Opus 5, Sonnet 5, Opus 4.8)
+    // Anthropic current-gen (Fable 5.1, Opus 5, Sonnet 5, Opus 4.8)
+    SeedModel {
+        // Fable 5.1 is Anthropic's top tier above Opus (successor to Fable 5,
+        // which is intentionally not seeded). Priced at 2x Opus 5, so Opus 5
+        // stays the recommended default while Fable 5.1 is available for the
+        // hardest reasoning and long-horizon agentic work.
+        id: seed_ids::CLAUDE_FABLE_5_1,
+        provider_id: seed_ids::ANTHROPIC_PROVIDER,
+        model_id: "claude-fable-5-1",
+        display_name: "Claude Fable 5.1",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
+    SeedModel {
+        // 1M-context twin of the 200K base above (driver sends the `context-1m`
+        // beta header for `[1m]` ids).
+        id: seed_ids::CLAUDE_FABLE_5_1_1M,
+        provider_id: seed_ids::ANTHROPIC_PROVIDER,
+        model_id: "claude-fable-5-1[1m]",
+        display_name: "Claude Fable 5.1 (1M)",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
     SeedModel {
         // Opus 5 is the current Opus flagship — the recommended Anthropic model.
         id: seed_ids::CLAUDE_OPUS_5,
@@ -3463,6 +3487,16 @@ mod tests {
             .await
             .unwrap();
         let anthropic = by_id(&anthropic);
+        assert_eq!(
+            anthropic.get("claude-fable-5-1"),
+            Some(&(true, true)),
+            "Fable 5.1 must be seeded as an enabled favorite"
+        );
+        assert_eq!(
+            anthropic.get("claude-fable-5-1[1m]"),
+            Some(&(true, true)),
+            "Fable 5.1 (1M) twin must be seeded and enabled"
+        );
         assert_eq!(
             anthropic.get("claude-opus-5"),
             Some(&(true, true)),

--- a/docs/capabilities/claude-tool-search.md
+++ b/docs/capabilities/claude-tool-search.md
@@ -50,7 +50,7 @@ Tool search requires model-level support. Per Anthropic, it is available on:
 | Opus 4.x (`claude-opus-4*`) | Yes |
 | Sonnet 4.5 / 4.6 (`claude-sonnet-4-5`, `claude-sonnet-4-6`) | Yes |
 | Haiku 4.5 (`claude-haiku-4-5`) | Yes |
-| Fable 5 (`claude-fable-5`) | Yes |
+| Fable 5.1 / 5 (`claude-fable-5-1`, `claude-fable-5`) | Yes |
 | Retired pre-4 Claude models | No (capability is silently ignored) |
 
 When the capability is enabled but the model doesn't support tool search, the feature is **silently skipped, full tool schemas are sent as usual**. This standalone capability does *not* add a client-side fallback: on an unsupported model it simply does nothing (no error, no behavior change). For automatic fallback to client-side deferral, use [Auto Tool Search](/capabilities/auto-tool-search/) (or add the [Tool Search](/capabilities/tool-search/) capability explicitly).

--- a/knowledge/execution/tool-search.md
+++ b/knowledge/execution/tool-search.md
@@ -212,7 +212,7 @@ let use_tool_search = profile.tool_search && config.tools.len() >= TOOL_SEARCH_T
 
 ## Model Profile Updates
 
-Set `tool_search: true` for models that support it. Default `false` for all others. See `crates/provider/src/model_profiles.rs` for current profile definitions. OpenAI sets the flag per model literal (the `gpt-5.4*` / `gpt-5.5*` families); Anthropic sets it centrally by family in `anthropic_family_supports_tool_search` (Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, Fable 5, per docs.claude.com), since the support rule is a clean family cutoff.
+Set `tool_search: true` for models that support it. Default `false` for all others. See `crates/provider/src/model_profiles.rs` for current profile definitions. OpenAI sets the flag per model literal (the `gpt-5.4*` / `gpt-5.5*` families); Anthropic sets it centrally by family in `anthropic_family_supports_tool_search` (Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, Fable 5.x, per docs.claude.com), since the support rule is a clean family cutoff.
 
 A model's `tool_search: true` flag must be backed by a verified end-to-end round-trip
 (deferred-load → schema fetch → tool call) against the live provider, not just the

--- a/knowledge/foundations/llm-drivers.md
+++ b/knowledge/foundations/llm-drivers.md
@@ -238,7 +238,7 @@ replay state (signature / encrypted payload), and identity (provider, item id,
 bound tool call). Only readable text is ever rendered or published; replay state
 is carried verbatim and never leaves the driver boundary.
 
-Anthropic has two thinking request forms, selected per model family by the driver. Recent Claude families (Fable 5, Opus 4.8/4.7, and the 4.6 family) take adaptive thinking (`thinking.type = "adaptive"` plus `output_config.effort`); the budget-based `budget_tokens` form is removed on Fable 5 and Opus 4.8/4.7 and returns 400 there. Older Claude models keep budget-based extended thinking. The family list lives in `crates/drivers/anthropic/src/driver.rs` and must stay in sync with the adaptive-thinking profiles in `crates/provider/src/model_profiles.rs`.
+Anthropic has two thinking request forms, selected per model family by the driver. Recent Claude families (Fable 5.x, Opus 5/4.8/4.7, Sonnet 5, and the 4.6 family) take adaptive thinking (`thinking.type = "adaptive"` plus `output_config.effort`); the budget-based `budget_tokens` form is removed on Fable 5.x, Opus 5/4.8/4.7, and Sonnet 5 and returns 400 there. Older Claude models keep budget-based extended thinking. The family list lives in `crates/drivers/anthropic/src/driver.rs` and must stay in sync with the adaptive-thinking profiles in `crates/provider/src/model_profiles.rs`.
 
 #### Stream Events
 


### PR DESCRIPTION
## What changed
- **Claude Fable 5.1 is a first-class model.** `claude-fable-5-1` and its 1M twin `claude-fable-5-1[1m]` resolve to their own profile (adaptive thinking, no sampling params, hosted tool search, 200K/1M context, 128K output, $10/$50 per MTok with $0.25 cache reads). The Anthropic driver treats the family as adaptive-thinking and 1M-capable, and the tool-search capability recognizes it. The `-1` suffix is deliberately not treated as a version suffix, so it does not fall back to the Fable 5 descriptor.
- **Seeded by default.** Both Fable 5.1 ids are seeded as enabled favorites next to Opus 5. Fable 5 stays unseeded, as before. Opus 5 remains the recommended default in the seed comments since Fable 5.1 costs 2x.
- **Live LLM matrix tracks current Anthropic tiers.** Fable 5.1 and Sonnet 5 join the basic and thinking suites; Opus 4.7 and Sonnet 4.6 leave the thinking rows and their constants are dropped. The stale "Fable returns Model not available" note is replaced (it dated from when Anthropic had Fable disabled; both ids serve inference on the Doppler key).
- **Thinking-with-tool-call prompt hardened.** Fable 5.1 rejects forced `tool_choice`, and with adaptive thinking on, Fable 5.1 and Sonnet 5 answered the old soft wording without calling `get_current_time` (3/3 clean sampling misses). The system prompt now states the agent has no clock and must call the tool first, and the user turn asks for a tool check. Every existing row still passes.
- Docs and knowledge pages that listed Fable 5 now say Fable 5.x.

## Why
Fable 5.1 is Anthropic's current top tier and the successor to Fable 5. The registry, driver family lists, seed catalog, and matrix all named Fable 5 only, so 5.1 was unselectable and unprofiled.

## Before / After
**Before:** `claude-fable-5-1` had no descriptor, so `get_model_profile(Anthropic, "claude-fable-5-1")` returned `None`, the driver did not classify it as adaptive-thinking, and it was absent from the seeded catalog.

**After** (dev-mode server, `GET /api/v1/models`):
```
{"model_id": "claude-fable-5-1", "display_name": "Claude Fable 5.1", "enabled": true, "is_favorite": true, "provider_type": "anthropic"}
  profile: {"name": "Claude Fable 5.1", "family": "claude-fable-5-1", "reasoning": true, "temperature": false, "tool_search": true} | context: 200000 | cost: {"input": 10.0, "output": 50.0, "cache_read": 0.25}
{"model_id": "claude-fable-5-1[1m]", "display_name": "Claude Fable 5.1 (1M)", ...} | context: 1000000 | cost: same
```

Live inference against the Doppler `ANTHROPIC_API_KEY` (one-token probe, HTTP 200 on both `claude-fable-5-1` and `claude-fable-5`), and the matrix rows below through the real Anthropic driver:

| Suite | Rows | Result |
|---|---|---|
| basic completion / tool call / file-system schemas | Fable 5.1, Sonnet 5 | pass |
| extended thinking | Fable 5.1, Opus 5, Sonnet 5 | pass |
| thinking with tool call | Fable 5.1, Opus 5, Sonnet 5, GPT-5.2, GPT-5.4, Meta Muse Spark | pass, no first-attempt misses; Sonnet 5 6/6 first-try after the prompt change (was ~5/7) |

Gemini skipped in every local run because its key resolves as unset in the Doppler config reachable here; that predates this branch.

Evidence commands: `cargo fmt --check`, `cargo clippy --all-targets -D warnings` on provider/anthropic/builtins/server/llm-tests, `cargo test --lib` on provider (incl. the structural registry invariant and new Fable 5.1 tests), anthropic driver, builtins, and server seed tests, `./scripts/lib/pre-push.sh`, `python3 scripts/check_okf.py knowledge`, migration ordering check.

## Risk
- Low
- A wrong profile value (pricing, limits) would misreport cost estimates or context budgets for Fable 5.1 only. Matrix rows add LLM CI spend (Fable 5.1 at $10/$50 on the basic and thinking suites). The hardened prompt could in principle change elicitation on non-Anthropic rows; all of them were re-run green.

## Security
- Threat categories reviewed: TM-LLM (provider keys, model profiles; TM-LLM-022 key resolution untouched), TM-AUTHZ (TM-AUTHZ-010 `enabled` gate: new seed rows go through the same `CreateModelRow` path with `source: "predefined"`), TM-DOS (no new unbounded work; profile lookup is a static match).
- Findings and resolutions: none. The diff adds static registry data, seed rows, family-list entries, tests, and prompt text; no new trust boundary, input parsing, or network path. No `THREAT` markers are near the touched code. Threat model unchanged.

## Follow-ups
- Sonnet 5 profile prices at $3/$15 with $0.30 cache reads while Anthropic's current table lists $2/$10; unrelated to this branch and needs a source check before changing.
- Gemini rows skip locally and possibly in CI because `GEMINI_API_KEY` resolves empty in the Doppler config; worth confirming CI coverage.
- No Bedrock seed for Fable 5.1: availability on Bedrock is unconfirmed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01CZaBEuvRbS8KDPCCmqbEyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZaBEuvRbS8KDPCCmqbEyk)_