### PR TITLE
docs(framework): show the essential code on each example page

### DIFF
--- a/docs/framework/examples/bashkit-repo-agent.md
+++ b/docs/framework/examples/bashkit-repo-agent.md
@@ -30,3 +30,39 @@ turn ends, the host re-reads the directory and prints one check per claim the
 agent made, exiting non-zero if the release did not land. That check list is
 what makes the example a test of the execution runtime rather than of the
 model's summary.
+
+## The important part
+
+```rust
+let agent = Agent::builder()
+    .name("bashkit-repo-agent")
+    // Tell the agent what the sandbox is, so it reaches for a portable
+    // alternative instead of retrying a builtin Bashkit does not implement.
+    .instructions("You are a release engineer for the repository mounted at \
+        /workspace. The bash tool is your only way to see or change anything. \
+        It is a sandboxed Bash interpreter, so there is no network, no host \
+        filesystem, and no git; work with the files in the working tree.")
+    .provider(OpenAI::from_env()?)
+    .model("gpt-5.6-terra")
+    // One real host directory becomes the session's `/workspace`. Every shell
+    // path resolves under it — nothing above it is addressable.
+    .workspace(&working_copy)
+    // Writing is an explicit opt-in; the default policy is read-only.
+    .workspace_policy(WorkspacePolicy::read_write())
+    // The only capability: a sandboxed shell over that workspace. No file
+    // tools, so every read and edit in the transcript is a bash command.
+    .capability(BashkitShell::new())
+    .build()?;
+
+let session = Engine::new().create(agent);
+// The example streams session events to print each shell script and its
+// output; `session.send_and_wait(request)` is the version without the observer.
+session.send_and_wait(&release_request(&release_date)).await?;
+
+// The turn is not the result — the directory is. The host re-reads the working
+// copy and checks each claim, so a confident summary over an unchanged tree
+// fails loudly.
+for check in verify(&working_copy, &release_date) {
+    println!("[{}] {}", if check.passed { "ok" } else { "FAIL" }, check.label);
+}
+```

--- a/docs/framework/examples/coding-review-agent.md
+++ b/docs/framework/examples/coding-review-agent.md
@@ -19,3 +19,32 @@ ANTHROPIC_API_KEY=... cargo run -p everruns-coding-review-agent
 ```
 
 Pass a different review instruction after `--` to change the review focus.
+
+## The important part
+
+```rust
+// The tool is what the reviewer is allowed to see. It serves one embedded
+// file and rejects every other path, so the model cannot turn a review
+// request into a file-read primitive over the host.
+#[everruns::tool]
+/// Read the self-contained code change that this example asks the agent to review.
+async fn inspect_change(path: String) -> Result<String, String> {
+    if path != "sample_payment.rs" {
+        return Err("This self-contained example exposes only sample_payment.rs.".into());
+    }
+    Ok(include_str!("../sample_payment.rs").into())
+}
+
+let agent = Agent::builder()
+    .name("coding-review-agent")
+    // The instructions carry the review standard, not the code: what counts as
+    // a finding, and what each finding must include.
+    .instructions("You are a code reviewer. Use inspect_change before reviewing \
+        the sample. Report only material, reproducible findings. For each finding, \
+        explain impact, point to the relevant code, and name a focused validation.")
+    // Anthropic is a driver crate; the agent builder takes any provider.
+    .provider(everruns_anthropic::provider("anthropic", api_key))
+    .model("claude-sonnet-5")
+    .tool(inspect_change())
+    .build()?;
+```

--- a/docs/framework/examples/everruns-support-agent.md
+++ b/docs/framework/examples/everruns-support-agent.md
@@ -23,3 +23,39 @@ agent for another Framework support issue.
 
 The documentation tool reads Markdown content from the official repository and
 returns source links alongside that evidence.
+
+## The important part
+
+```rust
+// A tool is ordinary async Rust, so it can reach the network. This one maps a
+// topic to a documentation page and returns the page with its source link, so
+// the model answers from fetched evidence rather than memory.
+#[everruns::tool]
+/// Read authoritative Framework documentation for a support topic.
+async fn search_docs(topic: String) -> Result<String, String> {
+    let topic = topic.to_lowercase();
+    let page = if topic.contains("custom") {
+        "custom-providers"
+    } else if topic.contains("provider") || topic.contains("model") {
+        "models-and-providers"
+    } else {
+        "examples"
+    };
+    // ... fetch https://raw.githubusercontent.com/.../docs/framework/{page}.md,
+    // strip the frontmatter, and cap the body at 16 000 characters so one tool
+    // result cannot swallow the context window.
+    Ok(format!("Source: https://docs.everruns.com/framework/{page}/\n{content}"))
+}
+
+let agent = Agent::builder()
+    .name("everruns-support-agent")
+    // Instructions that separate evidence from hypothesis are what make the
+    // fetched documentation useful rather than decorative.
+    .instructions("You support Everruns Framework users. Use search_docs before \
+        answering. Separate evidence from hypotheses and give the smallest safe \
+        next step with relevant documentation links.")
+    .provider(everruns_anthropic::provider("anthropic", api_key))
+    .model("claude-opus-5")
+    .tool(search_docs())
+    .build()?;
+```

--- a/docs/framework/examples/incident-commander-agent.md
+++ b/docs/framework/examples/incident-commander-agent.md
@@ -23,3 +23,33 @@ status updates and the instructions prohibit unsupported production claims.
 
 Updates are appended to `incident.log` in the example folder, retained across
 runs, and ignored by Git. No production infrastructure is modified.
+
+## The important part
+
+```rust
+// The tool validates before it writes. A tool is the right place for limits
+// the model must not be able to talk its way past.
+#[everruns::tool]
+/// Record a bounded, non-sensitive incident status update.
+async fn record_incident_update(update: String) -> Result<String, String> {
+    if update.len() > 500 {
+        return Err("Keep incident updates under 500 characters.".into());
+    }
+    // Appends one newline-free line to the example's incident.log and returns
+    // what was written, so the model's next turn sees the effect it had.
+    append_update(&manifest_dir().join("incident.log"), &update)
+}
+
+let agent = Agent::builder()
+    .name("incident-commander-agent")
+    // The last sentence is the one that matters during an incident: the model
+    // may only claim a change happened if a tool result says it did.
+    .instructions("You are an incident commander. Record a concise incident \
+        update before answering. State known impact, unknowns, owners, and safe \
+        next actions. Never claim that a production change occurred unless the \
+        tool result says so.")
+    .provider(everruns_meta::provider("meta", api_key))
+    .model("muse-spark-1.3")
+    .tool(record_incident_update())
+    .build()?;
+```

--- a/docs/framework/examples/research-agent.md
+++ b/docs/framework/examples/research-agent.md
@@ -20,3 +20,28 @@ OPENROUTER_API_KEY=... BRAVE_SEARCH_API_KEY=... cargo run -p everruns-research-a
 
 The example caps each query at five results. Use a web-fetch integration when a
 research task needs to inspect the contents of a particular source.
+
+## The important part
+
+```rust
+// Brave Search arrives as a capability, not a hand-written tool: a capability
+// packages one or more tools, their schemas, and their configuration behind a
+// single value you attach to the agent.
+let search = BraveSearch::from_env()?; // reads BRAVE_SEARCH_API_KEY
+
+let agent = Agent::builder()
+    .name("research-agent")
+    // The citation discipline lives in the instructions: use the tool first,
+    // cite what it returned, and label anything that goes beyond it.
+    .instructions("You are a research agent. Use brave_web_search before \
+        answering factual questions. Cite the returned source URLs, distinguish \
+        facts from inferences, and say when the evidence is incomplete.")
+    // The model is an OpenRouter slug; the provider is its own driver crate.
+    .provider(everruns_openrouter::provider("openrouter", api_key))
+    .model("z-ai/glm-5.2")
+    .capability(search) // `.capability(..)` for packaged tools, `.tool(..)` for one function
+    .build()?;
+```
+
+Capabilities and typed tools compose freely on the same builder, so an agent
+can carry a search integration and a bespoke function side by side.

--- a/docs/framework/examples/support-agent.md
+++ b/docs/framework/examples/support-agent.md
@@ -21,3 +21,41 @@ OPENAI_API_KEY=... cargo run -p everruns-support-agent
 The included `cust_demo` record is deliberately non-sensitive. Supply a
 different question after `--` to try another support flow. CI builds the agent
 with a placeholder credential; running the binary makes the real model call.
+
+## The important part
+
+The whole agent, minus the CLI plumbing:
+
+```rust
+// `#[everruns::tool]` derives the tool from the function itself: the doc
+// comment becomes the description the model reads, and the typed parameters
+// become its JSON schema. Returning `Err` hands the model a recoverable
+// error instead of failing the turn.
+#[everruns::tool]
+/// Look up the safe, public support state for a demo customer.
+async fn lookup_customer(customer_id: String) -> Result<String, String> {
+    match customer_id.as_str() {
+        "cust_demo" => Ok("cust_demo: verified account; password reset completed; \
+            no active lockout; next safe action is to retry in a private browser window.".into()),
+        // The tool is the trust boundary: it answers for one known record and
+        // refuses everything else, so no model input can widen the lookup.
+        _ => Err("Only the self-contained cust_demo record is available in this example.".into()),
+    }
+}
+
+let agent = Agent::builder()
+    .name("support-agent")
+    .instructions("You are a customer-support agent. Use lookup_customer before \
+        answering account questions. Do not expose private data.")
+    .provider(OpenAI::new(api_key)) // provider and model are chosen separately
+    .model("gpt-5.6-terra")
+    .tool(lookup_customer()) // calling the macro-generated constructor attaches it
+    .build()?;
+
+// The Engine owns runtime resources and snapshots the agent into a session.
+let session = Engine::new().create(agent);
+// The example subscribes to session events so it can print each tool call as
+// it happens; when you only want the answer, one call does it:
+let turn = session.send_and_wait(question).await?;
+println!("{}", turn.response);
+```


### PR DESCRIPTION
## What changed

Each of the six Framework example pages now carries an **The important part** section: a commented excerpt of the code that teaches the pattern, instead of only a link to the source and prose about it.

What each excerpt shows, chosen per example rather than templated:

- **Support Agent** — `#[everruns::tool]` deriving schema and description from the function, the tool as the trust boundary (one known record, everything else refused), the builder, and `Engine`/session.
- **Coding Review Agent** — a tool that serves one embedded file and rejects every other path, plus instructions that carry the review standard.
- **Everruns Support Agent** — a tool that reaches the network, maps a topic to a page, returns evidence with its source link, and caps the body so one result cannot swallow the context window.
- **Research Agent** — a packaged capability (`BraveSearch`) attached with `.capability(..)`, contrasted with `.tool(..)` for a single function, and the citation discipline living in the instructions.
- **Incident Commander Agent** — validation inside the tool, and the instruction that the model may not claim a production change unless a tool result says so.
- **Bashkit Repo Agent** — `.workspace(..)` + `WorkspacePolicy::read_write()` + `BashkitShell` as the only capability, and the host-side verification that makes the directory, not the summary, the result.

Excerpts are trimmed to the teaching path — argument parsing, the terminal observer, and long function bodies are elided, with the elisions marked — and each notes where the example streams session events rather than calling `send_and_wait`.

## Why

The pages described the examples but showed none of them, so a reader evaluating the Framework had to leave the docs and open GitHub to see what building an agent looks like. The shape of an agent is small enough to fit on the page.

## Before / After

Before — every page: intro prose, screencast, run command. No code.

After — the same, plus (Support Agent, abridged):

```rust
#[everruns::tool]
/// Look up the safe, public support state for a demo customer.
async fn lookup_customer(customer_id: String) -> Result<String, String> {
    match customer_id.as_str() {
        "cust_demo" => Ok("cust_demo: verified account; ...".into()),
        // The tool is the trust boundary: it answers for one known record and
        // refuses everything else, so no model input can widen the lookup.
        _ => Err("Only the self-contained cust_demo record is available in this example.".into()),
    }
}

let agent = Agent::builder()
    .name("support-agent")
    .instructions("You are a customer-support agent. Use lookup_customer before ...")
    .provider(OpenAI::new(api_key)) // provider and model are chosen separately
    .model("gpt-5.6-terra")
    .tool(lookup_customer()) // calling the macro-generated constructor attaches it
    .build()?;
```

Rendered and checked on the Cloudflare Pages preview for this branch: <https://d86936cd.everruns.pages.dev/framework/examples/support-agent/>

Evidence:

- `cd apps/docs && pnpm run check` — 0 errors, 0 warnings (2 pre-existing hints in an unrelated script).
- `cd apps/docs && pnpm run build` — clean; all six example pages render.
- `just pre-push` — 22/22 green.
- CI on `67a9ac4`: green, with the Rust jobs correctly skipped by the change filter for a docs-only diff; Docs Build & Check, Shell Tests, CodeQL and the Pages deploy all passed, and the `Build Check` gate confirms every required job passed. No CI opt-out label was used.
- Each excerpt was diffed against the example's `src/main.rs` by hand: identifiers, model ids, instruction text, and control flow match the source, and anything condensed is marked as elided rather than reworded into something the code does not do.

## Risk

- Low
- Documentation content only; no code, config, or infrastructure changes. The failure mode is drift — an excerpt outliving a change to its example. Excerpts were kept to the stable surface (builder shape, tool signature, capability wiring) to make that unlikely, and each page still links to the source as the authority.

## Security

- No security-relevant code changes: the diff is six Markdown files under `docs/`, adding illustrative snippets. No credential values appear — the excerpts show `api_key` as a parameter and `OpenAI::from_env()`, matching the sources.

## Follow-ups

No follow-ups. (A separate change extracting the examples' duplicated terminal observer into a shared crate follows on its own PR; it does not affect these pages.)

## Checklist
- [ ] Tests added or updated — n/a, docs-only; the docs check and build cover it
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed — the only comment is the Cloudflare Pages deploy bot reporting a successful preview

https://claude.ai/code/session_01V5a8GtuVKpzZTpxF68wXpc