### PR TITLE
test(gemini): stop asserting that no stream reconnect happened

### DIFF
--- a/crates/drivers/gemini/tests/chat_wire.rs
+++ b/crates/drivers/gemini/tests/chat_wire.rs
@@ -122,6 +122,33 @@ async fn drain_golden(mut stream: LlmResponseStream) -> Vec<Golden> {
     out
 }
 
+/// The one request the driver made, tolerating a reconnect that replayed it.
+///
+/// `connect_sse_with_reconnect` peeks the first SSE item and, when opening the
+/// body fails transiently, reconnects (see `stream_reconnect.rs`). That is
+/// correct driver behaviour and nothing the test controls: a loaded CI runner
+/// produces it, and asserting `requests.len() == 1` turned it into a failure
+/// of whichever test happened to hit it.
+///
+/// So assert what actually matters instead, and rather more than the count
+/// did: every attempt must be a byte-identical replay, since a reconnect that
+/// re-sent a *different* request would be a real bug.
+async fn replayed_request(server: &MockServer) -> wiremock::Request {
+    let requests = server
+        .received_requests()
+        .await
+        .expect("wiremock records requests");
+    let (first, retries) = requests.split_first().expect("driver sent a request");
+    for retry in retries {
+        assert_eq!(
+            (&retry.method, &retry.url, &retry.body),
+            (&first.method, &first.url, &first.body),
+            "a reconnect must replay the same request, not a different one"
+        );
+    }
+    requests.into_iter().next_back().expect("checked non-empty")
+}
+
 async fn mount_sse(server: &MockServer, body: String) {
     Mock::given(method("POST"))
         .and(path_regex(r"^/models/.+:streamGenerateContent$"))
@@ -159,13 +186,12 @@ async fn text_stream_golden_events() {
         .await
         .expect("gemini stream should start");
 
-    let requests = server.received_requests().await.unwrap();
-    assert_eq!(requests.len(), 1);
+    let request = replayed_request(&server).await;
     assert_eq!(
-        requests[0].url.path(),
+        request.url.path(),
         "/models/gemini-2.5-flash:streamGenerateContent"
     );
-    assert_eq!(requests[0].url.query(), Some("alt=sse"));
+    assert_eq!(request.url.query(), Some("alt=sse"));
     let events = drain_golden(stream).await;
     assert_eq!(
         events,
@@ -396,9 +422,8 @@ async fn tool_results_replay_function_names_and_object_payloads_on_wire() {
             finish: Some("stop".into())
         }]
     );
-    let requests = server.received_requests().await.unwrap();
-    assert_eq!(requests.len(), 1);
-    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    let request = replayed_request(&server).await;
+    let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
     assert_eq!(
         body["contents"],
         serde_json::json!([
@@ -481,4 +506,64 @@ async fn rejected_terminal_frame_never_releases_pending_tool_calls() {
             "{reason}"
         );
     }
+}
+
+/// A reconnect leaves the mock server holding two identical records, which is
+/// exactly what two identical calls produce. This does not reproduce a live
+/// transport failure (wiremock cannot sever a body mid-read, and only
+/// `EventStreamError::Transport` reconnects), but it is the state
+/// `replayed_request` has to tolerate, and the state that used to fail CI.
+#[tokio::test]
+async fn replayed_request_tolerates_an_identical_replay() {
+    let server = MockServer::start().await;
+    mount_sse(
+        &server,
+        "data: {\"candidates\":[{\"content\":{\"parts\":[]},\"finishReason\":\"STOP\"}]}\n\n"
+            .into(),
+    )
+    .await;
+    for _ in 0..2 {
+        let stream = provider(&server)
+            .chat_completion_stream(
+                vec![LlmMessage::text(LlmMessageRole::User, "hi")],
+                &config("gemini-2.5-flash"),
+            )
+            .await
+            .expect("stream should start");
+        drain_golden(stream).await;
+    }
+
+    assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    let request = replayed_request(&server).await;
+    assert_eq!(
+        request.url.path(),
+        "/models/gemini-2.5-flash:streamGenerateContent"
+    );
+}
+
+/// The count assertion was not worthless, only aimed wrong: a second attempt
+/// that sent *different* bytes would be a real bug, and that is what
+/// `replayed_request` still catches.
+#[tokio::test]
+#[should_panic(expected = "a reconnect must replay the same request")]
+async fn replayed_request_rejects_a_replay_that_changed_the_request() {
+    let server = MockServer::start().await;
+    mount_sse(
+        &server,
+        "data: {\"candidates\":[{\"content\":{\"parts\":[]},\"finishReason\":\"STOP\"}]}\n\n"
+            .into(),
+    )
+    .await;
+    for prompt in ["hi", "something else entirely"] {
+        let stream = provider(&server)
+            .chat_completion_stream(
+                vec![LlmMessage::text(LlmMessageRole::User, prompt)],
+                &config("gemini-2.5-flash"),
+            )
+            .await
+            .expect("stream should start");
+        drain_golden(stream).await;
+    }
+
+    replayed_request(&server).await;
 }


### PR DESCRIPTION
## What changed

`crates/drivers/gemini/tests/chat_wire.rs` no longer asserts `requests.len() == 1` on the wiremock recorder. A new `replayed_request` helper asserts the thing that count was reaching for, and rather more than it managed: **every recorded attempt must be a byte-identical replay**, then hands back the request to inspect.

## Why

`requests.len() == 1` does not only say "the driver sent this request". It also says "the driver never reconnected" — and the driver reconnects by design. `connect_sse_with_reconnect` peeks the first SSE item and retries when opening the response body fails transiently (`stream_reconnect.rs`, and only for `EventStreamError::Transport`). A loaded runner produces exactly that, so the assertion turns an ordinary transport hiccup into a failure of whichever test happened to hit it.

It took `Unit Tests (Pure)` red on `main` at c9e52f6:

```
crates/drivers/gemini/tests/chat_wire.rs:400
assertion `left == right` failed
  left: 2
 right: 1
```

The tell is in the timings: the failing test took **0.89s** while its seven siblings took ~0.003s each — a retry backoff, not a logic difference. The test is about the replayed request body carrying function names and object payloads; the attempt count is neither its subject nor something it controls.

## Before / After

**Before** — the count assertion fails whenever a reconnect occurs:

```
test tool_results_replay_function_names_and_object_payloads_on_wire ... FAILED
test result: FAILED. 7 passed; 1 failed
```

**After** — 10 passed, including two new tests covering the helper itself:

```
test replayed_request_tolerates_an_identical_replay ... ok
test replayed_request_rejects_a_replay_that_changed_the_request - should panic ... ok
test tool_results_replay_function_names_and_object_payloads_on_wire ... ok

test result: ok. 10 passed; 0 failed
```

Being straight about the limits of that coverage: neither new test reproduces a *live* transport failure. wiremock cannot sever a response body mid-read, and only `EventStreamError::Transport` triggers a reconnect, so they instead reproduce the recorded state a reconnect leaves behind — two identical entries — which is precisely the state that broke CI. The divergent-replay test pins the half of the old assertion that was worth keeping.

`cargo fmt --check`, `cargo clippy -p everruns-gemini --all-targets`, and `cargo test -p everruns-gemini` all clean.

## Risk

- Low
- Test-only; no product code changes.
- The tests get weaker in exactly one respect: they no longer detect a spurious *extra* attempt that happens to send identical bytes. That is the trade — it is indistinguishable from the legitimate reconnect the driver is supposed to perform, so no test at this layer can assert on it. Reconnect behaviour itself is covered by `stream_reconnect`'s own tests.

## Security

- Threat categories reviewed: none applicable. Test-only change in a driver test file; no production code, credentials, network boundaries, or data flow touched.
- Findings and resolutions: none.

## Follow-ups

- The same `assert_eq!(requests.len(), 1)` pattern sits in **15 other places**, each a latent version of this flake wherever the code under test streams SSE through the reconnecting path: `provider/openresponses_protocol.rs` (×2), `provider/openai_protocol.rs`, `drivers/{fireworks,gemini,mai,meta,bedrock,anthropic,openrouter}/src/driver.rs`, `drivers/openai/src/tests.rs` (×2), `drivers/openrouter/tests/request_wire.rs` (×2), `host/observability/braintrust.rs`, `host/session_services/capabilities/session.rs`. Left alone here rather than rewriting drivers this change does not otherwise touch; worth a sweep, ideally behind a shared test helper rather than 15 copies of this one. The last two are not SSE paths and are probably fine as they stand.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_014FwmauZkP2Gx9bq1aVgHWY)_