### PR TITLE
feat(ci): report which providers the live matrix actually exercised

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,10 @@ jobs:
               - 'scripts/test-*.sh'
               - 'tests/fixtures/external-consumer/**'
               - 'scripts/check_okf.py'
+              # The report generators are covered by scripts/test-*.sh, so a
+              # change to one has to run those tests. Without this a rewrite of
+              # a report script reached main with its own test never running.
+              - 'scripts/report_*.py'
               - 'scripts/lib/**'
               - 'scripts/sync-publish-pin-versions.py'
               # scripts/test-publish-crates-order.sh reads the publish workflow
@@ -1165,11 +1169,27 @@ jobs:
         # breaks still fail the step.
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          # Each matrix cell appends what it did here (EVE-951), so the summary
+          # below can say which providers this run actually exercised. A skipped
+          # cell leaves the step green, so without this a fully dark run and a
+          # fully covered one are indistinguishable.
+          LLM_MATRIX_COVERAGE_FILE: ${{ github.workspace }}/llm-matrix-coverage.tsv
         # A sampling miss fails the step once the in-test retries are exhausted:
         # a turn that never called the advertised tool proves nothing about the
         # provider's wire serialization, which is what this matrix exists to
         # check. `--nocapture` exposes the generations behind the failure.
         run: doppler run -- cargo test -p everruns-llm-tests --test agent_run_basic --test agent_run_with_thinking --test subagent_live_test --all-features -- --nocapture
+
+      - name: Report provider coverage
+        # `always()`: the coverage picture is most valuable when the step above
+        # failed, and it must never itself change the job's outcome — the report
+        # only describes what ran. Thin coverage is deliberately not an error
+        # here; failing on it would turn an out-of-credits account into red main,
+        # which EVE-943 established is a false positive.
+        if: always()
+        run: |
+          scripts/report_live_matrix_coverage.py "$GITHUB_WORKSPACE/llm-matrix-coverage.tsv" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
   # S3 blob-backend integration tests.
   # The PostgreSQL `integration-test` job above only exercises the inline

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -222,7 +222,7 @@ async fn test_model_not_available_returns_user_friendly_error(
     // billing error before it ever validates the model name, so the
     // "model not available" path can't be exercised — skip rather than fail
     // (same billing-condition handling as the other live cases).
-    skip_if_quota!(result, model_name);
+    skip_if_quota!(result, label = model_name);
 
     // The turn should complete (not crash) but with failure
     assert!(!result.success, "Turn should fail for nonexistent model");

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -98,7 +98,7 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
 
         let result = runner.run_turn(input).await.unwrap();
 
-        skip_if_quota!(result, config.label());
+        skip_if_quota!(result, cell = config);
 
         // Adaptive-thinking models occasionally answer correctly without emitting
         // a thinking block; for providers that keep reasoning on the private

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -60,12 +60,17 @@ impl ProviderModelConfig {
         if let Ok(skip) = std::env::var("SKIP_LLM_INTEGRATION_TESTS_PROVIDERS") {
             let provider = self.provider_type.to_string().to_lowercase();
             if skip.split(',').any(|s| s.trim().to_lowercase() == provider) {
+                self.record_outcome(CELL_SKIP_LIST);
                 return None;
             }
         }
-        let api_key = std::env::var(self.env_var).ok().filter(|k| !k.is_empty())?;
+        let Some(api_key) = std::env::var(self.env_var).ok().filter(|k| !k.is_empty()) else {
+            self.record_outcome(CELL_NO_KEY);
+            return None;
+        };
         let model = ModelSpec::on(self.provider_type.as_str(), self.model_name);
         let provider = ProviderConfig::new(self.provider_type.clone()).with_api_key(api_key);
+        self.record_outcome(CELL_CONFIGURED);
         Some((model, provider).into())
     }
 
@@ -73,7 +78,135 @@ impl ProviderModelConfig {
     pub fn label(&self) -> String {
         format!("{}:{}", self.env_var, self.model_name)
     }
+
+    /// Record this cell as reached-but-unverified (out of quota/credits).
+    ///
+    /// A method rather than `record_outcome(CELL_QUOTA)` at the call site
+    /// because both callers are `#[macro_export]` macros: a constant would have
+    /// to resolve in each expansion's scope, which it does not in this module's
+    /// own `mod tests` or in test binaries that do not glob-import the constant.
+    /// Method resolution needs no import.
+    pub fn record_quota(&self) {
+        self.record_outcome(CELL_QUOTA);
+    }
+
+    /// Append one machine-readable coverage record for this matrix cell to the
+    /// file named by `LLM_MATRIX_COVERAGE_FILE`, when that variable is set
+    /// (EVE-951). A no-op otherwise, so local runs are unchanged.
+    ///
+    /// The human-readable `eprintln!` skip messages next to each call site stay
+    /// as they are — they explain a single test to whoever is reading the log.
+    /// These records answer the different question the job summary needs: which
+    /// cells actually reached a provider, and which quietly did not.
+    ///
+    /// A file rather than stdout for two reasons. Test stdout and stderr
+    /// interleave under `--nocapture` with tests running in parallel, which
+    /// splices records into the middle of other lines and makes them
+    /// unparseable. And this module's own `mod tests` drives the recording
+    /// macros with synthetic configs, so anything written unconditionally to
+    /// the log would report fake cells as real coverage; CI sets the variable
+    /// only for the live matrix run.
+    ///
+    /// Records are appended with a single `write_all` of one short line, which
+    /// `O_APPEND` keeps atomic across the parallel test threads and across the
+    /// separate test binaries the step runs into the same file.
+    ///
+    /// `model()` is called more than once per test (the `is_none()` guard, then
+    /// again inside the turn, once per `run_live_turn!` attempt), so a cell
+    /// records the same outcome repeatedly. Folding duplicates is the reader's
+    /// job — `scripts/report_live_matrix_coverage.py` reduces per cell — which
+    /// keeps this side free of any cross-test state.
+    ///
+    /// Recording is best-effort: a coverage report must never be able to fail
+    /// the live matrix it is only describing, so I/O errors are dropped.
+    pub fn record_outcome(&self, outcome: &str) {
+        use std::io::Write;
+
+        if coverage_suppressed() {
+            return;
+        }
+        let Ok(path) = std::env::var(COVERAGE_FILE_ENV) else {
+            return;
+        };
+        if path.is_empty() {
+            return;
+        }
+        let line = format!(
+            "{outcome}\t{}\t{}\t{}\n",
+            self.provider_type.to_string().to_lowercase(),
+            self.env_var,
+            self.model_name,
+        );
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(path)
+        {
+            let _ = f.write_all(line.as_bytes());
+        }
+    }
 }
+
+/// Names the file matrix cells append their coverage records to. Unset outside
+/// the `live-provider-matrix` job, which makes recording a no-op everywhere else.
+pub const COVERAGE_FILE_ENV: &str = "LLM_MATRIX_COVERAGE_FILE";
+
+thread_local! {
+    static COVERAGE_SUPPRESSED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn coverage_suppressed() -> bool {
+    COVERAGE_SUPPRESSED.with(std::cell::Cell::get)
+}
+
+/// Suppresses coverage recording on the current thread until dropped.
+///
+/// This module's own unit tests drive `run_live_turn!` and `skip_if_quota!`
+/// with synthetic `TurnResult`s to assert the retry and skip behaviour, and
+/// they carry a *real* config (`ANTHROPIC_OPUS5`) as the label. Without this
+/// guard those tests append genuine-looking records — a live matrix run would
+/// then report `claude-opus-5` as quota-skipped when nothing of the sort
+/// happened, which is precisely the false coverage picture EVE-951 exists to
+/// remove.
+///
+/// Thread-local rather than an env var: the harness runs tests in parallel, so
+/// mutating process environment here would race across tests. Every test that
+/// needs it uses a current-thread runtime, so the flag and the code it guards
+/// are on the same thread.
+pub struct CoverageSuppressed(());
+
+impl CoverageSuppressed {
+    pub fn new() -> Self {
+        COVERAGE_SUPPRESSED.with(|c| c.set(true));
+        Self(())
+    }
+}
+
+impl Default for CoverageSuppressed {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for CoverageSuppressed {
+    fn drop(&mut self) {
+        COVERAGE_SUPPRESSED.with(|c| c.set(false));
+    }
+}
+
+/// The cell had a usable API key and reached the provider.
+pub const CELL_CONFIGURED: &str = "configured";
+
+/// The cell was skipped because its API key was absent or empty.
+pub const CELL_NO_KEY: &str = "no-key";
+
+/// The cell was skipped through `SKIP_LLM_INTEGRATION_TESTS_PROVIDERS`.
+pub const CELL_SKIP_LIST: &str = "skip-list";
+
+/// The cell reached the provider but the account was out of quota/credits, so
+/// its assertions never ran. A billing condition, not a code regression — but
+/// it leaves the cell unverified, which is what the report exists to surface.
+pub const CELL_QUOTA: &str = "quota";
 
 impl std::fmt::Display for ProviderModelConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -289,9 +422,28 @@ pub fn is_quota_exhausted(err: &str) -> bool {
 /// import the test files already rely on.
 #[macro_export]
 macro_rules! skip_if_quota {
-    ($result:expr, $label:expr) => {{
+    // `cell = <ProviderModelConfig>` — a real matrix cell. Records a `quota`
+    // coverage marker (EVE-951) so the job summary reports the cell as
+    // unverified instead of letting a green test result imply it was checked.
+    ($result:expr, cell = $config:expr) => {{
         // Bind once by reference so the expression isn't evaluated twice (no
         // duplicated side effects / moves if a caller passes a non-trivial expr).
+        let __result = &$result;
+        let __config = &$config;
+        if !__result.success {
+            if let Some(err) = __result.error.as_deref() {
+                if is_quota_exhausted(err) {
+                    eprintln!("SKIP: provider {} out of quota: {}", __config.label(), err);
+                    __config.record_quota();
+                    return;
+                }
+            }
+        }
+    }};
+    // `label = <&str>` — not a matrix cell. The nonexistent-model negative test
+    // builds its own `ModelSpec` rather than a `ProviderModelConfig`, so it has
+    // no cell to report coverage for.
+    ($result:expr, label = $label:expr) => {{
         let __result = &$result;
         if !__result.success {
             if let Some(err) = __result.error.as_deref() {
@@ -461,6 +613,9 @@ macro_rules! run_live_turn {
                 if let Some(err) = result.error.as_deref() {
                     if is_quota_exhausted(err) {
                         eprintln!("SKIP: {} out of quota: {}", $config.label(), err);
+                        // The cell reached the provider but never got to assert
+                        // anything (EVE-951): record it as unverified, not as run.
+                        $config.record_quota();
                         outcome = None;
                         break;
                     }
@@ -777,6 +932,8 @@ mod quota_detector_tests {
         use std::time::Duration;
         use tokio::time::Instant;
 
+        // Synthetic results against a real config: must not record coverage.
+        let _no_coverage = super::CoverageSuppressed::new();
         let config = super::ANTHROPIC_OPUS5;
         let attempts = Cell::new(0usize);
         let started = Instant::now();
@@ -803,6 +960,8 @@ mod quota_detector_tests {
         use std::time::Duration;
         use tokio::time::Instant;
 
+        // Synthetic results against a real config: must not record coverage.
+        let _no_coverage = super::CoverageSuppressed::new();
         let config = super::ANTHROPIC_OPUS5;
         let attempts = Cell::new(0usize);
         let started = Instant::now();
@@ -825,6 +984,8 @@ mod quota_detector_tests {
         use std::time::Duration;
         use tokio::time::Instant;
 
+        // Synthetic results against a real config: must not record coverage.
+        let _no_coverage = super::CoverageSuppressed::new();
         let config = super::ANTHROPIC_OPUS5;
         let attempts = Cell::new(0usize);
         let started = Instant::now();

--- a/crates/llm-tests/tests/subagent_live_test.rs
+++ b/crates/llm-tests/tests/subagent_live_test.rs
@@ -207,7 +207,7 @@ async fn background_spawn_agent_subagent_live_end_to_end() {
         )
         .await
         .expect("parent turn runs");
-    skip_if_quota!(turn, config.label());
+    skip_if_quota!(turn, cell = config);
     assert!(turn.success, "parent turn failed: {:?}", turn.error);
 
     let parent_messages = runtime.messages(parent_id).await.expect("parent messages");

--- a/scripts/report_live_matrix_coverage.py
+++ b/scripts/report_live_matrix_coverage.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Render live-provider-matrix coverage as Markdown for the job summary.
+
+The `Live Provider Matrix` job passes when every one of its cells was skipped:
+a missing API key and an out-of-credits account both skip, both are deliberate,
+and both leave the step green (EVE-951). That makes "the providers are covered"
+and "nothing reached a provider" look identical in CI, which is how OpenAI
+coverage stayed dark for roughly a week in August 2026 without anyone noticing.
+
+This reads the records the matrix cells append to `LLM_MATRIX_COVERAGE_FILE`
+(see `ProviderModelConfig::record_outcome`) and reports what the run actually
+exercised. It is reporting only: it does not decide whether the job passes, and
+it never exits non-zero on thin coverage — that judgement stays with a human
+reading the summary, and turning darkness into a hard failure would red main on
+a billing condition, which EVE-943 established is a false positive.
+
+Usage: report_live_matrix_coverage.py <coverage-file>
+"""
+
+import collections
+import sys
+
+# Cell outcomes, as written by `ProviderModelConfig::record_outcome`.
+CONFIGURED = "configured"
+NO_KEY = "no-key"
+SKIP_LIST = "skip-list"
+QUOTA = "quota"
+
+# What a cell is reported as, worst-first. A cell records several times per test
+# (the `is_none()` guard, then once per `run_live_turn!` attempt), so its
+# outcomes are folded by taking the first state in this order that it recorded.
+# `quota` outranks `configured` on purpose: such a cell did reach the provider,
+# but the billing error short-circuits the turn before any assertion runs, so it
+# verified nothing and must not be counted as covered.
+PRECEDENCE = [QUOTA, NO_KEY, SKIP_LIST, CONFIGURED]
+
+VERDICT = {
+    CONFIGURED: "ran",
+    QUOTA: "skipped — out of quota/credits",
+    NO_KEY: "skipped — API key not set",
+    SKIP_LIST: "skipped — SKIP_LLM_INTEGRATION_TESTS_PROVIDERS",
+}
+
+
+def parse(text):
+    """Fold coverage records into {(provider, env_var, model): outcome}.
+
+    Unparseable lines are ignored rather than raising: this report must never be
+    the reason a live matrix run fails.
+    """
+    seen = collections.defaultdict(set)
+    for line in text.splitlines():
+        fields = line.split("\t")
+        if len(fields) != 4:
+            continue
+        outcome, provider, env_var, model = (f.strip() for f in fields)
+        if outcome not in PRECEDENCE:
+            continue
+        seen[(provider, env_var, model)].add(outcome)
+
+    cells = {}
+    for cell, outcomes in seen.items():
+        for candidate in PRECEDENCE:
+            if candidate in outcomes:
+                cells[cell] = candidate
+                break
+    return cells
+
+
+def provider_rollup(cells):
+    """Per-provider (ran, total) counts, ordered by provider name."""
+    totals = collections.Counter()
+    ran = collections.Counter()
+    for (provider, _env_var, _model), outcome in cells.items():
+        totals[provider] += 1
+        if outcome == CONFIGURED:
+            ran[provider] += 1
+    return [(p, ran[p], totals[p]) for p in sorted(totals)]
+
+
+def format_report(cells):
+    lines = ["# Live provider matrix coverage", ""]
+
+    if not cells:
+        lines += [
+            "**No coverage recorded.** The step produced no cell records at all, so "
+            "nothing can be said about which providers were exercised. That is itself "
+            "a regression: either no matrix test ran, or the recording is broken.",
+            "",
+        ]
+        return lines
+
+    rollup = provider_rollup(cells)
+    total_ran = sum(r for _, r, _ in rollup)
+    total_cells = sum(t for _, _, t in rollup)
+
+    if total_ran == 0:
+        lines += [
+            f"**No provider was exercised.** All {total_cells} cells were skipped, so "
+            "this run verified no provider wire behaviour despite reporting success.",
+            "",
+        ]
+    else:
+        lines += [f"{total_ran} of {total_cells} cells reached a provider.", ""]
+
+    lines += ["| Provider | Cells run | Total |", "| --- | ---: | ---: |"]
+    for provider, ran, total in rollup:
+        mark = "" if ran else " ⚠️"
+        lines.append(f"| {provider}{mark} | {ran} | {total} |")
+    lines.append("")
+
+    dark = [(c, o) for c, o in cells.items() if o != CONFIGURED]
+    if not dark:
+        lines += ["Every cell ran.", ""]
+        return lines
+
+    lines += ["## Cells that did not run", "", "| Provider | Model | Reason |", "| --- | --- | --- |"]
+    for (provider, _env_var, model), outcome in sorted(dark):
+        lines.append(f"| {provider} | {model} | {VERDICT[outcome]} |")
+    lines.append("")
+    return lines
+
+
+def main(argv):
+    if len(argv) != 2:
+        print(__doc__.strip().splitlines()[-1], file=sys.stderr)
+        return 2
+    try:
+        with open(argv[1], encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError:
+        # A missing file is the same signal as an empty one: nothing recorded.
+        text = ""
+    print("\n".join(format_report(parse(text))))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/test-live-matrix-coverage-report.sh
+++ b/scripts/test-live-matrix-coverage-report.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Covers scripts/report_live_matrix_coverage.py: the outcome folding, the
+# per-provider rollup, and — the point of the script — that a run which skipped
+# every cell is reported as verifying nothing rather than as coverage (EVE-951).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+python3 - <<'PY'
+import sys
+
+sys.path.insert(0, "scripts")
+
+import report_live_matrix_coverage as r
+
+failures = []
+
+
+def check(name, condition, detail=""):
+    if condition:
+        print(f"  ok  {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        failures.append(name)
+
+
+def records(*rows):
+    return "\n".join("\t".join(row) for row in rows) + "\n"
+
+
+# --- folding -----------------------------------------------------------------
+
+# A cell records once per `model()` call — the `is_none()` guard plus one per
+# `run_live_turn!` attempt — so the same outcome repeats and must fold to one.
+cells = r.parse(
+    records(
+        ("configured", "anthropic", "ANTHROPIC_API_KEY", "claude-haiku-4-5-20251001"),
+        ("configured", "anthropic", "ANTHROPIC_API_KEY", "claude-haiku-4-5-20251001"),
+        ("configured", "anthropic", "ANTHROPIC_API_KEY", "claude-haiku-4-5-20251001"),
+    )
+)
+check("repeated records fold to one cell", len(cells) == 1, cells)
+check(
+    "a configured cell reads as run",
+    cells[("anthropic", "ANTHROPIC_API_KEY", "claude-haiku-4-5-20251001")] == r.CONFIGURED,
+)
+
+# The load-bearing case: a cell that had a key (so recorded `configured`) but hit
+# a billing error reached the provider and asserted nothing. Counting it as
+# covered is the exact false picture this report exists to remove.
+cells = r.parse(
+    records(
+        ("configured", "openai", "OPENAI_API_KEY", "gpt-6-astra"),
+        ("quota", "openai", "OPENAI_API_KEY", "gpt-6-astra"),
+    )
+)
+check(
+    "quota outranks configured",
+    cells[("openai", "OPENAI_API_KEY", "gpt-6-astra")] == r.QUOTA,
+    cells,
+)
+
+check("unparseable lines are ignored", r.parse("garbage\nalso garbage\n") == {})
+check("unknown outcomes are ignored", r.parse(records(("weird", "a", "B", "c"))) == {})
+check(
+    "short rows are ignored",
+    r.parse("configured\tanthropic\tANTHROPIC_API_KEY\n") == {},
+)
+
+# --- rollup ------------------------------------------------------------------
+
+cells = r.parse(
+    records(
+        ("configured", "anthropic", "ANTHROPIC_API_KEY", "claude-haiku-4-5-20251001"),
+        ("configured", "anthropic", "ANTHROPIC_API_KEY", "claude-sonnet-5"),
+        ("quota", "openai", "OPENAI_API_KEY", "gpt-6-astra"),
+        ("no-key", "gemini", "GEMINI_API_KEY", "gemini-2.5-flash"),
+    )
+)
+check(
+    "rollup counts run vs total per provider",
+    r.provider_rollup(cells) == [("anthropic", 2, 2), ("gemini", 0, 1), ("openai", 0, 1)],
+    r.provider_rollup(cells),
+)
+
+body = "\n".join(r.format_report(cells))
+check("report counts cells that reached a provider", "2 of 4 cells reached a provider." in body, body)
+check("a provider with no coverage is flagged", "| openai ⚠️ |" in body, body)
+check("a covered provider is not flagged", "| anthropic |" in body, body)
+check("quota skips name the billing reason", "out of quota/credits" in body, body)
+check("missing-key skips name the key", "API key not set" in body, body)
+
+# --- the silent-green cases --------------------------------------------------
+
+# Every cell skipped: the step is green and this must say so in as many words.
+body = "\n".join(
+    r.format_report(
+        r.parse(
+            records(
+                ("no-key", "openai", "OPENAI_API_KEY", "gpt-6-astra"),
+                ("quota", "anthropic", "ANTHROPIC_API_KEY", "claude-sonnet-5"),
+            )
+        )
+    )
+)
+check("a fully skipped run reports no provider exercised", "**No provider was exercised.**" in body, body)
+check("a fully skipped run gives the cell count", "All 2 cells were skipped" in body, body)
+
+# No records at all is a distinct failure from "all skipped": it means no matrix
+# test ran, or the recording itself broke.
+body = "\n".join(r.format_report(r.parse("")))
+check("an empty file reports no coverage recorded", "**No coverage recorded.**" in body, body)
+check("an empty file does not claim cells were skipped", "cells were skipped" not in body, body)
+
+# Full coverage must not carry a scary table of nothing.
+body = "\n".join(
+    r.format_report(
+        r.parse(records(("configured", "anthropic", "ANTHROPIC_API_KEY", "claude-sonnet-5")))
+    )
+)
+check("a fully covered run says so", "Every cell ran." in body, body)
+check("a fully covered run has no skip table", "Cells that did not run" not in body, body)
+check("a fully covered run is not flagged", "⚠️" not in body, body)
+
+# --- CLI ---------------------------------------------------------------------
+
+# A missing file must read as "nothing recorded", not crash the summary step.
+check("a missing file exits 0", r.main(["prog", "/nonexistent/coverage.tsv"]) == 0)
+check("a bad invocation exits 2", r.main(["prog"]) == 2)
+
+print()
+if failures:
+    print(f"{len(failures)} check(s) failed")
+    sys.exit(1)
+print("all checks passed")
+PY


### PR DESCRIPTION
## What changed

The `Live Provider Matrix` job now reports which of its cells actually reached a provider, as a per-provider rollup in the step summary.

Each matrix cell appends its outcome (`configured`, `no-key`, `skip-list`, `quota`) to the file named by `LLM_MATRIX_COVERAGE_FILE`; a new `Report provider coverage` step renders it. Recording is a no-op unless that variable is set, so local runs are unchanged.

**Reporting only.** What the tests skip on is unchanged, the step's pass/fail semantics are unchanged, and the `if: github.event_name == 'push'` gate and the secret model are untouched.

Also adds `scripts/report_*.py` to the `shell` path filter — a change to a report generator now runs the `scripts/test-*.sh` that covers it. `report_security_alerts.py` was already outside that filter, so its test could be skipped on a PR that rewrote it.

## Why

The job passes when every one of its cells was skipped. A missing API key and an out-of-credits account both skip, both are deliberate, and both leave the step green — so "the providers are covered" and "nothing reached a provider" are indistinguishable in CI.

That is not hypothetical. OpenAI coverage was dark for roughly a week in August 2026 on an exhausted account and the job reported green throughout; a real wire-protocol regression in that window would have reached `main` with no signal on the PR *or* the merge commit. It is also the failure mode the repo rejects elsewhere — the Deno quarantine in `integration-live-sweep.yml` removes a job rather than "let it silently skip/pass" (EVE-943, EVE-946).

## Before / After

**Before:** the only trace of a skipped cell was an `eprintln!` in `--nocapture` stderr; the step exited 0 and `ci-success` went green.

**After**, run live against the Doppler vault on this branch. The OpenAI account is out of credits right now, so this is the real failure being surfaced, not a synthetic fixture — `cargo test` reported `ok. 10 passed` for the same run:

```
# Live provider matrix coverage

7 of 10 cells reached a provider.

| Provider | Cells run | Total |
| --- | ---: | ---: |
| anthropic | 3 | 3 |
| fireworks | 1 | 1 |
| gemini | 1 | 1 |
| meta | 1 | 1 |
| openai ⚠️ | 0 | 3 |
| openrouter | 1 | 1 |

## Cells that did not run

| Provider | Model | Reason |
| --- | --- | --- |
| openai | gpt-5.4 | skipped — out of quota/credits |
| openai | gpt-5.6-luna | skipped — out of quota/credits |
| openai | gpt-6-astra | skipped — out of quota/credits |
```

With no keys at all, the report leads with **No provider was exercised.** With no records at all — no matrix test ran, or recording broke — it says **No coverage recorded**, which is a distinct signal.

Validation run: `cargo fmt --check`, `cargo clippy -p everruns-llm-tests --all-features --all-targets -- -D warnings`, the full `everruns-llm-tests` suite (122 tests across 5 binaries), `scripts/run-shell-tests.sh` for the new and neighbouring report tests, and `just pre-push` (22/22).

## Risk

- **Low**
- The new step is `if: always()` and only reads a file, so it cannot change the job's outcome. Recording is best-effort — I/O errors are dropped — because a coverage report must never fail the matrix it describes.
- Thin coverage is deliberately **not** an error. Failing on it would turn an out-of-credits account into red `main`, which EVE-943 established is a false positive.
- Two details worth review attention, both covered by tests:
  - A cell that recorded both `configured` and `quota` reads as `quota`: it reached the provider, but the billing error short-circuits the turn before any assertion runs, so it verified nothing and must not count as covered.
  - This module's own unit tests drive the recording macros with synthetic results against a *real* config (`ANTHROPIC_OPUS5`), so they take a thread-local `CoverageSuppressed` guard. Without it they append genuine-looking records and a live run reports `claude-opus-5` as quota-skipped when nothing of the sort happened — the exact false picture this PR removes.

## Security

- Threat categories reviewed: **TM-CI** (specifically TM-CI-001 and TM-CI-002), TM-FS.
- Findings and resolutions: none outstanding.
  - No change to the secret model. `DOPPLER_TOKEN` stays step-scoped on the existing test step, and the enclosing job keeps its `github.event_name == 'push'` condition, so TM-CI-001 and TM-CI-002 hold unchanged. The new step declares no `env:` and receives no secret.
  - The coverage file holds only provider names, env-var *names*, and model names — all already public in the workflow and in `llm_test_matrix/mod.rs`. No key material, and no error text (which can echo provider payloads) is recorded.
  - Nothing PR-controlled is interpolated into `run:` or into `$GITHUB_STEP_SUMMARY`: the job is push-gated, so the content originates from merged code, and the report is generated from a fixed set of outcome tokens with unparseable lines dropped.
  - Writes go to one path the workflow names inside `$GITHUB_WORKSPACE`, opened with append/create only.
- No new threat-model entry is required.

## Follow-ups

No follow-ups.

This is scoped to leave EVE-937 (whether a PR-time live signal is worth a different secret model) untouched — that is a maintainer's security-design decision. It is a prerequisite for any answer to it, since none of the options there mean anything if you cannot tell whether the run exercised the provider at all.

## Checklist

- [x] Tests added or updated (`scripts/test-live-matrix-coverage-report.sh`, 21 checks covering folding, the `quota` precedence rule, the rollup, both silent-green cases, and the CLI)
- [x] Backward compatibility considered (recording is off unless `LLM_MATRIX_COVERAGE_FILE` is set; the `skip_if_quota!` call sites are updated to the new `cell =` / `label =` forms in the same commit)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Fixes EVE-951

https://claude.ai/code/session_01X5ns4KLhNE45YdCosD1K7d

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5ns4KLhNE45YdCosD1K7d)_