### PR TITLE
feat(brave-search): support framework capability execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,10 @@ version = "0.18.2"
 dependencies = [
  "async-trait",
  "chrono",
+ "everruns",
+ "everruns-capability",
  "everruns-core",
+ "everruns-llmsim",
  "everruns-platform",
  "everruns-provider",
  "inventory",
@@ -3079,10 +3082,8 @@ name = "everruns-research-agent"
 version = "0.1.0"
 dependencies = [
  "everruns",
+ "everruns-integrations-brave-search",
  "everruns-openrouter",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
  "tokio",
 ]
 

--- a/docs/framework/capability-integrations.md
+++ b/docs/framework/capability-integrations.md
@@ -37,6 +37,30 @@ matching capability reference to the agent, and retain the documented role,
 network-access, and runtime feature gates. In particular, Bashkit, web fetch,
 and Lua remain high-risk capabilities in the hosted product.
 
+## Provider integrations
+
+Integration packages can expose typed values through `IntoCapability`. Brave
+Search supports the ordinary Framework builder:
+
+```rust
+use everruns::{Agent, Model};
+use everruns_integrations_brave_search::BraveSearch;
+
+let agent = Agent::builder()
+    .instructions("Search and cite primary sources.")
+    .model(Model::simulated("Ready."))
+    .capability(BraveSearch::from_env()?)
+    .build()?;
+```
+
+Depend on `everruns-integrations-brave-search` with `default-features = false`
+to omit Platform connector registration. The Framework adapter reads
+`BRAVE_SEARCH_API_KEY` at construction; `BraveSearch::new` accepts an explicit
+application-owned key. Keys are retained privately by the client, never placed
+in capability JSON. Hosted execution continues to resolve connections and
+session secrets at tool execution time. Both paths use the same search schema
+and operation. Framework calls use the application's direct HTTP client.
+
 ## Advanced host composition
 
 Advanced embedders select integrations on `everruns-host` and build the

--- a/examples/research-agent/Cargo.toml
+++ b/examples/research-agent/Cargo.toml
@@ -8,7 +8,5 @@ publish = false
 [dependencies]
 everruns = { path = "../../crates/everruns" }
 everruns-openrouter = { path = "../../crates/drivers/openrouter" }
-reqwest.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+everruns-integrations-brave-search = { path = "../../integrations/brave-search", default-features = false }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/research-agent/README.md
+++ b/examples/research-agent/README.md
@@ -1,7 +1,7 @@
 # Research Agent
 
 A self-contained Framework research agent. It uses OpenRouter's
-`z-ai/glm-5.2` with a typed Brave Search tool, then cites source URLs and
+`z-ai/glm-5.2` with the first-party `brave_web_search` capability, then cites source URLs and
 separates facts from inferences.
 
 ## Run
@@ -15,3 +15,7 @@ cargo test -p everruns-research-agent
 
 The test only validates agent construction; `cargo run` makes the real provider
 and web-search calls.
+
+The integration is configured with `BraveSearch::from_env()` and shares its
+request and result handling with the hosted Platform capability. The example
+contains no custom search HTTP client.

--- a/examples/research-agent/src/main.rs
+++ b/examples/research-agent/src/main.rs
@@ -5,81 +5,24 @@
 //! ```
 
 use everruns::{Agent, Engine, Turn};
-use serde::Deserialize;
+use everruns_integrations_brave_search::BraveSearch;
 
 const MODEL: &str = "z-ai/glm-5.2";
 const DEFAULT_QUESTION: &str = "Research durable agent sessions. Use web search before answering, cite the returned source URLs, and distinguish facts from inferences.";
 
-#[derive(Deserialize)]
-struct SearchResponse {
-    web: Option<SearchWeb>,
-}
-
-#[derive(Deserialize)]
-struct SearchWeb {
-    results: Vec<SearchResult>,
-}
-
-#[derive(Deserialize)]
-struct SearchResult {
-    title: String,
-    url: String,
-    description: String,
-}
-
-#[everruns::tool]
-/// Search the public web and return up to five titled, citable results.
-async fn search_web(query: String) -> Result<String, String> {
-    let api_key = std::env::var("BRAVE_SEARCH_API_KEY")
-        .map_err(|_| "BRAVE_SEARCH_API_KEY must be set to run web research".to_string())?;
-    let url = reqwest::Url::parse_with_params(
-        "https://api.search.brave.com/res/v1/web/search",
-        [("q", query.as_str()), ("count", "5")],
-    )
-    .map_err(|error| format!("Could not build Brave Search URL: {error}"))?;
-    let response = reqwest::Client::new()
-        .get(url)
-        .header("X-Subscription-Token", api_key)
-        .send()
-        .await
-        .map_err(|error| format!("Brave Search request failed: {error}"))?
-        .error_for_status()
-        .map_err(|error| format!("Brave Search returned an error: {error}"))?
-        .json::<SearchResponse>()
-        .await
-        .map_err(|error| format!("Brave Search response was invalid: {error}"))?;
-
-    let results = response
-        .web
-        .map(|web| web.results)
-        .unwrap_or_default()
-        .into_iter()
-        .take(5)
-        .map(|result| {
-            serde_json::json!({
-                "title": result.title,
-                "url": result.url,
-                "description": result.description,
-            })
-        })
-        .collect::<Vec<_>>();
-    serde_json::to_string_pretty(&results)
-        .map_err(|error| format!("Could not serialize search results: {error}"))
-}
-
-fn build_agent(api_key: &str) -> Result<Agent, everruns::BuildError> {
+fn build_agent(api_key: &str, search: BraveSearch) -> Result<Agent, everruns::BuildError> {
     Agent::builder()
         .name("research-agent")
-        .instructions("You are a research agent. Use search_web before answering factual questions. Cite the returned source URLs, distinguish facts from inferences, and say when the evidence is incomplete.")
+        .instructions("You are a research agent. Use brave_web_search before answering factual questions. Cite the returned source URLs, distinguish facts from inferences, and say when the evidence is incomplete.")
         .provider(everruns_openrouter::provider("openrouter", api_key))
         .model(MODEL)
-        .tool(search_web())
+        .capability(search)
         .build()
 }
 
 async fn run(question: &str) -> Result<Turn, Box<dyn std::error::Error>> {
     let api_key = std::env::var("OPENROUTER_API_KEY")?;
-    let agent = build_agent(&api_key)?;
+    let agent = build_agent(&api_key, BraveSearch::from_env()?)?;
     let engine = Engine::new();
     let session = engine.create(agent);
     Ok(session.send_and_wait(question).await?)
@@ -113,6 +56,6 @@ mod tests {
 
     #[test]
     fn builds_without_contacting_openrouter() {
-        assert!(build_agent("test-key").is_ok());
+        assert!(build_agent("test-key", super::BraveSearch::new("test-search-key")).is_ok());
     }
 }

--- a/integrations/brave-search/Cargo.toml
+++ b/integrations/brave-search/Cargo.toml
@@ -19,12 +19,13 @@ categories = ["api-bindings", "development-tools"]
 documentation = "https://docs.rs/everruns-integrations-brave-search"
 
 [dependencies]
+everruns-capability = { workspace = true, features = ["definition"] }
 everruns-core.workspace = true
 everruns-provider.workspace = true
 # Connector catalog (EVE-879): connectors register into the hosted connector
 # plugin system, which lives in the platform crate.
-everruns-platform.workspace = true
-inventory.workspace = true
+everruns-platform = { workspace = true, optional = true }
+inventory = { workspace = true, optional = true }
 
 # HTTP client for Brave Search API
 reqwest.workspace = true
@@ -40,8 +41,12 @@ chrono.workspace = true
 tracing.workspace = true
 
 [features]
+default = ["hosted"]
+hosted = ["dep:everruns-platform", "dep:inventory"]
 integration = [] # Gate real-API tests; CI passes --features integration
 
 [dev-dependencies]
+everruns = { path = "../../crates/everruns" }
+everruns-llmsim = { path = "../../crates/drivers/llmsim" }
 tokio = { workspace = true, features = ["full", "test-util"] }
 wiremock = "0.6"

--- a/integrations/brave-search/README.md
+++ b/integrations/brave-search/README.md
@@ -17,13 +17,30 @@ through the Everruns integration plugin system.
 ## Quick Example
 
 ```rust
-use everruns_core::capabilities::Capability;
-use everruns_integrations_brave_search::BraveSearchCapability;
+use everruns::{Agent, Model};
+use everruns_integrations_brave_search::BraveSearch;
 
-let capability = BraveSearchCapability;
-
-assert_eq!(capability.id(), "brave_search");
+let agent = Agent::builder()
+    .instructions("Search the web and cite source URLs.")
+    .model(Model::simulated("Ready."))
+    .capability(BraveSearch::from_env()?)
+    .build()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
+
+Framework applications select `default-features = false` on this integration
+dependency and enable the `everruns` `capabilities` feature (enabled by default).
+Set `BRAVE_SEARCH_API_KEY` before startup, or pass an application-owned key to
+`BraveSearch::new`. Credentials stay inside the client, outside agent config and
+metadata. `BraveSearch::with_client` accepts a client with a trusted custom
+endpoint for HTTP tests. Run the agent with `Engine::new().create(agent)`.
+
+The default `hosted` feature includes connector UI metadata and inventory
+registration for the Platform. Hosted tools retain lazy connection-token lookup
+and session-secret fallback. Both adapters share the `brave_web_search` schema,
+search operation, and result mapping. Framework credentials are read at
+construction; rebuild the capability to rotate them. Framework calls use the
+application-owned HTTP client, not hosted egress or connection policies.
 
 ## What It Provides
 

--- a/integrations/brave-search/SPEC.md
+++ b/integrations/brave-search/SPEC.md
@@ -1,171 +1,56 @@
 # Brave Search Capability Specification
 
-## Abstract
+## Intent
 
-The Brave Search capability integrates [Brave Search](https://brave.com/search/api/) web search as an agent tool. Agents can search the web and get relevant results including titles, URLs, and descriptions. Stateless, no per-resource state management needed.
+Brave Search supplies current web-search evidence to agents in both Framework
+and hosted execution. It is stateless apart from credentials. Hosted catalog
+discovery remains experimental and restricted to development deployments;
+Framework applications explicitly select the capability.
 
-**Status**: Experimental (Dev only)
+## Execution across contexts
 
-## Architecture
+The [Framework adapter](src/framework.rs) implements the neutral capability-author
+contract and captures an application-owned client. The [hosted adapter](src/tools.rs)
+resolves credentials from the current session. Both share the [tool protocol and
+search operation](src/search.rs) and [HTTP client](src/client.rs), so requests and
+result mapping cannot evolve independently.
 
-### Single API
+Application credentials are read at construction and never serialized into
+capability configuration or metadata. Hosted credentials resolve lazily through
+user connections, with session-secret fallback. User connections are preferred
+because they can be refreshed and reused across authorized sessions. Missing
+credentials produce an explicit failure rather than an unauthenticated request.
 
-Brave Search exposes one API layer:
+The hosted feature separates connector UI and inventory discovery from the
+Framework dependency graph. The [crate manifest](Cargo.toml) owns feature
+selection; [registration](src/lib.rs) owns deployment discovery. The
+[connector](src/connection.rs) owns hosted credential entry and validation.
+Neither adapter requires per-search resource provisioning or cleanup.
 
-1. **Web Search API** (`https://api.search.brave.com/res/v1/web/search`), query the web. Auth: `X-Subscription-Token: <API_KEY>`.
+## Security and errors
 
-```
-┌────────────────────────────────────────────┐
-│              Agent Session                  │
-│                                             │
-│  Tool Call (brave_web_search)              │
-│         ↓                                   │
-│  Resolve API key:                          │
-│    1. User connections (brave_search)       │
-│    2. Session secret (BRAVE_SEARCH_API_KEY) │
-│         ↓                                   │
-│  ┌─────────────────────────────────────┐   │
-│  │ BraveSearchClient                   │   │
-│  │  - Web Search API                   │   │
-│  └─────────────────────────────────────┘   │
-│         ↓                                   │
-│  Return results to agent                   │
-└────────────────────────────────────────────┘
-```
+Both adapters use the same direct HTTP client. Framework calls carry the
+application's network authority and do not acquire hosted tenant or connection
+authority. Keys remain private client state and are excluded from diagnostic
+capability values. Upstream error bodies are omitted because they may echo
+request credentials; HTTP status remains available for actionable errors.
 
-### API Key Resolution
+Search results are untrusted tool output. Search queries are disclosed to Brave;
+applications are responsible for deciding which information may be sent. See the
+[Brave threat assessment](../../knowledge/security/threat-model.md#20-brave-search-tm-llm).
 
-The API key is resolved lazily at tool execution time:
+## Acceptance evidence
 
-1. **User connections** (preferred): `connection_resolver.get_connection_token(session_id, "brave_search")`. User stores their API key via `PUT /v1/user/connections/api-key/brave_search`.
-2. **Session secret** (fallback): `storage_store.get_secret(session_id, "BRAVE_SEARCH_API_KEY")`.
-3. **Error**: Guidance to configure in Settings > Connections or via session secret.
+- [Framework acceptance tests](tests/framework.rs) cover public Engine execution
+  against mock HTTP, protocol parity, result persistence, and credential separation.
+- [Hosted tool tests](src/tools.rs) cover connection precedence, secret fallback,
+  missing credentials, and argument handling.
+- [Client tests](src/client.rs) cover response parsing, empty results, HTTP errors,
+  and malformed responses.
+- [Registration tests](tests/plugin_registration.rs) cover hosted discovery and
+  development/production gating.
+- [Live API tests](tests/smoke_real_api.rs) exercise Brave with explicit credentials;
+  the [integration workflow](../../.github/workflows/brave-search-integration.yml)
+  owns secret-safe PR and main-branch execution.
 
-## Tools
-
-### brave_web_search
-
-Search the web using Brave Search API.
-
-- **Parameters**:
-  - `query`: string (required), search query
-  - `count`: integer (optional, 1-20, default: 10), number of results
-  - `offset`: integer (optional), pagination offset
-  - `freshness`: string (optional), time filter: `pd` (past day), `pw` (past week), `pm` (past month), `py` (past year)
-- **Returns**: `{ query, results: [{title, url, description, age?}], count }`
-
-## Security
-
-- **API Key**: Resolved via user connections (encrypted at rest) or session secrets (encrypted at rest)
-- **No secrets in tool results**: API key never appears in tool results or message history
-- **Rate limiting**: Deferred to Brave Search API (returns 429 on rate limit)
-
-## Error Handling
-
-| Scenario | Result Type | Message |
-|----------|-------------|---------|
-| Missing query param | `ToolError` | "Missing required parameter: query" |
-| API key not configured | `ToolError` | "Brave Search API key not configured..." |
-| HTTP 401 | `ToolError` | "Brave Search API error (401): ..." |
-| HTTP 429 | `ToolError` | "Brave Search API error (429): ..." |
-| No context | `ToolError` | "brave_web_search requires context." |
-
-## User Connection
-
-### PUT /v1/user/connections/api-key/brave_search
-
-Store a Brave Search API key as an encrypted user connection.
-
-**Request:**
-```json
-{
-  "api_key": "BSA..."
-}
-```
-
-**Response:** `204 No Content`
-
-The API key is encrypted using envelope encryption (AES-256-GCM) before storage.
-
-### DELETE /v1/user/connections/brave_search
-
-Disconnect. Removes the stored API key.
-
-**Response:** `204 No Content`
-
-## Design Decisions
-
-### API key in user connections (not just session secrets)
-
-User connections are persistent across sessions and user-scoped. Session secrets are per-session and lost when the session ends. User connections are the preferred storage for long-lived API keys.
-
-### Stateless (no per-resource state)
-
-Unlike Daytona (which manages sandbox lifecycle), Brave Search is stateless. Each search is independent. No sandbox state, no session state beyond the API key.
-
-### No dependencies
-
-Unlike Daytona (which depends on `session_storage`), Brave Search has no capability dependencies. The API key resolution uses the connection resolver and storage store from ToolContext directly.
-
-## Testing
-
-### Unit & mock tests
-
-Run without flags, no API key needed:
-
-```bash
-cargo test -p everruns-integrations-brave-search
-```
-
-Uses `wiremock` for HTTP-level assertions (auth headers, query params, error codes).
-
-### Integration tests (real API)
-
-Gated behind the `integration` Cargo feature so they never compile in normal `cargo test` runs:
-
-```bash
-BRAVE_SEARCH_API_KEY=<key> cargo test -p everruns-integrations-brave-search --features integration
-```
-
-Tests: `smoke_basic_search`, `smoke_freshness_filter`, `smoke_pagination` in `tests/smoke_real_api.rs`.
-
-Tests use a `require_api_key!` macro that panics when `BRAVE_SEARCH_API_KEY` is unset or empty, preventing silent failures in CI.
-
-### CI
-
-Dedicated workflow `.github/workflows/brave-search-integration.yml`:
-
-- **Path-filtered**: only triggers when `integrations/brave-search/**` changes.
-- Runs on both `pull_request` and `push` because the coverage is cheap enough for PRs.
-- Fetches `BRAVE_SEARCH_API_KEY` from Doppler via `DOPPLER_TOKEN` GitHub Actions secret.
-- Fails if `DOPPLER_TOKEN` is not set (required, not optional).
-- Passes `--features integration` to compile and run the real-API tests.
-- `.github/workflows/integration-live-sweep.yml` reruns the same job weekly and on demand without path filters to catch shared regressions outside `integrations/brave-search/**`.
-
-Adding a new API-key-gated integration crate should follow this pattern: feature-gate the tests, use a panic macro for missing keys, add a path-filtered workflow, fetch the key from Doppler.
-
-## Crate Structure
-
-`integrations/brave-search/` → `everruns-integrations-brave-search`
-
-External integration crate, auto-registered via `inventory::submit!` plugin system.
-
-**Force-link required**: Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must contain `extern crate everruns_integrations_brave_search;`.
-
-| File | Purpose |
-|------|---------|
-| `src/lib.rs` | Plugin registration (capability + connection provider), constants, `BraveSearchCapability` impl |
-| `src/client.rs` | `BraveSearchClient` HTTP client, API response types |
-| `src/connection.rs` | `BraveSearchConnectionProvider`, form schema, validation |
-| `src/tools.rs` | `BraveWebSearchTool` implementation, API key resolution |
-| `tests/plugin_registration.rs` | Integration tests for inventory registration and dev/prod gating |
-| `tests/smoke_real_api.rs` | Real-API smoke tests (behind `integration` feature) |
-
-## Capability Registration
-
-- **ID**: `brave_search`
-- **Name**: `[Experimental] Brave Search`
-- **Status**: Available (Dev only)
-- **Icon**: `search`
-- **Category**: `Network`
-- **Dependencies**: none
+Application setup and commands live in the [README](README.md).

--- a/integrations/brave-search/src/client.rs
+++ b/integrations/brave-search/src/client.rs
@@ -96,7 +96,8 @@ impl BraveSearchClient {
             .map_err(|e| format!("Failed to read response: {e}"))?;
 
         if !status.is_success() {
-            return Err(format!("Brave Search API error ({status}): {body_text}"));
+            // Upstream error bodies can echo credentials or request headers.
+            return Err(format!("Brave Search API error ({status})"));
         }
 
         serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from Brave Search: {e}"))

--- a/integrations/brave-search/src/framework.rs
+++ b/integrations/brave-search/src/framework.rs
@@ -1,0 +1,79 @@
+//! Application-owned Brave credentials and the Framework capability adapter.
+
+use everruns_capability::{
+    CapabilitySpec, IntoCapability,
+    definition::{self, Handler},
+};
+use serde_json::Value;
+
+use crate::{BraveSearchCapability, client::BraveSearchClient, search::SearchInput};
+use everruns_core::Capability;
+
+/// Brave Search for `AgentBuilder::capability`.
+///
+/// The client retains credentials privately; they never enter capability config
+/// or metadata. Cloned agents reuse the HTTP connection pool.
+pub struct BraveSearch {
+    client: BraveSearchClient,
+}
+
+impl BraveSearch {
+    /// Configure an application-owned API key.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_client(BraveSearchClient::new(api_key.into()))
+    }
+
+    /// Read `BRAVE_SEARCH_API_KEY` once at application startup.
+    pub fn from_env() -> Result<Self, std::env::VarError> {
+        let key = std::env::var(crate::BRAVE_SEARCH_API_KEY_SECRET)?;
+        if key.trim().is_empty() {
+            return Err(std::env::VarError::NotPresent);
+        }
+        Ok(Self::new(key))
+    }
+
+    /// Supply a client, including a trusted custom endpoint for tests.
+    pub fn with_client(client: BraveSearchClient) -> Self {
+        Self { client }
+    }
+}
+
+impl IntoCapability for BraveSearch {
+    fn into_capability(self) -> CapabilitySpec {
+        let capability = BraveSearchCapability;
+        definition::Definition::new(capability.id(), capability.name(), capability.description())
+            .instructions(capability.system_prompt_addition().unwrap_or_default())
+            .tool(self)
+            .into()
+    }
+}
+
+#[definition::async_trait]
+impl Handler for BraveSearch {
+    type Input = SearchInput;
+    type Output = Value;
+    type Error = definition::Error;
+
+    fn name(&self) -> &str {
+        crate::search::TOOL_NAME
+    }
+    fn description(&self) -> &str {
+        crate::search::TOOL_DESCRIPTION
+    }
+    fn hints(&self) -> definition::Hints {
+        definition::Hints::default()
+            .readonly(true)
+            .idempotent(true)
+            .open_world(true)
+    }
+
+    async fn execute(
+        &self,
+        input: SearchInput,
+        _context: definition::Context,
+    ) -> Result<Value, Self::Error> {
+        crate::search::search(&self.client, input)
+            .await
+            .map_err(|error| definition::Error::user("brave_search_failed", error))
+    }
+}

--- a/integrations/brave-search/src/lib.rs
+++ b/integrations/brave-search/src/lib.rs
@@ -6,22 +6,35 @@
 //! # Example
 //!
 //! ```
-//! use everruns_integrations_brave_search::BraveSearchCapability;
+//! use everruns::{Agent, Model};
+//! use everruns_integrations_brave_search::BraveSearch;
 //!
-//! let capability = BraveSearchCapability;
-//! # let _ = capability;
+//! let agent = Agent::builder()
+//!     .instructions("Search the web and cite sources.")
+//!     .model(Model::simulated("Ready."))
+//!     .capability(BraveSearch::new("your-api-key"))
+//!     .build()?;
+//! # Ok::<(), everruns::BuildError>(())
 //! ```
 
 pub mod client;
+#[cfg(feature = "hosted")]
 pub mod connection;
+mod framework;
+mod search;
 mod tools;
 
-use everruns_core::capabilities::{
-    Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin,
-};
+pub use framework::BraveSearch;
+pub use search::SearchInput;
+
+#[cfg(feature = "hosted")]
+use everruns_core::capabilities::IntegrationPlugin;
+use everruns_core::capabilities::{Capability, CapabilityLocalization, CapabilityStatus};
 use everruns_core::tools::Tool;
+#[cfg(feature = "hosted")]
 use everruns_platform::connector::ConnectorPlugin;
 
+#[cfg(feature = "hosted")]
 use connection::BraveSearchConnector;
 use tools::BraveWebSearchTool;
 
@@ -29,6 +42,7 @@ use tools::BraveWebSearchTool;
 // Plugin Registration
 // ============================================================================
 
+#[cfg(feature = "hosted")]
 inventory::submit! {
     IntegrationPlugin {
         experimental_only: true,
@@ -37,6 +51,7 @@ inventory::submit! {
     }
 }
 
+#[cfg(feature = "hosted")]
 inventory::submit! {
     ConnectorPlugin {
         experimental_only: true,

--- a/integrations/brave-search/src/search.rs
+++ b/integrations/brave-search/src/search.rs
@@ -1,0 +1,100 @@
+//! Shared tool protocol and operation used by both execution contexts.
+
+use crate::client::BraveSearchClient;
+use everruns_capability::definition::schemars::{self, JsonSchema};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+pub(crate) const TOOL_NAME: &str = "brave_web_search";
+pub(crate) const TOOL_DESCRIPTION: &str = "Search the web using Brave Search. Returns relevant web results including titles, URLs, and descriptions.";
+
+/// Input to the Brave web-search tool.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SearchInput {
+    pub query: String,
+    pub count: Option<u64>,
+    pub offset: Option<u32>,
+    pub freshness: Option<String>,
+}
+
+impl JsonSchema for SearchInput {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "BraveWebSearchInput".into()
+    }
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schema().try_into().expect("search schema is an object")
+    }
+}
+
+pub(crate) fn schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query string"
+            },
+            "count": {
+                "type": "integer",
+                "description": "Number of results to return (1-20, default: 10)",
+                "minimum": 1,
+                "maximum": 20
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Pagination offset (default: 0)",
+                "minimum": 0
+            },
+            "freshness": {
+                "type": "string",
+                "enum": ["pd", "pw", "pm", "py"],
+                "description": "Time filter: pd (past day), pw (past week), pm (past month), py (past year)"
+            }
+        },
+        "required": ["query"],
+        "additionalProperties": false
+    })
+}
+
+pub(crate) async fn search(
+    client: &BraveSearchClient,
+    input: SearchInput,
+) -> Result<Value, String> {
+    if input.query.is_empty() {
+        return Err("Missing required parameter: query".into());
+    }
+    if input
+        .freshness
+        .as_deref()
+        .is_some_and(|value| !["pd", "pw", "pm", "py"].contains(&value))
+    {
+        return Err("Invalid freshness: expected pd, pw, pm, or py".into());
+    }
+    let response = client
+        .web_search(
+            &input.query,
+            input.count.map(|count| count.clamp(1, 20) as u32),
+            input.offset,
+            input.freshness.as_deref(),
+        )
+        .await?;
+    let results: Vec<Value> = response
+        .web
+        .map(|web| web.results)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|result| {
+            let mut item = json!({
+                "title": result.title,
+                "url": result.url,
+                "description": result.description,
+            });
+            if let Some(age) = result.age {
+                item["age"] = json!(age);
+            }
+            item
+        })
+        .collect();
+    Ok(json!({"query": input.query, "count": results.len(), "results": results}))
+}

--- a/integrations/brave-search/src/tools.rs
+++ b/integrations/brave-search/src/tools.rs
@@ -5,7 +5,7 @@ use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_provider::tool_types::ToolHints;
 
 use async_trait::async_trait;
-use serde_json::{Value, json};
+use serde_json::Value;
 use tracing::debug;
 
 use crate::BRAVE_SEARCH_API_KEY_SECRET;
@@ -77,42 +77,15 @@ impl Tool for BraveWebSearchTool {
     }
 
     fn name(&self) -> &str {
-        "brave_web_search"
+        crate::search::TOOL_NAME
     }
 
     fn description(&self) -> &str {
-        "Search the web using Brave Search. Returns relevant web results \
-         including titles, URLs, and descriptions."
+        crate::search::TOOL_DESCRIPTION
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Search query string"
-                },
-                "count": {
-                    "type": "integer",
-                    "description": "Number of results to return (1-20, default: 10)",
-                    "minimum": 1,
-                    "maximum": 20
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Pagination offset (default: 0)",
-                    "minimum": 0
-                },
-                "freshness": {
-                    "type": "string",
-                    "enum": ["pd", "pw", "pm", "py"],
-                    "description": "Time filter: pd (past day), pw (past week), pm (past month), py (past year)"
-                }
-            },
-            "required": ["query"],
-            "additionalProperties": false
-        })
+        crate::search::schema()
     }
 
     fn hints(&self) -> ToolHints {
@@ -134,56 +107,28 @@ impl Tool for BraveWebSearchTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        let query = match arguments.get("query").and_then(|v| v.as_str()) {
-            Some(q) if !q.is_empty() => q,
-            _ => {
-                return ToolExecutionResult::tool_error("Missing required parameter: query");
+        if arguments
+            .get("query")
+            .and_then(Value::as_str)
+            .is_none_or(str::is_empty)
+        {
+            return ToolExecutionResult::tool_error("Missing required parameter: query");
+        }
+        let input = match serde_json::from_value::<crate::SearchInput>(arguments) {
+            Ok(input) => input,
+            Err(error) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid search arguments: {error}"
+                ));
             }
         };
-
-        let count = arguments
-            .get("count")
-            .and_then(|v| v.as_u64())
-            .map(|c| c.min(20) as u32);
-        let offset = arguments
-            .get("offset")
-            .and_then(|v| v.as_u64())
-            .map(|o| o as u32);
-        let freshness = arguments.get("freshness").and_then(|v| v.as_str());
-
         let api_key = match get_api_key(context).await {
-            Ok(k) => k,
-            Err(e) => return e,
+            Ok(key) => key,
+            Err(error) => return error,
         };
-
-        let client = BraveSearchClient::new(api_key);
-
-        match client.web_search(query, count, offset, freshness).await {
-            Ok(response) => {
-                let results = response.web.map(|w| w.results).unwrap_or_default();
-
-                let result_items: Vec<Value> = results
-                    .iter()
-                    .map(|r| {
-                        let mut item = json!({
-                            "title": r.title,
-                            "url": r.url,
-                            "description": r.description,
-                        });
-                        if let Some(ref age) = r.age {
-                            item["age"] = json!(age);
-                        }
-                        item
-                    })
-                    .collect();
-
-                ToolExecutionResult::success(json!({
-                    "query": query,
-                    "results": result_items,
-                    "count": result_items.len()
-                }))
-            }
-            Err(e) => ToolExecutionResult::tool_error(e),
+        match crate::search::search(&BraveSearchClient::new(api_key), input).await {
+            Ok(result) => ToolExecutionResult::success(result),
+            Err(error) => ToolExecutionResult::tool_error(error),
         }
     }
 

--- a/integrations/brave-search/tests/framework.rs
+++ b/integrations/brave-search/tests/framework.rs
@@ -1,0 +1,132 @@
+//! The published integration executes through the ordinary Framework facade.
+
+use everruns::{Agent, ContentPart, Engine, IntoCapability, LlmSimConfig, Model};
+use everruns_core::Capability;
+use everruns_integrations_brave_search::{
+    BraveSearch, BraveSearchCapability, client::BraveSearchClient,
+};
+use everruns_llmsim::{SimToolCall, SimTurn};
+use serde_json::json;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{header, method, path, query_param},
+};
+
+#[tokio::test]
+async fn framework_reports_http_errors_without_upstream_credential_echoes() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(401).set_body_string("rejected sentinel-brave-credential"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    let definition = BraveSearch::with_client(BraveSearchClient::with_base_url(
+        "sentinel-brave-credential".into(),
+        server.uri(),
+    ))
+    .into_capability()
+    .into_parts()
+    .definition
+    .unwrap();
+    let error = definition.tools()[0]
+        .invoke(
+            json!({"query": "test"}),
+            everruns::capability::Context::new("brave_web_search", "session", "workspace"),
+        )
+        .await
+        .unwrap_err();
+    assert!(format!("{error:?}").contains("401"));
+    assert!(!format!("{error:?}").contains("sentinel-brave-credential"));
+}
+
+#[test]
+fn adapters_share_tool_protocol_and_keep_credentials_private() {
+    let spec = BraveSearch::new("sentinel-brave-credential").into_capability();
+    assert!(!format!("{spec:?}").contains("sentinel-brave-credential"));
+    assert_eq!(spec.capability_ref().id(), "brave_search");
+    let definition = spec.into_parts().definition.unwrap();
+    let hosted = BraveSearchCapability;
+    let tools = hosted.tools();
+    let framework = definition.tools()[0].spec();
+    assert_eq!(framework.name(), tools[0].name());
+    assert_eq!(framework.description(), tools[0].description());
+    let mut schema = framework.input_schema().clone();
+    schema.as_object_mut().unwrap().remove("$schema");
+    schema.as_object_mut().unwrap().remove("title");
+    assert_eq!(schema, tools[0].parameters_schema());
+    assert_eq!(
+        definition.instructions_text(),
+        hosted.system_prompt_addition()
+    );
+}
+
+#[tokio::test]
+async fn framework_turn_searches_with_real_integration_and_records_results() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/web/search"))
+        .and(header("X-Subscription-Token", "sentinel-brave-credential"))
+        .and(query_param("q", "Rust & agents"))
+        .and(query_param("count", "3"))
+        .and(query_param("offset", "2"))
+        .and(query_param("freshness", "pw"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"web": {"results": [
+            {"title": "Primary source", "url": "https://example.com/source", "description": "Evidence", "age": "1 day ago"}
+        ]}})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let agent = Agent::builder()
+        .instructions("Search before answering.")
+        .model(Model::simulated_with_config(LlmSimConfig::scripted(vec![
+            SimTurn::ToolCalls(vec![SimToolCall {
+                name: "brave_web_search".into(),
+                arguments: json!({"query": "Rust & agents", "count": 3, "offset": 2, "freshness": "pw"}),
+                id: Some("search_1".into()),
+            }]),
+            SimTurn::Assistant("Search complete.".into()),
+        ])))
+        .capability(BraveSearch::with_client(BraveSearchClient::with_base_url(
+            "sentinel-brave-credential".into(),
+            server.uri(),
+        )))
+        .build()
+        .unwrap();
+    assert!(!format!("{agent:?}").contains("sentinel-brave-credential"));
+    let session = Engine::new().create(agent);
+    let turn = session
+        .send_and_wait("Research Rust agents.")
+        .await
+        .unwrap();
+    assert!(turn.success);
+    assert_eq!(turn.tool_calls, 1);
+    let history = session.history().page().await.unwrap();
+    let result = history
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .find_map(|part| match part {
+            ContentPart::ToolResult(result) if result.tool_call_id == "search_1" => Some(result),
+            _ => None,
+        })
+        .expect("recorded search result");
+    assert!(result.error.is_none());
+    assert_eq!(
+        result.result,
+        Some(json!({
+            "query": "Rust & agents", "count": 1,
+            "results": [{"title": "Primary source", "url": "https://example.com/source", "description": "Evidence", "age": "1 day ago"}],
+        }))
+    );
+    let transcript = serde_json::to_string(
+        &history
+            .messages
+            .iter()
+            .map(|message| &message.content)
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    assert!(!transcript.contains("sentinel-brave-credential"));
+}

--- a/integrations/brave-search/tests/plugin_registration.rs
+++ b/integrations/brave-search/tests/plugin_registration.rs
@@ -1,5 +1,7 @@
 //! Integration test: verify Brave Search plugin registers via inventory.
 
+#![cfg(feature = "hosted")]
+
 use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
 use everruns_core::deployment::DeploymentGrade;
 use everruns_platform::connector::ConnectorPlugin;

--- a/knowledge/framework/application-api.md
+++ b/knowledge/framework/application-api.md
@@ -77,6 +77,23 @@ selection, plugin compiler, MCP client, and engine execution that an advanced
 host composes directly. The implementation and downstream acceptance fixtures
 are linked from the [source index](#source-index).
 
+## Integration execution across hosts
+
+An external-service integration should expose an application capability through
+the existing `IntoCapability` contract when its dependencies can be supplied by
+the application. Its Framework and hosted adapters share protocol schemas and
+the vendor operation, while each binds credentials from its owning context.
+Application clients retain secrets outside serialized capability configuration;
+hosted adapters retain lazy, session-scoped connection resolution. Connector UI
+and inventory discovery must be separable from the application's dependency
+graph. Registration alone does not supply platform persistence or orchestration.
+
+[Brave Search](../../integrations/brave-search/src/framework.rs) is the reference
+implementation. Its [acceptance test](../../integrations/brave-search/tests/framework.rs)
+checks schema parity, execution through the public Engine, and credential
+separation. Other integrations adopt this boundary as they gain Framework
+support; this does not imply the entire hosted catalog is executable by default.
+
 ## Supported dependency paths
 
 An ordinary application targets `everruns` alone for agent configuration and

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,13 @@
 # Everruns Knowledge Update Log
 
+## 2026-09-05
+
+* Integration capabilities can share their protocol and vendor operation across
+  Framework and hosted execution while binding credentials in each context.
+  Brave Search establishes the application adapter pattern and separates hosted
+  connector registration from the Framework dependency graph. See
+  [Framework application boundaries](framework/application-api.md).
+
 ## 2026-09-01
 
 * **A model switch is a conversation event, not a setting.** Changing the model

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -1280,6 +1280,14 @@ Client-side tools pause server execution and wait for client to submit results v
 
 Search results from Brave Search are returned as tool results. Adversarial content in search results could influence LLM behavior.
 
+The Framework adapter captures its application-owned credential in the HTTP
+client; hosted execution resolves session connections or secrets. Neither path
+places credentials in capability config or metadata. Upstream error bodies are
+omitted because they may echo request credentials. The public Engine acceptance
+test in `integrations/brave-search/tests/framework.rs` checks credential absence
+from agent diagnostics and recorded tool results. Framework calls carry the
+application's network authority, without hosted tenant policy.
+
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
 | TM-LLM-008 | Search result prompt injection | Medium | Results returned as `tool_result` role; inherent LLM limitation (same as TM-TOOL-005) | **ACCEPTED** |


### PR DESCRIPTION
## What changed
Framework agents can attach the first-party Brave Search integration with `.capability(BraveSearch::from_env()?)`. The Framework and hosted adapters share the tool schema, request handling, and result mapping. The research example now uses `brave_web_search`; disabling the integration's default features excludes Platform connector registration.

## Why
Using Brave from the application-facing Agent/Engine API required a duplicate HTTP tool despite the existing hosted integration. This supplies an application adapter through the existing capability contract and documents the same pattern for other integrations.

## Before / After
Before: the research example defined `search_web`, its own response structs, HTTP request, and result mapping.

After: it attaches `BraveSearch` and invokes the shared `brave_web_search` tool. Live smoke test using the documented Doppler development configuration:

```text
model: z-ai/glm-5.2
response: The official Rust programming language website is titled **"Rust Programming Language"** and its URL is **https://rust-lang.org/**.
iterations: 2, tool calls: 1
```

Validation: hosted and Framework-only test configurations pass; the simulated Engine acceptance test verifies real mock-HTTP requests and exact recorded results. Credential tests verify secret-free capability diagnostics and upstream error handling. `just pre-push` passed all applicable checks, including workspace-wide Clippy with all targets/features. The research example's normal dependency tree excludes `everruns-platform`.

## Risk
Medium: changes integration argument decoding and packaging. Valid tool requests retain their schema and result shape; malformed typed arguments now fail explicitly. The default hosted feature preserves existing server/worker registration. Framework credentials are captured at construction, so rotation requires reconstructing the capability. HTTP status errors remain visible while upstream error bodies are omitted.

## Security
- Threat categories reviewed: TM-LLM, TM-TOOL, TM-TENANT, TM-DOS.
- Findings and resolutions: credentials remain private client state, outside capability config and metadata. Removed upstream error bodies that could echo credentials; covered by a regression test. Hosted connection precedence and session-secret fallback remain intact. Search input is encoded by the shared client and result count is bounded. Framework requests use application network authority, as documented; hosted tenant authority is not exposed through the facade. Search results remain untrusted tool output.

## Follow-ups
No follow-ups. This PR implements the Brave reference integration and documents the reusable pattern; migration of the entire integration catalog is outside this change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
