### PR TITLE
feat(release): generate release cards

### DIFF
--- a/.agents/commands/prepare-release.md
+++ b/.agents/commands/prepare-release.md
@@ -105,13 +105,28 @@ changed, state that explicitly (`No published crate contracts changed this cycle
 dropping the subsection. Keep it consistent with the release PR's audit note and, if the GitHub
 Release notes were already generated at tag time, refresh that release body to match.
 
-## 6. Verify migrations without rewriting them
+## 6. Prepare the release card
+
+Update `release-card.yml` for this release. Keep the card editorial: one short headline, a one-to-three-line
+summary, and no more than three user-facing highlights. Every claim must already be supported by the release's
+`CHANGELOG.md` section. Each highlight's `source` is a PR or commit marker that the renderer verifies in that
+version's changelog section. Validate and render the reviewed card locally:
+
+```bash
+(cd apps/docs && pnpm run release-card --check --expect-version X.Y.Z)
+(cd apps/docs && pnpm run release-card --expect-version X.Y.Z)
+```
+
+The rendered PNG is generated, not committed. The release workflow regenerates it from the tagged commit and
+attaches it to the GitHub Release.
+
+## 7. Verify migrations without rewriting them
 
 Never squash, rename, or delete existing migrations for a release. Confirm the sorted basenames in
 `crates/server/migrations/` still start at `001_` and stay strictly sequential
 (`bash scripts/lib/check-migration-ordering.sh`).
 
-## 7. Refresh lockfiles
+## 8. Refresh lockfiles
 
 ```bash
 cargo generate-lockfile
@@ -119,7 +134,7 @@ cargo generate-lockfile
 (cd apps/docs && pnpm install --lockfile-only)
 ```
 
-## 8. Commit and open the PR
+## 9. Commit and open the PR
 
 Stage the files you touched by name, then:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,7 @@ jobs:
             docs:
               - 'apps/docs/**'
               - 'docs/**'
+              - 'release-card.yml'
               - '.github/workflows/ci.yml'
             docs_notebooks:
               - 'apps/docs/scripts/execute-notebooks.py'
@@ -1982,6 +1983,19 @@ jobs:
 
       - name: Build docs
         run: pnpm run build
+
+      - name: Validate release card
+        run: pnpm run release-card:test && pnpm run release-card --check
+
+      - name: Render release card preview
+        run: pnpm run release-card --output /tmp/release-card.png
+
+      - name: Upload release card preview
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-card-preview
+          path: /tmp/release-card.png
+          retention-days: 14
 
   # Docker image validation for PRs. Instead of recompiling the whole workspace
   # inside Docker (~28 min), this packages the binaries already built by

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,22 @@ jobs:
           echo "Release notes extracted:"
           cat release_notes.md
 
+      - name: Install release card renderer
+        run: |
+          set -euo pipefail
+          npm install --global pnpm@10.33.0
+          pnpm --dir apps/docs install --frozen-lockfile
+
+      - name: Render release card
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/docs run release-card \
+            --input ../../release-card.yml \
+            --expect-version "$VERSION" \
+            --output "../../release-card-v$VERSION.png"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -128,7 +144,8 @@ jobs:
           gh release create "v$VERSION" \
             --title "v$VERSION" \
             --notes-file release_notes.md \
-            --target "$TARGET_SHA"
+            --target "$TARGET_SHA" \
+            "release-card-v$VERSION.png#Everruns release card"
 
           echo "Created release v$VERSION"
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ node_modules/
 .next/
 dist/
 build/
+/release-card.png
+/release-card.svg
 
 # AI
 .claude/*.local.json

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,6 +13,8 @@
     "postbuild": "node scripts/verify-notebooks.mjs",
     "preview": "astro preview",
     "check": "astro check",
+    "release-card": "node scripts/generate-release-card.mjs",
+    "release-card:test": "node --test scripts/generate-release-card.test.mjs",
     "notebooks:exec": "python3 scripts/execute-notebooks.py"
   },
   "dependencies": {

--- a/apps/docs/scripts/generate-release-card.mjs
+++ b/apps/docs/scripts/generate-release-card.mjs
@@ -1,0 +1,232 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { load, JSON_SCHEMA } from "js-yaml";
+
+const WIDTH = 2400;
+const HEIGHT = 1350;
+const MONTHS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+
+function fail(message) {
+  throw new Error(`Invalid release card: ${message}`);
+}
+
+function text(value, field, maxLength) {
+  if (typeof value !== "string" || value.trim() === "") fail(`${field} must be a non-empty string`);
+  const result = value.trim();
+  if (result.length > maxLength) fail(`${field} must be at most ${maxLength} characters`);
+  return result;
+}
+
+function lines(value, field, { min, max, lineLength }) {
+  if (!Array.isArray(value) || value.length < min || value.length > max) {
+    fail(`${field} must contain ${min}-${max} lines`);
+  }
+  return value.map((line, index) => text(line, `${field}[${index}]`, lineLength));
+}
+
+function isCalendarDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day;
+}
+
+export function validateReleaseCard(value, expectedVersion) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail("document must be an object");
+
+  const version = text(value.version, "version", 24);
+  if (!/^\d+\.\d+\.\d+$/.test(version)) fail("version must be semantic version X.Y.Z");
+  if (expectedVersion && version !== expectedVersion) {
+    fail(`version ${version} does not match release ${expectedVersion}`);
+  }
+
+  const date = text(value.date, "date", 10);
+  if (!isCalendarDate(date)) {
+    fail("date must be a valid YYYY-MM-DD date");
+  }
+
+  const headline = lines(value.headline, "headline", { min: 1, max: 2, lineLength: 24 });
+  const summary = lines(value.summary, "summary", { min: 1, max: 3, lineLength: 48 });
+
+  if (!Array.isArray(value.highlights) || value.highlights.length < 1 || value.highlights.length > 3) {
+    fail("highlights must contain 1-3 items");
+  }
+  const highlights = value.highlights.map((item, index) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) fail(`highlights[${index}] must be an object`);
+    const highlight = {
+      title: text(item.title, `highlights[${index}].title`, 36),
+      description: text(item.description, `highlights[${index}].description`, 100),
+      source: text(item.source, `highlights[${index}].source`, 80),
+    };
+    if (wrap(highlight.description, 47).length > 2) {
+      fail(`highlights[${index}].description must fit on two lines`);
+    }
+    return highlight;
+  });
+
+  return { version, date, headline, summary, highlights };
+}
+
+export function validateChangelog(card, changelog) {
+  const heading = `## [${card.version}] - ${card.date}`;
+  const start = changelog.indexOf(heading);
+  if (start === -1) fail(`CHANGELOG.md is missing ${heading}`);
+  const next = changelog.indexOf("\n## [", start + heading.length);
+  const section = changelog.slice(start, next === -1 ? undefined : next);
+  for (const [index, highlight] of card.highlights.entries()) {
+    if (!section.includes(highlight.source)) {
+      fail(`highlights[${index}].source ${highlight.source} is not present in the v${card.version} changelog`);
+    }
+  }
+}
+
+export function readReleaseCard(inputPath, expectedVersion) {
+  const parsed = load(readFileSync(inputPath, "utf8"), { schema: JSON_SCHEMA });
+  return validateReleaseCard(parsed, expectedVersion);
+}
+
+function escapeXml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function wrap(value, maxCharacters) {
+  const words = value.split(/\s+/);
+  const result = [];
+  let current = "";
+  for (const word of words) {
+    if (current && `${current} ${word}`.length > maxCharacters) {
+      result.push(current);
+      current = word;
+    } else {
+      current = current ? `${current} ${word}` : word;
+    }
+  }
+  if (current) result.push(current);
+  return result;
+}
+
+function releaseLabel(card) {
+  const month = MONTHS[Number(card.date.slice(5, 7)) - 1];
+  return `RELEASE  ·  ${month} ${card.date.slice(0, 4)}  ·  V${card.version}`;
+}
+
+export function releaseCardSvg(card) {
+  const headline = card.headline
+    .map((line, index) => `<text x="210" y="${535 + index * 170}" class="headline">${escapeXml(line)}</text>`)
+    .join("\n    ");
+  const summaryStart = 790 + Math.max(0, card.headline.length - 2) * 40;
+  const summary = card.summary
+    .map((line, index) => `<text x="210" y="${summaryStart + index * 68}" class="summary">${escapeXml(line)}</text>`)
+    .join("\n    ");
+
+  const itemGap = card.highlights.length === 1 ? 0 : 250;
+  const itemsStart = card.highlights.length === 1 ? 570 : card.highlights.length === 2 ? 465 : 395;
+  const highlights = card.highlights
+    .map((item, index) => {
+      const y = itemsStart + index * itemGap;
+      const descriptionLines = wrap(item.description, 47).slice(0, 2);
+      return `<g transform="translate(1415 ${y})">
+      <text x="0" y="34" class="number">${String(index + 1).padStart(2, "0")}</text>
+      <line x1="98" y1="-16" x2="98" y2="155" class="item-rule"/>
+      <text x="155" y="34" class="item-title">${escapeXml(item.title)}</text>
+      ${descriptionLines.map((line, lineIndex) => `<text x="155" y="${91 + lineIndex * 48}" class="item-copy">${escapeXml(line)}</text>`).join("\n      ")}
+    </g>`;
+    })
+    .join("\n    ");
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" role="img" aria-label="Everruns release ${escapeXml(card.version)}">
+  <defs>
+    <radialGradient id="wash" cx="0" cy="0" r="1" gradientTransform="translate(2070 80) rotate(131) scale(1050 820)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#10263A" stop-opacity=".55"/>
+      <stop offset="1" stop-color="#07101A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="24"/>
+    </filter>
+    <style>
+      .sans { font-family: Arial, Helvetica, sans-serif; }
+      .mono { font-family: Menlo, Consolas, monospace; }
+      .headline { font-family: Arial, Helvetica, sans-serif; font-size: 152px; font-weight: 700; letter-spacing: -7px; fill: #F4F3EF; }
+      .summary { font-family: Arial, Helvetica, sans-serif; font-size: 46px; font-weight: 400; letter-spacing: -1px; fill: #A8B0BE; }
+      .number { font-family: Arial, Helvetica, sans-serif; font-size: 42px; font-weight: 400; fill: #D4A43A; }
+      .item-title { font-family: Arial, Helvetica, sans-serif; font-size: 41px; font-weight: 700; letter-spacing: -1px; fill: #F4F3EF; }
+      .item-copy { font-family: Arial, Helvetica, sans-serif; font-size: 34px; font-weight: 400; fill: #A8B0BE; }
+      .item-rule { stroke: #D4A43A; stroke-width: 4; }
+    </style>
+  </defs>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="#07101A"/>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#wash)"/>
+  <ellipse cx="580" cy="600" rx="620" ry="500" fill="#000812" opacity=".22" filter="url(#soft)"/>
+
+  <text x="115" y="135" class="sans" font-size="54" font-weight="700" letter-spacing="-2" fill="#F4F3EF">Everruns</text>
+  <text x="2285" y="127" class="mono" font-size="29" font-weight="700" letter-spacing="4" text-anchor="end" fill="#D4A43A">${escapeXml(releaseLabel(card))}</text>
+
+  <line x1="116" y1="378" x2="116" y2="1000" stroke="#D4A43A" stroke-width="6"/>
+  ${headline}
+  ${summary}
+
+  ${highlights}
+
+  <line x1="115" y1="1186" x2="2285" y2="1186" stroke="#D4A43A" stroke-width="2"/>
+  <text x="115" y="1260" class="mono" font-size="29" fill="#8F99A8">docs.everruns.com</text>
+  <text x="2285" y="1260" class="mono" font-size="29" text-anchor="end" fill="#8F99A8">github.com/everruns/everruns</text>
+</svg>`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    input: "../../release-card.yml",
+    changelog: "../../CHANGELOG.md",
+    output: "../../release-card.png",
+    check: false,
+    svgOutput: undefined,
+    expectedVersion: undefined,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (option === "--check") args.check = true;
+    else if (option === "--input") args.input = argv[++index];
+    else if (option === "--changelog") args.changelog = argv[++index];
+    else if (option === "--output") args.output = argv[++index];
+    else if (option === "--svg-output") args.svgOutput = argv[++index];
+    else if (option === "--expect-version") args.expectedVersion = argv[++index];
+    else fail(`unknown argument ${option}`);
+  }
+  if (!args.input) fail("--input requires a path");
+  if (!args.check && !args.output) fail("--output requires a path");
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const input = path.resolve(args.input);
+  const card = readReleaseCard(input, args.expectedVersion);
+  validateChangelog(card, readFileSync(path.resolve(args.changelog), "utf8"));
+  if (args.check) {
+    console.log(`release card v${card.version} is valid`);
+    return;
+  }
+
+  const svg = releaseCardSvg(card);
+  if (args.svgOutput) writeFileSync(path.resolve(args.svgOutput), svg);
+
+  const { default: sharp } = await import("sharp");
+  const output = path.resolve(args.output);
+  await sharp(Buffer.from(svg)).png().toFile(output);
+  console.log(`generated ${output}`);
+}
+
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isCli) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/apps/docs/scripts/generate-release-card.test.mjs
+++ b/apps/docs/scripts/generate-release-card.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { releaseCardSvg, validateChangelog, validateReleaseCard } from "./generate-release-card.mjs";
+
+const validCard = {
+  version: "1.2.3",
+  date: "2026-09-04",
+  headline: ["Reasoning,", "in order."],
+  summary: ["A concise release summary."],
+  highlights: [{ title: "Ordered artifacts", description: "Replay work in the order it happened.", source: "#123" }],
+};
+
+test("validates and normalizes release card content", () => {
+  assert.deepEqual(validateReleaseCard(validCard, "1.2.3"), validCard);
+});
+
+test("rejects a card for a different release", () => {
+  assert.throws(() => validateReleaseCard(validCard, "1.2.4"), /does not match release 1\.2\.4/);
+});
+
+test("rejects content that cannot fit the template", () => {
+  assert.throws(
+    () => validateReleaseCard({ ...validCard, headline: ["x".repeat(25)] }),
+    /headline\[0\] must be at most 24 characters/,
+  );
+  assert.throws(
+    () =>
+      validateReleaseCard({
+        ...validCard,
+        highlights: [
+          {
+            ...validCard.highlights[0],
+            description: "x ".repeat(49).trim(),
+          },
+        ],
+      }),
+    /description must fit on two lines/,
+  );
+});
+
+test("rejects impossible calendar dates", () => {
+  assert.throws(() => validateReleaseCard({ ...validCard, date: "2026-02-31" }), /valid YYYY-MM-DD date/);
+});
+
+test("requires highlight sources in the matching changelog section", () => {
+  const card = validateReleaseCard(validCard);
+  validateChangelog(card, "## [1.2.3] - 2026-09-04\n\n- Ordered artifacts ([#123](example))\n");
+  assert.throws(
+    () => validateChangelog(card, "## [1.2.3] - 2026-09-04\n\n- Something else\n"),
+    /source #123 is not present/,
+  );
+});
+
+test("escapes user-controlled SVG text", () => {
+  const svg = releaseCardSvg({
+    ...validCard,
+    highlights: [{ title: "Files & tools", description: "Use <guarded> input.", source: "#123" }],
+  });
+  assert.match(svg, /Files &amp; tools/);
+  assert.match(svg, /Use &lt;guarded&gt; input\./);
+  assert.doesNotMatch(svg, /Use <guarded>/);
+});

--- a/knowledge/project/release-process.md
+++ b/knowledge/project/release-process.md
@@ -23,6 +23,11 @@ This specification defines the release process for Everruns. The process is desi
 5. **User merges PR**: Squash merge to main
 6. **Auto-tagging**: GitHub Action detects release commit, creates tag + GitHub Release using CHANGELOG.md content
 
+The release PR also carries `release-card.yml`, a concise presentation of facts already recorded in the
+changelog. CI renders the card through the docs image toolchain for review. At tag time the Release workflow
+regenerates the PNG from the trusted commit and attaches it to the GitHub Release. The card is presentation
+metadata, not a second release-notes source: it cannot introduce claims absent from `CHANGELOG.md`.
+
 Release readiness also includes the integration backstops that are intentionally kept off the `pull_request` hot path. Before cutting a release PR or merging it, review the latest push-only live integration workflow runs on `main` and the latest `.github/workflows/integration-live-sweep.yml` result. Do not release through unresolved failures there unless the failure is understood, documented, and explicitly accepted.
 
 Release preparation also **audits the independently versioned library crates** (see [Library Crate Releases](#library-crate-releases)). This audit is a mandatory step of every product release, not an occasional side task: a product bump never carries a library crate's changes to crates.io, so any published crate whose public contract changed since its last release must get its own `/prepare-crate-release` — or the release PR must explicitly record that no published crate contracts changed. The decision must be visible in the PR, never silently skipped.
@@ -166,9 +171,10 @@ The workflow will extract release notes from CHANGELOG.md and create the GitHub 
 1. Tag format: `vX.Y.Z` (e.g., `v0.4.0`)
 2. Release title: `vX.Y.Z`
 3. Release body: Extracted from CHANGELOG.md section for that version
-4. Docker images tagged with version (triggered via `workflow_dispatch` from Release workflow)
-5. Pre-built CLI binaries attached as release assets (triggered via `workflow_dispatch` from Release workflow)
-6. crates.io packages are not published by the product release; each uses its
+4. Release card: `release-card-vX.Y.Z.png`, rendered from the reviewed `release-card.yml`
+5. Docker images tagged with version (triggered via `workflow_dispatch` from Release workflow)
+6. Pre-built CLI binaries attached as release assets (triggered via `workflow_dispatch` from Release workflow)
+7. crates.io packages are not published by the product release; each uses its
    own trusted package tag and **Publish Crate** workflow
 
 > **Note:** Tags created by `GITHUB_TOKEN` don't trigger other workflows (GitHub anti-recursion).

--- a/release-card.yml
+++ b/release-card.yml
@@ -1,0 +1,19 @@
+version: 0.22.0
+date: 2026-08-25
+headline:
+  - Reasoning,
+  - in order.
+summary:
+  - Model reasoning now replays as
+  - it happened—clearer to inspect,
+  - easier to trust.
+highlights:
+  - title: Ordered reasoning artifacts
+    description: Reasoning replays in production order with its classification visible.
+    source: "#3276"
+  - title: Bounded batch file reads
+    description: Read several guarded files in one policy-aware call.
+    source: "#3275"
+  - title: Cleaner replay events
+    description: Required summaries in; redundant recovery noise out.
+    source: "#3280"


### PR DESCRIPTION
## What changed
Release preparation now defines one concise YAML card alongside the changelog. CI validates its sources and layout, renders a review artifact, and the trusted release workflow regenerates and attaches the final PNG to the GitHub Release.

The generator produces a deterministic 2400×1350 Everruns card using the selected minimal editorial design.

## Why
Releases need a consistent, shareable visual without depending on a designer or a manual SaaS workflow. The changelog remains the source of truth while the card becomes a reviewed presentation layer.

## Before / After
Before: releases published notes and binaries but no reusable visual asset.

After:

![Everruns v0.22.0 release card](https://github.com/user-attachments/assets/4fd1f070-e3aa-4660-8f82-2d5946fd14f0)

The renderer also reports: release card v0.22.0 is valid.

## Risk
- Medium
- A malformed card can block docs CI or release creation; schema, version, changelog-source, calendar-date, line-fit, and XML-escaping tests make failure early and explicit.
- The write-scoped release job installs only the tagged docs lockfile with pnpm 10.33.0, then renders trusted repository content before release creation.

## Security
- Threat categories reviewed: TM-CI, TM-WEB, TM-DOS, and TM-FS.
- Findings and resolutions: release version data reaches shell only through a validated, quoted environment variable; text interpolated into SVG is bounded and XML-escaped; description wrapping cannot silently truncate; dependency resolution uses the frozen tagged lockfile. No secrets are exposed to PR-controlled jobs and no new threat-model entry is required.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)