### PR TITLE
fix(ci): absorb one transient Doppler CLI install failure

### DIFF
--- a/.github/workflows/ard.yml
+++ b/.github/workflows/ard.yml
@@ -89,6 +89,18 @@ jobs:
           shared-key: "debug"
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       # Optional bearer token for the registry. The reference registry is

--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -74,6 +74,18 @@ jobs:
           shared-key: "debug"
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Fetch Brave Search API key from Doppler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -886,6 +886,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
@@ -913,6 +925,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
@@ -940,6 +964,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
@@ -1112,7 +1148,19 @@ jobs:
       # token is never instantiated in a fork-PR context where untrusted
       # code (build.rs, proc-macros, test bodies) would see it via env.
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
         if: github.event_name == 'push'
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Run Slack integration tests (real API via Doppler)
@@ -1147,6 +1195,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain
@@ -1424,6 +1484,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -193,6 +193,18 @@ jobs:
           cat everruns.rb
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
 
       - name: Push formula to homebrew-tap

--- a/.github/workflows/cursor-integration.yml
+++ b/.github/workflows/cursor-integration.yml
@@ -61,6 +61,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain

--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -70,6 +70,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -66,6 +66,18 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Doppler CLI
+        id: doppler_install
+        # Absorbs one transient installer failure; see
+        # scripts/test-doppler-install-retry.sh for why.
+        continue-on-error: true
+        uses: dopplerhq/cli-action@v4
+
+      - name: Pause before Doppler CLI retry
+        if: steps.doppler_install.outcome == 'failure'
+        run: sleep 15
+
+      - name: Install Doppler CLI (retry)
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Install Rust toolchain

--- a/scripts/test-doppler-install-retry.sh
+++ b/scripts/test-doppler-install-retry.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Guard every `dopplerhq/cli-action` install against a single transient failure.
+#
+# The installer fetches the release tarball and its signature from the GitHub
+# release CDN. That CDN is not ours and it does fail: on Integration Live Sweep
+# run 34131004174 the `Brave Search API Tests` job died with
+#
+#     ERROR: Signature download failed with status code 504. Please try again.
+#
+# 32 seconds in, at step 3 of 7 — before a single test body ran. The seven other
+# jobs in the same run installed the same CLI in 1-2 seconds. One unlucky job
+# turned the whole scheduled sweep red while proving nothing about the code.
+#
+# A tool install that dies fetching bytes from someone else's CDN is not a
+# result, so it should not be reported as one. Each install therefore gets one
+# guarded retry, and this test keeps that property from eroding as workflows are
+# added or edited.
+#
+# The guard is deliberately narrow, because "retry until green" is how a real
+# failure gets laundered into a flake:
+#
+#   1. exactly one retry, not a loop;
+#   2. the retry is NOT continue-on-error, so a second failure still fails the
+#      job — this widens no fail-open window;
+#   3. the retry fires only on `outcome == 'failure'`, never on a skip.
+#
+# Rule 3 is load-bearing for TM-CI-001/TM-CI-002. `ci.yml`'s live provider
+# matrix installs Doppler only `if: github.event_name == 'push'`, keeping
+# DOPPLER_TOKEN away from runners executing PR-controlled `cargo test`. A
+# skipped step reports `outcome == 'skipped'`, not `'failure'`, so the retry
+# cannot resurrect that install on a pull request. Matching on the outcome
+# alone — rather than restating the push gate on the retry — also keeps the
+# gate in exactly one place, where it cannot drift out of sync.
+
+set -euo pipefail
+
+python3 - <<'PY'
+from pathlib import Path
+
+import yaml
+
+ACTION = "dopplerhq/cli-action@"
+RETRY_IF = "steps.doppler_install.outcome == 'failure'"
+
+errors = []
+guarded = 0
+
+for path in sorted(Path(".github/workflows").glob("*.yml")):
+    document = yaml.safe_load(path.read_text())
+    if not isinstance(document, dict):
+        continue
+
+    for job_name, job in (document.get("jobs") or {}).items():
+        steps = job.get("steps") or []
+        where = f"{path}:{job_name}"
+
+        installs = [
+            (index, step)
+            for index, step in enumerate(steps)
+            if isinstance(step.get("uses"), str) and step["uses"].startswith(ACTION)
+        ]
+        if not installs:
+            continue
+
+        # A guarded pair is (first attempt, retry). Anything else is unguarded.
+        first = [(i, s) for i, s in installs if s.get("id") == "doppler_install"]
+        retries = [(i, s) for i, s in installs if s.get("if") == RETRY_IF]
+
+        if len(first) != 1 or len(retries) != 1:
+            errors.append(
+                f"{where}: expected exactly one guarded install and one retry, "
+                f"found {len(first)} install(s) with id 'doppler_install' and "
+                f"{len(retries)} retry step(s) among {len(installs)} usage(s) of "
+                f"{ACTION}*"
+            )
+            continue
+
+        (first_index, first_step), (retry_index, retry_step) = first[0], retries[0]
+
+        if first_step.get("continue-on-error") is not True:
+            errors.append(
+                f"{where}: the first install must set continue-on-error: true, "
+                "otherwise the job dies before the retry can run"
+            )
+
+        if retry_step.get("continue-on-error") is not None:
+            errors.append(
+                f"{where}: the retry must not set continue-on-error — a second "
+                "failure has to fail the job, or a real outage reports green"
+            )
+
+        if retry_index <= first_index:
+            errors.append(f"{where}: the retry step precedes the install it retries")
+
+        if first_step["uses"] != retry_step["uses"]:
+            errors.append(
+                f"{where}: install and retry pin different refs "
+                f"({first_step['uses']} vs {retry_step['uses']})"
+            )
+
+        # A skipped first attempt reports outcome 'skipped'. Restating a step's
+        # own gate on the retry would let the two drift apart, so the retry is
+        # required to carry the outcome check and nothing else.
+        if retry_step.get("if") != RETRY_IF:
+            errors.append(f"{where}: the retry must be gated on exactly {RETRY_IF!r}")
+
+        guarded += 1
+
+if errors:
+    raise SystemExit("\n".join(errors))
+
+if guarded == 0:
+    raise SystemExit(
+        "no guarded Doppler installs found — this guard has lost its subject, "
+        "which means it is silently passing"
+    )
+
+print(f"all {guarded} Doppler CLI install(s) bind exactly one fail-closed retry")
+PY


### PR DESCRIPTION
## What changed

Every `dopplerhq/cli-action` install in CI — 12 sites across 7 workflows — now gets one guarded retry after a short pause. A single transient failure in the installer no longer turns a job, or a whole scheduled sweep, red.

A new guard, `scripts/test-doppler-install-retry.sh`, holds the property so it cannot erode as workflows are added or edited. It follows the shape of the existing ci.yml workflow guards and is picked up automatically by `run-shell-tests.sh`.

## Why

Integration Live Sweep [run 34131004174](https://github.com/everruns/everruns/actions/runs/34131004174) went red on main. Exactly one of its nine jobs failed — `Brave Search API Tests`, 32 seconds in, at step 3 of 7:

```
ERROR: Signature download failed with status code 504. Please try again.
```

The Doppler installer fetches the release tarball and its signature from the GitHub release CDN, and that CDN returned a 504. The seven other jobs in the same run installed the same CLI in 1–2 seconds. Nothing about this repository was involved, and no test body ran.

A tool install that dies fetching bytes from someone else's CDN is not a result, so it should not be reported as one. With 12 unguarded install sites, any one CDN blip reddens a gate — and a red that proves nothing is the failure mode that teaches people to ignore reds.

The guard is deliberately narrow, because "retry until green" is how a real failure gets laundered into a flake:

1. exactly one retry, not a loop;
2. the retry is **not** `continue-on-error`, so a second failure still fails the job — this widens no fail-open window;
3. the retry fires only on `outcome == 'failure'`, never on a skip.

## Before / After

**Before** — one 504 in any of 12 install sites fails its job and the workflow.

Re-running the failed job with **no code change** installed Doppler in one second and passed the live tests, taking the whole sweep green. That confirms the failure was the CDN and nothing else:

| Job | Attempt 1 | Attempt 2 (no code change) |
| -- | -- | -- |
| Brave Search API Tests | failure — 504 at `Install Doppler CLI` | success — installed in 1s, tests passed |
| other 8 jobs | success | success |

**After** — the same 504 is absorbed by one retry and the job proceeds. A second consecutive failure still fails the job.

Guard verified against four mutations, each of which it catches:

```
--- drop continue-on-error from first attempt
  caught: the first install must set continue-on-error: true, otherwise the job dies before the retry can run
--- remove the retry entirely
  caught: expected exactly one guarded install and one retry, found 1 install(s) with id 'doppler_install' and 0 retry step(s)
--- make the retry fail-open
  caught: the retry must not set continue-on-error — a second failure has to fail the job, or a real outage reports green
--- retry on always() instead of failure
  caught: expected exactly one guarded install and one retry, found ... 0 retry step(s) among 2 usage(s)
```

All 24 repo shell tests pass, including the existing ci.yml guards (`test-ci-job-timeouts.sh`, `test-ci-labeled-event-gate.sh`, `test-ci-provider-live-filter.sh`, `test-release-workflow-security.sh`). All seven touched workflows parse as YAML with no duplicate step ids.

## Risk

- Low
- CI configuration only; no runtime, dependency, or public interface change. No new action or third-party dependency is introduced — the retry re-invokes the action already in use, at the same ref (the SHA pin in `cli-binaries.yml` is preserved on both attempts, and the guard asserts install and retry never pin different refs).
- The worst case is a job taking ~15 seconds longer on the rare path where the first install fails. A genuine Doppler outage still fails the job on the second attempt, as before.

## Security

- Threat categories reviewed: **TM-CI-001**, **TM-CI-002**.
- Findings and resolutions: rule 3 above is load-bearing for both. `ci.yml`'s live provider matrix installs Doppler only `if: github.event_name == 'push'`, keeping `DOPPLER_TOKEN` away from runners executing PR-controlled `cargo test`. A skipped step reports `outcome == 'skipped'`, not `'failure'`, so the retry provably cannot resurrect that install on a pull request. Matching on the outcome alone — rather than restating the push gate on the retry — also keeps that gate in exactly one place where it cannot drift out of sync with the step it protects. The guard test asserts the retry condition is exactly the outcome check, so a future edit cannot silently widen it. No secret is newly exposed, and no permission surface changes.

## Follow-ups

No follow-ups.

Two unrelated conditions were observed while confirming main's health and are already tracked, not deferred by this PR: Dependabot alerts remain unreadable from scheduled sessions (EVE-926, reported by the Security Alerts job as a known 403 rather than a failure), and the Deno live entries stay quarantined pending a billing action (EVE-946).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_016XuGvZcNbNvWBKBYzKD5Wn


---
_Generated by [Claude Code](https://claude.ai/code/session_016XuGvZcNbNvWBKBYzKD5Wn)_