### PR TITLE
feat(models): add Muse Spark 1.3 and move Meta coverage onto it

### DIFF
--- a/crates/drivers/meta/src/driver.rs
+++ b/crates/drivers/meta/src/driver.rs
@@ -187,7 +187,7 @@ mod tests {
             META_DEFAULT_API_URL
         );
         assert!(driver.supports_stateful_responses());
-        assert!(driver.supports_parallel_tool_calls("muse-spark-1.2"));
+        assert!(driver.supports_parallel_tool_calls("muse-spark-1.3"));
     }
 
     #[test]
@@ -222,7 +222,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "object": "list",
                 "data": [{
-                    "id": "muse-spark-1.2",
+                    "id": "muse-spark-1.3",
                     "object": "model",
                     "created": 1_785_888_000_i64,
                     "owned_by": "meta"
@@ -244,7 +244,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(models.len(), 1);
-        assert_eq!(models[0].model_id, "muse-spark-1.2");
+        assert_eq!(models[0].model_id, "muse-spark-1.3");
         assert_eq!(models[0].owned_by.as_deref(), Some("meta"));
         assert!(models[0].created_at.is_some());
     }

--- a/crates/drivers/meta/tests/model_api_live.rs
+++ b/crates/drivers/meta/tests/model_api_live.rs
@@ -11,7 +11,7 @@ use everruns_provider::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy,
 };
 
-const LIVE_MODEL: &str = "muse-spark-1.2-contributor";
+const LIVE_MODEL: &str = "muse-spark-1.3-contributor";
 
 fn api_key() -> String {
     std::env::var("MODEL_API_KEY")

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -129,7 +129,7 @@ pub const GEMINI_FLASH: ProviderModelConfig =
 // terms are acceptable for these synthetic test prompts.
 pub const META_MUSE_SPARK_CONTRIBUTOR: ProviderModelConfig = ProviderModelConfig::new(
     DriverId::Meta,
-    "muse-spark-1.2-contributor",
+    "muse-spark-1.3-contributor",
     "MODEL_API_KEY",
 )
 .reasoning_as_text();

--- a/crates/provider/src/model_profiles.rs
+++ b/crates/provider/src/model_profiles.rs
@@ -435,6 +435,16 @@ static REGISTRY: &[ModelDescriptor] = &[
         MICROSOFT_MAI,
     ),
     md(
+        &["muse-spark-1.3", "meta/muse-spark-1.3"],
+        ModelVendor::Meta,
+        META_MUSE,
+    ),
+    md(
+        &["muse-spark-1.3-contributor"],
+        ModelVendor::Meta,
+        META_ONLY,
+    ),
+    md(
         &["muse-spark-1.2", "meta/muse-spark-1.2"],
         ModelVendor::Meta,
         META_MUSE,
@@ -681,36 +691,59 @@ fn profile_data(canonical: &str) -> Option<ModelProfile> {
 }
 
 fn meta_profile_data(model_id: &str) -> Option<ModelProfile> {
-    let (name, description, cost) = match model_id {
+    // Meta prices the Standard and Contributor tiers identically across Muse
+    // Spark 1.2 and 1.3; only the data-use terms differ between tiers.
+    const MUSE_STANDARD_COST: ModelCost = ModelCost {
+        input: 1.25,
+        output: 4.25,
+        cache_read: Some(0.15),
+        cost_tiers: vec![],
+    };
+    const MUSE_CONTRIBUTOR_COST: ModelCost = ModelCost {
+        input: 0.10,
+        output: 0.20,
+        cache_read: Some(0.002),
+        cost_tiers: vec![],
+    };
+
+    let (name, family, release_date, description, cost) = match model_id {
+        "muse-spark-1.3" => (
+            "Muse Spark 1.3",
+            "muse-spark-1.3",
+            "2026-09-02",
+            "Meta's Muse Spark model for long-horizon coding and multi-step agentic work, with native tool calling and MCP support. Prompts and completions are not used to train Meta models.",
+            MUSE_STANDARD_COST,
+        ),
+        "muse-spark-1.3-contributor" => (
+            "Muse Spark 1.3 Contributor",
+            "muse-spark-1.3",
+            "2026-09-02",
+            "Discounted Muse Spark 1.3 tier with the same model and capabilities as Standard. Prompts and completions are used to train and improve Meta models; rate-limited by tokens.",
+            MUSE_CONTRIBUTOR_COST,
+        ),
         "muse-spark-1.2" => (
             "Muse Spark 1.2",
+            "muse-spark-1.2",
+            "2026-08-05",
             "Meta's coding-optimized Muse Spark model. Prompts and completions are not used to train Meta models.",
-            ModelCost {
-                input: 1.25,
-                output: 4.25,
-                cache_read: Some(0.15),
-                cost_tiers: vec![],
-            },
+            MUSE_STANDARD_COST,
         ),
         "muse-spark-1.2-contributor" => (
             "Muse Spark 1.2 Contributor",
+            "muse-spark-1.2",
+            "2026-08-05",
             "Discounted Muse Spark 1.2 tier where prompts and completions may be used to train future Meta models.",
-            ModelCost {
-                input: 0.10,
-                output: 0.20,
-                cache_read: Some(0.002),
-                cost_tiers: vec![],
-            },
+            MUSE_CONTRIBUTOR_COST,
         ),
         _ => return None,
     };
 
     Some(ModelProfile {
         name: name.into(),
-        family: "muse-spark-1.2".into(),
+        family: family.into(),
         description: Some(description.into()),
-        release_date: Some("2026-08-05".into()),
-        last_updated: Some("2026-08-05".into()),
+        release_date: Some(release_date.into()),
+        last_updated: Some(release_date.into()),
         attachment: true,
         reasoning: true,
         temperature: true,
@@ -4714,9 +4747,10 @@ mod tests {
     }
 
     #[test]
-    fn test_muse_spark_1_2_profiles_and_tiers() {
-        let standard = get_model_profile(&DriverId::Meta, "muse-spark-1.2").unwrap();
-        assert_eq!(standard.name, "Muse Spark 1.2");
+    fn test_muse_spark_1_3_profiles_and_tiers() {
+        let standard = get_model_profile(&DriverId::Meta, "muse-spark-1.3").unwrap();
+        assert_eq!(standard.name, "Muse Spark 1.3");
+        assert_eq!(standard.family, "muse-spark-1.3");
         assert_eq!(standard.limits.as_ref().unwrap().context, 1_048_576);
         assert!(standard.tool_call);
         assert!(standard.tool_search);
@@ -4737,7 +4771,9 @@ mod tests {
         assert_eq!(standard_cost.cache_read, Some(0.15));
         assert_eq!(standard_cost.output, 4.25);
 
-        let contributor = get_model_profile(&DriverId::Meta, "muse-spark-1.2-contributor").unwrap();
+        let contributor = get_model_profile(&DriverId::Meta, "muse-spark-1.3-contributor").unwrap();
+        assert_eq!(contributor.name, "Muse Spark 1.3 Contributor");
+        assert_eq!(contributor.family, "muse-spark-1.3");
         let contributor_cost = contributor.cost.unwrap();
         assert_eq!(contributor_cost.input, 0.10);
         assert_eq!(contributor_cost.cache_read, Some(0.002));
@@ -4747,27 +4783,40 @@ mod tests {
                 .description
                 .as_deref()
                 .unwrap()
-                .contains("may be used to train")
+                .contains("used to train")
         );
         assert_eq!(
-            get_model_profile_key(&DriverId::Meta, "muse-spark-1.2-contributor").as_deref(),
-            Some("meta/muse-spark-1.2-contributor")
+            get_model_profile_key(&DriverId::Meta, "muse-spark-1.3-contributor").as_deref(),
+            Some("meta/muse-spark-1.3-contributor")
         );
     }
 
     #[test]
+    fn test_muse_spark_1_2_profiles_stay_resolvable() {
+        // 1.2 remains served by Meta and referenced by existing model records,
+        // so it keeps its own family and profile next to 1.3.
+        let standard = get_model_profile(&DriverId::Meta, "muse-spark-1.2").unwrap();
+        assert_eq!(standard.name, "Muse Spark 1.2");
+        assert_eq!(standard.family, "muse-spark-1.2");
+        let contributor = get_model_profile(&DriverId::Meta, "muse-spark-1.2-contributor").unwrap();
+        assert_eq!(contributor.name, "Muse Spark 1.2 Contributor");
+        assert_eq!(contributor.family, "muse-spark-1.2");
+        assert!(get_model_profile(&DriverId::OpenRouter, "muse-spark-1.2-contributor").is_none());
+    }
+
+    #[test]
     fn test_muse_surface_capabilities_are_transport_gated() {
-        let direct = get_model_profile(&DriverId::Meta, "muse-spark-1.2").unwrap();
+        let direct = get_model_profile(&DriverId::Meta, "muse-spark-1.3").unwrap();
         assert!(direct.supports_phases);
         assert!(direct.tool_search);
 
-        let openrouter = get_model_profile(&DriverId::OpenRouter, "meta/muse-spark-1.2").unwrap();
+        let openrouter = get_model_profile(&DriverId::OpenRouter, "meta/muse-spark-1.3").unwrap();
         assert!(!openrouter.supports_phases);
         assert!(!openrouter.tool_search);
 
-        assert!(get_model_profile(&DriverId::OpenRouter, "muse-spark-1.2-contributor").is_none());
+        assert!(get_model_profile(&DriverId::OpenRouter, "muse-spark-1.3-contributor").is_none());
         assert_eq!(
-            get_model_vendor(&DriverId::Meta, "muse-spark-1.2"),
+            get_model_vendor(&DriverId::Meta, "muse-spark-1.3"),
             Some(ModelVendor::Meta)
         );
     }

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -1,6 +1,6 @@
 ---
 title: Meta Model API
-description: Run Everruns agents on Muse Spark 1.2 through Meta Model API, including the discounted Contributor tier.
+description: Run Everruns agents on Muse Spark 1.3 through Meta Model API, including the discounted Contributor tier.
 sidebar:
   label: Meta Model API
 ---
@@ -22,22 +22,27 @@ replay, message phases, hosted tool search, and server-managed response history.
 The hosted endpoint is used by default. An optional base URL can point the
 driver at a compatible proxy; model discovery is disabled for non-Meta hosts.
 
-## Muse Spark 1.2 tiers
+## Muse Spark 1.3 tiers
 
-Both 1.2 model IDs have a 1,048,576-token context window and accept text,
-images, audio, video, and PDFs while producing text.
+Muse Spark 1.3 is built for long-horizon coding and multi-step agentic work,
+with native tool calling and MCP support. Both 1.3 model IDs have a
+1,048,576-token context window and accept text, images, audio, video, and PDFs
+while producing text.
 
 | Model | Data use | Input / cached input / output per million tokens |
 |---|---|---|
-| `muse-spark-1.2` | Prompts and completions are not used to train Meta models | $1.25 / $0.15 / $4.25 |
-| `muse-spark-1.2-contributor` | Prompts and completions may be used to train future Meta models | $0.10 / $0.002 / $0.20 |
+| `muse-spark-1.3` | Prompts and completions are not used to train Meta models | $1.25 / $0.15 / $4.25 |
+| `muse-spark-1.3-contributor` | Prompts and completions are used to train and improve Meta models; rate-limited by tokens | $0.10 / $0.002 / $0.20 |
 
 Choose the Contributor model only when the organization accepts its data-use
 terms. The distinction is part of the model ID, so changing tiers is an explicit
 model selection rather than a hidden provider setting.
 
+The previous `muse-spark-1.2` and `muse-spark-1.2-contributor` IDs remain
+available with the same tiers and pricing.
+
 ## Links
 
 - [Meta Model API documentation](https://dev.meta.ai/docs/overview/)
-- [Muse Spark 1.2 model page](https://developer.meta.com/ai/models/muse-spark/)
+- [Muse Spark model page](https://developer.meta.com/ai/models/muse-spark/)
 - [Migrate between providers](/how-to/migrate-providers/)


### PR DESCRIPTION
## What changed
Muse Spark 1.3 is now a first-class Meta model. `muse-spark-1.3` (plus the `meta/muse-spark-1.3` gateway alias) and `muse-spark-1.3-contributor` resolve to profiles with their own family, description, and release date, the same 1M joint context, modalities, tool search, and phase support as 1.2, and the identical Standard / Contributor pricing. The 1.2 ids stay registered so existing model records keep resolving.

Every place that exercised 1.2 now targets 1.3: the Meta driver unit tests, the ignored Meta live compatibility test, and the shared live LLM matrix row (`META_MUSE_SPARK_CONTRIBUTOR`), which already sits in the `agent_run_basic` and `agent_run_with_thinking` suites CI runs in the live provider matrix. The Meta provider docs describe the 1.3 tiers and note that 1.2 remains selectable.

## Why
Meta shipped Muse Spark 1.3 (long-horizon coding, native tool calling and MCP, fewer tokens than 1.2). Everruns should offer it out of the box and keep live coverage on the current model rather than the superseded one.

## Before / After
Before: `get_model_profile(&DriverId::Meta, "muse-spark-1.3")` returned `None`; the live matrix and Meta driver tests used `muse-spark-1.2-contributor`.

After (local):
```
cargo test -p everruns-provider --lib model_profiles
test model_profiles::tests::test_muse_spark_1_3_profiles_and_tiers ... ok
test model_profiles::tests::test_muse_spark_1_2_profiles_stay_resolvable ... ok
test model_profiles::tests::test_muse_surface_capabilities_are_transport_gated ... ok
test result: ok. 77 passed; 0 failed

cargo test -p everruns-meta
test result: ok. 5 passed; 0 failed   (unit)
test result: ok. 0 passed; 2 ignored  (live, needs MODEL_API_KEY)

cargo test -p everruns-llm-tests --all-features --no-run   -> Finished
cargo fmt --check / cargo clippy --all-features --tests    -> clean
cd apps/docs && pnpm run check                             -> 0 errors, 0 warnings
```
The live 1.3 calls run in the push-only `live-provider-matrix` CI job on `main` after merge (Doppler is not available in the authoring environment). No runtime behavior changes beyond profile lookup, so no stack smoke test beyond the unit and live suites.

## Risk
- Low
- A wrong profile field for 1.3 (price, context, capability gating) would mis-report cost or capabilities in the UI; the live matrix would surface any wire-level incompatibility on 1.3.

## Security
- Threat categories reviewed: No security-relevant code changes. The diff is static model metadata (ids, names, prices, dates), test targets, and docs; no auth, API, tool, tenancy, filesystem, SQL, or provider-key handling is touched (TM-LLM key handling unchanged).
- Findings and resolutions: none.

## Follow-ups
- The 1.3 release date is set to 2026-09-02 from the catalog's "New" badge; adjust if Meta publishes a different date. Trivial, not worth a separate issue.
- No Meta models are seeded (the seed catalog has none; Meta models arrive via provider discovery), so this PR keeps that pattern.

## CI notes
- No `ci:skip-*` labels were used. The first attempt's `Lockfile Check` failed on a crates.io `Connection reset by peer` inside `scripts/check-publish-cone.py --pre-merge` (unrelated to this diff, passes locally); the failed job was re-run once and passed.
- No migrations on either side since the merge base; `check-migration-ordering.sh` reports 001..125 sequential.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning) — none received

https://claude.ai/code/session_01DFhk8MvRBsjgTmNWArLjsX