### PR TITLE
fix(ci): back off before retrying a live turn that failed transiently

### DIFF
--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -539,6 +539,20 @@ mod quota_detector_tests {
     use everruns_provider::typed_id::TurnId;
     use everruns_test_support::in_memory_loop::{LlmGenerationSummary, TurnResult};
 
+    /// A turn that failed with `error`, for driving the retry macro.
+    fn failed_result(error: &str) -> TurnResult {
+        TurnResult {
+            response: String::new(),
+            iterations: 1,
+            tool_calls_count: 0,
+            success: false,
+            error: Some(error.into()),
+            stop_reason: TurnStopReason::EndTurn,
+            turn_id: TurnId::new(),
+            llm_generations: vec![],
+        }
+    }
+
     fn tool_result(
         available_tools: &[&str],
         output_tool_calls_count: usize,
@@ -740,5 +754,77 @@ mod quota_detector_tests {
         // Capped so a long retry budget cannot unbound the job.
         assert_eq!(live_retry_backoff(4), Duration::from_secs(30));
         assert_eq!(live_retry_backoff(50), Duration::from_secs(30));
+    }
+
+    /// Drive the macro itself with a synthetic turn so the retry/backoff path is
+    /// covered without live provider traffic. `start_paused` auto-advances
+    /// tokio's clock while the runtime is idle, so the real 15s of backoff costs
+    /// no wall-clock time but is still observable via `Instant::now()`.
+    #[tokio::test(start_paused = true)]
+    async fn transient_failure_retries_with_backoff() {
+        use std::cell::Cell;
+        use std::time::Duration;
+        use tokio::time::Instant;
+
+        let config = super::ANTHROPIC_OPUS5;
+        let attempts = Cell::new(0usize);
+        let started = Instant::now();
+
+        let outcome = run_live_turn!(config, 3, |r: &TurnResult| r.success, {
+            attempts.set(attempts.get() + 1);
+            failed_result("LLM error: Anthropic stream error: overloaded_error")
+        });
+
+        assert_eq!(attempts.get(), 3, "every attempt should be spent");
+        assert!(
+            outcome.is_some_and(|r| !r.success),
+            "the last failure is returned so the caller's assertion reports it"
+        );
+        // 5s after attempt 1 + 10s after attempt 2; none after the last.
+        assert_eq!(started.elapsed(), Duration::from_secs(15));
+    }
+
+    /// A model that cleanly declines the tool is not a transport problem, so the
+    /// retries must fire back to back with no delay.
+    #[tokio::test(start_paused = true)]
+    async fn sampling_miss_retries_without_backoff() {
+        use std::cell::Cell;
+        use std::time::Duration;
+        use tokio::time::Instant;
+
+        let config = super::ANTHROPIC_OPUS5;
+        let attempts = Cell::new(0usize);
+        let started = Instant::now();
+
+        let outcome = run_live_turn!(config, 3, |r: &TurnResult| r.tool_calls_count > 0, {
+            attempts.set(attempts.get() + 1);
+            tool_result(&["get_current_time"], 0, &["stop"], 0)
+        });
+
+        assert_eq!(attempts.get(), 3);
+        assert!(outcome.is_some());
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    /// Quota exhaustion still short-circuits to a skip on the first attempt,
+    /// without spending retries or backoff on an account that cannot recover.
+    #[tokio::test(start_paused = true)]
+    async fn quota_exhaustion_skips_immediately() {
+        use std::cell::Cell;
+        use std::time::Duration;
+        use tokio::time::Instant;
+
+        let config = super::ANTHROPIC_OPUS5;
+        let attempts = Cell::new(0usize);
+        let started = Instant::now();
+
+        let outcome = run_live_turn!(config, 3, |r: &TurnResult| r.success, {
+            attempts.set(attempts.get() + 1);
+            failed_result("LLM error: insufficient_quota: You exceeded your current quota")
+        });
+
+        assert_eq!(attempts.get(), 1, "quota is terminal, not worth retrying");
+        assert!(outcome.is_none(), "caller skips on None");
+        assert_eq!(started.elapsed(), Duration::ZERO);
     }
 }

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -294,10 +294,19 @@ macro_rules! skip_if_quota {
 }
 
 /// Substrings that mark a *transient* live-transport failure (network blip,
-/// streaming-decode hiccup, timeout) rather than a real, reproducible error.
-/// These tests hit real provider endpoints, so a single transport hiccup should
-/// be retried, not reported as a regression — e.g. the observed flake
-/// `LLM error: Stream error: Transport error: error decoding response body`.
+/// streaming-decode hiccup, timeout, provider-side overload) rather than a real,
+/// reproducible error. These tests hit real provider endpoints, so a single
+/// hiccup should be retried, not reported as a regression — e.g. the observed
+/// flake `LLM error: Stream error: Transport error: error decoding response body`.
+///
+/// `overloaded` and `service unavailable` are matched explicitly: a provider
+/// capacity rejection (Anthropic `overloaded_error` / HTTP 529, or a 503) is
+/// transient in exactly the same way, and is the condition that turned main CI
+/// red on `abda5cc`. It previously matched only by accident, because Anthropic
+/// wraps the payload in the string `Anthropic stream error: …` — a driver that
+/// reported the same rejection without the words "stream error" would have been
+/// treated as a hard regression. Bare status codes are deliberately *not*
+/// matched: `503`/`529` as substrings collide with token counts and request ids.
 pub fn is_transient_transport_error(err: &str) -> bool {
     let e = err.to_ascii_lowercase();
     [
@@ -314,6 +323,8 @@ pub fn is_transient_transport_error(err: &str) -> bool {
         "incomplete message",
         "unexpected eof",
         "tls",
+        "overloaded",
+        "service unavailable",
     ]
     .iter()
     .any(|s| e.contains(s))
@@ -415,10 +426,19 @@ pub fn assert_live_tool_call_contract(result: &TurnResult, expected_tool: &str, 
 /// assertions still produce a precise failure message. Retries fire when a turn
 /// hit a transient transport error or `$ok` was not yet met.
 ///
+/// A transient failure backs off before the next attempt (5s, then 10s);
+/// a sampling miss retries immediately. Without this the three attempts were
+/// issued back to back over a couple of seconds, so a provider overload lasting
+/// tens of seconds — the common shape — exhausted every attempt while still
+/// overloaded and failed the matrix. Only the transient path pays the delay,
+/// because re-sampling a model that cleanly declined a tool has nothing to wait
+/// for.
+///
 /// Exported via `#[macro_export]` so every test binary that includes this
 /// shared module can use it. `is_quota_exhausted`, `is_transient_transport_error`,
-/// and `TurnResult` are referenced unqualified and resolve at each call site
-/// (the test files already glob-import this module and `TurnResult`).
+/// `live_retry_backoff`, and `TurnResult` are referenced unqualified and resolve
+/// at each call site (the test files already glob-import this module and
+/// `TurnResult`).
 #[macro_export]
 macro_rules! run_live_turn {
     ($config:expr, $max:expr, $ok:expr, $run:block) => {{
@@ -463,9 +483,33 @@ macro_rules! run_live_turn {
                 },
             );
             outcome = Some(result);
+            if transient && attempt < $max {
+                let backoff = live_retry_backoff(attempt);
+                eprintln!(
+                    "{}: backing off {:?} before attempt {}/{}",
+                    $config.label(),
+                    backoff,
+                    attempt + 1,
+                    $max,
+                );
+                ::tokio::time::sleep(backoff).await;
+            }
         }
         outcome
     }};
+}
+
+/// Delay before retrying a live turn that failed transiently, after `attempt`
+/// (1-based) attempts. Exponential from a 5s base and capped, so a provider
+/// overload gets tens of seconds to clear without unbounding the job.
+///
+/// Free function rather than inline arithmetic so the schedule is unit-testable
+/// without issuing live provider traffic.
+pub fn live_retry_backoff(attempt: u32) -> std::time::Duration {
+    const BASE_SECS: u64 = 5;
+    const MAX_SECS: u64 = 30;
+    let exponent = attempt.saturating_sub(1).min(8);
+    std::time::Duration::from_secs((BASE_SECS << exponent).min(MAX_SECS))
 }
 
 // ============================================================================
@@ -489,7 +533,7 @@ pub fn all_providers_registry() -> DriverRegistry {
 mod quota_detector_tests {
     use super::{
         LiveToolCallOutcome, assert_live_tool_call_contract, classify_live_tool_call,
-        is_quota_exhausted,
+        is_quota_exhausted, is_transient_transport_error, live_retry_backoff,
     };
     use everruns_core::turn::TurnStopReason;
     use everruns_provider::typed_id::TurnId;
@@ -644,5 +688,57 @@ mod quota_detector_tests {
             "insufficient_quota but actually invalid api key"
         ));
         assert!(!is_quota_exhausted("permission denied for this model"));
+    }
+
+    #[test]
+    fn matches_provider_overload_as_transient() {
+        // The exact Anthropic payload that failed the Live Provider Matrix on
+        // abda5cc — a capacity rejection, not a regression in our code.
+        assert!(is_transient_transport_error(
+            "LLM error: Anthropic stream error: {\"type\":\"error\",\"error\":{\"details\":null,\"type\":\"overloaded_error\",\"message\":\"Overloaded\"},\"request_id\":\"req_011CeggG6uTebixJra5EYWEx\"}"
+        ));
+        // Matched on the overload itself, not on the "stream error" wrapper, so
+        // a driver reporting the same rejection differently still retries.
+        assert!(is_transient_transport_error("overloaded_error"));
+        assert!(is_transient_transport_error(
+            "Anthropic API error (529): Overloaded"
+        ));
+        assert!(is_transient_transport_error("HTTP 503 Service Unavailable"));
+        // Pre-existing transport signatures still match.
+        assert!(is_transient_transport_error(
+            "LLM error: Stream error: Transport error: error decoding response body"
+        ));
+    }
+
+    #[test]
+    fn does_not_treat_real_failures_as_transient() {
+        // A capacity rejection is transient; a functional break is not.
+        assert!(!is_transient_transport_error(
+            "Model not available: gpt-99-nonexistent"
+        ));
+        assert!(!is_transient_transport_error(
+            "Bad request: invalid schema for tool"
+        ));
+        assert!(!is_transient_transport_error("401 Unauthorized"));
+        assert!(!is_transient_transport_error(""));
+        // Bare status-code digits must not match: they collide with token
+        // counts and request ids, which is why 503/529 are not substrings.
+        assert!(!is_transient_transport_error(
+            "Bad request: max_tokens 65529 exceeds the model limit"
+        ));
+        assert!(!is_transient_transport_error(
+            "Invalid request id req_503_abc: unknown tool"
+        ));
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_and_caps() {
+        use std::time::Duration;
+        assert_eq!(live_retry_backoff(1), Duration::from_secs(5));
+        assert_eq!(live_retry_backoff(2), Duration::from_secs(10));
+        assert_eq!(live_retry_backoff(3), Duration::from_secs(20));
+        // Capped so a long retry budget cannot unbound the job.
+        assert_eq!(live_retry_backoff(4), Duration::from_secs(30));
+        assert_eq!(live_retry_backoff(50), Duration::from_secs(30));
     }
 }


### PR DESCRIPTION
## What changed

A live provider turn that fails transiently now backs off before the next attempt (5s, then 10s, capped at 30s) instead of retrying immediately. A sampling miss still retries back to back — re-sampling a model that cleanly declined a tool has nothing to wait for, so only the transient path pays the delay.

Provider overload is also now classified as transient on its own terms. `overloaded` and `service unavailable` join the existing transport signatures in `is_transient_transport_error`.

## Why

The Live Provider Matrix turned main CI red on `abda5cc` ([run 11099](https://github.com/everruns/everruns/actions/runs/33767805284)) with an Anthropic `overloaded_error` — a provider capacity rejection, not a regression. The harness classified it as transient and failed anyway, for two independent reasons:

1. `run_live_turn!` issued its three attempts back to back, so all three landed inside the same few seconds of overload. A capacity rejection typically clears over tens of seconds, so the whole retry budget was spent while the condition was still active.
2. The overload matched `is_transient_transport_error` only *by accident*, via the `stream error` substring in Anthropic's `Anthropic stream error: …` wrapper. A driver reporting the same rejection without that wording would have been treated as a hard regression.

Re-running the job confirmed the diagnosis — attempt 2 passed unchanged — so this removes the cause rather than the symptom. This failure shape has recurred (EVE-943, EVE-947).

## Before / After

Before, the three attempts and the give-up were ~23s apart end to end, all inside one overload window:

```
ANTHROPIC_API_KEY:claude-opus-5: attempt 1/3 not acceptable (transient_transport=true, ... "Overloaded"); retrying
ANTHROPIC_API_KEY:claude-opus-5: attempt 2/3 not acceptable (transient_transport=true, ... "Overloaded"); retrying
ANTHROPIC_API_KEY:claude-opus-5: attempt 3/3 not acceptable (transient_transport=true, ... "Overloaded"); giving up
thread 'test_thinking_with_tool_call::case_2_anthropic_opus5' panicked: Turn should succeed
```

After, each transient attempt is spaced, and the spacing is announced:

```
ANTHROPIC_API_KEY:claude-opus-5: attempt 1/3 not acceptable (transient_transport=true, ...); retrying
ANTHROPIC_API_KEY:claude-opus-5: backing off 5s before attempt 2/3
ANTHROPIC_API_KEY:claude-opus-5: backing off 10s before attempt 3/3
```

Bare status codes are deliberately *not* matched: `503`/`529` as substrings collide with token counts and request ids. Negative tests pin both cases (`max_tokens 65529`, `req_503_abc`).

## Risk

- Low
- Test-harness only; no production code, no workflow YAML, no change to which jobs run or what they receive.
- The added delay is bounded — it applies only to a transient failure, at most `$max - 1` times per case, capped at 30s each. On the observed failure that is +15s worst case for one case in a job that already runs ~40s. A green run pays nothing.
- Widening the transient matcher means a genuine outage now costs backoff before failing. It still fails, with the same message, just later.

## Security

- Threat categories reviewed: TM-CI (secret scoping in CI), TM-LLM (provider keys), TM-DOS (resource exhaustion).
- Findings and resolutions:
  - **TM-CI-001 / TM-CI-002** — unaffected. The diff touches no workflow file and does not change where `DOPPLER_TOKEN` or provider keys are injected; `live-provider-matrix` remains `push`-gated, so no secret reaches a runner executing PR-controlled code.
  - **TM-LLM** — the new `eprintln!` logs only a `Duration` and attempt counters plus `config.label()`, which is `format!("{}:{}", self.env_var, self.model_name)` — the env var *name*, never its value. No new data reaches the log.
  - **TM-DOS** — the backoff is bounded by construction: exponential from a 5s base, capped at 30s by `live_retry_backoff`, fired at most `$max - 1` times. `backoff_grows_exponentially_and_caps` pins the cap, including a large-attempt input.
  - No `THREAT[...]` markers sit near the diff, and no new threat surface is introduced, so `knowledge/security/threat-model.md` needs no update.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---

Validation:
- `cargo test -p everruns-llm-tests --test agent_run_with_thinking quota_detector_tests` — 13 passed / 0 failed, including three new tests driving `run_live_turn!` itself under `#[tokio::test(start_paused = true)]`, which assert the exact 15s backoff on tokio's virtual clock at no wall-clock cost.
- `cargo clippy -p everruns-llm-tests --all-targets` and `cargo fmt --check` — clean.
- Smoke tested against the live provider the failure came from: `test_thinking_with_tool_call::case_2_anthropic_opus5` passes against the Doppler `ANTHROPIC_API_KEY`.
- No migration changes on either side of the merge base, so merging without a further rebase is safe under the shipping spec; main CI will be watched after merge.

https://claude.ai/code/session_011uPnupTmTEpcybZRTksiEu

---
_Generated by [Claude Code](https://claude.ai/code/session_011uPnupTmTEpcybZRTksiEu)_