### PR TITLE
refactor(mcp): make --help the single source of truth for tree command flags

### DIFF
--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -945,7 +945,9 @@ async fn platform_command_surface_uses_session_owner_and_org() {
     assert!(output.contains("list_models"));
 
     for (query, expected) in [
-        ("create agent", ["create_agent", "default_model_id"]),
+        // A tree command advertises its spelling and defers its flags to
+        // `--help`, so discovery names the command, not its parameters.
+        ("create agent", ["create_agent", "agents create --help"]),
         (
             "create agent trigger",
             ["create_agent_trigger", "cron_expression"],

--- a/crates/server/src/services/platform_command_surface.rs
+++ b/crates/server/src/services/platform_command_surface.rs
@@ -109,11 +109,22 @@ fn discover(
         if include_schemas {
             value["input_schema"] = entry.input_schema.clone();
             value["output_schema"] = entry.output_schema.clone();
-            let usage_name = match &entry.cli {
-                Some(spelling) => format!("{} {spelling}", cli_tree::ROOT),
-                None => entry.name.to_string(),
-            };
-            value["bash_usage"] = json!(catalog::bash_usage(&usage_name, &entry.input_schema));
+            // A command in the tree documents its own flags through `--help`,
+            // generated from the same schema at the moment of asking. Printing
+            // a second rendering here gave the caller two sources for one
+            // truth, and they drifted: discovery advertised `--flag
+            // <true|false>` for booleans, which the interpreter rejects.
+            // Flat-only commands have no `--help`, so their usage still has to
+            // come from here.
+            match &entry.cli {
+                Some(spelling) => {
+                    value["help"] = json!(format!("{} {spelling} --help", cli_tree::ROOT));
+                }
+                None => {
+                    value["bash_usage"] =
+                        json!(catalog::bash_usage(entry.name, &entry.input_schema));
+                }
+            }
             value["output_fields"] = json!(catalog::schema_field_paths(&entry.output_schema));
             if serde_json::to_vec(&value).is_ok_and(|encoded| encoded.len() > 2_000) {
                 value
@@ -125,7 +136,7 @@ fn discover(
                     .expect("operation object")
                     .remove("output_schema");
                 value["schemas_omitted"] = json!(
-                    "Expanded schemas exceeded the discovery size limit. bash_usage and output_fields remain authoritative for scripting."
+                    "Expanded schemas exceeded the discovery size limit. Run the command's `help` for its flags, or use bash_usage and output_fields where present."
                 );
             }
         }
@@ -185,8 +196,9 @@ fn discover(
 
 fn script_guidance() -> Value {
     json!([
-        "Invoke operations as Bash builtins using exactly the flags shown in bash_usage.",
-        "Builtins do not implement --help; discover the exact command name for its schema and bash_usage.",
+        "Operations with a `cli` spelling document their own flags: run the command in `help` before scripting it.",
+        "Operations without a `cli` spelling are flat builtins with no --help; use exactly the flags shown in bash_usage.",
+        "A boolean flag is a switch: pass `--flag`, never `--flag true`.",
         "Filesystem redirection is disabled; keep intermediate JSON in shell variables and pipe it directly to jq.",
         "Pass array and object flag values as JSON text.",
         "Capture JSON output and use jq for dependent IDs; combine dependent mutations in one execute script.",
@@ -393,6 +405,25 @@ mod tests {
         assert!(!error.contains(PARTIAL_FAILURE_LABEL));
     }
 
+    fn all_flags() -> everruns_platform::FeatureFlags {
+        everruns_platform::FeatureFlags {
+            notifications: true,
+            evals: true,
+            skills: true,
+            memory: true,
+            knowledge: true,
+            plugins: true,
+            app_budgets: true,
+            agent_versions: true,
+            voice: true,
+            agent_delegation: true,
+            observers: true,
+            public_chat: true,
+            webmcp: true,
+            machine_payments: true,
+        }
+    }
+
     fn discover_for_test(arguments: &Value) -> Result<String, String> {
         discover(
             arguments,
@@ -452,6 +483,78 @@ mod tests {
         assert!(error.len() < 240);
     }
 
+    /// Flag names come from the schema, and a rename there silently changes
+    /// the surface a caller scripts against. Discovery used to guard this by
+    /// rendering usage for every operation; it now defers to `--help` for
+    /// tree-visible ones, so the guard moves onto the renderer directly.
+    #[test]
+    fn schema_flag_names_callers_script_against_do_not_drift() {
+        let flags = all_flags();
+        let entries = crate::domains::common::catalog_entries_with_schemas(true, &flags);
+        let usage_for = |command: &str| {
+            let entry = entries
+                .iter()
+                .find(|entry| entry.name == command)
+                .unwrap_or_else(|| panic!("{command} catalog entry"));
+            catalog::bash_usage(command, &entry.input_schema)
+        };
+
+        let create_agent = usage_for("create_agent");
+        assert!(create_agent.contains("--name"), "{create_agent}");
+        assert!(create_agent.contains("--system_prompt"), "{create_agent}");
+        assert!(
+            create_agent.contains("--default_model_id"),
+            "{create_agent}"
+        );
+        assert!(!create_agent.contains("--model_id "), "{create_agent}");
+        assert!(
+            create_agent.contains("--capabilities '[{"),
+            "{create_agent}"
+        );
+
+        let mcp = usage_for("create_mcp_server");
+        assert!(mcp.contains("--auth_mode"), "{mcp}");
+        assert!(mcp.contains("--api_key"), "{mcp}");
+        assert!(!mcp.contains("--authentication_type"), "{mcp}");
+    }
+
+    #[test]
+    fn a_tree_command_points_at_its_own_help_instead_of_a_second_usage_rendering() {
+        let output = discover_for_test(&json!({
+            "query": "create_agent",
+            "include_schemas": true
+        }))
+        .expect("discover create_agent");
+        let value: Value = serde_json::from_str(&output).expect("discover JSON");
+        let operation = &value["operations"][0];
+
+        assert_eq!(operation["cli"], "everruns agents create");
+        assert_eq!(operation["help"], "everruns agents create --help");
+        assert!(
+            operation["bash_usage"].is_null(),
+            "a command with --help must not carry a second usage rendering: {operation}"
+        );
+    }
+
+    #[test]
+    fn a_flat_command_still_carries_its_usage() {
+        // No `cli` spelling means no `--help` to defer to, so discovery stays
+        // the only place its flags are written down.
+        let output = discover_for_test(&json!({
+            "query": "create_agent_trigger",
+            "include_schemas": true
+        }))
+        .expect("discover create_agent_trigger");
+        let value: Value = serde_json::from_str(&output).expect("discover JSON");
+        let operation = &value["operations"][0];
+
+        assert!(operation["cli"].is_null(), "{operation}");
+        assert!(operation["help"].is_null(), "{operation}");
+        let usage = operation["bash_usage"].as_str().expect("bash_usage");
+        assert!(usage.contains("--agent_id"), "{usage}");
+        assert!(usage.contains("--cron_expression"), "{usage}");
+    }
+
     #[test]
     fn exact_discovery_returns_one_operation_with_runnable_usage() {
         let output = discover_for_test(&json!({
@@ -463,17 +566,9 @@ mod tests {
 
         assert_eq!(value["count"], 1);
         assert_eq!(value["operations"][0]["name"], "create_agent");
-        let usage = value["operations"][0]["bash_usage"]
-            .as_str()
-            .expect("bash_usage");
-        assert!(usage.contains("--name"));
-        assert!(usage.contains("--system_prompt"));
-        assert!(usage.contains("--default_model_id"));
-        assert!(!usage.contains("--model_id"));
-        assert!(usage.contains("--capabilities '[{"), "usage was {usage}");
-        assert!(
-            usage.contains(r#""ref":"current_time""#),
-            "usage was {usage}"
+        assert_eq!(
+            value["operations"][0]["help"],
+            "everruns agents create --help"
         );
         assert!(
             value["script_guidance"]
@@ -486,12 +581,10 @@ mod tests {
         let mcp_output = discover_for_test(&json!({ "query": "create_mcp_server" }))
             .expect("discover create_mcp_server");
         let mcp_value: Value = serde_json::from_str(&mcp_output).expect("MCP discover JSON");
-        let mcp_usage = mcp_value["operations"][0]["bash_usage"]
-            .as_str()
-            .expect("MCP bash_usage");
-        assert!(mcp_usage.contains("--auth_mode"));
-        assert!(mcp_usage.contains("--api_key"));
-        assert!(!mcp_usage.contains("--authentication_type"));
+        assert_eq!(
+            mcp_value["operations"][0]["help"],
+            "everruns mcp-servers create --help"
+        );
         assert!(mcp_output.len() < 10_000, "MCP discovery must stay compact");
 
         let trigger_output = discover_for_test(&json!({ "query": "create_agent_trigger" }))
@@ -534,10 +627,9 @@ mod tests {
             serde_json::from_str(&natural_name_output).expect("natural discover JSON");
         assert_eq!(natural_name_value["count"], 1);
         assert_eq!(natural_name_value["operations"][0]["name"], "create_agent");
-        assert!(
-            natural_name_value["operations"][0]
-                .get("bash_usage")
-                .is_some()
+        assert_eq!(
+            natural_name_value["operations"][0]["help"],
+            "everruns agents create --help"
         );
         assert!(natural_name_value.get("refine_hint").is_none());
 


### PR DESCRIPTION
## What changed

An operation with a `cli` spelling now carries `help` — the command to run —
instead of `bash_usage`:

```json
{ "name": "create_agent",
  "cli":  "everruns agents create",
  "help": "everruns agents create --help" }
```

An operation with no `cli` spelling keeps `bash_usage`. Those are flat builtins
with no `--help` to defer to, so discovery stays the only place their flags are
written down: 262 of 312 registered commands today, shrinking as categories opt
into the tree.

`script_guidance` now distinguishes the two kinds of operation, and states the
switch rule the old rendering got wrong.

## Why

Discovery and `--help` rendered the same argument forms from the same schema,
and they drifted. Discovery advertised `--include_archived <true|false>`; the
interpreter parses a boolean as a valueless switch and rejects the value with
`expected --flag, got: true`.

A live model followed the advertised form exactly, got the parse error, lost
that result, and answered from partial data. It happened to be right; with
archived rows present it would not have been.

#3495 makes the boolean rendering truthful, which fixes that instance. This
removes the class: two renderings of one truth will drift again. A tree
command's flags now come from the tree at the moment of asking, so they cannot
disagree with what the parser accepts.

## Before / After

```jsonc
// before — a second rendering, and a form that does not parse
{ "name": "list_agents",
  "cli": "everruns agents list",
  "bash_usage": "everruns agents list [--include_archived <true|false>] [--limit <number>]" }

// after — one place to look
{ "name": "list_agents",
  "cli": "everruns agents list",
  "help": "everruns agents list --help" }

// unchanged for a flat command with no --help
{ "name": "create_agent_trigger",
  "bash_usage": "create_agent_trigger --agent_id '<string>' [--cron_expression '<string>'] ..." }
```

## Risk

- **Medium**, because it removes information some caller may be reading.
- **The cost is one extra round trip.** A tree command's discovery result no
  longer names its parameters, so a caller that needs them must run `--help`.
  For a caller that already knows the flags, nothing changes; for one that
  does not, it is one more call in exchange for flags that are correct.
- Two existing tests asserted flag names in discovery output and now assert the
  `help` pointer. That was real coverage, so the flag-name regression guards
  moved onto the renderer directly — a schema rename (`--default_model_id`
  becoming `--model_id`, `--auth_mode` becoming `--authentication_type`) is
  still caught.
- 2275 `everruns-server` lib tests pass; 22/22 pre-push.

## Security

- **Threat categories reviewed:** TM-MCP, TM-TOOL. Not applicable: TM-AUTH /
  TM-AUTHZ / TM-TENANT (no change to identification, scoping, or which
  operations a caller may see — the same catalog entries are returned, with
  one field swapped), TM-BASH, TM-SQL, TM-WEB, TM-FS.
- **Findings and resolutions:**
  - *Strictly less disclosure.* The change removes a generated string from the
    response and adds a command name the caller could already construct from
    the `cli` field. No schema, field, or operation becomes visible that was
    not visible before.
  - *No new synthesis into shell text.* `help` is built from the same `cli`
    spelling already emitted; nothing caller-supplied reaches it.
  - *TM-DOS unaffected.* Responses get smaller, and the existing 2000-byte
    schema-omission guard still applies.

## Follow-ups

- **The `--help` a caller is sent to must be reachable.** On `/mcp` that means
  the `everruns_help` builtin, which is registered. #3495 fixes the case where
  `--help` on an unresolvable path returned root help at exit 0; these two are
  worth landing together, since this PR increases how often callers ask for
  help.
- **Discovery still ranks by name and description.** Deferring flags to
  `--help` does not change search quality, but it does mean a query that only
  matched on a parameter name will no longer match. No test covered that, and
  I did not measure it.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ais5r3YM9mfEtno2oLoZHz)_