### PR TITLE
fix(release): republish the everruns facade and close the under-bump hole

### DIFF
--- a/.agents/commands/prepare-crate-release.md
+++ b/.agents/commands/prepare-crate-release.md
@@ -31,7 +31,14 @@ dependants from the graph:
 python3 scripts/sync-publish-pin-versions.py --write
 python3 scripts/sync-publish-pin-versions.py --check
 cargo generate-lockfile
+python3 scripts/check-semver-bumps.py
 ```
+
+`check-semver-bumps.py` re-runs `cargo-semver-checks` over exactly the packages this change
+releases and fails a bump that is too small for the API it carries. Run it here, after the version
+is set — an under-bump is unrecoverable once published, because crates.io versions are immutable
+and yanking the new one breaks everything already released against it. CI enforces the same script
+in the **Crate Semver Bumps** job, so a bump it rejects will not merge.
 
 Review every rewritten pin. If dependant crates require public changes rather
 than a compatible dependency baseline update, release them separately after

--- a/.agents/commands/prepare-release.md
+++ b/.agents/commands/prepare-release.md
@@ -50,7 +50,12 @@ crates.io package silently drifts behind its source.
    (`0.18.0 → 0.18.1`) and the **minor** component only for a breaking change (`0.18.0 → 0.19.0`; the
    minor is the breaking slot for `0.x` crates). Do not round crates up to the product version for
    tidiness. Then run `/prepare-crate-release` to bump the package and run
-   `python3 scripts/sync-publish-pin-versions.py --write`. Tagging and publishing are automated: on
+   `python3 scripts/sync-publish-pin-versions.py --write`. With every bump set, run
+   `python3 scripts/check-semver-bumps.py` — it re-runs `cargo-semver-checks` over exactly the
+   crates this change releases and fails a bump that is too small for the API it carries. Do this
+   before opening the PR: an under-bump cannot be undone once published (crates.io versions are
+   immutable, and yanking the new one breaks everything already released against it). CI runs the
+   same script in the **Crate Semver Bumps** job. Tagging and publishing are automated: on
    merge to `main` the **Crate Release** workflow (`.github/workflows/crate-release.yml`) creates
    `crate/<pkg>/v<ver>` and dispatches Publish Crate for any version not yet on crates.io, in
    dependency order — you never push crate tags by hand. For an absorbed/deleted crate, record where

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,8 +393,8 @@ jobs:
   # an older facade that no longer compiled. This job compares *API*, on the
   # crates a change is actually releasing; run against that release it demands
   # the breaking slot. It does not see `#[doc(hidden)]` items, which
-  # cargo-semver-checks excludes by design -- see
-  # knowledge/project/release-process.md.
+  # cargo-semver-checks excludes by design, so nothing another published crate
+  # calls may carry that attribute -- see knowledge/project/release-process.md.
   semver-bumps:
     name: Crate Semver Bumps
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,11 @@ jobs:
               - 'examples/bashkit-repo-agent/**'
               - 'scripts/cli-e2e-test.sh'
               - 'scripts/lib/check-everruns-examples.sh'
-              # The lockfile job runs the publish-cone gate; re-run it when the
-              # gate or the pin-sync script it pairs with changes.
+              # The lockfile job runs the publish-cone gate and the semver-bumps
+              # job the bump gate; re-run them when either gate or the pin-sync
+              # script they pair with changes.
               - 'scripts/check-publish-cone.py'
+              - 'scripts/check-semver-bumps.py'
               - 'scripts/sync-publish-pin-versions.py'
               - 'Cargo.toml'
               - 'Cargo.lock'
@@ -382,6 +384,66 @@ jobs:
 
       - name: Check publish cone has no unhealed strands
         run: python3 scripts/check-publish-cone.py --pre-merge
+
+  # Companion guard to the publish cone, covering the class it structurally
+  # cannot see. check-publish-cone.py compares version *requirements*, so a
+  # breaking change released in the patch slot looks healthy: everruns-host
+  # 0.20.4 shipped API breakage while still satisfying every published
+  # dependant's `^0.20.3` pin, and downstream builds resolved the new host into
+  # an older facade that no longer compiled. This job compares *API*, on the
+  # crates a change is actually releasing; run against that release it demands
+  # the breaking slot. It does not see `#[doc(hidden)]` items, which
+  # cargo-semver-checks excludes by design -- see
+  # knowledge/project/release-process.md.
+  semver-bumps:
+    name: Crate Semver Bumps
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Self-test the semver-bump gate
+        run: python3 scripts/check-semver-bumps.py --self-test
+
+      # Crate versions move only in a release change, so ordinary PRs have no
+      # candidates and skip the expensive half of this job entirely.
+      - name: Resolve release candidates
+        id: plan
+        run: |
+          set -euo pipefail
+          candidates="$(python3 scripts/check-semver-bumps.py --candidates)"
+          if [ -n "$candidates" ]; then
+            echo "Releasing: $candidates"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No crate versions are being released in this change."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Cache Rust
+        if: steps.plan.outputs.found == 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "semver-checks"
+
+      # Pinned against rust-toolchain.toml, not independently: cargo-semver-checks
+      # parses rustdoc JSON and rejects a format version it does not know, so a
+      # toolchain bump can outrun an older pin (0.44.0 cannot read the v57 JSON
+      # that 1.96.0 emits). Bump this alongside the toolchain.
+      - name: Install cargo-semver-checks
+        if: steps.plan.outputs.found == 'true'
+        timeout-minutes: 15
+        run: cargo install cargo-semver-checks --version 0.50.0 --locked
+
+      - name: Check released crates are bumped large enough
+        if: steps.plan.outputs.found == 'true'
+        run: python3 scripts/check-semver-bumps.py
 
   msrv:
     name: Published Crate MSRV
@@ -2219,6 +2281,7 @@ jobs:
       - changes
       - format
       - lockfile
+      - semver-bumps
       - msrv
       - knowledge
       - clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ everruns-capability = { path = "crates/capability", version = "0.18.1", default-
 everruns-builtins = { path = "crates/builtins", version = "0.18.6" }
 everruns-core = { path = "crates/core", version = "0.19.1" }
 everruns-engine = { path = "crates/engine", version = "0.18.3" }
-everruns-host = { path = "crates/host", version = "0.20.4" }
+everruns-host = { path = "crates/host", version = "0.20.5" }
 everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.5", default-features = false }
 everruns-test-support = { path = "crates/test-support", version = "0.18.2", default-features = false }
 everruns-platform = { path = "crates/platform", version = "0.19.2" }

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns"
-version = "0.19.2"
+version = "0.20.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "everruns-host"
-version = "0.20.4"
+version = "0.20.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -138,7 +138,9 @@ pub struct TurnResult {
 ///
 /// The caller creates this value before dispatch so it can acknowledge the
 /// stable message id without waiting for execution to begin.
-#[doc(hidden)]
+///
+/// Part of the steering contract this crate owes the published `everruns`
+/// facade; see the module note on [`TurnSteering`].
 #[derive(Clone, Debug)]
 pub struct AcceptedTurnInput {
     message_id: MessageId,
@@ -171,16 +173,31 @@ impl AcceptedTurnInput {
 /// Closing and observing an empty queue is one atomic operation. A sender can
 /// therefore never be told that it steered a turn after that turn committed to
 /// completion; rejected input belongs to the next turn instead.
-#[doc(hidden)]
+///
+/// This type, [`AcceptedTurnInput`], [`TurnSteeringPushError`],
+/// [`InProcessRuntime::run_steerable_turn`] and
+/// [`InProcessRuntime::append_accepted_inputs`] form the steering surface the
+/// separately published `everruns` facade drives. It was `#[doc(hidden)]`
+/// while that was treated as internal plumbing, which is what let a signature
+/// change ship under a host patch release and break the published facade
+/// (everruns/yolop#665) -- `#[doc(hidden)]` hides an item from rustdoc and from
+/// `cargo-semver-checks`, but it does not make it private, and a contract
+/// crossing a crates.io boundary is public whatever it is annotated with.
+/// Change these together with a host minor bump and a facade release.
 #[derive(Clone, Debug)]
 pub struct TurnSteering {
     state: Arc<Mutex<TurnSteeringState>>,
 }
 
-#[doc(hidden)]
+/// Why a steered message could not join the running turn.
+///
+/// Either way the input is handed back so the caller can requeue it; see the
+/// note on [`TurnSteering`].
 #[derive(Debug)]
 pub enum TurnSteeringPushError {
+    /// The turn already committed to completion; the input belongs to the next one.
     Closed(Box<AcceptedTurnInput>),
+    /// The steering queue is at capacity and is rejecting overflow.
     Full(Box<AcceptedTurnInput>),
 }
 
@@ -1165,7 +1182,8 @@ impl InProcessRuntime {
 
     /// Execute one turn while accepting additional user messages at reason
     /// boundaries.
-    #[doc(hidden)]
+    ///
+    /// Part of the steering contract described on [`TurnSteering`].
     pub async fn run_steerable_turn(
         &self,
         session_id: SessionId,
@@ -1434,14 +1452,9 @@ impl InProcessRuntime {
 
     /// Persist accepted steering that could not reach another reason boundary.
     ///
-    /// `#[doc(hidden)]` here does not make this free to change: the separately
-    /// versioned `everruns` facade calls it across a published crate boundary,
-    /// so a change lands in a downstream consumer's build. cargo-semver-checks
-    /// excludes hidden items, so the bump gate will not catch it either --
-    /// adding the `turn_id` parameter under a host patch release is what broke
-    /// the published facade (everruns/yolop#665). Change the signature only
-    /// alongside a host minor bump and a facade release.
-    #[doc(hidden)]
+    /// Part of the steering contract described on [`TurnSteering`]. Adding the
+    /// `turn_id` parameter here under a host patch release is what broke the
+    /// published facade (everruns/yolop#665).
     pub async fn append_accepted_inputs(
         &self,
         session_id: SessionId,

--- a/crates/host/src/runtime.rs
+++ b/crates/host/src/runtime.rs
@@ -1433,6 +1433,14 @@ impl InProcessRuntime {
     }
 
     /// Persist accepted steering that could not reach another reason boundary.
+    ///
+    /// `#[doc(hidden)]` here does not make this free to change: the separately
+    /// versioned `everruns` facade calls it across a published crate boundary,
+    /// so a change lands in a downstream consumer's build. cargo-semver-checks
+    /// excludes hidden items, so the bump gate will not catch it either --
+    /// adding the `turn_id` parameter under a host patch release is what broke
+    /// the published facade (everruns/yolop#665). Change the signature only
+    /// alongside a host minor bump and a facade release.
     #[doc(hidden)]
     pub async fn append_accepted_inputs(
         &self,

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
+checksum = "7070bf0681439ff992bb94947cb3a361f57c880561c1e9e90ddb5941c7ec2d04"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1688,22 +1688,23 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
+checksum = "b6525f2f72c37c1a09f59a6d0d33f60ecf8beabd00be92fe8d49555cae15289c"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
+checksum = "4309c6b52390b1ebdd2053e513e9f23d4bb18d0c3c2df8142eded3eb188a85bf"
 dependencies = [
  "ahash",
  "bytecount",
  "fraction",
+ "getrandom 0.3.4",
  "num-cmp",
  "num-traits",
  "serde_json",
@@ -2254,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
+checksum = "0304d4734d208eaf24528093715e2cb5260c977b1be1eb81cd487f601e3ff35d"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
+checksum = "7070bf0681439ff992bb94947cb3a361f57c880561c1e9e90ddb5941c7ec2d04"
 dependencies = [
  "ahash",
  "bytecount",
@@ -946,22 +946,23 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
+checksum = "b6525f2f72c37c1a09f59a6d0d33f60ecf8beabd00be92fe8d49555cae15289c"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
+checksum = "4309c6b52390b1ebdd2053e513e9f23d4bb18d0c3c2df8142eded3eb188a85bf"
 dependencies = [
  "ahash",
  "bytecount",
  "fraction",
+ "getrandom 0.3.4",
  "num-cmp",
  "num-traits",
  "serde_json",
@@ -1305,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
+checksum = "0304d4734d208eaf24528093715e2cb5260c977b1be1eb81cd487f601e3ff35d"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "async-trait",
  "base64",

--- a/knowledge/project/release-process.md
+++ b/knowledge/project/release-process.md
@@ -104,16 +104,21 @@ published — crates.io versions are immutable, and yanking the new version brea
 released against it — which is why the classification happens before merge. Run against that
 release, `check-semver-bumps.py` demands the breaking slot for host 0.20.4.
 
-**Known gap: `#[doc(hidden)]` API crossing a published crate boundary.** `cargo-semver-checks`
-excludes `#[doc(hidden)]` items by design — the attribute declares "not public API, free to change
-without a bump" — so no API-diffing gate can cover them, this one included. That exemption only
-holds while such an item stays inside one crate. The break in
-[#665](https://github.com/everruns/yolop/issues/665) was precisely this: the published `everruns`
-facade calls the `#[doc(hidden)]` `InProcessRuntime::append_accepted_inputs`
-([`crates/host/src/runtime.rs`](../../crates/host/src/runtime.rs)) across a crate boundary, under a
-caret pin, so a host patch release changed an API a separately versioned crates.io package depends
-on. When changing a `#[doc(hidden)]` host item, check whether the facade calls it and release the
-two together; the gate will not do it for you.
+**Never `#[doc(hidden)]` an item another published crate calls.** `cargo-semver-checks` excludes
+hidden items by design — the attribute declares "not public API, free to change without a bump" —
+so no API-diffing gate can cover them, this one included. That exemption holds only while the item
+stays inside one crate. `#[doc(hidden)]` hides an item from rustdoc and from the gate; it does not
+make it private, and a contract crossing a crates.io boundary is public whatever it is annotated
+with.
+
+This is the whole of [#665](https://github.com/everruns/yolop/issues/665): the published `everruns`
+facade drives a hidden steering surface on `everruns-host`
+([`crates/host/src/runtime.rs`](../../crates/host/src/runtime.rs)) under a caret pin, so a host
+patch release changed an API a separately versioned crates.io package depends on, invisibly to both
+gates. That surface is now documented public contract, which puts it back under the bump gate:
+break it and the gate demands the minor slot, the old facade's caret stops admitting the new host,
+and `strand-check` forces the cascade. The rule generalizes — if a published crate calls it, it is
+contract, so document it rather than hiding it.
 
 **A breaking bump is not done until its dependants are handled — the whole cone, not just the
 crate.** A crates.io package is immutable, so a published dependant that pins the old, now-incompatible

--- a/knowledge/project/release-process.md
+++ b/knowledge/project/release-process.md
@@ -88,6 +88,33 @@ API takes a patch bump even in a release where the product minor moved. `cargo-s
 guards against under-bumping (shipping a breaking change as a patch), so run it on every crate you
 release.
 
+**Run the bump gate before merging, not only in CI.** `python3 scripts/check-semver-bumps.py`
+resolves the crates this change releases (a published package whose manifest version is not yet on
+crates.io) and runs `cargo-semver-checks` against each one's latest crates.io release. Ordinary
+changes bump no crate versions and the gate finds nothing to classify, so it is only ever
+meaningful on a release change — run it there before opening the PR, and take the bump it requires.
+CI runs the same script in the **Crate Semver Bumps** job.
+
+An under-bump is not caught by the publish-cone gate below, which compares version *requirements*
+rather than API. `everruns-host` 0.20.4 shipped API breakage in the patch slot: the `^0.20.3` pin of
+every published dependant still admitted it, so `strand-check` stayed green while the published
+`everruns` facade resolved the new host and no longer compiled for downstream consumers
+([#665](https://github.com/everruns/yolop/issues/665)). Under-bumps are unrecoverable once
+published — crates.io versions are immutable, and yanking the new version breaks everything already
+released against it — which is why the classification happens before merge. Run against that
+release, `check-semver-bumps.py` demands the breaking slot for host 0.20.4.
+
+**Known gap: `#[doc(hidden)]` API crossing a published crate boundary.** `cargo-semver-checks`
+excludes `#[doc(hidden)]` items by design — the attribute declares "not public API, free to change
+without a bump" — so no API-diffing gate can cover them, this one included. That exemption only
+holds while such an item stays inside one crate. The break in
+[#665](https://github.com/everruns/yolop/issues/665) was precisely this: the published `everruns`
+facade calls the `#[doc(hidden)]` `InProcessRuntime::append_accepted_inputs`
+([`crates/host/src/runtime.rs`](../../crates/host/src/runtime.rs)) across a crate boundary, under a
+caret pin, so a host patch release changed an API a separately versioned crates.io package depends
+on. When changing a `#[doc(hidden)]` host item, check whether the facade calls it and release the
+two together; the gate will not do it for you.
+
 **A breaking bump is not done until its dependants are handled — the whole cone, not just the
 crate.** A crates.io package is immutable, so a published dependant that pins the old, now-incompatible
 requirement (`everruns-host = "^0.18.0"` when host is now `0.19.0`) will forever resolve the old
@@ -111,7 +138,9 @@ To release a changed crate:
 1. Bump only the package whose public contract changed, by the smallest compatible increment above.
 2. Run `python3 scripts/sync-publish-pin-versions.py --write` so published
    dependants reference the dependency package's current version.
-3. Validate and merge the release change to `main`.
+3. Run `python3 scripts/check-semver-bumps.py` and confirm every bump is large enough for the API
+   it carries.
+4. Validate and merge the release change to `main`.
 
 Tagging and publishing are then automated — the same schema as the product
 release, where tags are created by CI rather than pushed by hand. On merge to

--- a/scripts/check-semver-bumps.py
+++ b/scripts/check-semver-bumps.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Deterministic guard against an under-bumped crate release.
+
+`cargo-semver-checks` classifies a change breaking vs non-breaking against a
+crate's latest crates.io release and fails a bump that is too small for it. The
+release process already names it the authority for choosing a version, but
+nothing enforced that, so a breaking change could ship in the patch slot: this
+is how `everruns-host` 0.20.4 added a required `turn_id` argument to
+`Runtime::append_accepted_inputs` while staying caret-compatible with every
+already-published dependant's `^0.20.3` pin. Downstream consumers resolved the
+new host into the old published `everruns` facade and hit a compile error in
+code they do not own.
+
+`check-publish-cone.py` cannot see that class of break. It compares version
+*requirements*, and `^0.20.3` still admits 0.20.4 -- nothing looks stranded.
+This gate compares *API*, which is the only thing that catches a breaking
+change smuggled into a compatible range.
+
+Scope is the crates this change is actually releasing: a published package
+whose manifest version is not yet on crates.io. Ordinary PRs bump no versions
+here (crate versions move only at release time), so they have nothing to check
+and the gate is free; a release PR is checked at exactly the point the version
+decision is made.
+
+`--self-test` exercises the pure planning logic against fixtures with no
+network access, so the gate's own correctness is guarded deterministically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+
+def index_path(name: str) -> str:
+    n = name.lower()
+    if len(n) == 1:
+        return f"1/{n}"
+    if len(n) == 2:
+        return f"2/{n}"
+    if len(n) == 3:
+        return f"3/{n[0]}/{n}"
+    return f"{n[0:2]}/{n[2:4]}/{n}"
+
+
+def published_versions(name: str) -> set[str]:
+    """Every version on the crates.io sparse index, yanked included.
+
+    Yanked releases count: a version already burned on crates.io can never be
+    published again, so it is not a version this change can be releasing.
+    """
+    try:
+        body = urllib.request.urlopen(
+            f"https://index.crates.io/{index_path(name)}", timeout=30
+        ).read().decode()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return set()  # never published
+        raise
+    return {json.loads(line)["vers"] for line in body.splitlines() if line.strip()}
+
+
+def workspace_versions() -> dict[str, str]:
+    meta = json.loads(
+        subprocess.check_output(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"], text=True
+        )
+    )
+    # Published packages are those whose manifest does not set publish = false
+    # (cargo reports publish = [] for those).
+    return {p["name"]: p["version"] for p in meta["packages"] if p.get("publish") != []}
+
+
+def plan(
+    current: dict[str, str], published: dict[str, set[str]]
+) -> tuple[list[str], list[str]]:
+    """Split published packages into (to check, skipped-with-reason).
+
+    A package is checked when its manifest version is not on crates.io -- this
+    change is releasing it, so its bump is a live decision. A first publish has
+    no baseline to diff against and is skipped; so is a package whose version
+    already exists upstream, because no version choice is being made for it.
+    """
+    check: list[str] = []
+    skipped: list[str] = []
+    for name in sorted(current):
+        versions = published.get(name) or set()
+        if not versions:
+            skipped.append(f"{name} {current[name]}: first publish, no baseline")
+        elif current[name] in versions:
+            skipped.append(f"{name} {current[name]}: already published")
+        else:
+            check.append(name)
+    return check, skipped
+
+
+def run_semver_checks(packages: list[str]) -> int:
+    """Run cargo-semver-checks over the release candidates in one invocation.
+
+    The baseline is left to cargo-semver-checks (the crate's latest crates.io
+    release), so a single call covers packages with different baselines. Its
+    feature selection is left at the default heuristic too: pinning
+    --all-features here would check feature combinations the crates never
+    publish together.
+    """
+    # `cargo <missing-subcommand>` exits 101 like a real check failure, so probe
+    # for the tool first rather than reporting a missing install as an
+    # under-bump.
+    probe = subprocess.run(
+        ["cargo", "semver-checks", "--version"], capture_output=True, text=True
+    )
+    if probe.returncode != 0:
+        print(
+            "::error::cargo-semver-checks is not installed, so this change's "
+            "crate bumps cannot be classified. Install it with "
+            "`cargo install cargo-semver-checks --locked`."
+        )
+        return 1
+    print(probe.stdout.strip())
+
+    argv = ["cargo", "semver-checks", "check-release"]
+    for name in packages:
+        argv += ["--package", name]
+    print(f"$ {' '.join(argv)}", flush=True)
+    return subprocess.call(argv)
+
+
+def run_check(plan_only: bool, candidates_only: bool) -> int:
+    current = workspace_versions()
+    published = {name: published_versions(name) for name in current}
+    packages, skipped = plan(current, published)
+
+    if candidates_only:
+        # Bare package names on stdout, nothing else: CI decides whether to
+        # install cargo-semver-checks at all by testing this for emptiness.
+        for name in packages:
+            print(name)
+        return 0
+
+    # The per-package reasons are long (one line per published crate) and only
+    # matter when the plan itself looks wrong, so they stay behind --plan.
+    print(f"{len(skipped)} published package(s) not being released here.")
+    if plan_only:
+        for note in skipped:
+            print(f"  skip {note}")
+    if not packages:
+        print(
+            f"No crate versions are being released across {len(current)} "
+            "published packages; nothing to classify."
+        )
+        return 0
+
+    print("Release candidates to classify against their latest crates.io release:")
+    for name in packages:
+        print(f"  - {name} {current[name]}")
+    if plan_only:
+        return 0
+
+    code = run_semver_checks(packages)
+    if code != 0:
+        print(
+            "::error::cargo-semver-checks did not pass. If it reports a "
+            "required bump, take it -- for a 0.x crate the minor is the "
+            "breaking slot (0.20.3 -> 0.21.0, not 0.20.4) -- then run "
+            "`python3 scripts/sync-publish-pin-versions.py --write` and close "
+            "the cone per knowledge/project/release-process.md. Shipping a "
+            "breaking change as a patch leaves every published dependant's "
+            "caret pin resolving into an API that no longer compiles, and a "
+            "published version cannot be taken back. If it instead failed to "
+            "run, check that its version understands this toolchain's rustdoc "
+            "JSON format; the two are pinned together in ci.yml."
+        )
+    return code
+
+
+def self_test() -> int:
+    """Network-free checks of the pure planning logic."""
+    failures: list[str] = []
+
+    def expect(label: str, got, want) -> None:
+        if got != want:
+            failures.append(f"{label}: got {got!r}, want {want!r}")
+
+    # The release that actually broke: host bumped (checked), the facade left at
+    # its published version (nothing to classify), model-profiles never
+    # published (no baseline to diff against).
+    current = {
+        "everruns-host": "0.20.4",
+        "everruns": "0.19.1",
+        "everruns-model-profiles": "0.1.0",
+    }
+    published = {
+        "everruns-host": {"0.20.2", "0.20.3"},
+        "everruns": {"0.19.0", "0.19.1"},
+        "everruns-model-profiles": set(),
+    }
+    packages, skipped = plan(current, published)
+    expect("bumped crate is checked", packages, ["everruns-host"])
+    expect("unbumped crate is skipped", any("already published" in s for s in skipped), True)
+    expect("first publish is skipped", any("no baseline" in s for s in skipped), True)
+
+    # A yanked version is still burned upstream, so re-using it is not a release
+    # this gate can classify.
+    packages, _ = plan({"everruns": "0.19.1"}, {"everruns": {"0.19.1"}})
+    expect("yanked-or-live published version is not a candidate", packages, [])
+
+    # The facade republish this gate is meant to let through.
+    packages, _ = plan({"everruns": "0.19.2"}, {"everruns": {"0.19.0", "0.19.1"}})
+    expect("republish is a candidate", packages, ["everruns"])
+
+    # A package absent from the index map behaves like one never published.
+    packages, skipped = plan({"brand-new": "0.1.0"}, {})
+    expect("unknown package is skipped", packages, [])
+    expect("unknown package explains why", any("no baseline" in s for s in skipped), True)
+
+    # Ordering is deterministic so CI output is diffable.
+    packages, _ = plan(
+        {"b-crate": "0.2.0", "a-crate": "0.2.0"},
+        {"b-crate": {"0.1.0"}, "a-crate": {"0.1.0"}},
+    )
+    expect("candidates are sorted", packages, ["a-crate", "b-crate"])
+
+    # Index path sharding must match crates.io, or every lookup 404s and the
+    # gate silently passes by treating live crates as first publishes.
+    expect("1-char shard", index_path("a"), "1/a")
+    expect("2-char shard", index_path("ab"), "2/ab")
+    expect("3-char shard", index_path("abc"), "3/a/abc")
+    expect("4+-char shard", index_path("everruns-host"), "ev/er/everruns-host")
+
+    for failure in failures:
+        print(f"  FAIL {failure}")
+    if failures:
+        print(f"{len(failures)} self-test failure(s)")
+        return 1
+    print("semver-bump gate self-test passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--plan",
+        action="store_true",
+        help="list the release candidates without running cargo-semver-checks",
+    )
+    parser.add_argument(
+        "--candidates",
+        action="store_true",
+        help="print only the release-candidate package names, one per line",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run the network-free checks of the planning logic",
+    )
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    return run_check(plan_only=args.plan, candidates_only=args.candidates)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/tests/fixtures/external-consumer/Cargo.lock
+++ b/tests/fixtures/external-consumer/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "async-trait",
  "chrono",


### PR DESCRIPTION
Fixes the break reported in [everruns/yolop#665](https://github.com/everruns/yolop/issues/665), and the gaps in the release process that let it happen.

## What changed

**The published `everruns` facade becomes installable again, as 0.20.0.** 0.19.1 on crates.io is unbuildable: it was cut while `everruns-host` was 0.20.3 and calls the two-argument `InProcessRuntime::append_accepted_inputs`. Host 0.20.4 added a required `turn_id` and shipped in the **patch** slot, so the facade's `^0.20.3` pin resolves it and downstream builds fail inside a crate they do not own. The call site was already corrected in tree but never republished — the v0.23.0 release bumped 19 crates and left the facade behind.

**Crate bumps are now classified before merge.** `cargo-semver-checks` was already named the authority for choosing a bump, but nothing ran it. `scripts/check-semver-bumps.py` resolves the crates a change is actually releasing — a published package whose manifest version is not yet on crates.io — and runs `cargo-semver-checks` against each one's latest release. Wired in as the **Crate Semver Bumps** CI job and into both release commands so the decision happens before the PR, not in review. A published version cannot be taken back, so pre-merge is the only useful place for it.

**The facade's steering surface on `everruns-host` becomes public contract.** `AcceptedTurnInput`, `TurnSteering`, `TurnSteeringPushError`, `run_steerable_turn` and `append_accepted_inputs` were `#[doc(hidden)]` while a separately published crate drove all five across a crates.io boundary under a caret pin. `#[doc(hidden)]` hides an item from rustdoc and from `cargo-semver-checks`; it does not make it private. Dropping the attribute puts the surface back under the gate. Host takes a patch bump to 0.20.5 for the added API surface.

## Why

`check-publish-cone.py` compares version *requirements*, and `^0.20.3` still admits 0.20.4 — so `strand-check` stayed green while the facade broke. Nothing in the pipeline compared API, and the one method that mattered was invisible to API comparison anyway. Both holes had to close, or the same failure recurs on the next host patch.

With all of it landed the existing cone machinery works end to end: break the steering surface → the gate demands the minor slot → the old facade's caret stops admitting the new host → `strand-check` forces the cascade.

## Before / After

The gate, run against the release that caused this (`everruns-host`, baseline `c59a67dc~1`):

```
Checking everruns-host v0.20.3 -> v0.20.4 (minor change)
 Summary semver requires new major version: 1 major and 0 minor checks failed
```

`#3487` would not have merged.

That the `#[doc(hidden)]` fix closes the specific hole — same parameter change applied as a probe, before and after:

```
# before: attribute present
196 checks: 196 pass, 58 skip — no semver update required

# after: attribute removed
--- failure method_parameter_count_changed: pub method parameter count changed ---
  everruns_host::InProcessRuntime::append_accepted_inputs takes 3 parameters ... but now takes 4
 Summary semver requires new major version
```

**The gate then caught a second, unrelated under-bump on its first real CI run — this PR's own.** The facade was originally bumped 0.19.1 → 0.19.2, and `Crate Semver Bumps` rejected it:

```
enum_struct_variant_field_missing — field `payload` of variant SessionEventKind::Other
enum_unit_variant_changed_kind   — variant SessionEventKind::ModelGeneration
 Summary semver requires new major version: 2 major and 0 minor checks failed
```

`SessionEventKind` has drifted breaking-ly from published 0.19.1 since that release — `Other` lost its `payload` field and `ModelGeneration` went from a unit to a struct variant — in [#3313](https://github.com/everruns/everruns/pull/3313) and [#3353](https://github.com/everruns/everruns/pull/3353), neither of which bumped the crate. For a 0.x crate the minor is the breaking slot, so the facade releases as **0.20.0**. Re-verified with `--baseline-version 0.19.1`: 0.19.1 → 0.20.0 needs no further bump, and `everruns-host` 0.20.4 → 0.20.5 reports *no semver update required*.

Worth noting how that was missed locally: `--baseline-rev origin/main` compares against main's *tree*, where the enum was already changed, so it saw no diff. CI compares against the *published* release, which is the baseline that matters — exactly the distinction the gate exists to enforce.

No runtime behavior changes. The only non-comment edit to `crates/host/src/runtime.rs` is the removal of five attributes; the surface was already `pub` and reachable.

## Risk

- **Low for the tooling, Medium for consumers of the facade.**
- `everruns` 0.20.0 is a genuine breaking release: consumers matching `^0.19` will not auto-upgrade, and anyone matching on `SessionEventKind::Other`/`ModelGeneration` has code to adapt. That break already exists in the source; this release reports it honestly instead of hiding it in a patch.
- The facade is a leaf in the publish graph — `check-publish-cone --pre-merge` reports no unhealed dependants across all 41 crates, so no cascade is needed.
- The new CI job is additive and gated on the `rust` path filter. Ordinary PRs release no crate versions, so it finds no candidates and skips its expensive half; it cannot be suppressed by any `ci:skip-*` label.
- `cargo-semver-checks` is pinned to 0.50.0 **against the toolchain**, not independently: it rejects a rustdoc JSON format it does not know, and 0.44.0 cannot read the v57 JSON that 1.96.0 emits. Noted at the pin — bump it alongside `rust-toolchain.toml`.

## Security

- Threat categories reviewed: **TM-DOS**, plus supply chain.
- `TM-DOS-036` (steering overflow) sits directly in the touched code. Its mitigation is unchanged — `TURN_STEERING_CAPACITY` and the rejection path are untouched, and `TurnSteeringPushError::Full` is now documented rather than hidden.
- Un-hiding the steering items widens no access. `#[doc(hidden)]` is documentation visibility, not access control; every item was already `pub` and callable by any consumer.
- Supply chain: the new job runs `cargo install cargo-semver-checks --version 0.50.0 --locked` — exact pin, locked, in a job inheriting `contents: read` / `pull-requests: read` with no secrets. `check-semver-bumps.py` reads only `cargo metadata` from the local workspace and the crates.io sparse index, and passes package names to `subprocess` as a list with no shell.
- No auth, authorization, API, tenancy, SQL, filesystem, or frontend surface touched.

## Follow-ups

Deferred, with rationale:

- **`scripts/test-caddy-api-compression.sh` is intermittent on CI runners.** It failed once here (Caddy served a 227 KB response uncompressed) and passed on the two subsequent runs with no change to it. Unrelated to this diff, which touches no Caddy, port, or proxy surface. Not fixed here because diagnosing a non-deterministic proxy test would widen an unrelated release PR; worth its own issue.
- **`everruns` 0.19.1 stays unbuildable on crates.io.** Consider yanking it via the **Yank Crate** workflow so new resolutions stop selecting it. Left to the maintainer since yanking is an operational decision, not a code change — and note 0.20.0 does *not* supersede it under a caret range, so the argument for yanking is stronger than it was for a patch release.
- **yolop's pin lift** belongs in [everruns/yolop#665](https://github.com/everruns/yolop/issues/665). It is now a larger job than that issue assumes: `everruns` moves to `=0.20.0`, and if yolop consumes `SessionEventKind` it has real code to adapt, not just a version move.

## Checklist
- [x] Tests added or updated — `--self-test` covers the gate's planning logic without network, matching `check-publish-cone.py`; the Rust change is attribute-only and adds no testable behavior
- [x] Backward compatibility considered — the facade's break is pre-existing in source and is now reported in the correct version slot; host and the steering surface change no signatures
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — 47 success, 6 skipped, no failures on `7fe6fdaa`
- [x] All review comments addressed (code change or written reasoning) — no reviews or review comments were left on this PR

**Validation:** `scripts/lib/pre-push.sh` 22/22 · `run-shell-tests.sh` 25/25 · `cargo test -p everruns-host -p everruns --all-features` 536 passed, 0 failed · `cargo doc` clean with `-D rustdoc::broken_intra_doc_links` · all four lockfiles satisfy `--locked` · `check-publish-cone.py --pre-merge` · `check-semver-bumps.py` against live crates.io for both release candidates.

**Smoke test:** no runtime surface changes, so the stack was not started. The only new executable is `check-semver-bumps.py`, exercised end to end against live crates.io — plan, candidate resolution, real `cargo-semver-checks` runs over both release candidates, the probe above proving it catches the regression it exists for, and one live catch of a real under-bump in this very PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpq2dZVHacBQcdG9aK7CPr)_