### PR TITLE
fix(deps): move off the yanked wnaf 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9530,13 +9530,14 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff",
  "group",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Lockfile-only bump of the transitive `wnaf` dependency from 0.14.0 to 0.14.1. No source, manifest, or behavior change.

## Why

License Check is red on `main`. Run [34070638792](https://github.com/everruns/everruns/actions/runs/34070638792) on cc7f4ef fails `cargo deny check advisories`:

```
error[yanked]: detected yanked crate (try `cargo update -p wnaf`)
    ┌─ Cargo.lock:773:1
773 │ wnaf 0.14.0 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
    ├ wnaf v0.14.0
      ├── k256 v0.14.0
      │   └── everruns-server v0.22.0
      └── primeorder v0.14.0
          └── k256 v0.14.0 (*)
```

Nothing in this repo selected `wnaf` directly — it arrives through `k256`, and 0.14.0 was yanked upstream after the fact. That is the same class of failure the `licenses.yml` schedule comment already names: advisories are published against a dependency tree that is not moving, so this went red with no change on our side.

## Before / After

Same `cargo-deny` 0.20.2 that CI pins, run locally against this tree:

Before (`main` @ cc7f4ef):
```
advisories FAILED
```

After (this branch):
```
$ cargo-deny check advisories
advisories ok
$ cargo-deny check licenses
licenses ok        (2 pre-existing license-not-encountered warnings, unchanged)
$ cargo fetch --locked
(resolves clean)
```

`cargo check -p everruns-server --all-features` compiles against the updated lock.

## Risk

- Low
- A patch release of a transitive scalar-multiplication helper under `k256`. 0.14.0 → 0.14.1 is semver-patch, no API surface reaches our code, and nothing here depends on `wnaf` directly. If 0.14.1 were itself broken, the workspace build would fail rather than misbehave silently.

## Security

- Threat categories reviewed: dependency supply chain. `wnaf` sits under `k256`, so it is on the ECDSA path; moving off a yanked release onto the maintainer's replacement is strictly the safer position. No auth, API, or data-handling code changes.
- Findings and resolutions: none beyond the yank itself, which this resolves.

## Follow-ups

No follow-ups. The recurring exposure — a yank landing between pushes — is already covered by the weekly `licenses.yml` schedule.

## Checklist
- [x] Tests added or updated — n/a, lockfile-only; `cargo deny` is the test and it is already in CI
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01R85iVUskikNDSEx3R7EJ5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01R85iVUskikNDSEx3R7EJ5f)_