### PR TITLE
docs(observability): OpenTelemetry page, and fix the OTLP traces endpoint

### DIFF
--- a/crates/host/src/observability/telemetry.rs
+++ b/crates/host/src/observability/telemetry.rs
@@ -213,7 +213,7 @@ fn build_otlp_tracer(
     // Use HTTP OTLP instead of gRPC - more reliable with Docker DNS
     let exporter = SpanExporter::builder()
         .with_http()
-        .with_endpoint(endpoint)
+        .with_endpoint(traces_endpoint(endpoint))
         .with_timeout(Duration::from_secs(10))
         .build()?;
 
@@ -229,9 +229,65 @@ fn build_otlp_tracer(
     Ok((provider, tracer))
 }
 
+/// Resolve the URL spans are POSTed to.
+///
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` is a base endpoint in the OpenTelemetry
+/// specification: the signal path is appended to it. The SDK only does that
+/// for endpoints it reads from the environment itself, and this exporter
+/// passes the value programmatically, so a plain `http://host:4318` would be
+/// POSTed to verbatim and rejected by every collector. Append the traces path
+/// when the configured endpoint carries none, and leave a full signal URL
+/// (`.../v1/traces`, or a gateway's own path) untouched.
+fn traces_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    match trimmed.split_once("://") {
+        Some((_, rest)) if rest.contains('/') => trimmed.to_string(),
+        // No scheme: treat the first slash as the start of the path.
+        None if trimmed.contains('/') => trimmed.to_string(),
+        _ => format!("{trimmed}/v1/traces"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn traces_path_is_appended_to_a_base_endpoint() {
+        assert_eq!(
+            traces_endpoint("http://localhost:4318"),
+            "http://localhost:4318/v1/traces"
+        );
+        assert_eq!(
+            traces_endpoint("http://localhost:4318/"),
+            "http://localhost:4318/v1/traces"
+        );
+        assert_eq!(
+            traces_endpoint("https://tempo.monitoring:4318"),
+            "https://tempo.monitoring:4318/v1/traces"
+        );
+        assert_eq!(
+            traces_endpoint("localhost:4318"),
+            "localhost:4318/v1/traces"
+        );
+    }
+
+    #[test]
+    fn a_full_signal_url_is_left_alone() {
+        assert_eq!(
+            traces_endpoint("http://localhost:4318/v1/traces"),
+            "http://localhost:4318/v1/traces"
+        );
+        assert_eq!(
+            traces_endpoint("http://localhost:6006/v1/traces/"),
+            "http://localhost:6006/v1/traces"
+        );
+        // A collector behind a gateway path keeps that path.
+        assert_eq!(
+            traces_endpoint("https://gw.example.com/otlp/v1/traces"),
+            "https://gw.example.com/otlp/v1/traces"
+        );
+    }
 
     #[test]
     fn test_config_defaults() {

--- a/docs/observability/index.md
+++ b/docs/observability/index.md
@@ -5,10 +5,11 @@ sidebar:
   order: 0
 ---
 
-Everruns emits structured events for every agent turn, model calls, tool invocations, retries, token usage, latency. The integrations in this section forward those signals to dedicated observability platforms so you can monitor agents in production, evaluate prompt changes, and debug failures with full trace context.
+Everruns emits structured events for every agent turn, model calls, tool invocations, retries, token usage, latency. The integrations in this section forward those signals to observability platforms so you can monitor agents in production, evaluate prompt changes, and debug failures with full trace context.
 
 ## Available Integrations
 
+- [OpenTelemetry](/observability/opentelemetry/), export traces over OTLP to any tracing backend. Spans follow the Gen-AI semantic conventions and the OpenInference conventions at once, so Grafana Tempo, Jaeger, Datadog, Langfuse, and Arize Phoenix all read them.
 - [Braintrust](/observability/braintrust/), LLM observability, evaluation, and trace visualization. Turn traces are grouped by session, with token usage, time-to-first-token, and tool execution times.
 
 ## Related

--- a/docs/observability/opentelemetry.md
+++ b/docs/observability/opentelemetry.md
@@ -1,0 +1,187 @@
+---
+title: OpenTelemetry
+description: Export Everruns agent traces over OTLP. Spans follow the OpenTelemetry Gen-AI and OpenInference conventions, so any tracing backend reads them.
+sidebar:
+  order: 1
+---
+
+Everruns turns every agent run into an OpenTelemetry trace and exports it over OTLP. Spans carry two attribute vocabularies at once, the [OpenTelemetry Gen-AI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/docs/gen-ai) and the [OpenInference conventions](https://arize-ai.github.io/openinference/spec/semantic_conventions.html), so one endpoint feeds general-purpose backends such as Grafana Tempo, Jaeger, and Datadog as well as LLM-native ones such as Arize Phoenix and Langfuse.
+
+## What You Get
+
+- **A trace per turn**: an `invoke_agent` root span named after your agent, with model calls, tool runs, and reasoning phases nested underneath
+- **Real timings**: spans start and end at the moment each event happened, so waterfalls show true model latency and tool duration
+- **Token and cost detail**: input, output, and prompt-cache tokens per call and per turn, plus cost where the provider reports it
+- **Tool visibility**: every tool call is its own span with name, description, call id, and outcome
+- **Failure detail**: a low-cardinality `error.type`, an error span status carrying the message, and an `exception` event
+- **Privacy by default**: prompts, completions, reasoning, and tool payloads are never exported unless you turn them on
+
+## Quick Start
+
+### 1. Point Everruns at a collector
+
+Set one variable. Any OTLP/HTTP endpoint works.
+
+```bash
+# Local collector, Grafana Tempo, Datadog agent, ...
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+
+# Name the service in your traces
+export OTEL_SERVICE_NAME=everruns-server
+```
+
+Traces are exported over OTLP HTTP/protobuf. Point the variable at the base endpoint, usually port `4318`, and Everruns appends the `/v1/traces` path; a full signal URL is used as given.
+
+### 2. Configure
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | - | OTLP/HTTP endpoint. Tracing stays off while unset |
+| `OTEL_SERVICE_NAME` | No | `everruns-server`, `everruns-worker` | Service name on the spans |
+| `OTEL_SERVICE_VERSION` | No | - | Service version on the spans |
+| `OTEL_ENVIRONMENT` | No | - | Deployment environment label |
+| `OTEL_SDK_DISABLED` | No | `false` | Disable tracing without unsetting the endpoint |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | No | `false` | Export instructions, messages, tool arguments and results |
+| `EVERRUNS_TRACE_CONVENTIONS` | No | `gen_ai,openinference` | Which attribute vocabularies to write |
+
+### 3. View traces
+
+Open your backend and look for the `invoke_agent` spans. In Arize Phoenix, point the same variable at Phoenix and its spans appear as AGENT, LLM, and TOOL rows with no extra configuration:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:6006
+```
+
+## Trace Structure
+
+Each turn is one trace. Reasoning and acting phases give the trace its shape, and extended thinking sits inside the model call it belongs to:
+
+```
+invoke_agent {agent name}          (root, INTERNAL)
+├── reason                         reasoning phase
+│   └── chat {model}               model call (CLIENT)
+│       └── thinking               extended thinking, when enabled
+├── act                            tool execution phase
+│   ├── execute_tool {name}
+│   └── execute_tool {name}
+├── reason
+│   └── chat {model}
+└── (no further tool calls, turn complete)
+```
+
+| Span | Kind | `gen_ai.operation.name` | `openinference.span.kind` |
+|------|------|-------------------------|---------------------------|
+| `invoke_agent {agent name}` | `INTERNAL` | `invoke_agent` | `AGENT` |
+| `chat {model}` | `CLIENT` | `chat` | `LLM` |
+| `execute_tool {name}` | `INTERNAL` | `execute_tool` | `TOOL` |
+| `reason`, `act`, `thinking` | `INTERNAL` | none | `CHAIN` |
+
+The reason, act, and thinking spans are Everruns phases rather than Gen-AI operations, so they carry no `gen_ai.operation.name` and backends do not count them as model calls.
+
+## OpenTelemetry Gen-AI Support
+
+| | Supported | Attributes |
+|---|-----------|------------|
+| ✅ | Agent span per turn | `gen_ai.agent.id`, `gen_ai.agent.name`, `gen_ai.agent.description` |
+| ✅ | Model call spans | `chat {model}`, CLIENT kind, real call duration |
+| ✅ | Provider and model identity | `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.response.id` |
+| ✅ | Finish reasons | `gen_ai.response.finish_reasons` as a string array |
+| ✅ | Token usage with cache split | `gen_ai.usage.input_tokens`, `output_tokens`, `cache_read.input_tokens`, `cache_write.input_tokens` |
+| ✅ | Request parameters | `gen_ai.request.temperature`, `max_tokens`, `reasoning.level`, `stream` |
+| ✅ | Streaming latency and compaction | `gen_ai.response.time_to_first_chunk`, `gen_ai.conversation.compacted` |
+| ✅ | Tool execution spans | `gen_ai.tool.name`, `gen_ai.tool.type`, `gen_ai.tool.call.id`, `gen_ai.tool.description` |
+| ✅ | Extended thinking | Nested inside the model call it belongs to |
+| ✅ | Errors | `error.type`, error span status, `exception` events |
+| ✅ | Conversation correlation | `gen_ai.conversation.id` on every span |
+| ✅ | Content capture (opt-in) | `gen_ai.system_instructions`, `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.tool.definitions`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` |
+| ✅ | Accurate timestamps | Spans start and end at the times the events record |
+
+Not emitted yet: `server.address` and `server.port` on model calls, and parameter schemas inside `gen_ai.tool.definitions`.
+
+## OpenInference Support
+
+| | Supported | Attributes |
+|---|-----------|------------|
+| ✅ | Span kinds | `openinference.span.kind`: `AGENT`, `CHAIN`, `LLM`, `TOOL` |
+| ✅ | Session and agent identity | `session.id`, `agent.name`, `metadata` |
+| ✅ | Model identity | `llm.model_name`, `llm.provider`, `llm.system` |
+| ✅ | Token counts | `llm.token_count.prompt`, `.completion`, `.total` |
+| ✅ | Prompt cache detail | `llm.token_count.prompt_details.cache_read`, `.cache_write` |
+| ✅ | Cost | `llm.cost.total` in USD, when the provider reports it |
+| ✅ | Invocation parameters and tools | `llm.invocation_parameters`, `llm.tools.N.tool.json_schema` |
+| ✅ | Input and output values (opt-in) | `input.value`, `output.value`, with `input.mime_type` and `output.mime_type` |
+| ✅ | Flattened messages (opt-in) | `llm.input_messages.N.message.*`, `llm.output_messages.N.message.*`, tool calls included |
+| ✅ | Tool spans | `tool.name`, `tool.description`, arguments and results as input and output values |
+| ✅ | Errors | Error span status with `exception` events |
+| ✅ | Phoenix out of the box | Point the OTLP endpoint at Phoenix, nothing else to configure |
+
+## Everruns Attributes
+
+Spans also carry a few Everruns-specific attributes under their own namespace, so they never collide with either convention:
+
+| Attribute | Spans | Description |
+|-----------|-------|-------------|
+| `everruns.turn.id`, `everruns.exec.id`, `everruns.input_message.id` | All | Correlation ids that match the [event stream](/features/events/) |
+| `everruns.phase` | `reason`, `act`, `thinking` | Which phase the span represents |
+| `everruns.turn.iterations`, `everruns.turn.tool_call_count`, `everruns.turn.llm_call_count`, `everruns.turn.status` | `invoke_agent` | Turn counters and outcome |
+| `everruns.tool.status`, `everruns.tool.capability.id` | `execute_tool` | Tool outcome and the capability that provided it |
+| `everruns.usage.cost_usd` | `chat`, `invoke_agent` | Cost when known |
+| `everruns.llm.retry.attempts`, `everruns.llm.retry.total_wait_ms` | `chat` | Provider retries behind a single call |
+| `everruns.span.orphaned`, `everruns.span.unterminated` | Any | Diagnostics: a span rebuilt from a terminal event, or closed because its turn ended first |
+
+## Choosing Conventions
+
+Both vocabularies are written by default. Narrow to one when a backend only reads one and you want smaller spans:
+
+```bash
+# OpenTelemetry Gen-AI only (Tempo, Jaeger, Datadog, Langfuse)
+export EVERRUNS_TRACE_CONVENTIONS=gen_ai
+
+# OpenInference only (Arize Phoenix)
+export EVERRUNS_TRACE_CONVENTIONS=openinference
+```
+
+Span names, kinds, and hierarchy are the same either way; only the attributes differ. An unrecognized value falls back to writing both.
+
+## Content Capture
+
+Prompts, completions, reasoning, and tool payloads are **not** exported by default. Turn them on with the standard OpenTelemetry variable:
+
+```bash
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
+```
+
+With capture on:
+
+- model call spans carry `gen_ai.system_instructions`, `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.tool.definitions` in the conventions' `{role, parts}` JSON, plus the OpenInference `input.value` and `output.value` and the flattened `llm.input_messages.N.message.*` keys
+- tool spans carry their arguments and results
+- the turn root carries the user's message and the final answer
+- the thinking span carries the model's reasoning text
+
+Two details worth knowing. Everruns keeps the agent's instructions separate from the conversation, so system messages are exported as `gen_ai.system_instructions` and left out of `gen_ai.input.messages`. Image bytes are never copied into a span; an image becomes a reference that names its media type only.
+
+Treat this as a data-retention decision. Everything captured leaves your deployment for whatever backend the OTLP endpoint points at.
+
+## Troubleshooting
+
+### No traces appear
+
+1. Confirm `OTEL_EXPORTER_OTLP_ENDPOINT` is set and reachable from the server and worker processes; without it, tracing is off and startup logs say so
+2. Confirm the endpoint speaks OTLP over **HTTP**, typically port `4318`, not the gRPC port `4317`
+3. Check startup logs for `OpenTelemetry tracing enabled` with your endpoint, or a warning that the exporter failed to initialize
+4. Confirm `OTEL_SDK_DISABLED` is not set to `true`
+
+### Traces appear but spans look empty
+
+1. Prompts and completions require `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`; without it, spans carry structure and metrics only, which is the default
+2. If your backend reads only one vocabulary, check `EVERRUNS_TRACE_CONVENTIONS` has not been narrowed to the other one
+
+### Turns are split across traces
+
+Each turn is deliberately its own trace. Group by `gen_ai.conversation.id`, or `session.id` in Phoenix, to follow a whole session.
+
+## Related
+
+- [Braintrust](/observability/braintrust/), LLM observability and evaluation with a dedicated exporter
+- [Events](/features/events/), the event stream every exporter is built on
+- [Environment Variables](/sre/environment-variables/), the full operator reference

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -592,8 +592,10 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo.monitoring:4318
 ```
 
 **Notes:**
-- When set, traces are exported via OTLP over HTTP/protobuf (use the backend's HTTP port, typically 4318)
+- When set, traces are exported via OTLP over HTTP/protobuf (use the backend's HTTP port, typically 4318, not the gRPC port 4317)
+- Point this at the base endpoint; the `/v1/traces` path is appended for you, and a full signal URL is used as given
 - Connect to any OTLP-compatible backend for trace visualization
+- See [OpenTelemetry](/observability/opentelemetry/) for the span model and attributes
 - Without this variable, only console logging is enabled
 
 ### OTEL_SERVICE_NAME

--- a/knowledge/operations/observability.md
+++ b/knowledge/operations/observability.md
@@ -95,6 +95,13 @@ backends (Grafana Tempo, Jaeger, Datadog, Langfuse) and in Phoenix alike.
 
 `OTEL_RECORD_CONTENT` is kept as a legacy alias of the content-capture switch.
 
+`OTEL_EXPORTER_OTLP_ENDPOINT` is a base endpoint per the OpenTelemetry
+specification, so `build_otlp_tracer` appends `/v1/traces` when the configured
+value carries no path, and leaves a full signal URL alone. The SDK only does
+that appending for endpoints it reads from the environment itself, and this
+exporter passes the value programmatically, so without it a plain
+`http://host:4318` is POSTed to verbatim and every collector rejects it.
+
 ### Span model
 
 | Event | Span name | Kind | `gen_ai.operation.name` | `openinference.span.kind` |


### PR DESCRIPTION
## What changed

A public [Observability → OpenTelemetry](https://docs.everruns.com/observability/opentelemetry/) page, so the tracing support that shipped in #3353 is documented outside the SRE reference. It covers what you get, a two-step quick start (any OTLP collector, and Arize Phoenix), the span model, both attribute vocabularies as support tables, the Everruns attribute namespace, the conventions switch, content capture and its retention implications, and troubleshooting. The observability index now lists it above Braintrust.

Writing the quick start surfaced a real defect, fixed here. `OTEL_EXPORTER_OTLP_ENDPOINT` is a *base* endpoint in the OpenTelemetry specification: the signal path is appended to it. The SDK only does that for endpoints it reads from the environment itself, and this exporter passes the value programmatically, so the documented `http://localhost:4318` was POSTed to verbatim and rejected by every collector. `build_otlp_tracer` now appends `/v1/traces` when the configured endpoint carries no path, and leaves a full signal URL (or a gateway's own path) untouched.

The SRE environment-variables reference and the internal observability notes were updated to state that endpoint contract.

## Why

Everruns had no public page describing OpenTelemetry support at all: readers looking for "does this work with Tempo or Phoenix" found only an operator variable list. And the endpoint the docs told them to set did not work.

## Before / After

**Endpoint resolution**, the behavior change:

| `OTEL_EXPORTER_OTLP_ENDPOINT` | Before, POSTed to | After |
|---|---|---|
| `http://localhost:4318` | `http://localhost:4318` (rejected) | `http://localhost:4318/v1/traces` |
| `http://localhost:6006` (Phoenix) | `http://localhost:6006` (rejected) | `http://localhost:6006/v1/traces` |
| `http://localhost:4318/v1/traces` | unchanged | unchanged |
| `https://gw.example.com/otlp/v1/traces` | unchanged | unchanged |

Covered by `traces_path_is_appended_to_a_base_endpoint` and `a_full_signal_url_is_left_alone`.

**Docs**: before, `docs/observability/` held only `braintrust.md`, and the OpenTelemetry support was described solely in `docs/sre/environment-variables.md`. After, the page builds into the site and renders five tables, including the two support matrices:

```
tables: 5  checks: 25
<title>OpenTelemetry | Everruns</title>
| Supported | Attributes |
| ✅ | Agent span per turn | gen_ai.agent.id, gen_ai.agent.name, gen_ai.agent.description |
| ✅ | Model call spans | chat {model}, CLIENT kind, real call duration |
```

Evidence gathered:

- `cd apps/docs && pnpm run build` → 492 pages, "All internal links are valid", new page present at `/observability/opentelemetry/`; the rendered HTML was inspected for table and checkmark rendering (above).
- `cargo test -p everruns-host --features observability` (56 observability tests, including the two new endpoint tests), `cargo fmt --all --check`, `cargo clippy --all-targets --features everruns-host/observability -- -D warnings` across core, host, engine, worker.
- `python3 scripts/check_okf.py knowledge` → conformant.
- Branch is cut from latest `origin/main`; no migrations on either side.

## Risk

- Low
- The endpoint change makes a previously broken configuration work; a deployment that already worked did so by setting the full `/v1/traces` URL, which is left untouched. Everything else is documentation.

## Security

- Threat categories reviewed: TM-OBS.
- Findings and resolutions: no new surface. The endpoint fix appends a path to an operator-configured URL and cannot redirect traces to a different host. The page documents that content capture is off by default, that enabling it sends prompts, completions, reasoning, and tool payloads to the configured endpoint, and that this is a retention decision, which matches TM-OBS-010 and TM-OBS-003.

## Follow-ups

No follow-ups. The three items deferred in #3353 (server address and port, tool parameter schemas, the yolop exporter) are unchanged and are recorded there; this PR documents them as not yet emitted rather than leaving readers to discover it.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYszNCcbg3y7kd3knm5sAu)_