### PR TITLE
fix(ui): align provider cards with the standard card anatomy

### DIFF
--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -266,8 +266,8 @@ describe("ProvidersPage", () => {
   it("shows provider model counts and links to filtered models", () => {
     render(<ProvidersPage />, { wrapper });
 
-    expect(screen.getByText("1 model available, 1 enabled")).toBeInTheDocument();
-    expect(screen.getByText("0 models available, 0 enabled")).toBeInTheDocument();
+    expect(screen.getByText("1 available, 1 enabled")).toBeInTheDocument();
+    expect(screen.getByText("0 available, 0 enabled")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /OpenAI Production/i })).toHaveAttribute(
       "href",
       "/settings/providers/provider-1",
@@ -336,13 +336,41 @@ describe("ProvidersPage", () => {
     expect(addButtons.length).toBeGreaterThan(0);
   });
 
-  it("shows API Key status correctly", () => {
+  it("shows API key status correctly", () => {
     render(<ProvidersPage />, { wrapper });
 
+    // Both cards render the shared "API key" detail row.
+    expect(screen.getAllByText("API key")).toHaveLength(2);
     // OpenAI has API key set
-    expect(screen.getByText(/API Key: Configured/i)).toBeInTheDocument();
+    expect(screen.getByText("Configured")).toBeInTheDocument();
     // Anthropic does not have API key set
-    expect(screen.getByText(/API Key: Not set/i)).toBeInTheDocument();
+    expect(screen.getByText("Not set")).toBeInTheDocument();
+  });
+
+  it("offers the credential action per provider and a delete overflow action", () => {
+    render(<ProvidersPage />, { wrapper });
+
+    // Neither fixture provider supports model sync, so the credential action is
+    // the visible primary action on each card.
+    expect(screen.getByRole("button", { name: "Update key" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Set key" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Delete provider" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "More provider actions" })).toHaveLength(2);
+  });
+
+  it("hides credential and delete actions for host-managed providers", () => {
+    mockUseProviders.mockReturnValue({
+      data: [{ ...mockProviders[0], id: "provider-3", name: "Managed OpenAI", managed: true }],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ProvidersPage />, { wrapper });
+
+    expect(screen.getByText("Managed")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /key/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete provider" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "More provider actions" })).not.toBeInTheDocument();
   });
 
   it("opens Add Provider dialog when clicking Add Provider button", async () => {

--- a/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
@@ -17,6 +17,7 @@ import { ResourceNotFound } from "@/components/resource-not-found";
 import { useModels, useProvider, useUpdateProvider } from "@/hooks/use-providers";
 import { usePageTitle } from "@/hooks";
 import { formatCountLabel } from "@/lib/formatting";
+import { getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import type { Provider } from "@/lib/api/types";
 import { ApiError } from "@/lib/api/client";
 
@@ -106,24 +107,11 @@ export default function ProviderDetailPage({
             <ProviderIcon providerType={provider.provider_type} size="md" />
             <EntityIdentity value={provider.id}>{provider.name}</EntityIdentity>
             {provider.managed && (
-              <Badge
-                variant="outline"
-                className="bg-blue-100 text-blue-800"
-                title="Managed by the host"
-              >
+              <Badge variant="outline" title="Managed by the host">
                 Managed
               </Badge>
             )}
-            <Badge
-              variant="outline"
-              className={
-                provider.status === "active"
-                  ? "bg-green-100 text-green-800"
-                  : "bg-gray-100 text-gray-800"
-              }
-            >
-              {provider.status}
-            </Badge>
+            <Badge variant={getEntityStatusBadgeVariant(provider.status)}>{provider.status}</Badge>
           </>
         }
         description={getProviderLabel(provider.provider_type)}

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Notice, NoticeDescription } from "@/components/ui/notice";
 import {
   useModels,
   useProviders,
@@ -101,21 +102,20 @@ export default function ProvidersPage() {
         </div>
 
         {providersError && (
-          <div className="bg-destructive/10 text-destructive p-4 mb-4">
-            Failed to load providers: {providersError.message}
-          </div>
+          <Notice variant="destructive" className="mb-4">
+            <NoticeDescription>
+              Failed to load providers: {providersError.message}
+            </NoticeDescription>
+          </Notice>
         )}
 
         {syncMessage && (
-          <div
-            className={`p-4 mb-4 ${
-              syncMessage.type === "success"
-                ? "bg-green-100 text-green-800"
-                : "bg-destructive/10 text-destructive"
-            }`}
+          <Notice
+            variant={syncMessage.type === "success" ? "success" : "destructive"}
+            className="mb-4"
           >
-            {syncMessage.text}
-          </div>
+            <NoticeDescription>{syncMessage.text}</NoticeDescription>
+          </Notice>
         )}
 
         {providersLoading ? (

--- a/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
@@ -2,13 +2,21 @@
 
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
+import { Card, CardActions, CardContent, CardHeader } from "@/components/ui/card";
+import { EntityCard, EntityCardDetail, EntityCardFooter } from "@/components/ui/entity-card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPositioner,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Key, Trash2, RefreshCw, Boxes, ExternalLink } from "lucide-react";
+import { IconTile } from "@/components/layout/page-layout";
+import { Key, Trash2, RefreshCw, Boxes, Ellipsis, ExternalLink, Link2 } from "lucide-react";
 import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
-import { formatCountLabel } from "@/lib/formatting";
+import { getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import type { Provider } from "@/lib/api/types";
 
 type ProviderModelCounts = {
@@ -36,111 +44,159 @@ export function ProviderCard({
   const canSync =
     provider.api_key_set && (!provider.base_url || isOpenRouterUrl(provider.base_url));
   const modelsHref = `/models?provider=${encodeURIComponent(provider.id)}`;
+  const keyActionLabel = provider.api_key_set ? "Update key" : "Set key";
+  // Host-managed providers are read-only to org admins (EVE-810): no credential
+  // edits, no deletion. Model sync stays available.
+  const canEdit = !provider.managed;
+
+  const syncButton = canSync ? (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => onSyncModels(provider.id)}
+      disabled={isSyncing}
+      title="Discover available models from provider API"
+    >
+      <RefreshCw className={`icon-sharp h-4 w-4 mr-1 ${isSyncing ? "animate-spin" : ""}`} />
+      {isSyncing ? "Syncing…" : "Sync models"}
+    </Button>
+  ) : null;
+
+  const keyButton = canEdit ? (
+    <Button variant="outline" size="sm" onClick={() => onSetApiKey(provider)}>
+      <Key className="icon-sharp h-4 w-4 mr-1" />
+      {keyActionLabel}
+    </Button>
+  ) : null;
+
+  // Highest-priority action stays visible at every card width; the rest collapse
+  // into an overflow menu when the card is too narrow for the full row.
+  const primaryAction = syncButton ?? keyButton;
+  const hasOverflow = canEdit && primaryAction !== keyButton;
 
   return (
     <EntityCard
-      icon={<ProviderIcon providerType={provider.provider_type} size="md" />}
+      icon={
+        <IconTile
+          size="md"
+          icon={
+            <ProviderIcon
+              providerType={provider.provider_type}
+              size="sm"
+              showBackground={false}
+              className="p-0"
+            />
+          }
+        />
+      }
       title={provider.name}
       href={`/settings/providers/${provider.id}`}
       copyValue={provider.id}
       subtitle={
-        <span className="text-sm text-muted-foreground">
+        <span className="text-xs text-muted-foreground">
           {getProviderLabel(provider.provider_type)}
         </span>
       }
       headerActions={
-        <div className="flex items-center gap-2">
+        <>
           {provider.managed && (
-            <Badge
-              variant="outline"
-              className="bg-blue-100 text-blue-800"
-              title="Managed by the host"
-            >
+            <Badge variant="outline" title="Managed by the host">
               Managed
             </Badge>
           )}
-          <Badge
-            variant="outline"
-            className={
-              provider.status === "active"
-                ? "bg-green-100 text-green-800"
-                : "bg-gray-100 text-gray-800"
-            }
-          >
-            {provider.status}
-          </Badge>
-        </div>
+          <Badge variant={getEntityStatusBadgeVariant(provider.status)}>{provider.status}</Badge>
+        </>
       }
       footer={
         <EntityCardFooter
           className="mt-4"
           actions={
-            <div className="flex items-center gap-2">
-              {canSync && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => onSyncModels(provider.id)}
-                  disabled={isSyncing}
-                  title="Discover available models from provider API"
-                >
-                  <RefreshCw className={`h-4 w-4 mr-1 ${isSyncing ? "animate-spin" : ""}`} />
-                  {isSyncing ? "Syncing..." : "Sync Models"}
-                </Button>
-              )}
-              {/* Host-managed providers are read-only to org admins (EVE-810):
-                  no credential edits, no deletion. Model sync stays available. */}
-              {!provider.managed && (
-                <>
-                  <Button variant="outline" size="sm" onClick={() => onSetApiKey(provider)}>
-                    <Key className="h-4 w-4 mr-1" />
-                    {provider.api_key_set ? "Update Key" : "Set Key"}
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-destructive"
-                    onClick={() => onDelete(provider.id)}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </>
-              )}
-            </div>
+            (primaryAction || canEdit) && (
+              <CardActions
+                primary={primaryAction}
+                expanded={
+                  hasOverflow || canEdit ? (
+                    <>
+                      {hasOverflow && keyButton}
+                      {canEdit && (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="text-destructive"
+                          aria-label="Delete provider"
+                          onClick={() => onDelete(provider.id)}
+                        >
+                          <Trash2 className="icon-sharp h-4 w-4" />
+                        </Button>
+                      )}
+                    </>
+                  ) : null
+                }
+                collapsed={
+                  canEdit ? (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={<Button variant="outline" size="icon-sm" />}
+                        aria-label="More provider actions"
+                      >
+                        <Ellipsis className="icon-sharp" />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuPositioner align="end">
+                        <DropdownMenuContent>
+                          {hasOverflow && (
+                            <DropdownMenuItem onClick={() => onSetApiKey(provider)}>
+                              <Key />
+                              {keyActionLabel}
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onClick={() => onDelete(provider.id)}
+                          >
+                            <Trash2 />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenuPositioner>
+                    </DropdownMenu>
+                  ) : null
+                }
+              />
+            )
           }
         />
       }
     >
-      <div className="space-y-2 text-sm">
+      <div className="space-y-1.5">
         {provider.base_url && (
-          <p className="text-muted-foreground truncate">URL: {provider.base_url}</p>
+          <EntityCardDetail icon={<Link2 className="icon-sharp size-3.5" />} label="Endpoint">
+            <span className="min-w-0 truncate font-mono" title={provider.base_url}>
+              {provider.base_url}
+            </span>
+          </EntityCardDetail>
         )}
-        <div className="flex items-center gap-2">
-          <Key className="h-4 w-4 text-muted-foreground" />
-          <span className="text-muted-foreground">
-            API Key: {provider.api_key_set ? "Configured" : "Not set"}
-          </span>
-        </div>
-        <div className="flex items-start gap-2">
-          <Boxes className="h-4 w-4 text-muted-foreground mt-0.5" />
+        <EntityCardDetail icon={<Key className="icon-sharp size-3.5" />} label="API key">
+          <span className="truncate">{provider.api_key_set ? "Configured" : "Not set"}</span>
+        </EntityCardDetail>
+        <EntityCardDetail icon={<Boxes className="icon-sharp size-3.5" />} label="Models">
           {modelsLoading ? (
             <Skeleton className="h-4 w-40" />
           ) : (
-            <div className="text-muted-foreground">
+            // Wraps instead of truncating so the count stays readable in a narrow card.
+            <span className="flex min-w-0 flex-wrap items-center gap-x-1.5">
               <span>
-                {formatCountLabel(modelCounts.total, "model")} available, {modelCounts.enabled}{" "}
-                enabled
+                {modelCounts.total} available, {modelCounts.enabled} enabled
               </span>
               <Link
                 href={modelsHref}
-                className="ml-2 inline-flex items-center gap-1 text-foreground hover:underline"
+                className="inline-flex items-center gap-1 text-foreground hover:underline"
               >
                 View models
-                <ExternalLink className="h-3 w-3" />
+                <ExternalLink className="icon-sharp h-3 w-3" />
               </Link>
-            </div>
+            </span>
           )}
-        </div>
+        </EntityCardDetail>
       </div>
     </EntityCard>
   );
@@ -155,23 +211,28 @@ function isOpenRouterUrl(baseUrl: string): boolean {
   }
 }
 
+/** Mirrors {@link ProviderCard}'s EntityCard anatomy so loading does not shift layout. */
 export function ProviderCardSkeleton() {
   return (
-    <Card>
+    <Card className="bg-background">
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9" />
-          <div className="space-y-2">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <Skeleton className="size-8 flex-shrink-0" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
             <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-24" />
           </div>
         </div>
-        <Skeleton className="h-5 w-16" />
+        <Skeleton className="h-5 w-16 flex-shrink-0" />
       </CardHeader>
       <CardContent>
-        <Skeleton className="h-4 w-full mb-4" />
-        <Skeleton className="h-4 w-2/3 mb-4" />
-        <Skeleton className="h-8 w-24 ml-auto" />
+        <div className="space-y-1.5">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-56" />
+        </div>
+        <div className="mt-4 flex justify-end">
+          <Skeleton className="h-8 w-28" />
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## What changed

Settings → LLM Providers cards now look and behave like every other entity card.

- Leading icon is the shared gold `IconTile` instead of a primary-tinted pill, so providers match agents, harnesses, skills and sessions in the grid.
- Body rows use `EntityCardDetail` (`Endpoint`, `API key`, `Models`) instead of ad-hoc `text-sm` rows, so density and icon sizing match other cards. The model count wraps rather than truncating in a narrow card.
- Status and "Managed" badges use the `Badge` variants (`getEntityStatusBadgeVariant`) instead of hardcoded `bg-green-100` / `bg-blue-100` / `bg-gray-100`. Those were light-mode-only and rendered as near-white text on white in dark mode. Same fix on the provider detail page header.
- The action row uses `CardActions`: the highest-priority action stays visible (Sync models, or Set/Update key when sync is unavailable) and the rest collapse into an overflow menu when the card is too narrow — the documented card behavior in `apps/ui/DESIGN.md`. Previously three controls were crammed into one row at grid width.
- Sync/error banners use the `Notice` primitive instead of raw colored divs (the success banner was also light-mode-only).
- Action labels are sentence case per the design system ("Sync models", "Update key"), and the loading skeleton mirrors the card anatomy so nothing shifts when data lands.

Host-managed providers keep their read-only behavior (EVE-810): sync only, no credential edit or delete, and therefore no overflow menu.

## Why

The provider card had drifted from the shared card language: wrong icon treatment, oversized detail rows, dark-mode-broken badge colors, and an action row that overflowed at grid width.

## Before / After

Before (reported): round-ish grey icon tile, `API Key: Configured` at body text size, a light-only green `active` badge, and `Sync Models` + `Update Key` + delete crowding one row.

After (captured from a local dev render of `ProviderCard` at grid width and at 320px, light and dark):

- Gold icon tile; `API key  Configured` / `Models  12 available, 3 enabled` as compact detail rows with `View models`.
- `active` renders as the `success` badge variant, legible in dark mode; `disabled` renders as `outline`.
- At 320px the card keeps `Sync models` visible and collapses `Update key` + `Delete` into an `⋯` menu.

## Risk

- Low
- Presentation-only change to one settings surface. Behavior (sync, key dialog, delete confirm, managed read-only rules) is unchanged; delete is now also reachable from the overflow menu at narrow widths.

## Security

- Threat categories reviewed: no security-relevant code changes — presentation only, no new data exposed (the card still shows only whether a key is configured, never the key).
- Findings and resolutions: none.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
