### PR TITLE
chore(release): prepare v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.23.0] - 2026-09-09
+## [0.24.0] - 2026-09-09
 
 ### Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "everruns-capability",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/release-card.yml
+++ b/release-card.yml
@@ -1,4 +1,4 @@
-version: 0.23.0
+version: 0.24.0
 date: 2026-09-09
 headline:
   - Faster starts,


### PR DESCRIPTION
## What changed

Cuts the **v0.24.0** product release. This carries the work already merged in the 0.23.0 release-prep PR (#3487) — 188 commits since v0.22.0 — but bumps the **product** version to **0.24.0** because the `v0.23.0` git tag was already taken.

Only the product version moves here: `Cargo.toml` (`workspace.package.version`), `apps/ui/package.json`, the `CHANGELOG.md` section heading, `release-card.yml`, and the refreshed `Cargo.lock`. The independently versioned crate releases were cut in #3487 and are unchanged.

## Why — the 0.23.0 tag collision

#3487 prepared 0.23.0 and merged green, but the **Release** workflow then failed with `Tag v0.23.0 already exists`. Investigation:
- `v0.23.0` is an **orphaned git tag** pointing to `bf23034f` (PR #3321), a mid-development commit where `Cargo.toml` was still `0.22.0` — not a release-prep commit.
- There is **no GitHub Release** for `v0.23.0` (404), no release assets, no Docker images, no CLI binaries — the Release workflow never completed for it. Nothing consumes the tag (the SaaS submodule pins a different commit).
- The tag could not be deleted (GitHub returned 403 — `v*` tags are protected).

Since the tag name is burned and can't be removed, the clean, non-destructive fix is to release the next free version. Tags exist through `v0.23.0`, so this release is **v0.24.0**. Product `0.23.0` is skipped; it was never a real release.

## Before / After

Release-metadata only; no runtime behavior changes. Validations run locally:
- `cargo generate-lockfile` → `everruns-server`/`everruns-worker` at `0.24.0`
- `bash scripts/lib/check-migration-ordering.sh` → `migrations sequential (001..125)`
- `pnpm run release-card --check --expect-version 0.24.0` → `release card v0.24.0 is valid`

## Library crate release audit

Unchanged from #3487 and already merged: new `everruns-model-profiles` 0.1.0 plus non-breaking patch bumps across `everruns-core`, `-provider`, `-host`, `-mcp`, `-engine`, `-builtins`, `-platform`, `-cli`, `-test-support`, `-turbopuffer`, and the driver crates. No public item removed/renamed/re-signatured → no cone to close. This product bump does not affect crate versions.

## Risk
- Low
- Version/metadata-only. On merge the Release workflow creates `v0.24.0` (no tag conflict), the GitHub Release, Docker images, and CLI binaries.

## Security
- Threat categories reviewed: No security-relevant code changes — version strings, changelog, lockfile, release card only.
- Findings and resolutions: none.

## Follow-ups
- The orphaned `v0.23.0` tag (→ `bf23034f`) remains and can't be deleted without elevated tag permissions; harmless (no release/artifacts). A maintainer with tag-delete rights may remove it for tidiness.

## Checklist
- [x] Tests added or updated (N/A — release metadata)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGW5YASDekcC64dHLbHu9m

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGW5YASDekcC64dHLbHu9m)_