### PR TITLE
chore(release): prepare v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,242 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-09-09
+
+### Highlights
+
+- **~3.5x faster agent startup** - Agent startup-to-ready latency cut by roughly 3.5x ([#3486](https://github.com/everruns/everruns/pull/3486)).
+- **MCP URL-mode elicitation with a consent pause** - MCP elicitation now works in URL mode on both sides, with an explicit consent pause surfaced in the UI ([#3354](https://github.com/everruns/everruns/pull/3354)).
+- **Gen-AI and OpenInference trace conventions** - Observability now emits Gen-AI agent and OpenInference trace conventions for standard agent tracing ([#3353](https://github.com/everruns/everruns/pull/3353)).
+- **Expanded model catalog** - Added OpenAI GPT-6 Astra, Claude Fable 5.1, and Muse Spark 1.3 profiles with live-matrix coverage ([#3363](https://github.com/everruns/everruns/pull/3363), [#3351](https://github.com/everruns/everruns/pull/3351), [#3352](https://github.com/everruns/everruns/pull/3352)).
+- **Broad provider wire-contract hardening** - A large sweep of driver and provider fixes plus expanded contract tests across Anthropic, OpenAI, Gemini, OpenRouter, Bedrock, MAI, Meta, and Fireworks, tightening streaming, usage, reasoning, and request-shaping behavior.
+
+### What's Changed
+
+- fix(release): cascade-bump integration crates and gate the publish cone ([#3286](https://github.com/everruns/everruns/pull/3286)) by [@chaliy](https://github.com/chaliy)
+- fix(release): republish everruns facade as 0.19.1 ([#3287](https://github.com/everruns/everruns/pull/3287)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): gate postgres integration on all provider crates ([#3289](https://github.com/everruns/everruns/pull/3289)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump distroless/cc-debian12 in /crates/worker ([#3282](https://github.com/everruns/everruns/pull/3282)) by [@dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump distroless/cc-debian12 in /crates/server ([#3281](https://github.com/everruns/everruns/pull/3281)) by [@dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump distroless/cc-debian12 in /docker ([#3283](https://github.com/everruns/everruns/pull/3283)) by [@dependabot](https://github.com/apps/dependabot)
+- fix(ci): stop reporting a pass for runs that executed nothing ([#3290](https://github.com/everruns/everruns/pull/3290)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump the cargo group with 2 updates ([#3284](https://github.com/everruns/everruns/pull/3284)) by [@dependabot](https://github.com/apps/dependabot)
+- fix(reasoning): persist Chat Completions reasoning, and run the tests CI never ran ([#3288](https://github.com/everruns/everruns/pull/3288)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): repair the workflow tests that first ran on main ([#3291](https://github.com/everruns/everruns/pull/3291)) by [@chaliy](https://github.com/chaliy)
+- chore(agents): drop the GitHub API token guidance ([#3293](https://github.com/everruns/everruns/pull/3293)) by [@chaliy](https://github.com/chaliy)
+- chore(models): retire sunset models and seed Bedrock Claude 5 ([#3294](https://github.com/everruns/everruns/pull/3294)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): lock the chat composer when no model is available ([#3295](https://github.com/everruns/everruns/pull/3295)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): stop losing the first message of a fresh chat thread ([#3296](https://github.com/everruns/everruns/pull/3296)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): give the live provider matrix its own job and gate ([#3297](https://github.com/everruns/everruns/pull/3297)) by [@chaliy](https://github.com/chaliy)
+- chore(models): retire Claude Sonnet 4 ([#3298](https://github.com/everruns/everruns/pull/3298)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): skip live workflow tests when the provider account is blocked ([#3299](https://github.com/everruns/everruns/pull/3299)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): surface live-provider skips in a green run's step summary ([#3300](https://github.com/everruns/everruns/pull/3300)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): echo live-provider skips into the job log, not just the summary ([#3301](https://github.com/everruns/everruns/pull/3301)) by [@chaliy](https://github.com/chaliy)
+- fix(scripts): install just without the GitHub API so cloud sessions get it ([#3302](https://github.com/everruns/everruns/pull/3302)) by [@chaliy](https://github.com/chaliy)
+- fix(scripts): verify gh and caddy checksums in the cloud bootstrap ([#3303](https://github.com/everruns/everruns/pull/3303)) by [@chaliy](https://github.com/chaliy)
+- fix(evals): send typed ReasoningEffort from the generic eval subject ([#3331](https://github.com/everruns/everruns/pull/3331)) by [@claude](https://github.com/apps/claude)
+- fix(everruns): disable repository Git hooks in LocalGitWorkspaceProvider ([#3304](https://github.com/everruns/everruns/pull/3304)) by [@chaliy](https://github.com/chaliy)
+- fix(engine): prevent replay of provider-executed OpenRouter server tools ([#3305](https://github.com/everruns/everruns/pull/3305)) by [@chaliy](https://github.com/chaliy)
+- fix(tools): validate arguments and enable strict schemas ([#3336](https://github.com/everruns/everruns/pull/3336)) by [@chaliy](https://github.com/chaliy)
+- fix(budgets): price retrieval embeddings ([#3307](https://github.com/everruns/everruns/pull/3307)) by [@chaliy](https://github.com/chaliy)
+- fix(core): exclude MCP connection secrets from serialized execution snapshots ([#3308](https://github.com/everruns/everruns/pull/3308)) by [@chaliy](https://github.com/chaliy)
+- fix(host): enforce `user_prompt_submit` hooks on finalized steering ([#3309](https://github.com/everruns/everruns/pull/3309)) by [@chaliy](https://github.com/chaliy)
+- fix(server): enforce org-effective feature flags for gRPC platform commands ([#3311](https://github.com/everruns/everruns/pull/3311)) by [@chaliy](https://github.com/chaliy)
+- Preserve generation estimates when folding compaction cost (fix budgets) ([#3306](https://github.com/everruns/everruns/pull/3306)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): redact security alert report details ([#3318](https://github.com/everruns/everruns/pull/3318)) by [@chaliy](https://github.com/chaliy)
+- fix(host): secure local event log opening ([#3310](https://github.com/everruns/everruns/pull/3310)) by [@chaliy](https://github.com/chaliy)
+- fix(agents): enforce HARNESS_VIEW before exposing effective_harness metadata ([#3312](https://github.com/everruns/everruns/pull/3312)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): gate skills server prefetch ([#3319](https://github.com/everruns/everruns/pull/3319)) by [@chaliy](https://github.com/chaliy)
+- fix(dev): generate private per-prefix KEK for local persisted provider keys ([#3320](https://github.com/everruns/everruns/pull/3320)) by [@chaliy](https://github.com/chaliy)
+- fix(server): require admin for organization updates ([#3315](https://github.com/everruns/everruns/pull/3315)) by [@chaliy](https://github.com/chaliy)
+- fix(providers): protect managed model catalogs ([#3316](https://github.com/everruns/everruns/pull/3316)) by [@chaliy](https://github.com/chaliy)
+- fix(guardrails): make secret-leak judge stage-agnostic and add test ([#3317](https://github.com/everruns/everruns/pull/3317)) by [@chaliy](https://github.com/chaliy)
+- fix(evals): surface event stream lag ([#3322](https://github.com/everruns/everruns/pull/3322)) by [@chaliy](https://github.com/chaliy)
+- fix(everruns): preserve Agent Plugins v1 name validation during capability validation ([#3323](https://github.com/everruns/everruns/pull/3323)) by [@chaliy](https://github.com/chaliy)
+- fix(cli): use versioned /v1/ API paths for plugins, skills, and knowledge-bases ([#3326](https://github.com/everruns/everruns/pull/3326)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): include knowledge job in aggregate Build Check ([#3328](https://github.com/everruns/everruns/pull/3328)) by [@chaliy](https://github.com/chaliy)
+- fix(models): preserve verbosity in merged profiles ([#3329](https://github.com/everruns/everruns/pull/3329)) by [@chaliy](https://github.com/chaliy)
+- fix(host): prevent concurrent JSONL writer corruption ([#3325](https://github.com/everruns/everruns/pull/3325)) by [@chaliy](https://github.com/chaliy)
+- fix(evals): allow generic workspace writes ([#3324](https://github.com/everruns/everruns/pull/3324)) by [@chaliy](https://github.com/chaliy)
+- chore(deno): mark the Deno integration unsupported and drop its live tests ([#3335](https://github.com/everruns/everruns/pull/3335)) by [@claude](https://github.com/apps/claude)
+- fix(tests): truncate live response previews on char boundaries ([#3340](https://github.com/everruns/everruns/pull/3340)) by [@claude](https://github.com/apps/claude)
+- fix(models): allow clearing organization default model ([#3321](https://github.com/everruns/everruns/pull/3321)) by [@chaliy](https://github.com/chaliy)
+- fix(local): serialize reconnect with wake fallback ([#3327](https://github.com/everruns/everruns/pull/3327)) by [@chaliy](https://github.com/chaliy)
+- fix(everruns): split reviewed and canonical session-event surfaces ([#3313](https://github.com/everruns/everruns/pull/3313)) by [@chaliy](https://github.com/chaliy)
+- feat(events): record mid-session model changes in the transcript ([#3346](https://github.com/everruns/everruns/pull/3346)) by [@chaliy](https://github.com/chaliy)
+- fix(sessions): limit run summary utility spend ([#3330](https://github.com/everruns/everruns/pull/3330)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): keep active voice stop control enabled ([#3333](https://github.com/everruns/everruns/pull/3333)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): reject semantic model suffix fallbacks ([#3334](https://github.com/everruns/everruns/pull/3334)) by [@chaliy](https://github.com/chaliy)
+- fix(core): prevent spawn target narration spoofing ([#3337](https://github.com/everruns/everruns/pull/3337)) by [@chaliy](https://github.com/chaliy)
+- fix(server): reject git source redirects ([#3339](https://github.com/everruns/everruns/pull/3339)) by [@chaliy](https://github.com/chaliy)
+- fix(engine): guard retained reasoning output ([#3338](https://github.com/everruns/everruns/pull/3338)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): include live provider matrix in build check ([#3332](https://github.com/everruns/everruns/pull/3332)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump rust from 1.97.1-slim to 1.98.0-slim in /crates/worker ([#3343](https://github.com/everruns/everruns/pull/3343)) by [@dependabot](https://github.com/apps/dependabot)
+- chore(deps): bump rust from 1.97.1-slim-bookworm to 1.98.0-slim-bookworm in /docker ([#3344](https://github.com/everruns/everruns/pull/3344)) by [@dependabot](https://github.com/apps/dependabot)
+- fix(ui): patch browserslist advisories in the UI lockfile ([#3347](https://github.com/everruns/everruns/pull/3347)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump rust from 1.97.1-slim to 1.98.0-slim in /crates/server ([#3342](https://github.com/everruns/everruns/pull/3342)) by [@dependabot](https://github.com/apps/dependabot)
+- fix(tests): assert message-history index support, not planner choice ([#3348](https://github.com/everruns/everruns/pull/3348)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump the cargo group with 9 updates ([#3345](https://github.com/everruns/everruns/pull/3345)) by [@dependabot](https://github.com/apps/dependabot)
+- chore(deps): migrate to argon2 0.6 with a cross-version hash test ([#3349](https://github.com/everruns/everruns/pull/3349)) by [@chaliy](https://github.com/chaliy)
+- feat(models): add Claude Fable 5.1 profile, seed it, and cover it in the live matrix ([#3351](https://github.com/everruns/everruns/pull/3351)) by [@chaliy](https://github.com/chaliy)
+- feat(models): add Muse Spark 1.3 and move Meta coverage onto it ([#3352](https://github.com/everruns/everruns/pull/3352)) by [@chaliy](https://github.com/chaliy)
+- docs: lead README with framework ([`ab13179`](https://github.com/everruns/everruns/commit/ab13179f82adb5df2fd07848205d1490faff3d0d)) by [@chaliy](https://github.com/chaliy)
+- docs(readme): add Everruns banner ([#3355](https://github.com/everruns/everruns/pull/3355)) by [@chaliy](https://github.com/chaliy)
+- feat(observability): Gen-AI agent and OpenInference trace conventions ([#3353](https://github.com/everruns/everruns/pull/3353)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates ([#3357](https://github.com/everruns/everruns/pull/3357)) by [@dependabot](https://github.com/apps/dependabot)
+- docs(readme): refine framework entry point ([#3359](https://github.com/everruns/everruns/pull/3359)) by [@chaliy](https://github.com/chaliy)
+- fix(server): honour NATS_URL credentials and cut Sentry noise from prod logs ([#3356](https://github.com/everruns/everruns/pull/3356)) by [@chaliy](https://github.com/chaliy)
+- docs(observability): OpenTelemetry page, and fix the OTLP traces endpoint ([#3360](https://github.com/everruns/everruns/pull/3360)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): URL mode elicitation on both sides, with a consent pause in the UI ([#3354](https://github.com/everruns/everruns/pull/3354)) by [@chaliy](https://github.com/chaliy)
+- fix(platform): surface partial script failures and composed boolean flags ([#3358](https://github.com/everruns/everruns/pull/3358)) by [@chaliy](https://github.com/chaliy)
+- feat(examples): add runnable framework agents ([#3361](https://github.com/everruns/everruns/pull/3361)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): back off before retrying a live turn that failed transiently ([#3362](https://github.com/everruns/everruns/pull/3362)) by [@chaliy](https://github.com/chaliy)
+- feat(models): add OpenAI GPT-6 Astra profile, favorite, and live-matrix coverage ([#3363](https://github.com/everruns/everruns/pull/3363)) by [@chaliy](https://github.com/chaliy)
+- feat(examples): add real framework agent demos ([#3364](https://github.com/everruns/everruns/pull/3364)) by [@chaliy](https://github.com/chaliy)
+- feat(release): generate release cards ([#3365](https://github.com/everruns/everruns/pull/3365)) by [@chaliy](https://github.com/chaliy)
+- feat(ci): report which providers the live matrix actually exercised ([#3366](https://github.com/everruns/everruns/pull/3366)) by [@chaliy](https://github.com/chaliy)
+- fix(security): bump fast-uri override to 3.1.6 ([#3367](https://github.com/everruns/everruns/pull/3367)) by [@chaliy](https://github.com/chaliy)
+- refactor(provider): move model profiles into everruns-model-profiles crate ([#3368](https://github.com/everruns/everruns/pull/3368)) by [@chaliy](https://github.com/chaliy)
+- test: replace weak checks and fix provider URL errors ([#3369](https://github.com/everruns/everruns/pull/3369)) by [@chaliy](https://github.com/chaliy)
+- feat(brave-search): support framework capability execution ([#3370](https://github.com/everruns/everruns/pull/3370)) by [@chaliy](https://github.com/chaliy)
+- feat(examples): show useful live agent demos ([#3372](https://github.com/everruns/everruns/pull/3372)) by [@chaliy](https://github.com/chaliy)
+- chore(tests): track reviews and strengthen ARD tests ([#3373](https://github.com/everruns/everruns/pull/3373)) by [@chaliy](https://github.com/chaliy)
+- fix(core): replace stale ARD agents and improve listener tests ([#3375](https://github.com/everruns/everruns/pull/3375)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen policy and path conformance assertions ([#3376](https://github.com/everruns/everruns/pull/3376)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen event protocol assertions ([#3379](https://github.com/everruns/everruns/pull/3379)) by [@chaliy](https://github.com/chaliy)
+- test(core): cover message preservation and index boundaries ([#3380](https://github.com/everruns/everruns/pull/3380)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve workspace roots after rejected updates ([#3377](https://github.com/everruns/everruns/pull/3377)) by [@chaliy](https://github.com/chaliy)
+- test: consolidate portable contracts at their owning types ([#3378](https://github.com/everruns/everruns/pull/3378)) by [@chaliy](https://github.com/chaliy)
+- fix(daytona): preserve command paths and streamed Unicode ([#3381](https://github.com/everruns/everruns/pull/3381)) by [@chaliy](https://github.com/chaliy)
+- test(core): isolate environment fixtures and verify complete overlays ([#3382](https://github.com/everruns/everruns/pull/3382)) by [@chaliy](https://github.com/chaliy)
+- test: tighten model, CLI, and release-card coverage ([#3374](https://github.com/everruns/everruns/pull/3374)) by [@chaliy](https://github.com/chaliy)
+- test(core): isolate feature gates and deployment environment cases ([#3384](https://github.com/everruns/everruns/pull/3384)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve network policy boundaries during narrowing ([#3385](https://github.com/everruns/everruns/pull/3385)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen telemetry projection and privacy contracts ([#3386](https://github.com/everruns/everruns/pull/3386)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): reject browser-normalized external return paths ([#3388](https://github.com/everruns/everruns/pull/3388)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve tool payloads when attaching raw output ([#3387](https://github.com/everruns/everruns/pull/3387)) by [@chaliy](https://github.com/chaliy)
+- test(core): verify runtime assembly and snapshot boundaries ([#3383](https://github.com/everruns/everruns/pull/3383)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen model router boundaries and wire contracts ([#3389](https://github.com/everruns/everruns/pull/3389)) by [@chaliy](https://github.com/chaliy)
+- fix(core): align hook glob validation and strengthen boundary tests ([#3390](https://github.com/everruns/everruns/pull/3390)) by [@chaliy](https://github.com/chaliy)
+- test(evals): add opt-in harness behavior comparison ([#3371](https://github.com/everruns/everruns/pull/3371)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen file encoding and grep result contracts ([#3393](https://github.com/everruns/everruns/pull/3393)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve mount segment boundaries in grep filters ([#3392](https://github.com/everruns/everruns/pull/3392)) by [@chaliy](https://github.com/chaliy)
+- test(server): isolate message history index eligibility from planner costs ([#3394](https://github.com/everruns/everruns/pull/3394)) by [@chaliy](https://github.com/chaliy)
+- fix(server): accept reserved characters in the NATS_URL password ([#3395](https://github.com/everruns/everruns/pull/3395)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve output lines and tighten sanitizer tests ([#3396](https://github.com/everruns/everruns/pull/3396)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): accept OAuth config and strengthen domain tests ([#3398](https://github.com/everruns/everruns/pull/3398)) by [@chaliy](https://github.com/chaliy)
+- fix(core): honor narration aliases and strengthen tests ([#3397](https://github.com/everruns/everruns/pull/3397)) by [@chaliy](https://github.com/chaliy)
+- fix(tests): inventory conflicted source files only once ([#3402](https://github.com/everruns/everruns/pull/3402)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen guardrail boundaries and action coverage ([#3400](https://github.com/everruns/everruns/pull/3400)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): reject ambiguous server prefixes across routing ([#3399](https://github.com/everruns/everruns/pull/3399)) by [@chaliy](https://github.com/chaliy)
+- test(core): verify permission matrices and rule precedence ([#3401](https://github.com/everruns/everruns/pull/3401)) by [@chaliy](https://github.com/chaliy)
+- fix(skills): preserve literal and empty positional arguments ([#3403](https://github.com/everruns/everruns/pull/3403)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen capability composition coverage ([#3404](https://github.com/everruns/everruns/pull/3404)) by [@chaliy](https://github.com/chaliy)
+- fix(capabilities): validate reserved skill path boundaries ([#3406](https://github.com/everruns/everruns/pull/3406)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen output guardrail orchestration coverage ([#3407](https://github.com/everruns/everruns/pull/3407)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen citation annotation orchestration ([#3409](https://github.com/everruns/everruns/pull/3409)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen progress reporting behavior checks ([#3408](https://github.com/everruns/everruns/pull/3408)) by [@chaliy](https://github.com/chaliy)
+- fix(core): audit context reduction and prompt accounting ([#3410](https://github.com/everruns/everruns/pull/3410)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): audit typed ids and correct schema examples ([#3411](https://github.com/everruns/everruns/pull/3411)) by [@chaliy](https://github.com/chaliy)
+- fix(skills): preserve reconstructed metadata without leaks ([#3405](https://github.com/everruns/everruns/pull/3405)) by [@chaliy](https://github.com/chaliy)
+- test(core): verify completion decisions and independent budgets ([#3412](https://github.com/everruns/everruns/pull/3412)) by [@chaliy](https://github.com/chaliy)
+- fix(core): release drained wake queues and verify delivery ([#3413](https://github.com/everruns/everruns/pull/3413)) by [@chaliy](https://github.com/chaliy)
+- test(core): cover schedule limits and store failures ([#3414](https://github.com/everruns/everruns/pull/3414)) by [@chaliy](https://github.com/chaliy)
+- fix(core): serialize observed task transitions and audit tests ([#3415](https://github.com/everruns/everruns/pull/3415)) by [@chaliy](https://github.com/chaliy)
+- test(core): verify hook executor payloads and output boundaries ([#3416](https://github.com/everruns/everruns/pull/3416)) by [@chaliy](https://github.com/chaliy)
+- test(core): verify lifecycle hook ordering and failure policies ([#3417](https://github.com/everruns/everruns/pull/3417)) by [@chaliy](https://github.com/chaliy)
+- test(core): verify fingerprints and execution workspace lineage ([#3418](https://github.com/everruns/everruns/pull/3418)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen resource ownership enforcement coverage ([#3420](https://github.com/everruns/everruns/pull/3420)) by [@chaliy](https://github.com/chaliy)
+- test(core): audit plugin file ingestion boundaries ([#3421](https://github.com/everruns/everruns/pull/3421)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve trait implementation types in outlines ([#3422](https://github.com/everruns/everruns/pull/3422)) by [@chaliy](https://github.com/chaliy)
+- test(llm): accept complete opaque OpenAI reasoning artifacts ([#3424](https://github.com/everruns/everruns/pull/3424)) by [@chaliy](https://github.com/chaliy)
+- test(core): remove no-value service tests and verify requests ([#3419](https://github.com/everruns/everruns/pull/3419)) by [@chaliy](https://github.com/chaliy)
+- test(core): strengthen exec output and MCP proxy contracts ([#3426](https://github.com/everruns/everruns/pull/3426)) by [@chaliy](https://github.com/chaliy)
+- fix(core): audit plugin compilation and allow IPv6 loopback ([#3423](https://github.com/everruns/everruns/pull/3423)) by [@chaliy](https://github.com/chaliy)
+- fix(core): preserve concurrent task artifacts and strengthen lifecycle tests ([#3427](https://github.com/everruns/everruns/pull/3427)) by [@chaliy](https://github.com/chaliy)
+- test(provider): strengthen credential precedence and document contracts ([#3428](https://github.com/everruns/everruns/pull/3428)) by [@chaliy](https://github.com/chaliy)
+- test(core): audit support contracts and reduce fixture overhead ([#3425](https://github.com/everruns/everruns/pull/3425)) by [@chaliy](https://github.com/chaliy)
+- test(core): consolidate private fixture tests around stored behavior ([#3429](https://github.com/everruns/everruns/pull/3429)) by [@chaliy](https://github.com/chaliy)
+- test(provider): verify complete streaming call assembly and flush behavior ([#3430](https://github.com/everruns/everruns/pull/3430)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): preserve tool schema values during strict conversion ([#3431](https://github.com/everruns/everruns/pull/3431)) by [@chaliy](https://github.com/chaliy)
+- test(provider): consolidate model and driver identity contracts ([#3433](https://github.com/everruns/everruns/pull/3433)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): clear stale error disclosure metadata ([#3435](https://github.com/everruns/everruns/pull/3435)) by [@chaliy](https://github.com/chaliy)
+- test(provider): strengthen error classification contracts ([#3436](https://github.com/everruns/everruns/pull/3436)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): join endpoint paths on complete URL segments ([#3432](https://github.com/everruns/everruns/pull/3432)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): preserve stream recovery time budgets ([#3438](https://github.com/everruns/everruns/pull/3438)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): remove stale duplicate request headers on override ([#3434](https://github.com/everruns/everruns/pull/3434)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): enforce retry deadlines and numeric bounds ([#3437](https://github.com/everruns/everruns/pull/3437)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): validate discovery targets and ranking limits ([#3439](https://github.com/everruns/everruns/pull/3439)) by [@chaliy](https://github.com/chaliy)
+- test(provider): strengthen tool wire contracts ([#3440](https://github.com/everruns/everruns/pull/3440)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): preserve operation query parameters ([#3444](https://github.com/everruns/everruns/pull/3444)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): enforce OpenResponses wire contracts ([#3441](https://github.com/everruns/everruns/pull/3441)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): preserve OpenRouter routing price units ([#3442](https://github.com/everruns/everruns/pull/3442)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): preserve chat completion terminal reasons ([#3443](https://github.com/everruns/everruns/pull/3443)) by [@chaliy](https://github.com/chaliy)
+- fix(gemini): preserve tool replay and complete streamed frames ([#3446](https://github.com/everruns/everruns/pull/3446)) by [@chaliy](https://github.com/chaliy)
+- test(provider): verify responses authentication on the wire ([#3445](https://github.com/everruns/everruns/pull/3445)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): preserve reported usage in streamed chat ([#3450](https://github.com/everruns/everruns/pull/3450)) by [@chaliy](https://github.com/chaliy)
+- test(provider): replace weak and duplicate registry tests ([#3449](https://github.com/everruns/everruns/pull/3449)) by [@chaliy](https://github.com/chaliy)
+- fix(gemini): preserve streamed unicode and schema literals ([#3451](https://github.com/everruns/everruns/pull/3451)) by [@chaliy](https://github.com/chaliy)
+- test(meta): verify complete provider wire contracts ([#3452](https://github.com/everruns/everruns/pull/3452)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): stabilize Responses tool-search cache identity ([#3447](https://github.com/everruns/everruns/pull/3447)) by [@chaliy](https://github.com/chaliy)
+- fix(deps): move off the yanked wnaf 0.14.0 ([#3457](https://github.com/everruns/everruns/pull/3457)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): absorb one transient Doppler CLI install failure ([#3458](https://github.com/everruns/everruns/pull/3458)) by [@chaliy](https://github.com/chaliy)
+- fix(bedrock): preserve unsigned tool argument precision ([#3453](https://github.com/everruns/everruns/pull/3453)) by [@chaliy](https://github.com/chaliy)
+- test(mai): verify auth precedence and token refresh contracts ([#3454](https://github.com/everruns/everruns/pull/3454)) by [@chaliy](https://github.com/chaliy)
+- test(daytona): verify dead sessions without real-time waits ([#3455](https://github.com/everruns/everruns/pull/3455)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): preserve query parameters in compact requests ([#3448](https://github.com/everruns/everruns/pull/3448)) by [@chaliy](https://github.com/chaliy)
+- fix(mai): preserve endpoint queries and review driver contracts ([#3456](https://github.com/everruns/everruns/pull/3456)) by [@chaliy](https://github.com/chaliy)
+- test(openrouter): verify request decoration and retry metadata ([#3468](https://github.com/everruns/everruns/pull/3468)) by [@chaliy](https://github.com/chaliy)
+- feat(engine): preserve Astra effort through compaction ([#3391](https://github.com/everruns/everruns/pull/3391)) by [@chaliy](https://github.com/chaliy)
+- fix(openrouter): initialize reasoning state in test fixture ([#3473](https://github.com/everruns/everruns/pull/3473)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): preserve file previews with stronger test contracts ([#3475](https://github.com/everruns/everruns/pull/3475)) by [@chaliy](https://github.com/chaliy)
+- fix(openrouter): reject invalid discovered model prices ([#3469](https://github.com/everruns/everruns/pull/3469)) by [@chaliy](https://github.com/chaliy)
+- fix(anthropic): complete unit-test review and preserve metadata ([#3472](https://github.com/everruns/everruns/pull/3472)) by [@chaliy](https://github.com/chaliy)
+- fix(openai): expose stateful continuation and verify contracts ([#3471](https://github.com/everruns/everruns/pull/3471)) by [@chaliy](https://github.com/chaliy)
+- test(ci): run nested driver suites and enforce enumeration ([#3467](https://github.com/everruns/everruns/pull/3467)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): preserve discovery origin before authentication ([#3470](https://github.com/everruns/everruns/pull/3470)) by [@chaliy](https://github.com/chaliy)
+- fix(web-fetch): reject invalid methods and tighten tests ([#3476](https://github.com/everruns/everruns/pull/3476)) by [@chaliy](https://github.com/chaliy)
+- test(core): preserve reasoning controls in reduction contracts ([#3477](https://github.com/everruns/everruns/pull/3477)) by [@chaliy](https://github.com/chaliy)
+- chore(tests): revalidate reviews after state field changes ([#3481](https://github.com/everruns/everruns/pull/3481)) by [@chaliy](https://github.com/chaliy)
+- test(provider): cover native compaction replay state ([#3478](https://github.com/everruns/everruns/pull/3478)) by [@chaliy](https://github.com/chaliy)
+- fix(test-support): emit one mock completion per response ([#3479](https://github.com/everruns/everruns/pull/3479)) by [@chaliy](https://github.com/chaliy)
+- perf(everruns): cut agent startup to ready by ~3.5x ([#3486](https://github.com/everruns/everruns/pull/3486)) by [@chaliy](https://github.com/chaliy)
+
+### Crate Releases
+
+Independently versioned crates published this cycle. This release carries broad behavior fixes,
+additive features, and a re-export-preserving crate extraction; no public item was removed,
+renamed, or re-signatured, so every existing crate takes the smallest compatible (patch) bump.
+
+New crate (first crates.io publish):
+- `everruns-model-profiles` 0.1.0 - dependency-light leaf crate holding model identity, profile, and service-taxonomy types, extracted from `everruns-provider` (which re-exports them for source compatibility) ([#3368](https://github.com/everruns/everruns/pull/3368))
+
+Patch bumps (behavior/additive, non-breaking):
+- `everruns-core` 0.19.0 → 0.19.1
+- `everruns-provider` 0.20.0 → 0.20.1
+- `everruns-host` 0.20.3 → 0.20.4
+- `everruns-mcp` 0.19.2 → 0.19.3
+- `everruns-engine` 0.18.2 → 0.18.3
+- `everruns-builtins` 0.18.5 → 0.18.6
+- `everruns-platform` 0.19.1 → 0.19.2
+- `everruns-cli` 0.18.2 → 0.18.3
+- `everruns-test-support` 0.18.4 → 0.18.5
+- `everruns-turbopuffer` 0.18.2 → 0.18.3
+- `everruns-anthropic` 0.18.2 → 0.18.3
+- `everruns-bedrock` 0.18.2 → 0.18.3
+- `everruns-fireworks` 0.18.2 → 0.18.3
+- `everruns-gemini` 0.18.2 → 0.18.3
+- `everruns-llmsim` 0.18.4 → 0.18.5
+- `everruns-mai` 0.18.2 → 0.18.3
+- `everruns-meta` 0.18.2 → 0.18.3
+- `everruns-openai` 0.18.2 → 0.18.3
+- `everruns-openrouter` 0.18.2 → 0.18.3
+
+Already republished in-cycle: `everruns` (facade) 0.19.0 → 0.19.1 ([#3287](https://github.com/everruns/everruns/pull/3287)).
+
+No public-contract change this cycle (not bumped): `everruns-ard`, `everruns-capability`, `everruns-macros`.
+
+
 ## [0.22.0] - 2026-08-25
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,13 +106,13 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -276,7 +276,7 @@ checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "password-hash",
 ]
 
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+checksum = "24a8ec73eb862508b7041723c89386365894b4e7d9f6998bf1b8529e5b0ee254"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -379,7 +379,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+checksum = "ef47857a1d4488b528f4a5d5715fa7c3300820897824152234d3fa22b1426657"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.142.0"
+version = "1.143.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4844547a354fb4e41895f4c9c423e7a7de13e3b2adc3f3493a2f2d8aa397c294"
+checksum = "492a63a8e903a7b8f7c77537ef05fc75d71ba268cf23a0eee41fb6f0da605029"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+checksum = "9c054752dd9e4dc73d0b75748c99ac2d0feafbf2f25c7b0516f03a3534161223"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+checksum = "8f94d16e797ec62cd999fc9d5942b48fa7050c3093ddadff48e4d7528d16fcb9"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+checksum = "209f3a6d82a6e9e5f94abbed94c7a26e1c052341002bf57a5fb5481f625896fc"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -874,7 +874,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "ed25519-dalek 3.0.0",
- "fancy-regex 0.19.0",
+ "fancy-regex 0.19.1",
  "flate2",
  "futures-core",
  "futures-util",
@@ -888,7 +888,7 @@ dependencies = [
  "os_display",
  "rand 0.10.2",
  "regex",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustls",
  "serde",
  "serde_json",
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "buffa"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e6224bc4ee1f189ad257120c156fb05f95b826f5369d620b24984476c200a"
+checksum = "a92f2f5df67a9d5ccfc65237bfc954c56328aee40a04a9b92381ecba370be246"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-codegen"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2074a9c2f76b2ebe6af40f7bf67b6a19d6ce3663253ef2a55124dc93f38b230e"
+checksum = "bb4bea10ef85ea3d06a20412c67cb612527feb25f33367eab850139441fb5dd9"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-descriptor"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964d735e0b06cb24fa15a68c5aa99549abcc7e0bbeb76298f2fec57912fb79c1"
+checksum = "2b7dd79a6898e70dac8adae959c8ad2cae51ed96397935c91c996280cedcb55e"
 dependencies = [
  "buffa",
  "rustversion",
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1181,7 +1181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -1251,7 +1251,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1289,9 +1289,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "100590da849306918656ffbb22576bbdfc1382b50ad10d1d50ec177d3b205fb2"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "connectrpc"
@@ -1470,6 +1470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1553,18 +1559,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1572,27 +1578,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+checksum = "03e8bd762f7479489c70ed6c768ddca99d7296857de437a68dcb2a94365b3fae"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crossterm"
@@ -1710,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -1751,7 +1757,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1762,7 +1768,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1853,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid 0.10.2",
  "zeroize",
@@ -1934,7 +1940,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1970,7 +1976,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der 0.8.1",
+ "der 0.8.2",
  "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
@@ -2075,11 +2081,17 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "2a7a45518d2863d18aa47f4a0cf9faec2aa4304cc09df5e41299f276b3ad135e"
 dependencies = [
  "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
 ]
 
 [[package]]
@@ -2200,14 +2212,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
  "eventsource-stream",
  "everruns-provider",
  "futures",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2226,7 +2238,7 @@ dependencies = [
  "everruns-platform",
  "everruns-provider",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2237,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2255,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2283,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2296,7 +2308,7 @@ dependencies = [
  "hostname",
  "ignore",
  "notify",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2337,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2374,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2399,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2418,13 +2430,13 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-provider",
  "futures",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2438,19 +2450,19 @@ dependencies = [
  "everruns",
  "everruns-anthropic",
  "libc",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "tokio",
 ]
 
 [[package]]
 name = "everruns-gemini"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "eventsource-stream",
  "everruns-provider",
  "futures",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2460,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2486,7 +2498,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand 0.10.2",
  "regex",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2543,7 +2555,7 @@ dependencies = [
  "everruns-platform",
  "everruns-provider",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2563,7 +2575,7 @@ dependencies = [
  "everruns-provider",
  "futures-util",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustls",
  "rustls-native-certs",
  "serde",
@@ -2583,7 +2595,7 @@ dependencies = [
  "everruns-platform",
  "everruns-provider",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2601,7 +2613,7 @@ dependencies = [
  "everruns-platform",
  "everruns-provider",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tempfile",
@@ -2625,7 +2637,7 @@ dependencies = [
  "hickory-resolver",
  "http 1.5.0",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustls",
  "rustls-native-certs",
  "serde",
@@ -2661,7 +2673,7 @@ dependencies = [
  "everruns-core",
  "everruns-provider",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2687,7 +2699,7 @@ dependencies = [
  "inventory",
  "prost",
  "protox",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustls",
  "rustls-native-certs",
  "serde",
@@ -2728,7 +2740,7 @@ dependencies = [
  "everruns-core",
  "everruns-provider",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2764,7 +2776,7 @@ dependencies = [
  "everruns-provider",
  "futures",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2779,7 +2791,7 @@ dependencies = [
  "async-trait",
  "everruns-core",
  "everruns-provider",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2795,7 +2807,7 @@ dependencies = [
  "everruns-platform",
  "everruns-provider",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2811,7 +2823,7 @@ dependencies = [
  "everruns-platform",
  "everruns-provider",
  "inventory",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2843,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "chrono",
  "everruns-capability",
@@ -2864,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2896,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2914,18 +2926,18 @@ version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "everruns-mai"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-provider",
  "futures",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2935,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2959,12 +2971,12 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-provider",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2982,12 +2994,12 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-provider",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2997,13 +3009,13 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-provider",
  "futures",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "tokio",
@@ -3012,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3037,7 +3049,7 @@ dependencies = [
  "include_dir",
  "inventory",
  "jsonschema",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3054,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3068,7 +3080,7 @@ dependencies = [
  "http 1.5.0",
  "rand 0.10.2",
  "regex",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustls",
  "serde",
  "serde_json",
@@ -3104,7 +3116,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "getrandom 0.4.3",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "secrecy",
  "serde",
  "serde_json",
@@ -3116,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3185,7 +3197,7 @@ dependencies = [
  "prost-types",
  "rand 0.10.2",
  "regex",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rusqlite",
  "serde",
  "serde_html_form 0.4.1",
@@ -3204,7 +3216,7 @@ dependencies = [
  "tokio-tungstenite",
  "tonic",
  "tower",
- "tower-http 0.7.0",
+ "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3225,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-test-support"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3248,14 +3260,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "async-trait",
  "everruns-core",
  "everruns-platform",
  "everruns-provider",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -3266,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3305,7 +3317,7 @@ dependencies = [
  "everruns-provider",
  "mimalloc",
  "prost-types",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "serde",
  "serde_json",
  "sqlx",
@@ -3324,7 +3336,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -3351,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
@@ -3389,7 +3401,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "schemars",
  "serde",
  "serde_json",
@@ -3446,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "finl_unicode"
@@ -3562,7 +3574,7 @@ dependencies = [
  "futures",
  "log",
  "parking_lot",
- "rand 0.8.7",
+ "rand 0.8.8",
  "redis-protocol",
  "rustls",
  "rustls-native-certs",
@@ -3670,7 +3682,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3845,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3917,9 +3929,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -3929,9 +3941,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+checksum = "084e7bd6a377435d568f652153e571b50970d7ccc1d1eeec0519f834632287e1"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3953,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+checksum = "7e2da0694c15b44c6f68a6b05e0233617008c54080e31d6eb848d858a9c5b38d"
 dependencies = [
  "data-encoding",
  "idna",
@@ -3973,9 +3985,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+checksum = "0e4f9f4603319422d482738f3f6fe5aac03157fdbfed1cd85a3ff45adb09072f"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4107,9 +4119,9 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
 dependencies = [
  "subtle",
  "typenum",
@@ -4392,9 +4404,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -4478,7 +4490,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4505,9 +4517,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 dependencies = [
  "serde",
 ]
@@ -4544,9 +4556,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7561783b20275a6c9cb576e39208b0c635f34ef14357f1f05a2927a774f3adec"
+checksum = "f72ba7158fe9fc1bc4baace1b71e6d0d3d27c6839dd87dc1f233dd408f5dd85b"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -4555,9 +4567,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d801b0b57f10064c4e9f5a4f6c97d0ccf62649b179ff8ac23cd494a3120ee9"
+checksum = "4be2f53207ffb1313a2d2ad819cfa8bfaa7936cb85a110eda10fd5da822cec94"
 dependencies = [
  "bstr",
  "bytes",
@@ -4574,9 +4586,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7941c8de9c591052050550f228c62ef80d3ecbd84c330f5c454bc8ebb7a04089"
+checksum = "9f90e485abfd3189510c996e77be55056a51038b0fa5805e6c97b5dcf0d9ab55"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -4703,9 +4715,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4714,15 +4726,15 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.52.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee5867390f14ee43278d8d05d3af5f5314eeccb4684e6049033f2ba4ae3d4ae"
+checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
 dependencies = [
  "ahash",
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex 0.19.0",
+ "fancy-regex 0.19.1",
  "fraction",
  "getrandom 0.3.4",
  "itoa",
@@ -4814,7 +4826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -5039,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.2"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5054,18 +5066,18 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lua-src"
-version = "550.1.1"
+version = "551.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c110c2fa33f34e0de05448e1f3eb2e0631e7a69e2d8ae1586cffc9fc9f9949"
+checksum = "d400ffef0e3d4d29287092bdc5a276d0bf468b2c69709d5bab0d469312d9f947"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "luajit-src"
-version = "210.7.2+b925b3e"
+version = "210.7.3+1ee778a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920cf654b23d217c550ceea57c32cd2a413ea27b6d47ed77b5ee0cf655adefa6"
+checksum = "869665372263eb337b14f480cfb864b89f12eade4eb42cb415f71517b4a67572"
 dependencies = [
  "cc",
  "which",
@@ -5218,9 +5230,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -5230,9 +5242,9 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad72ffa037cf5970c9860674f32f703fda25d86cf217475fe7a79c5f9961bcaa"
+checksum = "d96e5d00f19d8c46c71ceaced99593b90c31c57aa1fe2cb3e93a8b1698eedba9"
 dependencies = [
  "bstr",
  "either",
@@ -5249,9 +5261,9 @@ dependencies = [
 
 [[package]]
 name = "mlua-sys"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92136787b906d4e55cfe96cd6c62e010bb1a56889d0d6cf83eb016dbad07576b"
+checksum = "b806d7ade031f5d6607eae3e283fb034cb795a76247dd0d1ba753c8c42debccf"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5315,6 +5327,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "multiversion"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edb7f0ff51249dfda9ab96b5823695e15a052dc15074c9dbf3d118afaf2c201"
+dependencies = [
+ "multiversion-macros",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5356,7 +5396,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "log",
- "rand 0.8.7",
+ "rand 0.8.8",
  "signatory",
 ]
 
@@ -5417,7 +5457,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
 dependencies = [
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -5562,7 +5602,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5623,7 +5663,7 @@ dependencies = [
  "bytes",
  "http 1.5.0",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
 ]
 
 [[package]]
@@ -5638,7 +5678,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
+ "reqwest 0.13.5",
  "thiserror 2.0.20",
 ]
 
@@ -5840,9 +5880,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5850,9 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5860,9 +5900,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
 dependencies = [
  "pest",
  "pest_meta",
@@ -5873,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
 dependencies = [
  "pest",
 ]
@@ -5938,7 +5978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -6020,7 +6060,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.1",
+ "der 0.8.2",
  "spki 0.8.0",
 ]
 
@@ -6050,7 +6090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "universal-hash",
 ]
 
@@ -6062,9 +6102,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -6452,9 +6492,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6717,7 +6757,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6829,11 +6869,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -6987,9 +7027,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7122,7 +7162,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7145,7 +7185,7 @@ checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
  "ctutils",
- "der 0.8.1",
+ "der 0.8.2",
  "hybrid-array",
  "subtle",
  "zeroize",
@@ -7233,7 +7273,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7244,7 +7284,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7315,7 +7355,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7382,7 +7422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -7410,7 +7450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -7572,9 +7612,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -7655,7 +7695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.1",
+ "der 0.8.2",
 ]
 
 [[package]]
@@ -7943,9 +7983,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8011,10 +8051,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-triple"
-version = "1.0.1"
+name = "target-features"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
+
+[[package]]
+name = "target-tuple"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876fef147edbcbddc8ac5cbbba92c7b86519e314e86638596c09673b2ed01e7f"
 
 [[package]]
 name = "tempfile"
@@ -8162,7 +8208,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -8218,9 +8264,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8256,14 +8302,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -8324,7 +8370,7 @@ dependencies = [
  "futures-sink",
  "http 1.5.0",
  "httparse",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -8334,9 +8380,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -8496,9 +8542,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+checksum = "08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
@@ -8617,9 +8663,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+checksum = "ca0d1bf6fdd806e43ae5198f82f527056d359def39e54e67a0f478ac09dac081"
 
 [[package]]
 name = "tree-sitter-python"
@@ -8659,15 +8705,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+checksum = "c0cabaa10be1917331a313866bd94526343e03c77bcf69144b62b072ad35d47c"
 dependencies = [
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
- "target-triple",
+ "target-tuple",
  "termcolor",
  "toml",
 ]
@@ -9001,9 +9047,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9014,9 +9060,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9024,9 +9070,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9034,22 +9080,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -9082,9 +9128,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9207,9 +9253,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]
@@ -9583,18 +9629,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9672,7 +9718,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -9724,18 +9770,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "64d80649ab6db9d9f6f9c80a40becd948eda4714a0a5ac8c4d157a32231c7882"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -199,18 +199,18 @@ futures-util = "0.3"
 # Everruns SDK
 everruns-sdk = "0.2.0"
 everruns-capability = { path = "crates/capability", version = "0.18.1", default-features = false }
-everruns-builtins = { path = "crates/builtins", version = "0.18.5" }
-everruns-core = { path = "crates/core", version = "0.19.0" }
-everruns-engine = { path = "crates/engine", version = "0.18.2" }
-everruns-host = { path = "crates/host", version = "0.20.3" }
-everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.4", default-features = false }
+everruns-builtins = { path = "crates/builtins", version = "0.18.6" }
+everruns-core = { path = "crates/core", version = "0.19.1" }
+everruns-engine = { path = "crates/engine", version = "0.18.3" }
+everruns-host = { path = "crates/host", version = "0.20.4" }
+everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.5", default-features = false }
 everruns-test-support = { path = "crates/test-support", version = "0.18.2", default-features = false }
-everruns-platform = { path = "crates/platform", version = "0.19.1" }
-everruns-provider = { path = "crates/provider", version = "0.20.0", default-features = false }
+everruns-platform = { path = "crates/platform", version = "0.19.2" }
+everruns-provider = { path = "crates/provider", version = "0.20.1", default-features = false }
 everruns-model-profiles = { path = "crates/model-profiles", version = "0.1.0" }
-everruns-mcp = { path = "crates/mcp", version = "0.19.2" }
+everruns-mcp = { path = "crates/mcp", version = "0.19.3" }
 everruns-ard = { path = "crates/ard", version = "0.18.0" }
-everruns-openai = { path = "crates/drivers/openai", version = "0.18.2" }
+everruns-openai = { path = "crates/drivers/openai", version = "0.18.3" }
 everruns = { path = "crates/everruns", version = "0.18.0" }
 everruns-macros = { path = "crates/macros", version = "0.18.1" }
 everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-builtins"
-version = "0.18.5"
+version = "0.18.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ categories = ["development-tools", "asynchronous"]
 # execution values. It owns no host, platform, database, network, process, or
 # interpreter implementation edge.
 everruns-capability.workspace = true
-everruns-core = { path = "../core", version = "0.19.0", default-features = false }
+everruns-core = { path = "../core", version = "0.19.1", default-features = false }
 everruns-provider.workspace = true
 
 async-trait.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "everruns-cli"
 readme = "README.md"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-core"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/drivers/anthropic/Cargo.toml
+++ b/crates/drivers/anthropic/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-anthropic"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -43,7 +43,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.20.0" }
+everruns-provider = { path = "../../provider", version = "0.20.1" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/bedrock/Cargo.toml
+++ b/crates/drivers/bedrock/Cargo.toml
@@ -8,7 +8,7 @@ name = "everruns-bedrock"
 readme = "README.md"
 keywords = ["agent", "llm", "ai", "bedrock", "aws"]
 categories = ["api-bindings", "asynchronous"]
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -39,7 +39,7 @@ base64.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.20.0" }
+everruns-provider = { path = "../../provider", version = "0.20.1" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/drivers/fireworks/Cargo.toml
+++ b/crates/drivers/fireworks/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-fireworks"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -35,7 +35,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { version = "0.20.0", path = "../../provider" }
+everruns-provider = { version = "0.20.1", path = "../../provider" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures discovery requests;

--- a/crates/drivers/gemini/Cargo.toml
+++ b/crates/drivers/gemini/Cargo.toml
@@ -7,7 +7,7 @@ name = "everruns-gemini"
 readme = "README.md"
 keywords = ["agent", "llm", "ai", "gemini", "google"]
 categories = ["api-bindings", "asynchronous"]
-version = "0.18.2"
+version = "0.18.3"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -40,7 +40,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.20.0" }
+everruns-provider = { path = "../../provider", version = "0.20.1" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/llmsim/Cargo.toml
+++ b/crates/drivers/llmsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-llmsim"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/drivers/mai/Cargo.toml
+++ b/crates/drivers/mai/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-mai"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { version = "0.20.0", path = "../../provider" }
+everruns-provider = { version = "0.20.1", path = "../../provider" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver/token requests;

--- a/crates/drivers/meta/Cargo.toml
+++ b/crates/drivers/meta/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "everruns-meta"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -24,7 +24,7 @@ serde.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.20.0" }
+everruns-provider = { path = "../../provider", version = "0.20.1" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/openai/Cargo.toml
+++ b/crates/drivers/openai/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-openai"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.20.0" }
+everruns-provider = { path = "../../provider", version = "0.20.1" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/openrouter/Cargo.toml
+++ b/crates/drivers/openrouter/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-openrouter"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -34,7 +34,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.20.0" }
+everruns-provider = { path = "../../provider", version = "0.20.1" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "everruns-engine"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "everruns-host"
-version = "0.20.3"
+version = "0.20.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-mcp"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "everruns-platform"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "everruns-provider"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "everruns-test-support"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -44,7 +44,7 @@ fixtures = ["dep:everruns-platform"]
 host = ["dep:everruns-host", "sim", "everruns-llmsim/host"]
 
 [dependencies]
-everruns-core = { path = "../core", version = "0.19.0", default-features = false }
+everruns-core = { path = "../core", version = "0.19.1", default-features = false }
 everruns-engine.workspace = true
 everruns-capability.workspace = true
 everruns-provider.workspace = true

--- a/crates/turbopuffer/Cargo.toml
+++ b/crates/turbopuffer/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-turbopuffer"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -88,7 +88,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -105,9 +105,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -364,7 +364,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -390,9 +390,9 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -422,9 +422,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -462,18 +462,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crypto-common"
@@ -579,7 +579,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -865,7 +865,7 @@ version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -931,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -954,9 +954,9 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -1083,7 +1083,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1248,18 +1248,18 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1407,9 +1407,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1478,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "itoa"
@@ -1649,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1769,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -1819,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -2025,7 +2025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -2184,9 +2184,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -2234,22 +2234,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2306,11 +2306,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2454,9 +2454,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2516,7 +2516,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2587,7 +2587,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2598,7 +2598,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2759,9 +2759,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
@@ -2819,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2878,7 +2878,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2893,9 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2931,14 +2931,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -2959,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3152,9 +3152,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3221,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3234,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3244,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3254,22 +3254,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3540,18 +3540,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3598,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3609,13 +3609,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -157,9 +157,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -210,9 +210,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -241,18 +241,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crypto-common"
@@ -288,7 +288,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -481,17 +481,25 @@ version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "everruns-model-profiles"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "everruns-provider"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "chrono",
+ "everruns-model-profiles",
  "futures",
  "hex",
  "rand 0.10.2",
@@ -508,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -519,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fluent-uri"
@@ -551,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
 dependencies = [
  "num",
  "num-bigint",
@@ -625,7 +633,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -721,9 +729,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
 dependencies = [
  "typenum",
 ]
@@ -822,9 +830,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -874,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -899,9 +907,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -910,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.50.1"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b6bb4e22283b09119c671e57ac6a185e9a0c70c31585e56b729b626d877753"
+checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
 dependencies = [
  "ahash",
  "bytecount",
@@ -921,7 +929,6 @@ dependencies = [
  "fancy-regex",
  "fraction",
  "getrandom 0.3.4",
- "idna",
  "itoa",
  "jsonschema-regex",
  "jsonschema-value",
@@ -939,18 +946,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.50.1"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497fbf3b1ca53b1e23a253f636e88e7a2031387388b8140199a0f240fcadf647"
+checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.50.1"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84ca3f39446973a810fc90fc2645ada8c24284f6deb009c78b776813973887d"
+checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
 dependencies = [
  "ahash",
  "bytecount",
@@ -958,6 +965,7 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "serde_json",
+ "zmij",
 ]
 
 [[package]]
@@ -1001,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
@@ -1019,9 +1027,9 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -1164,7 +1172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -1236,9 +1244,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -1277,29 +1285,29 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "referencing"
-version = "0.50.1"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0a32a2a2c2d7dd0ee54705b5fd641be73037271928f68e9b0e7205b71c9d30"
+checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -1384,7 +1392,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1420,7 +1428,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1431,7 +1439,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1525,9 +1533,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
@@ -1579,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1616,7 +1624,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1654,7 +1662,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1672,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1784,9 +1792,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -1844,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1857,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1867,22 +1875,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2048,18 +2056,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2100,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2111,13 +2119,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/release-card.yml
+++ b/release-card.yml
@@ -1,19 +1,19 @@
-version: 0.22.0
-date: 2026-08-25
+version: 0.23.0
+date: 2026-09-09
 headline:
-  - Reasoning,
-  - in order.
+  - Faster starts,
+  - broader reach.
 summary:
-  - Model reasoning now replays as
-  - it happened—clearer to inspect,
-  - easier to trust.
+  - Agents reach ready ~3.5x faster,
+  - MCP gains consent-paused URL elicitation,
+  - and tracing speaks Gen-AI and OpenInference.
 highlights:
-  - title: Ordered reasoning artifacts
-    description: Reasoning replays in production order with its classification visible.
-    source: "#3276"
-  - title: Bounded batch file reads
-    description: Read several guarded files in one policy-aware call.
-    source: "#3275"
-  - title: Cleaner replay events
-    description: Required summaries in; redundant recovery noise out.
-    source: "#3280"
+  - title: ~3.5x faster agent startup
+    description: Startup-to-ready latency cut by roughly 3.5x.
+    source: "#3486"
+  - title: MCP URL-mode elicitation
+    description: Two-sided URL elicitation with a consent pause in the UI.
+    source: "#3354"
+  - title: Gen-AI & OpenInference tracing
+    description: Observability emits standard Gen-AI agent and OpenInference conventions.
+    source: "#3353"

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -192,9 +192,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -313,18 +313,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crypto-common"
@@ -360,7 +360,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -571,7 +571,7 @@ version = "0.18.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fluent-uri"
@@ -804,7 +804,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -954,9 +954,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
 dependencies = [
  "typenum",
 ]
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.1"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "itoa"
@@ -1255,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1387,9 +1387,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -1748,7 +1748,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1799,11 +1799,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "16a1cfa75cc186dd73d5818e510e042e40927bccc9c236b061cea97e1eb08029"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1995,7 +1995,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2060,7 +2060,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2071,7 +2071,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2253,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2299,7 +2299,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2314,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2352,14 +2352,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -2380,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2618,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2631,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2641,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2651,22 +2651,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2686,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2937,18 +2937,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3012,7 +3012,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Cuts the **v0.23.0** product release (from 0.22.0). This is a maintenance-and-hardening release covering 188 commits since v0.22.0.

Product version bumps (`Cargo.toml`, `apps/ui/package.json`), a new `CHANGELOG.md` section, refreshed `Cargo.lock`, and an updated `release-card.yml`.

User-facing highlights:
- **~3.5x faster agent startup** ([#3486](https://github.com/everruns/everruns/pull/3486))
- **MCP URL-mode elicitation with a UI consent pause** ([#3354](https://github.com/everruns/everruns/pull/3354))
- **Gen-AI & OpenInference trace conventions** ([#3353](https://github.com/everruns/everruns/pull/3353))
- **Expanded model catalog**: GPT-6 Astra, Claude Fable 5.1, Muse Spark 1.3
- **Broad provider/driver wire-contract hardening** plus a large expansion of contract tests

## Why

Regular release cadence: publish the accumulated work on `main` since v0.22.0 as a tagged product release, and keep the independently versioned crates in sync with their changed contracts.

## Library crate release audit (mandatory)

Each published crate was checked for public-contract change since its last crates.io release (judging exported API / behavior / features, not churn). `cargo-semver-checks` was not runnable in this environment; the classification is by change nature. All changes this cycle are behavior fixes, additive features, or a re-export-preserving crate extraction — **no public item was removed, renamed, or re-signatured**, so every existing crate takes the smallest compatible (patch) bump. No breaking bumps → no dependency cone to close (`strand-check` stays green).

**New crate (first publish):**
- `everruns-model-profiles` 0.1.0 — leaf crate extracted from `everruns-provider` ([#3368](https://github.com/everruns/everruns/pull/3368)); provider re-exports the types for source compatibility.

**Patch bumps (behavior/additive, non-breaking):** `everruns-core` 0.19.0→0.19.1, `everruns-provider` 0.20.0→0.20.1, `everruns-host` 0.20.3→0.20.4, `everruns-mcp` 0.19.2→0.19.3, `everruns-engine` 0.18.2→0.18.3, `everruns-builtins` 0.18.5→0.18.6, `everruns-platform` 0.19.1→0.19.2, `everruns-cli` 0.18.2→0.18.3, `everruns-test-support` 0.18.4→0.18.5, `everruns-turbopuffer` 0.18.2→0.18.3, and drivers `everruns-anthropic`/`everruns-bedrock`/`everruns-fireworks`/`everruns-gemini`/`everruns-llmsim`/`everruns-mai`/`everruns-meta`/`everruns-openai`/`everruns-openrouter` 0.18.2→0.18.3 (llmsim 0.18.4→0.18.5).

**Already republished in-cycle:** `everruns` (facade) 0.19.0→0.19.1 ([#3287](https://github.com/everruns/everruns/pull/3287)).

**No public-contract change (not bumped):** `everruns-ard`, `everruns-capability`, `everruns-macros`.

Internal pins re-synced with `scripts/sync-publish-pin-versions.py --write` (19 pins; verified for 41 packages).

## Before / After

Release-metadata only; no runtime behavior changes in this PR. Validations run locally:
- `bash scripts/lib/check-migration-ordering.sh` → `migrations sequential (001..125)`
- `python3 scripts/sync-publish-pin-versions.py --write` → `independent crate versions and pins verified for 41 package(s)`
- `cargo metadata --locked` → resolves clean
- `pnpm run release-card --check --expect-version 0.23.0` → `release card v0.23.0 is valid`

Release readiness: latest `integration-live-sweep.yml` run on `main` is green (run #36).

## Risk
- Low
- Version/metadata-only change. On merge, the release tag, GitHub Release, Docker images, and CLI binaries follow automatically; the Crate Release workflow publishes the crate versions above (and `strand-check` validates the cone).

## Security
- Threat categories reviewed: No security-relevant code changes — version strings, changelog, lockfile, and release card only.
- Findings and resolutions: none.

## Follow-ups
- If authoritative semver classification is desired, run `cargo semver-checks` per bumped crate; the changes are additive/behavior-only, so patch is expected to hold.

## Checklist
- [x] Tests added or updated (N/A — release metadata)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGW5YASDekcC64dHLbHu9m

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGW5YASDekcC64dHLbHu9m)_