### PR TITLE
fix(platform): surface partial script failures and composed boolean flags

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -140,14 +140,24 @@ fn bashkit_inventory_schema(mut schema: serde_json::Value) -> serde_json::Value 
         .or_else(|| schema.get("definitions"))
         .and_then(|value| value.as_object())
         .cloned();
-    retype_aggregate_properties_in_place(&mut schema, defs_snapshot.as_ref(), 0);
+    retype_aggregate_properties_in_place(&mut schema, defs_snapshot.as_ref(), 0, false);
     schema
 }
 
+/// Retype the flags bashkit's parser cannot coerce into JSON text.
+///
+/// `composed` marks a schema reached through `$defs` or an `allOf`/`oneOf`/
+/// `anyOf` branch. Bashkit coerces scalar flags only for direct top-level
+/// properties, so a `#[serde(flatten)]` field such as `create_agent_trigger
+/// --enabled true` arrived as the string "true" and bashkit's own schema
+/// validation rejected it before dispatch. Under composition we therefore
+/// retype scalars too and let `coerce_json_text_params` parse them back.
+/// Direct top-level scalars keep their declared type.
 fn retype_aggregate_properties_in_place(
     schema: &mut serde_json::Value,
     defs: Option<&serde_json::Map<String, serde_json::Value>>,
     depth: u8,
+    composed: bool,
 ) {
     if depth >= SCHEMA_WALK_MAX_DEPTH {
         return;
@@ -157,7 +167,9 @@ fn retype_aggregate_properties_in_place(
         .and_then(|value| value.as_object_mut())
     {
         for (_name, property) in properties.iter_mut() {
-            if !property_is_aggregate(property, defs, 0) {
+            let retype = property_is_aggregate(property, defs, 0)
+                || (composed && property_has_json_scalar_type(property, defs, 0));
+            if !retype {
                 continue;
             }
             let Some(object) = property.as_object_mut() else {
@@ -198,13 +210,13 @@ fn retype_aggregate_properties_in_place(
         && let Some(defs_obj) = schema.get_mut(key).and_then(|value| value.as_object_mut())
     {
         for (_, def) in defs_obj.iter_mut() {
-            retype_aggregate_properties_in_place(def, defs, depth + 1);
+            retype_aggregate_properties_in_place(def, defs, depth + 1, true);
         }
     }
     for key in ["allOf", "oneOf", "anyOf"] {
         if let Some(branches) = schema.get_mut(key).and_then(|value| value.as_array_mut()) {
             for branch in branches.iter_mut() {
-                retype_aggregate_properties_in_place(branch, defs, depth + 1);
+                retype_aggregate_properties_in_place(branch, defs, depth + 1, true);
             }
         }
     }
@@ -878,6 +890,43 @@ mod tests {
         assert!(error.contains("--auth_mode"));
         assert_eq!(params["api_key"], "secret");
         assert!(params.get("api-key").is_none());
+    }
+
+    #[test]
+    fn inventory_schema_retypes_composed_scalars_so_bashkit_accepts_flag_text() {
+        // `create_agent_trigger --enabled true` failed with
+        // "schema error: input.enabled must be boolean": bashkit does not
+        // coerce scalars reached through `allOf`/`$ref`, so its own validation
+        // rejected the raw flag text before dispatch could repair it.
+        let schema = serde_json::json!({
+            "$defs": {
+                "CreateAgentTriggerRequest": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": { "type": "boolean" },
+                        "cron_expression": { "type": "string" },
+                        "max_runs": { "type": "integer" }
+                    }
+                }
+            },
+            "type": "object",
+            "properties": { "verbose": { "type": "boolean" } },
+            "allOf": [
+                { "$ref": "#/$defs/CreateAgentTriggerRequest" },
+                { "type": "object", "properties": { "agent_id": { "type": "string" } } }
+            ]
+        });
+
+        let rewritten = bashkit_inventory_schema(schema);
+
+        let composed = rewritten["$defs"]["CreateAgentTriggerRequest"]["properties"]
+            .as_object()
+            .expect("composed properties");
+        assert_eq!(composed["enabled"]["type"], "string");
+        assert_eq!(composed["max_runs"]["type"], "string");
+        assert_eq!(composed["cron_expression"]["type"], "string");
+        // Direct top-level scalars are coerced by bashkit itself; leave them typed.
+        assert_eq!(rewritten["properties"]["verbose"]["type"], "boolean");
     }
 
     #[test]

--- a/crates/server/src/services/platform_command_surface.rs
+++ b/crates/server/src/services/platform_command_surface.rs
@@ -350,7 +350,10 @@ mod tests {
         )
         .expect("exit code 0 stays a success");
         assert!(outcome.contains("\"agent\": null"), "stdout is preserved");
-        assert!(outcome.contains(PARTIAL_FAILURE_LABEL), "stderr is labelled");
+        assert!(
+            outcome.contains(PARTIAL_FAILURE_LABEL),
+            "stderr is labelled"
+        );
         assert!(
             outcome.contains("Agent name must contain only lowercase letters"),
             "the failing command's error is surfaced: {outcome}"
@@ -366,8 +369,12 @@ mod tests {
 
     #[test]
     fn script_outcome_reports_a_nonzero_exit_as_an_error() {
-        let error = script_outcome(2, String::new(), "create_agent: bad_request: boom\n".to_string())
-            .expect_err("non-zero exit is an error");
+        let error = script_outcome(
+            2,
+            String::new(),
+            "create_agent: bad_request: boom\n".to_string(),
+        )
+        .expect_err("non-zero exit is an error");
         assert!(error.contains("boom"), "{error}");
         assert!(!error.contains(PARTIAL_FAILURE_LABEL));
     }

--- a/crates/server/src/services/platform_command_surface.rs
+++ b/crates/server/src/services/platform_command_surface.rs
@@ -273,28 +273,49 @@ async fn script(
     .await;
 
     match result {
-        Ok(response) if response.exit_code == 0 => Ok(response.stdout),
-        Ok(response) => {
-            let combined = if response.stderr.is_empty() {
-                response.stdout
-            } else if response.stdout.is_empty() {
-                response.stderr
-            } else {
-                format!("{}\n{}", response.stdout, response.stderr)
-            };
-            let trimmed = combined.trim();
-            if trimmed.is_empty() {
-                Err(format!(
-                    "Command failed with exit code {}",
-                    response.exit_code
-                ))
-            } else {
-                Err(sanitize_script_error(trimmed))
-            }
-        }
+        Ok(response) => script_outcome(response.exit_code, response.stdout, response.stderr),
         Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),
     }
 }
+
+/// Shape a finished script run into the tool result.
+///
+/// A multi-command script exits 0 whenever its *last* command succeeds, so a
+/// mid-script failure would otherwise be invisible: the caller sees only the
+/// surviving stdout (often a jq object with null fields) and no hint that a
+/// create failed. Keep stdout first and authoritative, then append the
+/// captured stderr so partial failures are actionable.
+fn script_outcome(exit_code: i32, stdout: String, stderr: String) -> Result<String, String> {
+    if exit_code == 0 {
+        let trimmed_stderr = stderr.trim();
+        if trimmed_stderr.is_empty() {
+            return Ok(stdout);
+        }
+        return Ok(format!(
+            "{}\n\n{PARTIAL_FAILURE_LABEL}\n{}",
+            stdout.trim_end(),
+            sanitize_script_error(trimmed_stderr)
+        ));
+    }
+
+    let combined = if stderr.is_empty() {
+        stdout
+    } else if stdout.is_empty() {
+        stderr
+    } else {
+        format!("{stdout}\n{stderr}")
+    };
+    let trimmed = combined.trim();
+    if trimmed.is_empty() {
+        Err(format!("Command failed with exit code {exit_code}"))
+    } else {
+        Err(sanitize_script_error(trimmed))
+    }
+}
+
+/// Marks stderr captured from a script that still exited 0. Some commands in it
+/// failed, so the caller must verify state with `query` before reporting success.
+const PARTIAL_FAILURE_LABEL: &str = "script_stderr (one or more commands in this script failed even though the script exited 0; verify the resulting state with query before reporting success):";
 
 fn sanitize_script_error(message: &str) -> String {
     if message.contains("jq: runtime error")
@@ -315,6 +336,41 @@ fn sanitize_script_error(message: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn script_outcome_surfaces_stderr_from_a_partially_failed_script() {
+        // A create failed mid-script; the trailing `jq -s` still exited 0 and
+        // produced an object with null fields. Without the stderr section the
+        // caller cannot tell a failure from an intentionally empty result.
+        let outcome = script_outcome(
+            0,
+            "{\n  \"agent\": null\n}\n".to_string(),
+            "create_agent: bad_request: Agent name must contain only lowercase letters, digits, and hyphens\n"
+                .to_string(),
+        )
+        .expect("exit code 0 stays a success");
+        assert!(outcome.contains("\"agent\": null"), "stdout is preserved");
+        assert!(outcome.contains(PARTIAL_FAILURE_LABEL), "stderr is labelled");
+        assert!(
+            outcome.contains("Agent name must contain only lowercase letters"),
+            "the failing command's error is surfaced: {outcome}"
+        );
+    }
+
+    #[test]
+    fn script_outcome_returns_bare_stdout_when_nothing_failed() {
+        let outcome = script_outcome(0, "{\"id\":\"agent_1\"}".to_string(), String::new())
+            .expect("clean run");
+        assert_eq!(outcome, "{\"id\":\"agent_1\"}");
+    }
+
+    #[test]
+    fn script_outcome_reports_a_nonzero_exit_as_an_error() {
+        let error = script_outcome(2, String::new(), "create_agent: bad_request: boom\n".to_string())
+            .expect_err("non-zero exit is an error");
+        assert!(error.contains("boom"), "{error}");
+        assert!(!error.contains(PARTIAL_FAILURE_LABEL));
+    }
 
     fn discover_for_test(arguments: &Value) -> Result<String, String> {
         discover(

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1613,6 +1613,31 @@ async fn test_mcp_execute_missing_commands() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_query_allows_empty_jq_result() {
+    // `list_harnesses` returns a bare array and takes no --limit, so the
+    // original script here produced its empty output by failing outright
+    // rather than by matching no rows. Search for a name that cannot exist
+    // instead, so the emptiness is a real empty result set.
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(
+        &server,
+        "query",
+        json!({
+            "commands": "list_harnesses --search 'no-such-harness-xyz' | jq -c '.[] | {id, name, system_prompt}'"
+        }),
+    )
+    .await;
+
+    assert!(!tool_is_error(&resp), "empty jq output is valid");
+    assert_eq!(tool_text(&resp), "");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_query_surfaces_stderr_from_a_command_that_failed_mid_script() {
+    // A script exits 0 when its last command succeeds, so a failed command
+    // earlier in the pipeline used to vanish: the caller saw empty output and
+    // no indication that anything went wrong. `--limit` is not a
+    // `list_harnesses` flag, so the command fails and jq then succeeds over
+    // empty input.
     let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(
         &server,
@@ -1623,8 +1648,19 @@ async fn test_mcp_query_allows_empty_jq_result() {
     )
     .await;
 
-    assert!(!tool_is_error(&resp), "empty jq output is valid");
-    assert_eq!(tool_text(&resp), "");
+    assert!(
+        !tool_is_error(&resp),
+        "the script itself exited 0; the failure is reported in the result"
+    );
+    let text = tool_text(&resp);
+    assert!(
+        text.contains("unknown flag(s): --limit"),
+        "the failing command's error must be surfaced: {text}"
+    );
+    assert!(
+        text.contains("verify the resulting state with query"),
+        "the partial-failure label must tell the caller to re-verify: {text}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## What changed

Two ways a Platform Chat `execute` script could fail without saying so.

A multi-command script exits 0 whenever its *last* command succeeds, so a failure
partway through was invisible: the caller saw only the surviving stdout (often a
`jq` object with null fields) and the failing command's stderr was dropped
entirely. Stdout stays first and authoritative; captured stderr is now appended
under an explicit label telling the caller to re-verify with `query`.

`create_agent_trigger --enabled true` was rejected with `schema error:
input.enabled must be boolean` — the exact flag form `bash_usage` advertises.
`enabled` lives behind `#[serde(flatten)]`, and bashkit does not coerce scalar
flags reached through `allOf`/`$ref`, so its own schema validation rejected the
text before the existing repair pass (`coerce_json_text_params`) could run.
Composed scalars are now retyped to string in the bash inventory schema, the same
treatment aggregates already get; direct top-level scalars keep their declared
type.

## Why

Found running `test_cases/agents/platform_chat/TC004` end to end against a full
stack. Between them these cost the provisioning turn four extra round trips, and
the model recovered only by chance: it re-ran the failed command on its own and
happened to guess a compliant agent name. TC004 already calls for a partial
multi-command failure to be followed by `query` rather than reported as success,
which the silent case makes impossible.

## Before / After

First `execute`, before — `create_agent` failed on name validation mid-script and
the result carried no error at all:

```json
{ "mcp": { "id": "mcp_01a05ac5...", "name": "Visti", "status": "active" },
  "agent": null, "credential_binding": null, "trigger": null }
```

After, the same run surfaces the cause:

```
{ "mcp": {...}, "agent": null, ... }

script_stderr (one or more commands in this script failed even though the script
exited 0; verify the resulting state with query before reporting success):
create_agent: bad_request: Agent name must contain only lowercase letters, digits, and hyphens
```

Trigger creation, before: `create_agent_trigger ... --enabled true` →
`create_agent_trigger: schema error: input.enabled must be boolean`. After: the
flag parses and the trigger is created.

## Risk

- Low
- `script_outcome` now returns `Ok` with an appended stderr section where it
  previously returned bare stdout. A caller that parses the result as strict JSON
  sees trailing text — only on a script that had a failing command, which
  previously returned a misleading success.
- Composed scalars are advertised as `string` in the bashkit inventory schema.
  This is the bash scripting surface only, matching how aggregates are already
  handled, and `coerce_json_text_params` parses them back before dispatch;
  already-typed values pass through untouched.

## Security

- Threat categories reviewed: no security-relevant code changes. Both changes are
  in the platform command-surface plumbing: error reporting for scripts and flag
  type coercion. No change to authentication, authorization, policy evaluation,
  credential handling, or multitenancy scoping. Command dispatch still runs the
  same policies, and `sanitize_script_error` is applied to the newly surfaced
  stderr on the same terms as before.

## Follow-ups

No follow-ups. A separate change for chat-provisioned MCP credentials is parked
on `claude/credential-chat-provisioning-f05ct9` pending security review and an
end-to-end run; it is deliberately not part of this PR.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Verified locally: `cargo check -p everruns-server` clean; `cargo test -p
everruns-server --lib` 35 passed / 0 failed, including three new regression tests
(`script_outcome_surfaces_stderr_from_a_partially_failed_script`,
`script_outcome_returns_bare_stdout_when_nothing_failed`,
`script_outcome_reports_a_nonzero_exit_as_an_error`) and
`inventory_schema_retypes_composed_scalars_so_bashkit_accepts_flag_text`. CI has
not run yet.

https://claude.ai/code/session_015hTrTovme74jQpq9TNi5PE

---
_Generated by [Claude Code](https://claude.ai/code/session_015hTrTovme74jQpq9TNi5PE)_