### PR TITLE
fix(cli): stop the command tree making a wrong guess look valid

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -564,7 +564,12 @@ pub(crate) fn bash_usage(command_name: &str, schema: &serde_json::Value) -> Stri
                     .map(|example| format!("'{}'", example.replace('\'', "'\"'\"'")))
                     .unwrap_or_else(|| "'<json>'".to_string())
             } else if property_has_type(property, defs, "boolean", 0) {
-                "<true|false>".to_string()
+                // A boolean is a switch, not a flag that takes a value. The
+                // interpreter inserts `true` on sight and consumes nothing, so
+                // the next token is parsed as a flag: `--include_archived true`
+                // fails with "expected --flag, got: true". Rendering a
+                // `<true|false>` placeholder documents a form that cannot work.
+                String::new()
             } else if property_has_type(property, defs, "integer", 0)
                 || property_has_type(property, defs, "number", 0)
             {
@@ -572,7 +577,11 @@ pub(crate) fn bash_usage(command_name: &str, schema: &serde_json::Value) -> Stri
             } else {
                 "'<string>'".to_string()
             };
-            let flag = format!("--{name} {placeholder}");
+            let flag = if placeholder.is_empty() {
+                format!("--{name}")
+            } else {
+                format!("--{name} {placeholder}")
+            };
             (required.contains(name), name, flag)
         })
         .collect::<Vec<_>>();
@@ -805,6 +814,40 @@ fn decorate_mcp_capability_refs(value: &mut serde_json::Value) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bash_usage_renders_booleans_as_switches() {
+        // The interpreter parses a boolean flag as a valueless switch, so a
+        // usage string promising `<true|false>` documents a form that errors
+        // with "expected --flag, got: true". A live model followed exactly
+        // that advertised form and lost the result.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "include_archived": { "type": "boolean" },
+                "nullable_flag": { "type": ["boolean", "null"] },
+                "limit": { "type": "integer" },
+                "search": { "type": "string" },
+            }
+        });
+
+        let usage = bash_usage("list_agents", &schema);
+
+        assert!(
+            usage.contains("[--include_archived]"),
+            "boolean must render as a bare switch: {usage}"
+        );
+        assert!(
+            usage.contains("[--nullable_flag]"),
+            "a nullable boolean is still a switch: {usage}"
+        );
+        assert!(
+            !usage.contains("true|false"),
+            "no boolean may advertise a value: {usage}"
+        );
+        assert!(usage.contains("[--limit <number>]"), "{usage}");
+        assert!(usage.contains("[--search '<string>']"), "{usage}");
+    }
 
     #[test]
     fn inventory_command_defs_expose_structured_param_schemas() {

--- a/integrations/bashkit/src/cli.rs
+++ b/integrations/bashkit/src/cli.rs
@@ -365,7 +365,8 @@ fn resolve_invocation(bytes: &[u8], mut i: usize, tree: &CliTree) -> (String, us
     // stray flags reach the help builtin.
     let end = statement_end(bytes, i);
     if wants_help || contains_help_flag(bytes, i, end) {
-        return (help_call(&path, None), end);
+        let (scope, unknown) = split_at_unknown(tree, &path);
+        return (help_call(&scope, unknown.as_deref()), end);
     }
     if let Some(leaf) = tree.leaf(&path) {
         return (leaf.command.to_string(), i);
@@ -376,15 +377,8 @@ fn resolve_invocation(bytes: &[u8], mut i: usize, tree: &CliTree) -> (String, us
 
     // Unresolved: report against the deepest node that does exist, so the
     // error names real neighbours rather than the whole tree.
-    let mut known: Vec<&str> = path.split(' ').collect();
-    let unknown = known.pop().unwrap_or_default().to_string();
-    let mut parent = known.join(" ");
-    while !parent.is_empty() && !tree.is_node(&parent) {
-        let mut segments: Vec<&str> = parent.split(' ').collect();
-        segments.pop();
-        parent = segments.join(" ");
-    }
-    (help_call(&parent, Some(&unknown)), i)
+    let (scope, unknown) = split_at_unknown(tree, &path);
+    (help_call(&scope, unknown.as_deref()), i)
 }
 
 /// End of the current simple command: the next unquoted statement separator.
@@ -640,11 +634,10 @@ impl CliBuiltin {
 
         if wants_help {
             // Help beats execution: a caller asking what a command does must
-            // never accidentally run it.
-            return CliPlan::Help {
-                path: nearest_known(&self.tree, &spelling),
-                unknown: None,
-            };
+            // never accidentally run it. It must still fail when the path is
+            // not real, or a typo renders as a working help page.
+            let (path, unknown) = split_at_unknown(&self.tree, &spelling);
+            return CliPlan::Help { path, unknown };
         }
         if let Some(leaf) = self.tree.leaf(&spelling) {
             return CliPlan::Run {
@@ -659,12 +652,8 @@ impl CliBuiltin {
             };
         }
 
-        let mut known: Vec<&str> = spelling.split(' ').collect();
-        let unknown = known.pop().unwrap_or_default().to_string();
-        CliPlan::Help {
-            path: nearest_known(&self.tree, &known.join(" ")),
-            unknown: Some(unknown),
-        }
+        let (path, unknown) = split_at_unknown(&self.tree, &spelling);
+        CliPlan::Help { path, unknown }
     }
 
     /// Render help, or run the command and return its output.
@@ -694,14 +683,29 @@ enum CliPlan {
     },
 }
 
-fn nearest_known(tree: &CliTree, path: &str) -> String {
-    let mut candidate = path.to_string();
-    while !candidate.is_empty() && !tree.is_node(&candidate) && tree.leaf(&candidate).is_none() {
-        let mut segments: Vec<&str> = candidate.split(' ').collect();
-        segments.pop();
-        candidate = segments.join(" ");
+/// Split a typed path into the deepest prefix the tree knows and the first
+/// segment that does not resolve under it.
+///
+/// Walking forward matters. Collapsing to the nearest known ancestor and
+/// blaming whatever word was left over reports the *last* token, so
+/// `gadgets resize thing 4` becomes "unknown command `4`" when `gadgets` is
+/// the word that does not exist. The first unresolvable segment is the one
+/// the caller got wrong; everything after it was never reachable.
+fn split_at_unknown(tree: &CliTree, path: &str) -> (String, Option<String>) {
+    let mut known: Vec<&str> = Vec::new();
+
+    for segment in path.split(' ').filter(|segment| !segment.is_empty()) {
+        let mut candidate = known.clone();
+        candidate.push(segment);
+        let joined = candidate.join(" ");
+        if tree.is_node(&joined) || tree.leaf(&joined).is_some() {
+            known = candidate;
+        } else {
+            return (known.join(" "), Some(segment.to_string()));
+        }
     }
-    candidate
+
+    (known.join(" "), None)
 }
 
 /// Parse `--flag value` pairs into a JSON object.
@@ -955,6 +959,43 @@ mod tests {
             !out.contains("\"ran\""),
             "help must not run the command: {out}"
         );
+    }
+
+    #[tokio::test]
+    async fn an_unknown_noun_names_the_noun_not_the_last_word() {
+        // A live model that guesses the wrong noun types a whole invocation,
+        // not one word. Blaming the trailing token sends it looking for a verb
+        // when the noun is what does not exist.
+        let error = builtin()
+            .run(&argv("gadgets resize thing 4"))
+            .await
+            .expect_err("an unknown noun must fail");
+        assert!(
+            error.contains("unknown command `gadgets`"),
+            "should name the first unresolvable segment: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn help_on_an_unknown_noun_is_an_error_not_root_help() {
+        // Rendering root help here is worse than saying nothing: it is the
+        // same shape as a valid `everruns widgets --help`, so the caller reads
+        // a typo as a working command.
+        let error = builtin()
+            .run(&argv("gadgets --help"))
+            .await
+            .expect_err("help on an unknown noun must fail");
+        assert!(
+            error.contains("unknown command `gadgets`"),
+            "should name the unknown noun: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn help_on_a_real_node_still_succeeds() {
+        let out = builtin().run(&argv("widgets --help")).await.expect("help");
+        assert!(out.contains("list"), "{out}");
+        assert!(out.contains("parts"), "{out}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Three defects in the noun-verb tree, each of which let a caller's mistake read
as a working command.

- **`unknown command` named the wrong word.** The reporting path collapsed to
  the nearest known ancestor and blamed whatever token was left over, which is
  the *last* one. Now the first unresolvable segment is named. A single
  `split_at_unknown` replaces `nearest_known` in both adapters, which had each
  grown their own copy of the collapse.
- **`--help` on a path that does not resolve rendered root help and exited 0.**
  It now fails and names the unknown noun. Help still beats execution, and
  `--help` on a real node is unchanged.
- **`bash_usage` advertised `--flag <true|false>` for booleans.** The
  interpreter parses a boolean as a valueless switch, so the following token
  fails as `expected --flag, got: true`. Booleans now render as bare switches.

## Why

Found by running a live model (`gpt-5.6-luna`, `gpt-4o-mini`) against the tree
rather than a simulator, which had only ever issued commands that were already
correct.

The tree's value is that a wrong guess is recoverable: the error names real
neighbours and the caller retries. All three defects break that contract in the
same direction — they make a wrong guess look accepted.

`everruns service scale api 4` reported `unknown command `4``, sending the
model looking for a verb when `service` is the noun that does not exist. Asking
`everruns service --help` then returned root help at exit 0, indistinguishable
from help for a real noun, so the model read its typo as accepted and kept
hunting. It burned 11 tool calls and gave up. Separately, a model followed
`bash_usage` exactly — `everruns agents list --include_archived true` — got a
parse error, silently lost that result, and answered from partial data.

## Before / After

Unknown noun, with the trailing-token misattribution:

```console
# before
$ everruns service scale api 4
unknown command `4` under `everruns`

# after
$ everruns service scale api 4
unknown command `service` under `everruns`
```

`--help` on a noun that does not exist:

```console
# before  (exit 0)
$ everruns service --help
Usage: everruns <command> [--flags]

Commands:
  fleet  ...

# after  (exit 1)
$ everruns service --help
unknown command `service` under `everruns`
...
```

Boolean flags, as advertised by `discover`:

```console
# before: the documented form does not parse
bash_usage: everruns agents list [--include_archived <true|false>] [--limit <number>]
$ everruns agents list --include_archived true
expected --flag, got: true

# after: usage matches the parser
bash_usage: everruns agents list [--include_archived] [--limit <number>]
```

`everruns fleet --help` and `everruns widgets lst` are unchanged; both have
tests pinning them, since correct-node help is the behavior the second bug was
disguised as.

## Risk

- **Low**
- Error paths and a generated usage string only; no change to dispatch,
  policy checks, or how any command runs.
- The one behavior change a caller could depend on is `--help` on an
  unresolvable path now exiting non-zero. It previously printed root help, so
  a script relying on that was already not getting what it asked for.
- 115 bashkit tests and 2273 `everruns-server` lib tests pass; 22/22 pre-push.

## Security

- **Threat categories reviewed:** TM-BASH, TM-MCP. Not applicable: TM-AUTH /
  TM-AUTHZ / TM-TENANT (no change to how a caller is identified or scoped),
  TM-SQL, TM-WEB, TM-FS, TM-DOS.
- **Findings and resolutions:**
  - *TM-BASH-011 (the rewriter emits shell text).* `split_at_unknown` returns
    borrowed segments of the already-tokenized path and synthesizes nothing;
    the unknown word still reaches `help_call`, whose existing sanitizer and
    `[A-Za-z0-9_-]` tokenizer are unchanged. `rewrite_safety_tests` still
    passes.
  - *Path walking stays bounded.* The new walk is a single forward pass over
    segments already capped by `MAX_PATH_WORDS`, replacing a backward loop —
    no new unbounded iteration.
  - *No new disclosure.* The error names a word the caller typed and the
    children of a node they could already list with `--help`.

## Follow-ups

- **One unexplained observation.** `everruns sessions list --include_archived
  true --limit 1` succeeded live while the `agents` equivalent failed. Both
  should be switches by the interpreter's rules, so the difference is not
  understood; my likely explanation is that `include_archived` is absent from
  the top-level `properties` the interpreter inspects for that command, since
  `bash_usage` walks `$defs` and the interpreter does not. The fix here is
  correct either way — no boolean accepts a value — but the asymmetry deserves
  its own look.
- **Verified by tests, not by a live run.** The local stack that produced these
  findings was torn down before the fixes existed. Worth one live re-check
  before merge.
- **The root token is still hardcoded** (`pub const ROOT = "everruns"`), so a
  Framework host's own operations are spelled under the everruns brand. Being
  addressed separately.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ais5r3YM9mfEtno2oLoZHz)_