### PR TITLE
fix(server): honour NATS_URL credentials and cut Sentry noise from prod logs

### DIFF
--- a/apps/ui/src/__tests__/use-session-tasks.test.tsx
+++ b/apps/ui/src/__tests__/use-session-tasks.test.tsx
@@ -1,0 +1,139 @@
+// EVERRUNS-1M: every useSessionTasks instance used to open its own SSE stream,
+// so the header chips plus the Work tab on a couple of tabs exhausted the
+// server's per-session stream cap. These tests pin the shared, ref-counted
+// stream per session.
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import type { SessionTask } from "@/lib/api/types";
+import { useSessionTasks } from "@/hooks/use-session-tasks";
+import { queryKeys } from "@/lib/query-keys";
+
+const mockSseListeners: Record<string, Array<(e: MessageEvent) => void>> = {};
+const mockStreams: Array<{ close: jest.Mock }> = [];
+
+jest.mock("@/lib/event-stream", () => ({
+  createEventStream: jest.fn(() => {
+    const stream = {
+      addEventListener: (type: string, listener: (e: MessageEvent) => void) => {
+        (mockSseListeners[type] ||= []).push(listener);
+      },
+      removeEventListener: () => {},
+      close: jest.fn(),
+      onopen: null,
+      onerror: null,
+    };
+    mockStreams.push(stream);
+    return stream;
+  }),
+}));
+
+const { createEventStream } = jest.requireMock("@/lib/event-stream") as {
+  createEventStream: jest.Mock;
+};
+
+const initialTask: SessionTask = {
+  id: "task_1",
+  session_id: "session-1",
+  root_session_id: "session-1",
+  kind: "subagent",
+  display_name: "Indexer",
+  state: "running",
+  attempt: 1,
+  wake_policy: "always",
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+} as unknown as SessionTask;
+
+jest.mock("@/lib/api/session-tasks", () => ({
+  listSessionTasks: jest.fn(async () => [initialTask]),
+  getSessionTask: jest.fn(),
+  cancelSessionTask: jest.fn(),
+  postSessionTaskMessage: jest.fn(),
+}));
+
+jest.mock("@/lib/api/events", () => ({
+  getSseUrl: jest.fn((sessionId: string) => `/sessions/${sessionId}/sse`),
+}));
+
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({ currentOrg: { public_id: "org-1" }, isLoading: false }),
+}));
+
+function fireTaskEvent(type: string, task: SessionTask) {
+  for (const handler of mockSseListeners[type] ?? []) {
+    handler({ data: JSON.stringify({ data: { task } }) } as MessageEvent);
+  }
+}
+
+describe("useSessionTasks shared SSE stream", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockStreams.length = 0;
+    for (const key of Object.keys(mockSseListeners)) delete mockSseListeners[key];
+  });
+
+  it("opens one stream per session across hook instances and closes it with the last", async () => {
+    const first = renderHook(() => useSessionTasks("session-1"), { wrapper });
+    const second = renderHook(() => useSessionTasks("session-1"), { wrapper });
+    await waitFor(() => expect(first.result.current.data).toHaveLength(1));
+    await waitFor(() => expect(second.result.current.data).toHaveLength(1));
+
+    expect(createEventStream).toHaveBeenCalledTimes(1);
+    expect(createEventStream).toHaveBeenCalledWith("/sessions/session-1/sse", {
+      withCredentials: true,
+    });
+
+    first.unmount();
+    expect(mockStreams[0].close).not.toHaveBeenCalled();
+
+    second.unmount();
+    expect(mockStreams[0].close).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens separate streams for different sessions", async () => {
+    const a = renderHook(() => useSessionTasks("session-1"), { wrapper });
+    const b = renderHook(() => useSessionTasks("session-2"), { wrapper });
+    await waitFor(() => expect(createEventStream).toHaveBeenCalledTimes(2));
+    a.unmount();
+    b.unmount();
+    expect(mockStreams.every((s) => s.close.mock.calls.length === 1)).toBe(true);
+  });
+
+  it("patches task snapshots into the shared list cache", async () => {
+    const view = renderHook(() => useSessionTasks("session-1"), { wrapper });
+    await waitFor(() => expect(view.result.current.data).toHaveLength(1));
+    await waitFor(() => expect(mockSseListeners["task.updated"]?.length).toBeGreaterThan(0));
+
+    act(() => {
+      fireTaskEvent("task.updated", { ...initialTask, state: "succeeded" });
+    });
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<SessionTask[]>(queryKeys.sessionTasks.list("session-1"))?.[0]
+          .state,
+      ).toBe("succeeded"),
+    );
+    view.unmount();
+  });
+
+  it("reopens a stream after the last subscriber released it", async () => {
+    const first = renderHook(() => useSessionTasks("session-1"), { wrapper });
+    await waitFor(() => expect(createEventStream).toHaveBeenCalledTimes(1));
+    first.unmount();
+    expect(mockStreams[0].close).toHaveBeenCalledTimes(1);
+
+    const second = renderHook(() => useSessionTasks("session-1"), { wrapper });
+    await waitFor(() => expect(createEventStream).toHaveBeenCalledTimes(2));
+    second.unmount();
+    expect(mockStreams[1].close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ui/src/hooks/use-session-tasks.ts
+++ b/apps/ui/src/hooks/use-session-tasks.ts
@@ -8,8 +8,8 @@
 // invalidate the per-task detail key.
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import {
   cancelSessionTask,
   getSessionTask,
@@ -33,6 +33,132 @@ export function upsertTask(tasks: SessionTask[] | undefined, task: SessionTask):
   return next;
 }
 
+// One SSE stream per session, shared by every `useSessionTasks` instance.
+//
+// Task chips in the header and the Work tab both subscribe to the same
+// session, and the server caps streams per session (SSE_PER_SESSION_MAX). With
+// a stream per hook instance, a couple of tabs on one session exhausted the
+// cap and the client looped on 429 (Sentry EVERRUNS-1M). Ref-counting keeps
+// the last subscriber's stream open and closes it when nobody listens.
+type SessionTaskStream = { refs: number; dispose: () => void };
+const sessionTaskStreams = new Map<string, SessionTaskStream>();
+
+/** Open (or join) the shared task stream for a session. Returns a release
+ *  function; the stream closes when the last subscriber releases it. */
+export function acquireSessionTaskStream(sessionId: string, queryClient: QueryClient): () => void {
+  let entry = sessionTaskStreams.get(sessionId);
+  if (!entry) {
+    entry = { refs: 0, dispose: subscribeSessionTasks(sessionId, queryClient) };
+    sessionTaskStreams.set(sessionId, entry);
+  }
+  const stream = entry;
+  stream.refs += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    stream.refs -= 1;
+    if (stream.refs > 0) return;
+    stream.dispose();
+    if (sessionTaskStreams.get(sessionId) === stream) sessionTaskStreams.delete(sessionId);
+  };
+}
+
+/** Subscribe to one session's SSE stream and patch task snapshots into the
+ *  session task cache. Returns a disposer that stops reconnects and closes
+ *  the stream. */
+function subscribeSessionTasks(sessionId: string, queryClient: QueryClient): () => void {
+  const tracker = createReconnectTracker();
+  let stream: EventStreamLike | null = null;
+  let cancelled = false;
+
+  const closeStream = () => {
+    if (stream) {
+      stream.close();
+      stream = null;
+    }
+  };
+
+  const connect = () => {
+    closeStream();
+
+    // No since_id and no event-type filter: the server rejects unknown
+    // event types in filters, and task.* events are full snapshots patched
+    // over a fresh list fetched on every connect.
+    const source = createEventStream(getSseUrl(sessionId), { withCredentials: true });
+    stream = source;
+
+    source.addEventListener("connected", () => {
+      tracker.reset();
+      // Close the fetch-then-subscribe gap: refetch the snapshot on every
+      // connect (initial + reconnects) so missed events are recovered.
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessionTasks.list(sessionId) });
+    });
+
+    source.addEventListener("disconnecting", (messageEvent) => {
+      try {
+        const data = JSON.parse(messageEvent.data) as { retry_ms?: number };
+        const retryMs = tracker.onGraceful(data.retry_ms ?? 1000);
+        closeStream();
+        setTimeout(() => {
+          if (!cancelled) connect();
+        }, retryMs);
+      } catch {
+        closeStream();
+        if (!cancelled) connect();
+      }
+    });
+
+    // task.created / task.updated carry full task snapshots.
+    const onTaskSnapshot = (messageEvent: MessageEvent) => {
+      try {
+        const event = JSON.parse(messageEvent.data) as { data?: { task?: SessionTask } };
+        const task = event.data?.task;
+        if (!task) return;
+        queryClient.setQueryData<SessionTask[]>(queryKeys.sessionTasks.list(sessionId), (tasks) =>
+          upsertTask(tasks, task),
+        );
+      } catch (e) {
+        console.error("Failed to parse session task event:", e);
+      }
+    };
+    source.addEventListener("task.created", onTaskSnapshot);
+    source.addEventListener("task.updated", onTaskSnapshot);
+
+    // task.message.* only invalidate the per-task detail thread.
+    const onTaskMessage = (messageEvent: MessageEvent) => {
+      try {
+        const event = JSON.parse(messageEvent.data) as { data?: { task_id?: string } };
+        const taskId = event.data?.task_id;
+        if (!taskId) return;
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sessionTasks.detail(sessionId, taskId),
+        });
+      } catch (e) {
+        console.error("Failed to parse session task message event:", e);
+      }
+    };
+    source.addEventListener("task.message.sent", onTaskMessage);
+    source.addEventListener("task.message.received", onTaskMessage);
+
+    source.onerror = () => {
+      closeStream();
+      const delayMs = tracker.onError();
+      if (delayMs === null) return;
+      setTimeout(() => {
+        if (!cancelled) connect();
+      }, delayMs);
+    };
+  };
+
+  connect();
+
+  return () => {
+    cancelled = true;
+    closeStream();
+  };
+}
+
 /** List a session's tasks with live SSE-driven cache updates. */
 export function useSessionTasks(sessionId: string | undefined) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
@@ -46,104 +172,10 @@ export function useSessionTasks(sessionId: string | undefined) {
     enabled,
   });
 
-  const eventSourceRef = useRef<EventStreamLike | null>(null);
-  const reconnectRef = useRef(createReconnectTracker());
-
-  const cleanup = useCallback(() => {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-    }
-  }, []);
-
   useEffect(() => {
-    if (!enabled || !sessionId) {
-      cleanup();
-      return;
-    }
-
-    reconnectRef.current = createReconnectTracker();
-    let cancelled = false;
-
-    const connectSSE = () => {
-      cleanup();
-
-      // No since_id and no event-type filter: the server rejects unknown
-      // event types in filters, and task.* events are full snapshots patched
-      // over a fresh list fetched on every connect.
-      const eventSource = createEventStream(getSseUrl(sessionId), { withCredentials: true });
-      eventSourceRef.current = eventSource;
-
-      eventSource.addEventListener("connected", () => {
-        reconnectRef.current.reset();
-        // Close the fetch-then-subscribe gap: refetch the snapshot on every
-        // connect (initial + reconnects) so missed events are recovered.
-        queryClient.invalidateQueries({ queryKey: queryKeys.sessionTasks.list(sessionId) });
-      });
-
-      eventSource.addEventListener("disconnecting", (messageEvent) => {
-        try {
-          const data = JSON.parse(messageEvent.data) as { retry_ms?: number };
-          const retryMs = reconnectRef.current.onGraceful(data.retry_ms ?? 1000);
-          cleanup();
-          setTimeout(() => {
-            if (!cancelled) connectSSE();
-          }, retryMs);
-        } catch {
-          cleanup();
-          if (!cancelled) connectSSE();
-        }
-      });
-
-      // task.created / task.updated carry full task snapshots.
-      const onTaskSnapshot = (messageEvent: MessageEvent) => {
-        try {
-          const event = JSON.parse(messageEvent.data) as { data?: { task?: SessionTask } };
-          const task = event.data?.task;
-          if (!task) return;
-          queryClient.setQueryData<SessionTask[]>(queryKeys.sessionTasks.list(sessionId), (tasks) =>
-            upsertTask(tasks, task),
-          );
-        } catch (e) {
-          console.error("Failed to parse session task event:", e);
-        }
-      };
-      eventSource.addEventListener("task.created", onTaskSnapshot);
-      eventSource.addEventListener("task.updated", onTaskSnapshot);
-
-      // task.message.* only invalidate the per-task detail thread.
-      const onTaskMessage = (messageEvent: MessageEvent) => {
-        try {
-          const event = JSON.parse(messageEvent.data) as { data?: { task_id?: string } };
-          const taskId = event.data?.task_id;
-          if (!taskId) return;
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.sessionTasks.detail(sessionId, taskId),
-          });
-        } catch (e) {
-          console.error("Failed to parse session task message event:", e);
-        }
-      };
-      eventSource.addEventListener("task.message.sent", onTaskMessage);
-      eventSource.addEventListener("task.message.received", onTaskMessage);
-
-      eventSource.onerror = () => {
-        cleanup();
-        const delayMs = reconnectRef.current.onError();
-        if (delayMs === null) return;
-        setTimeout(() => {
-          if (!cancelled) connectSSE();
-        }, delayMs);
-      };
-    };
-
-    connectSSE();
-
-    return () => {
-      cancelled = true;
-      cleanup();
-    };
-  }, [enabled, sessionId, cleanup, queryClient]);
+    if (!enabled || !sessionId) return;
+    return acquireSessionTaskStream(sessionId, queryClient);
+  }, [enabled, sessionId, queryClient]);
 
   return {
     ...query,

--- a/crates/host/src/observability/braintrust.rs
+++ b/crates/host/src/observability/braintrust.rs
@@ -34,7 +34,7 @@ use rand::RngExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::time::{self, Duration};
@@ -160,6 +160,12 @@ struct BraintrustState {
     dropped_events: AtomicU64,
     retried_batches: AtomicU64,
     failed_batches: AtomicU64,
+    /// A permanent rejection (auth, unknown project) repeats on every batch
+    /// until the deployment is reconfigured. Report it once per process at
+    /// error level; later repeats are counted in `failed_batches` and logged
+    /// at debug so one misconfiguration does not flood error alerting
+    /// (Sentry EVERRUNS-1K).
+    permanent_failure_logged: AtomicBool,
 }
 
 #[derive(Debug)]
@@ -466,6 +472,7 @@ impl BraintrustListener {
             dropped_events: AtomicU64::new(0),
             retried_batches: AtomicU64::new(0),
             failed_batches: AtomicU64::new(0),
+            permanent_failure_logged: AtomicBool::new(false),
         });
 
         if tokio::runtime::Handle::try_current().is_ok() {
@@ -568,7 +575,9 @@ impl BraintrustListener {
                 {
                     state.retried_batches.fetch_add(1, Ordering::Relaxed);
                     let backoff = Self::retry_delay(&state.config.delivery, attempt);
-                    warn!(
+                    // Retries are the expected handling of transient upstream
+                    // errors; only exhausting them is worth surfacing.
+                    debug!(
                         attempt = attempt + 1,
                         max_retries = state.config.delivery.max_retries,
                         retry_in_ms = backoff.as_millis(),
@@ -577,9 +586,21 @@ impl BraintrustListener {
                     );
                     time::sleep(backoff).await;
                 }
-                DeliveryAttempt::Retryable(reason) | DeliveryAttempt::Permanent(reason) => {
+                DeliveryAttempt::Retryable(reason) => {
                     state.failed_batches.fetch_add(1, Ordering::Relaxed);
                     error!(reason = %reason, "Failed to send Braintrust batch");
+                    return;
+                }
+                DeliveryAttempt::Permanent(reason) => {
+                    state.failed_batches.fetch_add(1, Ordering::Relaxed);
+                    if state.permanent_failure_logged.swap(true, Ordering::Relaxed) {
+                        debug!(reason = %reason, "Braintrust batch rejected again");
+                    } else {
+                        error!(
+                            reason = %reason,
+                            "Braintrust rejected batch; further rejections are logged at debug until reconfigured"
+                        );
+                    }
                     return;
                 }
             }
@@ -3786,6 +3807,54 @@ mod tests {
         assert_eq!(requests.len(), 1);
         let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
         assert_eq!(body["events"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_permanent_rejection_is_reported_once_per_process() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/project_logs/test-project-id/insert"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let mut config = test_config();
+        config.api_url = server.uri();
+        config.delivery.flush_interval = Duration::from_millis(10);
+        let listener = BraintrustListener::new(config).unwrap();
+        assert!(
+            !listener
+                .state
+                .permanent_failure_logged
+                .load(Ordering::Relaxed)
+        );
+
+        for _ in 0..2 {
+            let turn_id = TurnId::new();
+            let input_message_id = MessageId::new();
+            listener
+                .on_event(&Event::new(
+                    SessionId::new(),
+                    EventContext::turn(turn_id, input_message_id),
+                    EventData::TurnStarted(TurnStartedData {
+                        turn_id,
+                        input_message_id,
+                        input_content: Some("hello".to_string()),
+                    }),
+                ))
+                .await;
+            sleep(Duration::from_millis(60)).await;
+        }
+
+        assert_eq!(listener.state.failed_batches.load(Ordering::Relaxed), 2);
+        assert_eq!(listener.state.retried_batches.load(Ordering::Relaxed), 0);
+        assert!(
+            listener
+                .state
+                .permanent_failure_logged
+                .load(Ordering::Relaxed)
+        );
     }
 
     #[tokio::test]

--- a/crates/host/src/observability/braintrust.rs
+++ b/crates/host/src/observability/braintrust.rs
@@ -3841,6 +3841,9 @@ mod tests {
                         turn_id,
                         input_message_id,
                         input_content: Some("hello".to_string()),
+                        agent_id: None,
+                        agent_name: None,
+                        agent_description: None,
                     }),
                 ))
                 .await;

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -196,7 +196,11 @@ impl Default for SseConnectionLimits {
     fn default() -> Self {
         Self {
             global_max: 10_000,
-            per_session_max: 5,
+            // A session page holds a chat stream plus a task stream, and the
+            // Work view adds one per live session, so a handful of browser
+            // tabs on one session legitimately reach a dozen streams. The
+            // per-org and global caps carry the DoS protection.
+            per_session_max: 12,
             per_org_max: 1_000,
         }
     }
@@ -872,7 +876,7 @@ mod tests {
         let limits = SseConnectionLimits::from_env();
         assert_eq!(limits.global_max, 10_000);
         assert_eq!(limits.per_org_max, 1_000);
-        assert_eq!(limits.per_session_max, 5);
+        assert_eq!(limits.per_session_max, 12);
 
         // --- multi-instance divides global and org ---
         unsafe {

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -738,7 +738,7 @@ mod tests {
     fn test_connection_limits_defaults() {
         let limits = SseConnectionLimits::default();
         assert_eq!(limits.global_max, 10_000);
-        assert_eq!(limits.per_session_max, 5);
+        assert_eq!(limits.per_session_max, 12);
         assert_eq!(limits.per_org_max, 1_000);
     }
 
@@ -891,7 +891,7 @@ mod tests {
         // 1_000 / 4 = 250
         assert_eq!(limits.per_org_max, 250);
         // Per-session NOT divided
-        assert_eq!(limits.per_session_max, 5);
+        assert_eq!(limits.per_session_max, 12);
 
         // Clean up
         unsafe {

--- a/crates/server/src/event_delivery.rs
+++ b/crates/server/src/event_delivery.rs
@@ -56,7 +56,7 @@ impl EventDelivery {
                 }
                 Err(e) => {
                     warn!(
-                        error = %e,
+                        error = %crate::nats::error_chain(&e),
                         "Failed to connect to NATS — falling back to in-memory event delivery. \
                          SSE will only work within this process instance."
                     );
@@ -215,7 +215,7 @@ pub struct NatsEventDelivery {
 
 impl NatsEventDelivery {
     pub async fn connect(url: &str) -> Result<Self> {
-        let client = async_nats::connect(url)
+        let client = crate::nats::connect(url)
             .await
             .context("Failed to connect to NATS")?;
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -76,6 +76,7 @@ pub mod task_notifications;
 pub use task_notifications::{TaskBroadcaster, TaskNotificationBroadcaster};
 
 // NATS-backed task notification broadcaster
+pub mod nats;
 pub mod nats_task_notifications;
 
 // Event notification broadcaster for push-based SSE delivery (legacy PG NOTIFY)

--- a/crates/server/src/nats.rs
+++ b/crates/server/src/nats.rs
@@ -1,0 +1,120 @@
+// Shared NATS client connection for the control plane.
+//
+// Decision: credentials embedded in `NATS_URL` (`nats://user:pass@host:4222`)
+// are applied explicitly. async-nats parses the URL userinfo into
+// `ServerAddr::username()` / `password()` but never sends it in the CONNECT
+// handshake, so a server running with `authorization {}` rejected every
+// client and the control plane silently degraded to in-memory event delivery
+// and PG NOTIFY on each boot (Sentry EVERRUNS-2 / EVERRUNS-4).
+//
+// Decision: connection failures are reported with the full error chain.
+// `anyhow` `Display` prints only the outermost context, which hid the
+// authorization violation behind "Failed to connect to NATS".
+
+use anyhow::{Context, Result};
+use async_nats::{Client, ConnectOptions, ServerAddr};
+
+/// Parse `NATS_URL`: one server URL or a comma-separated list of them.
+fn parse_server_addrs(url: &str) -> Result<Vec<ServerAddr>> {
+    url.split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.parse::<ServerAddr>()
+                .with_context(|| format!("Invalid NATS URL: {part}"))
+        })
+        .collect()
+}
+
+/// Extract `(user, password)` from a NATS URL, percent-decoded.
+///
+/// The first server that carries a username wins. Returns `None` when no
+/// server does. A username without a password yields an empty password,
+/// matching NATS token-less user auth.
+pub fn credentials_from_url(url: &str) -> Result<Option<(String, String)>> {
+    for addr in parse_server_addrs(url)? {
+        let Some(user) = addr.username() else {
+            continue;
+        };
+        let user = urlencoding::decode(user)
+            .context("Invalid percent-encoding in NATS username")?
+            .into_owned();
+        let pass = match addr.password() {
+            Some(pass) => urlencoding::decode(pass)
+                .context("Invalid percent-encoding in NATS password")?
+                .into_owned(),
+            None => String::new(),
+        };
+        return Ok(Some((user, pass)));
+    }
+    Ok(None)
+}
+
+/// Connect to NATS, honouring credentials embedded in the URL.
+pub async fn connect(url: &str) -> Result<Client> {
+    let addrs = parse_server_addrs(url)?;
+    if addrs.is_empty() {
+        anyhow::bail!("NATS URL is empty");
+    }
+    let mut options = ConnectOptions::new();
+    if let Some((user, pass)) = credentials_from_url(url)? {
+        options = options.user_and_password(user, pass);
+    }
+    options
+        .connect(addrs)
+        .await
+        .context("NATS connection failed")
+}
+
+/// Render an error with its full context chain on one line for log fields.
+pub fn error_chain(error: &anyhow::Error) -> String {
+    format!("{error:#}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credentials_absent_without_userinfo() {
+        assert_eq!(credentials_from_url("nats://localhost:4222").unwrap(), None);
+    }
+
+    #[test]
+    fn credentials_parsed_and_percent_decoded() {
+        assert_eq!(
+            credentials_from_url("nats://control:p%40ss%2Fw0rd@nats:4222").unwrap(),
+            Some(("control".to_string(), "p@ss/w0rd".to_string()))
+        );
+    }
+
+    #[test]
+    fn username_without_password_yields_empty_password() {
+        assert_eq!(
+            credentials_from_url("nats://token@nats:4222").unwrap(),
+            Some(("token".to_string(), String::new()))
+        );
+    }
+
+    #[test]
+    fn credentials_found_in_a_server_list() {
+        assert_eq!(
+            credentials_from_url("nats://nats1:4222, nats://u:p@nats2:4222").unwrap(),
+            Some(("u".to_string(), "p".to_string()))
+        );
+    }
+
+    #[test]
+    fn invalid_url_is_an_error() {
+        assert!(credentials_from_url("not a url").is_err());
+    }
+
+    #[test]
+    fn error_chain_includes_context() {
+        let error = anyhow::anyhow!("authorization violation").context("NATS connection failed");
+        assert_eq!(
+            error_chain(&error),
+            "NATS connection failed: authorization violation"
+        );
+    }
+}

--- a/crates/server/src/nats_task_notifications.rs
+++ b/crates/server/src/nats_task_notifications.rs
@@ -43,7 +43,7 @@ impl NatsTaskNotificationBroadcaster {
     /// Connect to NATS and start listening for task notifications.
     /// Verifies the initial subscription succeeds before returning.
     pub async fn new(nats_url: &str) -> Result<Self> {
-        let client = async_nats::connect(nats_url)
+        let client = crate::nats::connect(nats_url)
             .await
             .context("Failed to connect to NATS for task notifications")?;
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -12,14 +12,14 @@ use crate::storage::{
     EncryptionService, StorageBackend,
     models::{
         CreateMcpServerRow, CreateModelRow, CreateOrganizationRow, CreateProviderRow,
-        CreateUserRow, UpdateProvider,
+        CreateUserRow, ModelRow, UpdateModel, UpdateProvider,
     },
     password::hash_password,
 };
 use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DeploymentGrade};
 use everruns_host::HostComposition;
 use everruns_platform::{ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
@@ -2116,6 +2116,12 @@ async fn seed_models_with_host_composition(
     let mut result = SeedResult::default();
     let enabled_provider_ids = enabled_seed_provider_ids(host_composition);
 
+    // Provider discovery may have catalogued a seed model under a generated id
+    // before its seed entry existed. `models(provider_id, model_id)` is unique,
+    // so inserting the seed id would fail on every boot (Sentry EVERRUNS-6).
+    // Adopt the existing row instead of forcing the seed id onto it.
+    let mut existing_by_provider: HashMap<Uuid, Vec<ModelRow>> = HashMap::new();
+
     for seed in SEED_MODELS {
         if !enabled_provider_ids.contains(&seed.provider_id) {
             tracing::debug!(
@@ -2123,6 +2129,49 @@ async fn seed_models_with_host_composition(
                 id = %seed.id,
                 "Skipping seed model because its provider driver is not registered by the platform definition"
             );
+            continue;
+        }
+        let existing = match existing_by_provider.entry(seed.provider_id) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => entry.insert(
+                db.list_models_for_provider(DEFAULT_ORG_ID, seed.provider_id)
+                    .await?,
+            ),
+        };
+        if let Some(row) = existing
+            .iter()
+            .find(|row| row.model_id == seed.model_id && row.id.uuid() != seed.id)
+        {
+            let unchanged = row.display_name == seed.display_name
+                && row.is_favorite == seed.is_favorite
+                && row.enabled == seed.enabled;
+            if unchanged {
+                tracing::debug!(
+                    model_id = seed.model_id,
+                    id = %row.id,
+                    "Seed model already catalogued by discovery; up to date"
+                );
+                result.unchanged += 1;
+            } else {
+                db.update_model(
+                    DEFAULT_ORG_ID,
+                    row.id.uuid(),
+                    UpdateModel {
+                        display_name: Some(seed.display_name.to_string()),
+                        is_favorite: Some(seed.is_favorite),
+                        enabled: Some(seed.enabled),
+                        ..UpdateModel::default()
+                    },
+                )
+                .await?;
+                tracing::info!(
+                    model_id = seed.model_id,
+                    id = %row.id,
+                    seed_id = %seed.id,
+                    "Updated seed model on the row discovery catalogued"
+                );
+                result.updated += 1;
+            }
             continue;
         }
         let input = CreateModelRow {
@@ -3262,6 +3311,73 @@ mod tests {
         assert_eq!(terra.model_id, "gpt-5.6-terra");
         assert!(terra.enabled, "gpt-5.6-terra should be enabled");
         assert!(terra.is_favorite, "gpt-5.6-terra should be favorite");
+    }
+
+    /// Discovery can catalogue a model under a generated id before the seed
+    /// entry for it exists. Seeding must adopt that row rather than trip the
+    /// `(provider_id, model_id)` unique index on every boot.
+    #[tokio::test]
+    async fn test_seed_all_adopts_model_discovered_before_seed() {
+        let db = make_db();
+        // Seed once so the provider rows exist, then plant a discovered twin
+        // of a seed model under a different id.
+        seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
+            .await
+            .unwrap();
+        let seeded = db
+            .get_model(DEFAULT_ORG_ID, seed_ids::TEXT_EMBEDDING_3_SMALL)
+            .await
+            .unwrap()
+            .expect("seed model present");
+        assert!(
+            db.delete_model(DEFAULT_ORG_ID, seeded.id.uuid())
+                .await
+                .unwrap()
+        );
+        let discovered = db
+            .create_model(
+                DEFAULT_ORG_ID,
+                CreateModelRow {
+                    provider_id: seed_ids::OPENAI_PROVIDER.into(),
+                    model_id: "text-embedding-3-small".to_string(),
+                    display_name: "text-embedding-3-small".to_string(),
+                    capabilities: vec![],
+                    is_favorite: false,
+                    enabled: false,
+                    source: "discovered".to_string(),
+                    provider_metadata: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_ne!(discovered.id.uuid(), seed_ids::TEXT_EMBEDDING_3_SMALL);
+
+        let result = seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
+            .await
+            .expect("seeding must not fail on a discovered twin");
+        assert!(result.updated >= 1, "discovered row must be updated");
+
+        let models = db
+            .list_models_for_provider(DEFAULT_ORG_ID, seed_ids::OPENAI_PROVIDER)
+            .await
+            .unwrap();
+        let twins: Vec<_> = models
+            .iter()
+            .filter(|m| m.model_id == "text-embedding-3-small")
+            .collect();
+        assert_eq!(twins.len(), 1, "exactly one row per provider/model");
+        assert_eq!(twins[0].id, discovered.id, "discovered row is kept");
+        assert!(
+            twins[0].enabled && twins[0].is_favorite,
+            "seed fields applied"
+        );
+        assert_eq!(twins[0].display_name, "Text Embedding 3 Small");
+
+        // A further run is a no-op.
+        let result = seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
+            .await
+            .unwrap();
+        assert_eq!(result.updated, 0);
     }
 
     #[tokio::test]

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -162,6 +162,17 @@ impl ModelSyncService {
         for org in &orgs {
             let providers = self.db.list_providers(org.org_id).await?;
             for provider in providers {
+                // Seeded catalog providers exist in every org before a key is
+                // configured. Without a key there is nothing to sync, so skip
+                // quietly instead of reporting a failure each interval.
+                if !provider.api_key_set {
+                    tracing::debug!(
+                        provider_id = %provider.id,
+                        org_id = provider.org_id,
+                        "Skipping model sync: no API key configured for provider"
+                    );
+                    continue;
+                }
                 let result = self
                     .sync_provider(provider.org_id, provider.id.uuid())
                     .await
@@ -336,6 +347,34 @@ mod tests {
             }
             _ => panic!("Expected Failed variant"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_sync_all_skips_providers_without_api_key() {
+        use everruns_core::DEFAULT_ORG_ID;
+
+        let db = Arc::new(StorageBackend::in_memory());
+        let registry = Arc::new(DriverRegistry::new());
+        let service = ModelSyncService::new(db.clone(), registry, None);
+
+        db.create_provider(
+            DEFAULT_ORG_ID,
+            CreateProviderRow {
+                name: "OpenAI".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let results = service.sync_all().await.unwrap();
+        assert!(
+            results.is_empty(),
+            "providers without a key must be skipped, not reported as failed: {results:?}"
+        );
     }
 
     // --- resolve_api_key tests ---

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -349,34 +349,6 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_sync_all_skips_providers_without_api_key() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let db = Arc::new(StorageBackend::in_memory());
-        let registry = Arc::new(DriverRegistry::new());
-        let service = ModelSyncService::new(db.clone(), registry, None);
-
-        db.create_provider(
-            DEFAULT_ORG_ID,
-            CreateProviderRow {
-                name: "OpenAI".to_string(),
-                provider_type: "openai".to_string(),
-                base_url: None,
-                api_key_encrypted: None,
-                settings: None,
-            },
-        )
-        .await
-        .unwrap();
-
-        let results = service.sync_all().await.unwrap();
-        assert!(
-            results.is_empty(),
-            "providers without a key must be skipped, not reported as failed: {results:?}"
-        );
-    }
-
     // --- resolve_api_key tests ---
 
     #[tokio::test]
@@ -470,7 +442,7 @@ mod tests {
     // --- sync_all multi-org tests ---
 
     #[tokio::test]
-    async fn test_sync_all_enumerates_providers_across_orgs() {
+    async fn test_sync_all_skips_keyless_providers_across_orgs() {
         use everruns_core::DEFAULT_ORG_ID;
 
         let db = Arc::new(StorageBackend::in_memory());
@@ -520,27 +492,15 @@ mod tests {
             .await
             .unwrap();
 
-        // sync_all should hit providers from both orgs
+        // sync_all walks both orgs, but a provider with no key has nothing to
+        // sync: it is skipped rather than reported as a failure every interval
+        // (Sentry EVERRUNS-A). Cross-org enumeration with keys configured is
+        // covered by `test_sync_all_with_encrypted_keys_across_orgs`.
         let results = service.sync_all().await.unwrap();
-        assert_eq!(
-            results.len(),
-            2,
-            "Expected 2 providers (one per org), got {}",
-            results.len()
+        assert!(
+            results.is_empty(),
+            "keyless providers must be skipped, not reported as failed: {results:?}"
         );
-
-        // Both should fail (no API key available) but the point is they were enumerated
-        for (pid, result) in &results {
-            match result {
-                SyncResult::Failed { error } => {
-                    assert!(
-                        error.contains("No API key"),
-                        "Expected 'No API key' error for {pid}, got: {error}"
-                    );
-                }
-                other => panic!("Expected Failed for {pid}, got: {other:?}"),
-            }
-        }
     }
 
     #[tokio::test]
@@ -700,6 +660,8 @@ mod tests {
         let db = Arc::new(StorageBackend::in_memory());
         let registry = Arc::new(DriverRegistry::new());
         let service = ModelSyncService::new(db.clone(), registry, None);
+        // Keyed: a provider with no key is skipped entirely, which would make
+        // this assertion pass for the wrong reason.
         let _p1 = db
             .create_provider(
                 DEFAULT_ORG_ID,
@@ -707,7 +669,7 @@ mod tests {
                     name: "OpenAI".to_string(),
                     provider_type: "openai".to_string(),
                     base_url: None,
-                    api_key_encrypted: None,
+                    api_key_encrypted: Some(vec![1, 2, 3]),
                     settings: None,
                 },
             )

--- a/crates/server/src/storage/memory/providers.rs
+++ b/crates/server/src/storage/memory/providers.rs
@@ -281,9 +281,32 @@ impl InMemoryDatabase {
     // LLM Models (continued)
     // ============================================
 
+    /// Mirror the SQL `idx_models_provider_model` unique index so seed and
+    /// discovery collisions surface in in-memory tests as they do in Postgres.
+    fn ensure_provider_model_unique(
+        models: &std::collections::HashMap<ModelId, ModelRow>,
+        provider_id: ProviderId,
+        model_id: &str,
+    ) -> Result<()> {
+        if models
+            .values()
+            .any(|row| row.provider_id == provider_id && row.model_id == model_id)
+        {
+            anyhow::bail!(
+                "duplicate key value violates unique constraint \"idx_models_provider_model\""
+            );
+        }
+        Ok(())
+    }
+
     pub async fn create_model(&self, org_id: i64, input: CreateModelRow) -> Result<ModelRow> {
         let now = Self::now();
         let id = ModelId::new();
+        Self::ensure_provider_model_unique(
+            &self.models.read(),
+            input.provider_id,
+            &input.model_id,
+        )?;
         let row = ModelRow {
             id,
             org_id,
@@ -333,6 +356,7 @@ impl InMemoryDatabase {
             models.insert(id, row.clone());
             return Ok(Some(row));
         }
+        Self::ensure_provider_model_unique(&models, input.provider_id, &input.model_id)?;
 
         let row = ModelRow {
             id,

--- a/crates/server/src/task_notifications.rs
+++ b/crates/server/src/task_notifications.rs
@@ -215,7 +215,7 @@ impl TaskBroadcaster {
                 }
                 Err(e) => {
                     warn!(
-                        error = %e,
+                        error = %crate::nats::error_chain(&e),
                         "Failed to connect NATS for task notifications, falling back to PG NOTIFY"
                     );
                 }

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -297,6 +297,9 @@ NATS_URL=nats://localhost:4222
 
 # Cluster
 NATS_URL=nats://nats1:4222,nats://nats2:4222,nats://nats3:4222
+
+# Server with `authorization { users: [...] }`
+NATS_URL=nats://control:s3cret@nats:4222
 ```
 
 **Notes:**
@@ -306,7 +309,8 @@ NATS_URL=nats://nats1:4222,nats://nats2:4222,nats://nats3:4222
   - **Task notifications**: `task.available.{activity_type}` subjects replace PG NOTIFY for push-based worker notification. Lower latency (~1ms vs ~30ms), supports multi-instance deployments.
 - When NATS event delivery is active, the server skips the legacy PostgreSQL event listener used only for SSE wakeups.
 - NATS JetStream must be enabled on the server (`--jetstream` flag)
-- Fail-graceful: if NATS connection fails at startup, falls back to PG NOTIFY + in-memory delivery with a warning
+- Credentials embedded in the URL (`nats://user:password@host`) are sent as user/password auth; percent-encode reserved characters in the password
+- Fail-graceful: if NATS connection fails at startup, falls back to PG NOTIFY + in-memory delivery with a warning that includes the connection error
 - Only used by control-plane (server); workers communicate via gRPC and don't need NATS access
 - Default port: 4222 (or `PORT_PREFIX22` with `PORT_PREFIX`)
 - `just start-all` automatically starts NATS and exports `NATS_URL` if `nats-server` is installed
@@ -410,7 +414,7 @@ The UI makes all REST API requests (including SSE) to `/api/*` paths. The backen
 | `SSE_MONITORING_CYCLE_SECS` | `600` | Connection cycle interval for durable monitoring streams (seconds) |
 | `SSE_HEARTBEAT_INTERVAL_SECS` | `30` | Interval between heartbeat comments on all SSE streams (seconds) |
 | `SSE_GLOBAL_MAX` | `10000` | Maximum total SSE connections across all users |
-| `SSE_PER_SESSION_MAX` | `5` | Maximum SSE connections per session |
+| `SSE_PER_SESSION_MAX` | `12` | Maximum SSE connections per session |
 | `SSE_PER_ORG_MAX` | `1000` | Maximum SSE connections per organization |
 
 **Notes:**


### PR DESCRIPTION
## What changed
Root-cause fixes for the noisiest issues in the everruns Sentry project (14d window):

- **NATS auth (EVERRUNS-2, EVERRUNS-4, 86 events each).** `async-nats` parses `user:pass` out of `NATS_URL` but never sends it in the CONNECT handshake. A server running with `authorization {}` rejected every boot and the control plane silently fell back to in-memory event delivery + PG NOTIFY. Credentials embedded in the URL (single server or comma-separated list, percent-encoded) are now applied explicitly, and the fallback warning carries the full error chain instead of just "Failed to connect to NATS".
- **SSE per-session cap (EVERRUNS-1M, 79 events).** Every `useSessionTasks` instance opened its own stream, so the header chips plus the Work tab on a couple of tabs exhausted `SSE_PER_SESSION_MAX=5` and the client backoff-looped on 429. Session task streams are now ref-counted and shared per session; the default cap is 12 to cover the streams a session page legitimately holds (per-org and global caps unchanged).
- **Seeding (EVERRUNS-6, 58 events).** A model discovered under a generated id before its seed entry existed tripped `idx_models_provider_model` on every boot, so seeding never completed. Seeding now adopts the discovered row (applies the seed fields, keeps the id). The in-memory backend enforces the same uniqueness so the case is covered by tests.
- **Model sync (EVERRUNS-A, 180 events).** Providers without an API key are skipped at debug instead of "Model sync failed" every interval.
- **Braintrust (EVERRUNS-1K, EVERRUNS-G).** A permanent rejection (403 / unknown project) is reported once per process, later repeats are debug and counted; retry attempts are debug.

The sixth issue in that set, "LLM generation failed" (EVERRUNS-5, 276 events), needs no change here: #3353 replaced the unconditional `tracing::error!` with span-level failure recording, so it stops reaching error alerting on main.

## Why
Each of these produced a recurring Sentry issue with no operator action, and the NATS one hid a real regression: production was never actually using NATS.

## Before / After
- NATS: before, every startup logged `Failed to connect to NATS — falling back to in-memory event delivery` with `error="Failed to connect to NATS"`. After, the client authenticates with the URL credentials; a genuine failure logs e.g. `error="NATS connection failed: authorization violation"`.
- SSE: before, two tabs on one session produced `SSE connection rejected reason="per-session SSE connection limit reached"` bursts (observed backoff pattern 0s/2s/6s/12s/28s). After, one task stream per session per tab (`use-session-tasks.test.tsx`).
- Seed: before, `Seeding failed (non-fatal)... duplicate key value violates unique constraint "idx_models_provider_model"` daily. After, `test_seed_all_adopts_model_discovered_before_seed` passes.

## Risk
- Low / Medium
- NATS: deployments on unauthenticated NATS are unaffected (no userinfo → no auth options). Deployments that set credentials in the URL start actually using NATS; JetStream must be enabled there, as already documented.
- UI: task stream sharing changes when a stream closes (last subscriber releases). Covered by tests.

## Security
- Threat categories reviewed: TM-DOS-003 (SSE limits). Per-session cap raised from 5 to 12; per-org (1000) and global (10000) caps unchanged, so the DoS bound is preserved.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
