### PR TITLE
refactor(builtins): use write_todos only for substantial multi-step work

### DIFF
--- a/crates/builtins/src/stateless_todo_list.rs
+++ b/crates/builtins/src/stateless_todo_list.rs
@@ -109,12 +109,10 @@ impl Capability for StatelessTodoListCapability {
 /// from the schema.
 const SYSTEM_PROMPT: &str = r#"## Task Management (`write_todos`)
 
-Use for work spanning 3+ distinct steps. Skip for greetings, single-step
-edits, or read-only checks.
+Use sparingly, only for substantial multi-step work needing tracking. Default to skipping it. Never use for greetings, single-step edits, read-only checks, or simple short tasks.
 
 Each `write_todos` call replaces the full list. Keep exactly one task
-`in_progress`. Mark `completed` only when the step is fully done (tests
-pass, no unresolved errors)."#;
+`in_progress`. Mark `completed` only when fully done (tests pass, no unresolved errors)."#;
 
 // ============================================================================
 // Tool: write_todos


### PR DESCRIPTION
## What changed
Tightened the `write_todos` system prompt in `stateless_todo_list.rs`: default to skipping the todo list, reserve it for substantial multi-step work needing progress tracking. Drops the "3+ distinct steps" numeric trigger that caused todo bookkeeping on routine short tasks.

## Why
Todo-list overhead on simple fixes and short tasks adds noise without value; the prompt should steer agents to just do the work unless tracking is genuinely useful.

## Before / After
No observable product behavior — agent-internal bookkeeping default only. Prompt stays within the 450B prompt-budget (`stateless_todo_list_prompt_within_budget` passes).

Before:
> Use for work spanning 3+ distinct steps. Skip for greetings, single-step edits, or read-only checks.

After:
> Use sparingly, only for substantial multi-step work needing tracking. Default to skipping it. Never use for greetings, single-step edits, read-only checks, or simple short tasks.

## Risk
- Low
- What can break: agents may under-use todos on genuinely multi-step work; wording keeps the "substantial multi-step work needing tracking" carve-out for that case.

## Security
- Threat categories reviewed: TM-LLM (prompts) — static instruction string, no interpolation of untrusted input, no new prompt-injection surface; no auth/API/data-flow changes.
- Findings and resolutions: none. No threat-model update needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing unit + prompt-budget tests cover it; 8 passed)
- [x] Backward compatibility considered (internal prompt, no API change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR (`just pre-push` green)
- [ ] All review comments addressed (pending review)

Produced by [yolop](https://everruns.com/yolop)