### PR TITLE
perf(everruns): cut agent startup to ready by ~3.5x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ version = "0.1.0"
 dependencies = [
  "everruns",
  "everruns-anthropic",
+ "libc",
  "reqwest 0.13.4",
  "tokio",
 ]

--- a/crates/drivers/anthropic/src/driver.rs
+++ b/crates/drivers/anthropic/src/driver.rs
@@ -86,7 +86,6 @@ const MESSAGE_CACHE_BREAKPOINTS: usize = 2;
 /// ```
 #[derive(Clone)]
 pub struct AnthropicChatDriver {
-    client: Client,
     /// Retry configuration for rate limit errors
     retry_config: LlmRetryConfig,
 }
@@ -107,9 +106,16 @@ impl AnthropicChatDriver {
     /// Create a new provider with the given API key
     pub fn new() -> Self {
         Self {
-            client: driver_helpers::shared_streaming_http_client(),
             retry_config: LlmRetryConfig::default(),
         }
+    }
+
+    /// The process-wide streaming HTTP client, resolved per request rather than
+    /// held as a field. Building it loads the platform trust store (~1.3 ms),
+    /// which would otherwise land in `Agent::build` on the startup path; after
+    /// the first request this is a `OnceLock` read and an `Arc` clone.
+    fn client(&self) -> Client {
+        driver_helpers::shared_streaming_http_client()
     }
 
     /// Configure retry behavior for rate limit errors
@@ -209,7 +215,7 @@ impl AnthropicChatDriver {
                         })?;
                     let resolved = endpoint.resolve("POST", url, &body).await.map_err(SendOutcome::Fatal)?;
                     driver_headers.extend(resolved.headers);
-                    let mut request_builder = self.client.post(&resolved.url);
+                    let mut request_builder = self.client().post(&resolved.url);
                     for (name, value) in
                         driver_helpers::merge_request_headers(driver_headers, extra_headers)
                     {
@@ -1262,7 +1268,7 @@ impl ChatDriver for AnthropicChatDriver {
             .ok_or_else(|| AgentLoopError::config("Anthropic provider has no base URL"))?;
         let resolved = endpoint.resolve("GET", url, &[]).await?;
         let mut request = self
-            .client
+            .client()
             .get(&resolved.url)
             .header("anthropic-version", ANTHROPIC_VERSION);
         for (name, value) in resolved.headers {

--- a/crates/drivers/anthropic/src/driver.rs
+++ b/crates/drivers/anthropic/src/driver.rs
@@ -105,6 +105,11 @@ struct SendMessagesOptions<'a> {
 impl AnthropicChatDriver {
     /// Create a new provider with the given API key
     pub fn new() -> Self {
+        // EVE-924: choose the rustls backend on the startup path. The shared
+        // client installs it as well, but that now happens on the first
+        // request, and products expect the process-wide choice to be settled
+        // while providers are being constructed.
+        everruns_provider::install_default_crypto_provider();
         Self {
             retry_config: LlmRetryConfig::default(),
         }

--- a/crates/drivers/fireworks/src/driver.rs
+++ b/crates/drivers/fireworks/src/driver.rs
@@ -114,7 +114,7 @@ impl ChatDriver for FireworksChatDriver {
         }
 
         let models_url = models_url_for_api_url(&api_url);
-        list_fireworks_models(self.inner.client(), endpoint, &models_url).await
+        list_fireworks_models(&self.inner.client(), endpoint, &models_url).await
     }
 }
 

--- a/crates/drivers/gemini/src/driver.rs
+++ b/crates/drivers/gemini/src/driver.rs
@@ -58,7 +58,6 @@ pub fn provider(
 /// Supports streaming responses and tool calls.
 #[derive(Clone)]
 pub struct GeminiChatDriver {
-    client: Client,
     retry_config: LlmRetryConfig,
 }
 
@@ -66,9 +65,16 @@ impl GeminiChatDriver {
     /// Create a new driver with the given API key
     pub fn new() -> Self {
         Self {
-            client: everruns_provider::driver_helpers::shared_streaming_http_client(),
             retry_config: LlmRetryConfig::default(),
         }
+    }
+
+    /// The process-wide streaming HTTP client, resolved per request rather than
+    /// held as a field. Building it loads the platform trust store (~1.3 ms),
+    /// which would otherwise land on the agent startup path; after the first
+    /// request this is a `OnceLock` read and an `Arc` clone.
+    fn client(&self) -> Client {
+        everruns_provider::driver_helpers::shared_streaming_http_client()
     }
 
     fn convert_role(role: &LlmMessageRole) -> &'static str {
@@ -359,7 +365,7 @@ impl GeminiChatDriver {
                     .resolve("POST", url, &body)
                     .await
                     .map_err(SendOutcome::Fatal)?;
-                let mut builder = self.client.post(&resolved.url);
+                let mut builder = self.client().post(&resolved.url);
                 let mut headers = resolved.headers;
                 headers.push(("Content-Type".to_string(), "application/json".to_string()));
                 for (name, value) in
@@ -534,7 +540,7 @@ impl ChatDriver for GeminiChatDriver {
             .url("models")
             .ok_or_else(|| AgentLoopError::config("Gemini provider has no base URL"))?;
         let resolved = endpoint.resolve("GET", url, &[]).await?;
-        let mut request = self.client.get(&resolved.url);
+        let mut request = self.client().get(&resolved.url);
         for (name, value) in resolved.headers {
             request = request.header(name, value);
         }

--- a/crates/drivers/gemini/src/driver.rs
+++ b/crates/drivers/gemini/src/driver.rs
@@ -64,6 +64,11 @@ pub struct GeminiChatDriver {
 impl GeminiChatDriver {
     /// Create a new driver with the given API key
     pub fn new() -> Self {
+        // EVE-924: choose the rustls backend on the startup path. The shared
+        // client installs it as well, but that now happens on the first
+        // request, and products expect the process-wide choice to be settled
+        // while providers are being constructed.
+        everruns_provider::install_default_crypto_provider();
         Self {
             retry_config: LlmRetryConfig::default(),
         }

--- a/crates/drivers/mai/src/driver.rs
+++ b/crates/drivers/mai/src/driver.rs
@@ -117,7 +117,7 @@ impl ChatDriver for MaiChatDriver {
         }
 
         list_foundry_models(
-            self.inner.client(),
+            &self.inner.client(),
             endpoint,
             &models_url_for_api_url(&api_url),
         )

--- a/crates/drivers/meta/src/driver.rs
+++ b/crates/drivers/meta/src/driver.rs
@@ -83,7 +83,7 @@ impl ChatDriver for MetaChatDriver {
         }
 
         let models_url = models_url_for_api_url(&api_url);
-        list_meta_models(self.inner.client(), endpoint, &models_url).await
+        list_meta_models(&self.inner.client(), endpoint, &models_url).await
     }
 }
 

--- a/crates/drivers/openai/src/driver.rs
+++ b/crates/drivers/openai/src/driver.rs
@@ -156,7 +156,7 @@ impl ChatDriver for OpenAIChatDriver {
         }
 
         let models_url = models_url_for_api_url(&api_url);
-        list_openai_models(self.inner.client(), endpoint, &models_url).await
+        list_openai_models(&self.inner.client(), endpoint, &models_url).await
     }
 
     fn supports_compact(&self) -> bool {
@@ -250,7 +250,7 @@ impl ChatDriver for OpenAICompletionsChatDriver {
         }
 
         let models_url = models_url_for_api_url(&api_url);
-        list_openai_models(self.inner.client(), endpoint, &models_url).await
+        list_openai_models(&self.inner.client(), endpoint, &models_url).await
     }
 
     fn supports_parallel_tool_calls(&self, model: &str) -> bool {

--- a/crates/drivers/openai/src/embeddings.rs
+++ b/crates/drivers/openai/src/embeddings.rs
@@ -9,6 +9,11 @@ pub struct OpenAIEmbeddingsDriver;
 
 impl OpenAIEmbeddingsDriver {
     pub fn new() -> Self {
+        // EVE-924: choose the rustls backend on the startup path. The shared
+        // client installs it as well, but that now happens on the first
+        // request, and products expect the process-wide choice to be settled
+        // while providers are being constructed.
+        everruns_provider::install_default_crypto_provider();
         Self
     }
 

--- a/crates/drivers/openai/src/embeddings.rs
+++ b/crates/drivers/openai/src/embeddings.rs
@@ -5,15 +5,19 @@ use everruns_provider::{EmbedRequest, EmbedResponse, EmbeddingsDriver, Embedding
 use serde::{Deserialize, Serialize};
 
 /// Embeddings driver for OpenAI's `/v1/embeddings` endpoint.
-pub struct OpenAIEmbeddingsDriver {
-    client: reqwest::Client,
-}
+pub struct OpenAIEmbeddingsDriver;
 
 impl OpenAIEmbeddingsDriver {
     pub fn new() -> Self {
-        Self {
-            client: shared_request_http_client(),
-        }
+        Self
+    }
+
+    /// The process-wide request HTTP client, resolved per request rather than
+    /// held as a field. Building it loads the platform trust store (~1.3 ms),
+    /// which would otherwise land on the agent startup path; after the first
+    /// request this is a `OnceLock` read and an `Arc` clone.
+    fn client(&self) -> reqwest::Client {
+        shared_request_http_client()
     }
 }
 
@@ -73,7 +77,7 @@ impl EmbeddingsDriver for OpenAIEmbeddingsDriver {
                 .await
                 .map_err(|error| EmbeddingsDriverError::Provider(error.to_string()))?;
             let mut builder = self
-                .client
+                .client()
                 .post(&resolved.url)
                 .header("content-type", "application/json");
             for (name, value) in resolved.headers {

--- a/crates/drivers/openrouter/src/driver.rs
+++ b/crates/drivers/openrouter/src/driver.rs
@@ -86,7 +86,7 @@ impl ChatDriver for OpenRouterChatDriver {
         }
 
         let models_url = models_url_for_api_url(&api_url);
-        list_openrouter_models(self.inner.client(), endpoint, &models_url).await
+        list_openrouter_models(&self.inner.client(), endpoint, &models_url).await
     }
 }
 

--- a/crates/everruns/src/events.rs
+++ b/crates/everruns/src/events.rs
@@ -26,7 +26,7 @@
 //! post-commit durable events plus live-only ephemeral events. Sink absence,
 //! lag, or failure cannot create, roll back, or replace conversation history.
 
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 use everruns_core::events::{
     self, Event, EventContext, EventData, EventRequest, InputMessageData,
@@ -799,7 +799,14 @@ impl CancellationToken {
 /// [`EventStream`] as a projected [`SessionEvent`]. Sending never blocks, so an
 /// observer can never stall or fail a turn.
 pub(crate) struct FacadeEventBus {
-    sender: broadcast::Sender<SessionEvent>,
+    /// Created on first subscribe, not with the session. A broadcast channel
+    /// preallocates all `capacity` slots up front (~1.5 MB at 4096), which is
+    /// the single largest cost of creating a session. Deferring it is
+    /// observationally identical: a subscriber only receives events sent after
+    /// it subscribed, so events emitted while no channel exists were
+    /// unobservable either way.
+    sender: OnceLock<broadcast::Sender<SessionEvent>>,
+    capacity: usize,
     active_turn: Mutex<Option<EventContext>>,
 }
 
@@ -809,16 +816,20 @@ impl FacadeEventBus {
     }
 
     fn with_capacity(capacity: usize) -> Self {
-        let (sender, _rx) = broadcast::channel(capacity);
         Self {
-            sender,
+            sender: OnceLock::new(),
+            capacity,
             active_turn: Mutex::new(None),
         }
     }
 
-    /// Subscribe a new [`EventStream`] to this bus.
+    /// Subscribe a new [`EventStream`] to this bus, allocating the broadcast
+    /// channel on the first subscribe.
     pub(crate) fn subscribe(&self) -> EventStream {
-        EventStream::new(self.sender.subscribe())
+        let sender = self
+            .sender
+            .get_or_init(|| broadcast::channel(self.capacity).0);
+        EventStream::new(sender.subscribe())
     }
 
     /// Build a correlated terminal request after the facade drops a cancelled
@@ -881,7 +892,9 @@ impl FacadeEventBus {
         // can subscribe before the next turn. Observation is best-effort and
         // absence is equivalent to the host's no-op sink, not a delivery
         // failure worth counting on every canonical append.
-        let _ = self.sender.send(SessionEvent::from_core_event(event));
+        if let Some(sender) = self.sender.get() {
+            let _ = sender.send(SessionEvent::from_core_event(event));
+        }
         Ok(())
     }
 }
@@ -1058,6 +1071,38 @@ mod tests {
             Err(EventStreamError::Lagged { missed: 1 })
         ));
         assert!(stream.recv().await.expect("gap reported").is_some());
+    }
+
+    #[tokio::test]
+    async fn subscriber_after_earlier_events_still_observes_later_ones() {
+        // The broadcast channel is allocated on the first subscribe, so this
+        // pins the semantics that laziness relies on: events emitted before
+        // anyone subscribed are not replayed, and later events still arrive.
+        let session_id = SessionId::new();
+        let bus = Arc::new(FacadeEventBus::new());
+        let emitter = host(bus.clone());
+
+        emitter
+            .emit(turn_started(session_id, TurnId::new()))
+            .await
+            .expect("emitting without a subscriber succeeds");
+
+        let mut stream = bus.subscribe();
+        let turn_id = TurnId::new();
+        emitter
+            .emit(turn_started(session_id, turn_id))
+            .await
+            .expect("emitting to a live subscriber succeeds");
+
+        let observed = stream
+            .recv()
+            .await
+            .expect("stream stays open")
+            .expect("the event emitted after subscribing arrives");
+        assert_eq!(
+            observed.turn_id.as_deref(),
+            Some(turn_id.to_string().as_str())
+        );
     }
 
     #[tokio::test]

--- a/crates/provider/src/openai_protocol.rs
+++ b/crates/provider/src/openai_protocol.rs
@@ -134,7 +134,6 @@ pub fn models_api_status_error(status: reqwest::StatusCode) -> AgentLoopError {
 /// ```
 #[derive(Clone)]
 pub struct OpenAIProtocolChatDriver {
-    client: Client,
     /// Retry configuration for rate limit errors
     retry_config: LlmRetryConfig,
 }
@@ -143,7 +142,6 @@ impl OpenAIProtocolChatDriver {
     /// Create a wire-only OpenAI Chat Completions protocol driver.
     pub fn new() -> Self {
         Self {
-            client: crate::driver_helpers::shared_streaming_http_client(),
             retry_config: LlmRetryConfig::default(),
         }
     }
@@ -154,9 +152,15 @@ impl OpenAIProtocolChatDriver {
         self
     }
 
-    /// Get the HTTP client (for subclass access)
-    pub fn client(&self) -> &Client {
-        &self.client
+    /// The process-wide streaming HTTP client, resolved per request rather than
+    /// held as a field. Building it loads the platform trust store (~1.3 ms),
+    /// which would otherwise land on the agent startup path; after the first
+    /// request this is a `OnceLock` read and an `Arc` clone.
+    ///
+    /// Returned by value for subclass access; a `reqwest::Client` is an `Arc`
+    /// handle, so cloning it shares the same connection pool.
+    pub fn client(&self) -> Client {
+        crate::driver_helpers::shared_streaming_http_client()
     }
 
     /// Send one streaming chat-completion request, applying the shared
@@ -190,7 +194,7 @@ impl OpenAIProtocolChatDriver {
                     .resolve("POST", api_url, &body)
                     .await
                     .map_err(SendOutcome::Fatal)?;
-                let mut request_builder = self.client.post(&resolved.url);
+                let mut request_builder = self.client().post(&resolved.url);
                 let mut headers = resolved.headers;
                 headers.push(("Content-Type".to_string(), "application/json".to_string()));
                 for (name, value) in

--- a/crates/provider/src/openai_protocol.rs
+++ b/crates/provider/src/openai_protocol.rs
@@ -141,6 +141,11 @@ pub struct OpenAIProtocolChatDriver {
 impl OpenAIProtocolChatDriver {
     /// Create a wire-only OpenAI Chat Completions protocol driver.
     pub fn new() -> Self {
+        // EVE-924: choose the rustls backend on the startup path. The shared
+        // client installs it as well, but that now happens on the first
+        // request, and products expect the process-wide choice to be settled
+        // while providers are being constructed.
+        crate::install_default_crypto_provider();
         Self {
             retry_config: LlmRetryConfig::default(),
         }

--- a/crates/provider/src/openresponses_protocol.rs
+++ b/crates/provider/src/openresponses_protocol.rs
@@ -108,7 +108,6 @@ pub trait OpenResponsesRequestExtension: Send + Sync {
 
 #[derive(Clone)]
 pub struct OpenResponsesProtocolChatDriver {
-    client: Client,
     /// Retry configuration for rate limit errors
     retry_config: LlmRetryConfig,
     /// Optional provider-specific request-body decorator (see
@@ -128,7 +127,6 @@ impl OpenResponsesProtocolChatDriver {
             // resolver). The api_url is org-configurable, so a bare
             // `Client::new()` would leave this provider open to DNS-rebind /
             // redirect SSRF (TM-API-013, EVE-623).
-            client: crate::driver_helpers::shared_streaming_http_client(),
             retry_config: LlmRetryConfig::default(),
             request_extension: None,
             stateful_responses: None,
@@ -250,7 +248,7 @@ impl OpenResponsesProtocolChatDriver {
                     headers.insert(name, value);
                 }
 
-                self.client
+                self.client()
                     .post(&resolved.url)
                     .headers(headers)
                     .header("Content-Type", "application/json")
@@ -344,9 +342,15 @@ impl OpenResponsesProtocolChatDriver {
         .await
     }
 
-    /// Get the HTTP client (for subclass access)
-    pub fn client(&self) -> &Client {
-        &self.client
+    /// The process-wide streaming HTTP client, resolved per request rather than
+    /// held as a field. Building it loads the platform trust store (~1.3 ms),
+    /// which would otherwise land on the agent startup path; after the first
+    /// request this is a `OnceLock` read and an `Arc` clone.
+    ///
+    /// Returned by value for subclass access; a `reqwest::Client` is an `Arc`
+    /// handle, so cloning it shares the same connection pool.
+    pub fn client(&self) -> Client {
+        crate::driver_helpers::shared_streaming_http_client()
     }
 
     fn convert_role(role: &LlmMessageRole) -> &'static str {
@@ -673,7 +677,7 @@ impl OpenResponsesProtocolChatDriver {
                     .resolve("POST", &compact_url, &body)
                     .await
                     .map_err(SendOutcome::Fatal)?;
-                let mut builder = self.client.post(&resolved.url);
+                let mut builder = self.client().post(&resolved.url);
                 for (name, value) in resolved.headers {
                     builder = builder.header(name, value);
                 }

--- a/crates/provider/src/openresponses_protocol.rs
+++ b/crates/provider/src/openresponses_protocol.rs
@@ -122,11 +122,12 @@ pub struct OpenResponsesProtocolChatDriver {
 impl OpenResponsesProtocolChatDriver {
     /// Create a wire-only Open Responses protocol driver.
     pub fn new() -> Self {
+        // EVE-924: choose the rustls backend on the startup path. The shared
+        // client installs it as well, but that now happens on the first
+        // request, and products expect the process-wide choice to be settled
+        // while providers are being constructed.
+        crate::install_default_crypto_provider();
         Self {
-            // SSRF-hardened shared client (redirects disabled + DNS-pinned
-            // resolver). The api_url is org-configurable, so a bare
-            // `Client::new()` would leave this provider open to DNS-rebind /
-            // redirect SSRF (TM-API-013, EVE-623).
             retry_config: LlmRetryConfig::default(),
             request_extension: None,
             stateful_responses: None,
@@ -349,6 +350,11 @@ impl OpenResponsesProtocolChatDriver {
     ///
     /// Returned by value for subclass access; a `reqwest::Client` is an `Arc`
     /// handle, so cloning it shares the same connection pool.
+    ///
+    /// The shared client is SSRF-hardened (redirects disabled + DNS-pinned
+    /// resolver). The api_url is org-configurable, so a bare `Client::new()`
+    /// would leave this provider open to DNS-rebind / redirect SSRF
+    /// (TM-API-013, EVE-623).
     pub fn client(&self) -> Client {
         crate::driver_helpers::shared_streaming_http_client()
     }

--- a/crates/turbopuffer/src/lib.rs
+++ b/crates/turbopuffer/src/lib.rs
@@ -48,6 +48,11 @@ impl TurbopufferVectorStore {
     /// Build a new backend. `base_url` is the regional Turbopuffer endpoint
     /// (any trailing slash is trimmed); `api_key` authenticates every request.
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        // EVE-924: choose the rustls backend on the startup path. The shared
+        // client installs it as well, but that now happens on the first
+        // request, and products expect the process-wide choice to be settled
+        // while providers are being constructed.
+        everruns_provider::install_default_crypto_provider();
         Self {
             base_url: base_url.into().trim_end_matches('/').to_string(),
             api_key: api_key.into(),

--- a/crates/turbopuffer/src/lib.rs
+++ b/crates/turbopuffer/src/lib.rs
@@ -38,7 +38,6 @@ const DISTANCE_METRIC: &str = "cosine_distance";
 /// Cheap to clone is unnecessary; construct once and share behind an `Arc` (as
 /// the platform definition does).
 pub struct TurbopufferVectorStore {
-    http: reqwest::Client,
     /// Regional base URL, e.g. `https://gcp-us-central1.turbopuffer.com`. No
     /// trailing slash.
     base_url: String,
@@ -50,12 +49,20 @@ impl TurbopufferVectorStore {
     /// (any trailing slash is trimmed); `api_key` authenticates every request.
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
-            // EVE-635: shared client with connect + overall request timeouts so
-            // a hung vector-store read cannot block indefinitely.
-            http: everruns_provider::driver_helpers::shared_request_http_client(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
             api_key: api_key.into(),
         }
+    }
+
+    /// The process-wide request HTTP client, resolved per request rather than
+    /// held as a field. Building it loads the platform trust store (~1.3 ms),
+    /// which would otherwise land in `new`; after the first request this is a
+    /// `OnceLock` read and an `Arc` clone.
+    ///
+    /// EVE-635: the shared client carries connect + overall request timeouts so
+    /// a hung vector-store read cannot block indefinitely.
+    fn http(&self) -> reqwest::Client {
+        everruns_provider::driver_helpers::shared_request_http_client()
     }
 
     fn namespace_url(&self, namespace: &str) -> String {
@@ -65,7 +72,7 @@ impl TurbopufferVectorStore {
     /// POST a JSON body to the namespace write endpoint and require a 2xx.
     async fn post_write(&self, namespace: &str, body: Value, op: &str) -> Result<()> {
         let resp = self
-            .http
+            .http()
             .post(self.namespace_url(namespace))
             .bearer_auth(&self.api_key)
             .json(&body)
@@ -165,7 +172,7 @@ impl VectorStore for TurbopufferVectorStore {
         };
 
         let resp = self
-            .http
+            .http()
             .post(format!("{}/query", self.namespace_url(namespace)))
             .bearer_auth(&self.api_key)
             .json(&body)
@@ -210,7 +217,7 @@ impl VectorStore for TurbopufferVectorStore {
 
     async fn delete_namespace(&self, namespace: &str) -> Result<()> {
         let resp = self
-            .http
+            .http()
             .delete(self.namespace_url(namespace))
             .bearer_auth(&self.api_key)
             .send()

--- a/examples/everruns-support-agent/Cargo.toml
+++ b/examples/everruns-support-agent/Cargo.toml
@@ -9,4 +9,5 @@ publish = false
 reqwest.workspace = true
 everruns = { path = "../../crates/everruns" }
 everruns-anthropic = { path = "../../crates/drivers/anthropic" }
+libc = "0.2"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/everruns-support-agent/src/bin/startup_bench.rs
+++ b/examples/everruns-support-agent/src/bin/startup_bench.rs
@@ -1,0 +1,120 @@
+//! Startup latency benchmark for the Framework support agent.
+//!
+//! Measures the local, provider-free cost of getting the agent ready to accept
+//! a message: build the Agent, construct the Engine, create the Session, and
+//! start it (binds the default environment and initializes host backends).
+//! No network calls are made; the API key is a placeholder.
+//!
+//! ```text
+//! cargo run --release -p everruns-framework-support-agent --bin startup_bench
+//! ```
+
+use std::time::{Duration, Instant};
+
+use everruns::{Agent, Engine};
+
+const MODEL: &str = "claude-opus-5";
+const ITERATIONS: usize = 500;
+
+#[everruns::tool]
+/// Read authoritative Framework documentation for a support topic.
+async fn search_docs(topic: String) -> Result<String, String> {
+    Ok(topic)
+}
+
+fn build_agent(api_key: &str) -> Result<Agent, everruns::BuildError> {
+    Agent::builder()
+        .name("everruns-support-agent")
+        .instructions("Keep the final answer within 150 words. You support Everruns Framework users. Use search_docs before answering. Separate evidence from hypotheses and give the smallest safe next step with relevant documentation links.")
+        .provider(everruns_anthropic::provider("anthropic", api_key))
+        .model(MODEL)
+        .tool(search_docs())
+        .build()
+}
+
+fn report(label: &str, mut samples: Vec<Duration>) {
+    samples.sort_unstable();
+    let micros = |d: Duration| d.as_secs_f64() * 1_000.0;
+    let p = |q: f64| micros(samples[((samples.len() - 1) as f64 * q) as usize]);
+    let mean = samples.iter().sum::<Duration>().as_secs_f64() * 1_000.0 / samples.len() as f64;
+    println!(
+        "{label:<28} min {:>8.3}ms  p50 {:>8.3}ms  mean {:>8.3}ms  p99 {:>8.3}ms  max {:>8.3}ms",
+        micros(samples[0]),
+        p(0.50),
+        mean,
+        p(0.99),
+        micros(samples[samples.len() - 1]),
+    );
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let process_start = Instant::now();
+
+    // Cold path: the very first time through, before any caches are warm.
+    let cold = Instant::now();
+    let agent = build_agent("bench-key")?;
+    let cold_build = cold.elapsed();
+    let cold = Instant::now();
+    let engine = Engine::new();
+    let session = engine.create(agent);
+    let cold_create = cold.elapsed();
+    let cold = Instant::now();
+    session.start().await?;
+    let cold_start = cold.elapsed();
+    let cold_total = process_start.elapsed();
+
+    if std::env::var_os("STARTUP_BENCH_COLD_ONLY").is_some() {
+        println!("cold total {:.3}ms", cold_total.as_secs_f64() * 1e3);
+        return Ok(());
+    }
+
+    let mut build = Vec::with_capacity(ITERATIONS);
+    let mut engine_new = Vec::with_capacity(ITERATIONS);
+    let mut create = Vec::with_capacity(ITERATIONS);
+    let mut start = Vec::with_capacity(ITERATIONS);
+    let mut total = Vec::with_capacity(ITERATIONS);
+
+    for _ in 0..ITERATIONS {
+        let all = Instant::now();
+        let step = Instant::now();
+        let agent = build_agent("bench-key")?;
+        build.push(step.elapsed());
+        let step = Instant::now();
+        let engine = Engine::new();
+        engine_new.push(step.elapsed());
+        let step = Instant::now();
+        let session = engine.create(agent);
+        create.push(step.elapsed());
+        let step = Instant::now();
+        session.start().await?;
+        start.push(step.elapsed());
+        total.push(all.elapsed());
+    }
+
+    println!("iterations: {ITERATIONS}\n");
+    println!("cold (first pass in a fresh process)");
+    println!(
+        "  Agent::build           {:>8.3}ms",
+        cold_build.as_secs_f64() * 1e3
+    );
+    println!(
+        "  Engine::new + create   {:>8.3}ms",
+        cold_create.as_secs_f64() * 1e3
+    );
+    println!(
+        "  Session::start         {:>8.3}ms",
+        cold_start.as_secs_f64() * 1e3
+    );
+    println!(
+        "  total                  {:>8.3}ms",
+        cold_total.as_secs_f64() * 1e3
+    );
+    println!();
+    report("Agent::build", build);
+    report("Engine::new", engine_new);
+    report("Engine::create", create);
+    report("Session::start", start);
+    report("ready-to-send (total)", total);
+    Ok(())
+}

--- a/examples/everruns-support-agent/src/bin/startup_bench.rs
+++ b/examples/everruns-support-agent/src/bin/startup_bench.rs
@@ -67,10 +67,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let main_entry = monotonic();
     let started = Instant::now();
 
+    // `--current-thread` measures the single-threaded runtime; the default
+    // matches `#[tokio::main]`, which starts one worker thread per core.
+    let current_thread = std::env::args().any(|arg| arg == "--current-thread");
     let step = Instant::now();
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?;
+    let runtime = if current_thread {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+    } else {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()?
+    };
     let runtime_built = step.elapsed();
 
     if std::env::args().any(|arg| arg == "--warm") {

--- a/examples/everruns-support-agent/src/bin/startup_bench.rs
+++ b/examples/everruns-support-agent/src/bin/startup_bench.rs
@@ -1,17 +1,25 @@
 //! Startup latency benchmark for the Framework support agent.
 //!
-//! Measures the local, provider-free cost of getting the agent ready to accept
-//! a message: build the Agent, construct the Engine, create the Session, and
-//! start it (binds the default environment and initializes host backends).
-//! No network calls are made; the API key is a placeholder.
+//! Measures the time to a session that is ready to accept a message: the tokio
+//! runtime, the Agent, the Engine, the Session, and `Session::start` (binds the
+//! default environment and initializes host backends). It stops at ready. No
+//! model call is made and process teardown is excluded (the process exits
+//! immediately, without running destructors).
 //!
 //! ```text
+//! # one cold process, the number that matters
 //! cargo run --release -p everruns-framework-support-agent --bin startup_bench
+//! # steady-state cost of the same path, 500 iterations in one process
+//! cargo run --release -p everruns-framework-support-agent --bin startup_bench -- --warm
 //! ```
+//!
+//! `startup_launcher.c` next to this file prints a CLOCK_MONOTONIC timestamp
+//! and then `execv`s this binary, which is how exec and dynamic-linking time
+//! before `main` is attributed.
 
 use std::time::{Duration, Instant};
 
-use everruns::{Agent, Engine};
+use everruns::{Agent, Engine, Session};
 
 const MODEL: &str = "claude-opus-5";
 const ITERATIONS: usize = 500;
@@ -32,89 +40,86 @@ fn build_agent(api_key: &str) -> Result<Agent, everruns::BuildError> {
         .build()
 }
 
-fn report(label: &str, mut samples: Vec<Duration>) {
-    samples.sort_unstable();
-    let micros = |d: Duration| d.as_secs_f64() * 1_000.0;
-    let p = |q: f64| micros(samples[((samples.len() - 1) as f64 * q) as usize]);
-    let mean = samples.iter().sum::<Duration>().as_secs_f64() * 1_000.0 / samples.len() as f64;
-    println!(
-        "{label:<28} min {:>8.3}ms  p50 {:>8.3}ms  mean {:>8.3}ms  p99 {:>8.3}ms  max {:>8.3}ms",
-        micros(samples[0]),
-        p(0.50),
-        mean,
-        p(0.99),
-        micros(samples[samples.len() - 1]),
-    );
+/// CLOCK_MONOTONIC in seconds, comparable with the launcher's timestamp.
+fn monotonic() -> f64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: `ts` is a valid, writable timespec for the duration of the call.
+    unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+    ts.tv_sec as f64 + ts.tv_nsec as f64 / 1e9
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let process_start = Instant::now();
+fn ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1e3
+}
 
-    // Cold path: the very first time through, before any caches are warm.
-    let cold = Instant::now();
+async fn ready() -> Result<Session, Box<dyn std::error::Error>> {
     let agent = build_agent("bench-key")?;
-    let cold_build = cold.elapsed();
-    let cold = Instant::now();
     let engine = Engine::new();
     let session = engine.create(agent);
-    let cold_create = cold.elapsed();
-    let cold = Instant::now();
     session.start().await?;
-    let cold_start = cold.elapsed();
-    let cold_total = process_start.elapsed();
+    Ok(session)
+}
 
-    if std::env::var_os("STARTUP_BENCH_COLD_ONLY").is_some() {
-        println!("cold total {:.3}ms", cold_total.as_secs_f64() * 1e3);
-        return Ok(());
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let main_entry = monotonic();
+    let started = Instant::now();
+
+    let step = Instant::now();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let runtime_built = step.elapsed();
+
+    if std::env::args().any(|arg| arg == "--warm") {
+        return runtime.block_on(warm());
     }
 
-    let mut build = Vec::with_capacity(ITERATIONS);
-    let mut engine_new = Vec::with_capacity(ITERATIONS);
-    let mut create = Vec::with_capacity(ITERATIONS);
-    let mut start = Vec::with_capacity(ITERATIONS);
-    let mut total = Vec::with_capacity(ITERATIONS);
+    let step = Instant::now();
+    let agent = build_agent("bench-key")?;
+    let agent_built = step.elapsed();
 
+    let step = Instant::now();
+    let engine = Engine::new();
+    let session = engine.create(agent);
+    let session_created = step.elapsed();
+
+    let step = Instant::now();
+    runtime.block_on(session.start())?;
+    let session_started = step.elapsed();
+
+    let in_process = started.elapsed();
+
+    println!("main_entry_monotonic {main_entry:.6}");
+    println!("tokio_runtime_ms     {:.3}", ms(runtime_built));
+    println!("agent_build_ms       {:.3}", ms(agent_built));
+    println!("session_create_ms    {:.3}", ms(session_created));
+    println!("session_start_ms     {:.3}", ms(session_started));
+    println!("main_to_ready_ms     {:.3}", ms(in_process));
+    println!("ready_monotonic      {:.6}", monotonic());
+
+    // Stop at ready: no model call, and no teardown in the measured window.
+    std::process::exit(0);
+}
+
+async fn warm() -> Result<(), Box<dyn std::error::Error>> {
+    let mut samples = Vec::with_capacity(ITERATIONS);
     for _ in 0..ITERATIONS {
-        let all = Instant::now();
         let step = Instant::now();
-        let agent = build_agent("bench-key")?;
-        build.push(step.elapsed());
-        let step = Instant::now();
-        let engine = Engine::new();
-        engine_new.push(step.elapsed());
-        let step = Instant::now();
-        let session = engine.create(agent);
-        create.push(step.elapsed());
-        let step = Instant::now();
-        session.start().await?;
-        start.push(step.elapsed());
-        total.push(all.elapsed());
+        let session = ready().await?;
+        samples.push(step.elapsed());
+        drop(session);
     }
-
-    println!("iterations: {ITERATIONS}\n");
-    println!("cold (first pass in a fresh process)");
+    samples.sort_unstable();
+    let mean = samples.iter().sum::<Duration>().as_secs_f64() * 1e3 / samples.len() as f64;
+    let at = |quantile: f64| ms(samples[((samples.len() - 1) as f64 * quantile) as usize]);
     println!(
-        "  Agent::build           {:>8.3}ms",
-        cold_build.as_secs_f64() * 1e3
+        "warm ready (excludes tokio runtime, {ITERATIONS} iterations): min {:.3}ms p50 {:.3}ms mean {mean:.3}ms p99 {:.3}ms",
+        ms(samples[0]),
+        at(0.50),
+        at(0.99),
     );
-    println!(
-        "  Engine::new + create   {:>8.3}ms",
-        cold_create.as_secs_f64() * 1e3
-    );
-    println!(
-        "  Session::start         {:>8.3}ms",
-        cold_start.as_secs_f64() * 1e3
-    );
-    println!(
-        "  total                  {:>8.3}ms",
-        cold_total.as_secs_f64() * 1e3
-    );
-    println!();
-    report("Agent::build", build);
-    report("Engine::new", engine_new);
-    report("Engine::create", create);
-    report("Session::start", start);
-    report("ready-to-send (total)", total);
     Ok(())
 }

--- a/examples/everruns-support-agent/src/bin/startup_launcher.c
+++ b/examples/everruns-support-agent/src/bin/startup_launcher.c
@@ -1,0 +1,22 @@
+/* Prints a CLOCK_MONOTONIC timestamp and execs the benchmark binary, so the
+ * exec and dynamic-linking cost before main() is attributable.
+ *   cc -O2 -o startup_launcher startup_launcher.c
+ *   ./startup_launcher ./target/release/startup_bench
+ */
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    fprintf(stderr, "usage: %s <binary> [args...]\n", argv[0]);
+    return 2;
+  }
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  printf("exec_monotonic       %.6f\n", ts.tv_sec + ts.tv_nsec / 1e9);
+  fflush(stdout);
+  execv(argv[1], &argv[1]);
+  perror("execv");
+  return 127;
+}


### PR DESCRIPTION
## What changed

Creating a Framework agent and getting a session ready to accept a message is
~3.5x faster. Two costs that had no reason to be on that path were moved off it:

- **Provider HTTP clients are resolved per request, not in driver constructors.**
  The clients are already process-wide `OnceLock` singletons, so holding one in a
  driver struct bought nothing but made every driver construction pay the first
  build — which loads the platform trust store. Anthropic, the OpenAI and
  OpenResponses protocol drivers, Gemini, the OpenAI embeddings driver, and the
  Turbopuffer store now call the shared accessor at request time.
- **A session's broadcast channel is allocated on first subscribe.** `broadcast::channel`
  preallocates all `capacity` slots up front (~1.5 MB at 4096), which was the single
  largest cost of creating a session — paid by every session, including the many that
  nobody ever subscribes to. It is now created on the first `subscribe()`.

The deferral of the client build also deferred `install_default_crypto_provider`,
which the client build calls. That is harmless (the install still runs inside the
client's `OnceLock`, before any TLS config exists) but it moved the process-wide
rustls backend choice (EVE-924) off the startup path, where products expect it
settled, and made `crates/everruns/tests/tls_startup.rs` pass vacuously. The
constructors now install it explicitly — 7.7 µs, against the 5.3 ms client build
they no longer pull in.

Two public accessors change shape: `OpenAIProtocolChatDriver::client()` and
`OpenResponsesProtocolChatDriver::client()` return `Client` by value instead of
`&Client`. A `reqwest::Client` is an `Arc` handle, so subclass drivers still share
one connection pool.

The first two commits add the benchmark used to measure all of this
(`examples/everruns-support-agent/src/bin/startup_bench.rs`, plus a small C launcher
that timestamps before `execv` so exec and dynamic-linking time is attributable).

## Why

Nothing in agent construction needs a TLS trust store or a megabyte of event slots.
Both were incidental: a client cached in a struct that was already a singleton, and
a channel eagerly sized for a subscriber that may never arrive. For an embedding
application that builds an agent per request or per task, this is pure fixed overhead
on every one.

## Before / After

Release build, same container, `startup_launcher` + `startup_bench`, three cold runs
each. Baseline is `origin/main` with the same benchmark binary.

| | before (main) | after |
|---|---|---|
| exec → ready | 3.82 / 3.59 / 3.61 ms | **2.35 / 2.30 / 2.12 ms** |
| main → ready | 2.24 / 1.93 / 2.02 ms | **0.64 / 0.59 / 0.50 ms** |
| `Agent::build` | 1.20 / 1.04 / 1.06 ms | **0.26 / 0.16 / 0.14 ms** |
| `Engine::create` | 0.71 / 0.57 / 0.66 ms | **0.017 / 0.013 / 0.025 ms** |

Per constructor, measured directly:

| | before | after |
|---|---|---|
| `OpenAIProtocolChatDriver::new` | 0.83–0.92 ms | **0.000 ms** |
| `TurbopufferVectorStore::new` | 0.72–0.80 ms | **0.000 ms** |
| `install_default_crypto_provider` (restored) | — | 0.0077 ms first call, 0.0033 ms after |

The win is cold-start. Steady state is unchanged, as expected — 500 iterations in one
process, the singletons already populated and the allocator's arenas warm:

```
before: min 0.030ms p50 0.032ms mean 0.038ms p99 0.062ms
after:  min 0.020ms p50 0.022ms mean 0.024ms p99 0.044ms
```

Separately from latency, a session that nobody subscribes to no longer holds ~1.5 MB
of broadcast slots — a structural consequence of the diff, not measured here.

## Risk

- **Low**
- The behavioral edge is the broadcast channel: events emitted before anyone subscribes
  are not delivered. That was already true — a `broadcast` subscriber only receives
  what is sent after it subscribes — so eager and lazy allocation are observationally
  identical, and `docs/framework/canonical-events.md` already documents the live stream
  as non-replaying with `Session::history()` as the recovery path. A test now pins it
  (`subscriber_after_earlier_events_still_observes_later_ones`).
- The `client()` signature change is source-breaking for any out-of-tree driver that
  binds the result as `&Client`. All in-tree callers are updated; the workspace builds
  clean with `-D warnings`.
- Resolving the client per request costs a `OnceLock` read and an `Arc` clone. The
  first request in a process now pays the ~5 ms trust-store build inline, ahead of a
  network round trip that dominates it.

## Security

- **Threat categories reviewed:** TM-API (SSRF via provider base URL), TM-LLM (provider
  key handling), TM-DOS (resource exhaustion), TM-OBS (event delivery).
- **Findings and resolutions:**
  - *TM-API-013 — no change in posture.* The drivers resolve the same
    `driver_helpers::shared_*_http_client()` singletons, which are built through
    `harden_builder` (redirects disabled, SSRF-guarding DNS resolver). Only the moment
    of resolution moved; the hardening is inside the `OnceLock` initializer and cannot
    be bypassed. The rationale comment that documented this lived on the deleted client
    field in `openresponses_protocol.rs`; it is moved onto the accessor that now resolves
    it rather than dropped.
  - *EVE-924 — regression found and fixed in this PR.* See "What changed"; the backend
    choice is explicitly installed at construction again.
  - *TM-LLM — unchanged.* API keys are still held per driver/store and applied per
    request; no key moves into a shared or longer-lived structure, and no new value
    reaches logs or errors. `non_2xx_fails_closed_without_leaking_api_key` still passes.
  - *TM-DOS — improved.* The change removes a ~1.5 MB per-session allocation that
    previously happened whether or not anyone observed the session. Nothing becomes
    unbounded: the channel is still created with the same fixed capacity, once.
  - *TM-OBS — no new exposure.* Emission with no channel is a no-op, matching the
    existing "no subscriber is not a failed sink" contract that
    `no_subscriber_is_a_noop_not_a_closed_sink_failure` covers.
- No `THREAT[...]` mitigation in the touched files is affected; none of them guard the
  construction path.

## Follow-ups

- `BedrockAuth::new` builds an AWS SDK client eagerly, so it still pays a client build
  on the startup path. It is not a process-wide singleton — it is keyed to a credential
  — so deferring it needs a credential-keyed cache rather than this PR's one-line move.
  Deferred as a distinct change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — all 51 checks completed green on `653afa1`, no `ci:skip-*` labels set, `CI Opt-Out Policy` passed
- [x] All review comments addressed (code change or written reasoning) — no review comments were left

https://claude.ai/code/session_01FKqikR6V3C4PXiP2E2ji6H