### PR TITLE
fix(server): accept reserved characters in the NATS_URL password

### DIFF
--- a/crates/server/src/nats.rs
+++ b/crates/server/src/nats.rs
@@ -7,57 +7,94 @@
 // client and the control plane silently degraded to in-memory event delivery
 // and PG NOTIFY on each boot (Sentry EVERRUNS-2 / EVERRUNS-4).
 //
+// Decision: credentials are split off the raw string before the URL is
+// parsed, rather than read back out of a parsed `ServerAddr`. Generated
+// passwords routinely contain characters that are reserved in a URL
+// authority — a single `/` ends it, so `nats://u:pa/ss@host:4222` parses as
+// host `u:pa` and fails with "invalid port number", and the deployment falls
+// back with no usable diagnosis. Splitting first accepts those passwords
+// unencoded, which is what an operator pasting a generated secret expects;
+// percent-encoded passwords keep working because the value is decoded when it
+// is still a valid encoding.
+//
 // Decision: connection failures are reported with the full error chain.
-// `anyhow` `Display` prints only the outermost context, which hid the
-// authorization violation behind "Failed to connect to NATS".
+// `anyhow` `Display` prints only the outermost context, which hid the real
+// cause behind "Failed to connect to NATS".
 
 use anyhow::{Context, Result};
 use async_nats::{Client, ConnectOptions, ServerAddr};
 
-/// Parse `NATS_URL`: one server URL or a comma-separated list of them.
-fn parse_server_addrs(url: &str) -> Result<Vec<ServerAddr>> {
-    url.split(',')
-        .map(str::trim)
-        .filter(|part| !part.is_empty())
-        .map(|part| {
-            part.parse::<ServerAddr>()
-                .with_context(|| format!("Invalid NATS URL: {part}"))
-        })
-        .collect()
+/// Username and password parsed out of a NATS URL's userinfo.
+type Credentials = (String, String);
+
+/// Split one server URL into `(url_without_userinfo, credentials)`.
+///
+/// The authority ends at the last `@`, so a password may itself contain `@`
+/// or `/`. The returned URL carries no userinfo, so it always parses even
+/// when the password does not survive URL syntax.
+fn split_credentials(part: &str) -> (String, Option<Credentials>) {
+    let Some((scheme, rest)) = part.split_once("://") else {
+        return (part.to_string(), None);
+    };
+    let Some((userinfo, host)) = rest.rsplit_once('@') else {
+        return (part.to_string(), None);
+    };
+    if userinfo.is_empty() {
+        return (format!("{scheme}://{host}"), None);
+    }
+    let (user, pass) = match userinfo.split_once(':') {
+        Some((user, pass)) => (user, pass),
+        None => (userinfo, ""),
+    };
+    (
+        format!("{scheme}://{host}"),
+        Some((decode(user), decode(pass))),
+    )
 }
 
-/// Extract `(user, password)` from a NATS URL, percent-decoded.
+/// Percent-decode when the value is valid percent-encoding, else take it
+/// literally. A generated password containing a bare `%` is not an encoding
+/// mistake to reject — it is a password.
+fn decode(raw: &str) -> String {
+    urlencoding::decode(raw)
+        .map(|decoded| decoded.into_owned())
+        .unwrap_or_else(|_| raw.to_string())
+}
+
+/// Parse `NATS_URL`: one server URL or a comma-separated list of them.
 ///
-/// The first server that carries a username wins. Returns `None` when no
-/// server does. A username without a password yields an empty password,
-/// matching NATS token-less user auth.
-pub fn credentials_from_url(url: &str) -> Result<Option<(String, String)>> {
-    for addr in parse_server_addrs(url)? {
-        let Some(user) = addr.username() else {
-            continue;
-        };
-        let user = urlencoding::decode(user)
-            .context("Invalid percent-encoding in NATS username")?
-            .into_owned();
-        let pass = match addr.password() {
-            Some(pass) => urlencoding::decode(pass)
-                .context("Invalid percent-encoding in NATS password")?
-                .into_owned(),
-            None => String::new(),
-        };
-        return Ok(Some((user, pass)));
+/// Returns the addresses with userinfo stripped, plus the first credentials
+/// found. A username without a password yields an empty password, matching
+/// NATS token-less user auth.
+fn parse_nats_url(url: &str) -> Result<(Vec<ServerAddr>, Option<Credentials>)> {
+    let mut addrs = Vec::new();
+    let mut credentials = None;
+    for part in url.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+        let (bare, found) = split_credentials(part);
+        addrs.push(
+            bare.parse::<ServerAddr>()
+                .with_context(|| format!("Invalid NATS URL: {bare}"))?,
+        );
+        if credentials.is_none() {
+            credentials = found;
+        }
     }
-    Ok(None)
+    Ok((addrs, credentials))
+}
+
+/// Extract `(user, password)` from a NATS URL.
+pub fn credentials_from_url(url: &str) -> Result<Option<Credentials>> {
+    Ok(parse_nats_url(url)?.1)
 }
 
 /// Connect to NATS, honouring credentials embedded in the URL.
 pub async fn connect(url: &str) -> Result<Client> {
-    let addrs = parse_server_addrs(url)?;
+    let (addrs, credentials) = parse_nats_url(url)?;
     if addrs.is_empty() {
         anyhow::bail!("NATS URL is empty");
     }
     let mut options = ConnectOptions::new();
-    if let Some((user, pass)) = credentials_from_url(url)? {
+    if let Some((user, pass)) = credentials {
         options = options.user_and_password(user, pass);
     }
     options
@@ -88,6 +125,42 @@ mod tests {
         );
     }
 
+    /// The shape that left production on the in-memory fallback: a generated
+    /// password with a bare `/`, which ends the URL authority and made the
+    /// whole URL fail to parse.
+    #[test]
+    fn password_with_an_unencoded_slash_is_accepted() {
+        let (addrs, creds) = parse_nats_url("nats://everruns_prod_nats:ODC05x/uceWsdB@nats:4222")
+            .expect("a bare slash in the password must not fail the parse");
+        assert_eq!(addrs.len(), 1);
+        assert_eq!(addrs[0].host(), "nats");
+        assert_eq!(addrs[0].port(), 4222);
+        assert_eq!(
+            creds,
+            Some((
+                "everruns_prod_nats".to_string(),
+                "ODC05x/uceWsdB".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn password_may_contain_reserved_characters() {
+        for (password, label) in [
+            ("pa@ss", "at sign"),
+            ("pa/ss", "slash"),
+            ("pa:ss", "colon"),
+            ("pa?ss#frag", "query and fragment markers"),
+            ("100%pure", "bare percent"),
+        ] {
+            assert_eq!(
+                credentials_from_url(&format!("nats://u:{password}@nats:4222")).unwrap(),
+                Some(("u".to_string(), password.to_string())),
+                "{label} must survive"
+            );
+        }
+    }
+
     #[test]
     fn username_without_password_yields_empty_password() {
         assert_eq!(
@@ -99,9 +172,24 @@ mod tests {
     #[test]
     fn credentials_found_in_a_server_list() {
         assert_eq!(
-            credentials_from_url("nats://nats1:4222, nats://u:p@nats2:4222").unwrap(),
-            Some(("u".to_string(), "p".to_string()))
+            credentials_from_url("nats://nats1:4222, nats://u:p/w@nats2:4222").unwrap(),
+            Some(("u".to_string(), "p/w".to_string()))
         );
+    }
+
+    /// Every server in the list must still be dialled, and none of them may
+    /// carry userinfo into the address the client connects to.
+    #[test]
+    fn every_server_is_kept_and_userinfo_is_stripped() {
+        let (addrs, creds) = parse_nats_url("nats://u:p/w@nats1:4222,nats://nats2:4223").unwrap();
+        assert_eq!(addrs.len(), 2);
+        assert_eq!((addrs[0].host(), addrs[0].port()), ("nats1", 4222));
+        assert_eq!((addrs[1].host(), addrs[1].port()), ("nats2", 4223));
+        assert!(
+            addrs.iter().all(|a| a.username().is_none()),
+            "userinfo must not reach the dialled address"
+        );
+        assert_eq!(creds, Some(("u".to_string(), "p/w".to_string())));
     }
 
     #[test]

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -309,7 +309,7 @@ NATS_URL=nats://control:s3cret@nats:4222
   - **Task notifications**: `task.available.{activity_type}` subjects replace PG NOTIFY for push-based worker notification. Lower latency (~1ms vs ~30ms), supports multi-instance deployments.
 - When NATS event delivery is active, the server skips the legacy PostgreSQL event listener used only for SSE wakeups.
 - NATS JetStream must be enabled on the server (`--jetstream` flag)
-- Credentials embedded in the URL (`nats://user:password@host`) are sent as user/password auth; percent-encode reserved characters in the password
+- Credentials embedded in the URL (`nats://user:password@host`) are sent as user/password auth. Reserved characters in the password (`/`, `@`, `:`, `%`) are accepted as-is, so a generated secret can be pasted unmodified; percent-encoded passwords are decoded and also work
 - Fail-graceful: if NATS connection fails at startup, falls back to PG NOTIFY + in-memory delivery with a warning that includes the connection error
 - Only used by control-plane (server); workers communicate via gRPC and don't need NATS access
 - Default port: 4222 (or `PORT_PREFIX22` with `PORT_PREFIX`)


### PR DESCRIPTION
## What changed
Credentials are split off the `NATS_URL` string before it is parsed as a URL, instead of being read back out of a parsed `ServerAddr`. The authority ends at the last `@`, so the password may contain `/`, `@`, `:`, `?`, `#` or a bare `%`. Percent-encoded passwords still decode, and the address the client dials never carries userinfo.

## Why
**Production has never actually used NATS.** `NATS_PASSWORD` there contains a bare `/`. A single `/` ends a URL authority, so

```
nats://everruns_prod_nats:ODC05x…qq7iS/uceWsdB…@nats:4222
```

parsed as host `everruns_prod_nats:ODC05x…qq7iS` and failed with `invalid port number`. Every boot fell back to in-memory event delivery and PG NOTIFY — EVERRUNS-2 and EVERRUNS-4, 89 events each, still firing on 2026-09-05 after #3356 shipped.

#3356 did not cause this and did not fix it; it made the fallback legible by logging the full error chain. That is how the cause was finally identifiable, and this PR fixes it. A generated secret pasted into the URL should work unmodified — which is what an operator expects, and what every other client in the stack does.

## Before / After
Before, against the production URL shape:

```
Failed to connect to NATS — falling back to in-memory event delivery.
error="Failed to connect to NATS: Invalid NATS URL:
       nats://everruns_prod_nats:…iS/uceWsdB…@nats:4222:
       NATS server URL is invalid: invalid port number"
```

After, `password_with_an_unencoded_slash_is_accepted` parses that exact shape to host `nats`, port `4222`, user `everruns_prod_nats`, password `ODC05x/uceWsdB`. `password_may_contain_reserved_characters` covers `@`, `/`, `:`, `?#` and a bare `%`; `every_server_is_kept_and_userinfo_is_stripped` pins that a server list still dials every entry and that no userinfo reaches the dialled address.

Verified locally: `cargo fmt --all --check` clean, `cargo clippy -p everruns-server --all-targets --all-features -D warnings` clean, `everruns-server` lib suite green (2240 passed).

## Risk
- Low
- Strictly widens what parses. A URL that worked before still works: percent-encoded passwords are decoded exactly as before, and a URL with no userinfo takes an early return.
- Deployments whose password contained a reserved character were already failing to connect and silently degrading, so the only behaviour change for them is that NATS starts working. On this repo's own production that means event delivery and task notifications move off the in-memory/PG fallback onto NATS, which is the intended configuration.

## Security
- Threat categories reviewed: credential handling. The password is never logged; only the URL with its userinfo appears in a parse-error context, which is unchanged from before. The dialled `ServerAddr` no longer carries userinfo at all, so it cannot leak through address logging.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HcVQmuxYFDtuDodMUGz8Ko)_