### PR TITLE
feat(harnesses): widen Platform Chat capability set

### DIFF
--- a/crates/server/src/harnesses/platform_chat.rs
+++ b/crates/server/src/harnesses/platform_chat.rs
@@ -19,6 +19,24 @@ pub fn definition() -> BuiltInHarnessDefinition {
     .with_capabilities([
         BuiltInCapabilityDefinition::new("platform"),
         BuiltInCapabilityDefinition::new("btw"),
+        // This is the chat surface the UI renders, so model-authored tool
+        // narration and message timestamps are user-visible quality, not
+        // bookkeeping. `current_time` grounds relative-time questions ("which
+        // sessions ran today") that the platform catalog alone cannot answer.
+        BuiltInCapabilityDefinition::new("human_intent"),
+        BuiltInCapabilityDefinition::new("current_time"),
+        BuiltInCapabilityDefinition::new("message_metadata"),
+        // The preflight below mandates one bounded pass over five authoritative
+        // list views; serial tool calls fight that instruction.
+        BuiltInCapabilityDefinition::with_config(
+            "parallel_tool_calls",
+            serde_json::json!({"mode": "prefer"}),
+        ),
+        // Multi-step platform mutations become visible progress in the thread.
+        BuiltInCapabilityDefinition::new("stateless_todo_list"),
+        // Long-lived operator threads re-send a large system prompt every turn.
+        BuiltInCapabilityDefinition::new("prompt_caching"),
+        BuiltInCapabilityDefinition::new("tool_call_repair"),
         BuiltInCapabilityDefinition::new("loop_detection"),
         BuiltInCapabilityDefinition::with_config(
             "error_disclosure",
@@ -33,6 +51,13 @@ pub fn definition() -> BuiltInHarnessDefinition {
             }),
         ),
     ])
+    // Deliberately excluded: `tool_output_distillation` and `memory` both
+    // depend on `session_file_system`. Distillation only replaces a result once
+    // the full original is persisted to the session VFS, and Memory is driven by
+    // `mounts[]` entries naming concrete per-org `mem_` IDs that a built-in
+    // definition cannot know. Enabling either here would resolve a file-system
+    // tool surface into the chat harness to buy a no-op. Revisit together with a
+    // VFS decision, not separately.
 }
 
 const SYSTEM_PROMPT: &str = "\
@@ -120,11 +145,34 @@ mod tests {
             [
                 "platform",
                 "btw",
+                "human_intent",
+                "current_time",
+                "message_metadata",
+                "parallel_tool_calls",
+                "stateless_todo_list",
+                "prompt_caching",
+                "tool_call_repair",
                 "loop_detection",
                 "error_disclosure",
                 "compaction"
             ]
         );
+    }
+
+    /// Both depend on `session_file_system`, which this harness deliberately
+    /// does not have; see the note on `definition()`.
+    #[test]
+    fn platform_chat_omits_vfs_dependent_capabilities() {
+        let definition = definition();
+        let capabilities = definition
+            .capabilities
+            .iter()
+            .map(|capability| capability.capability_id())
+            .collect::<Vec<_>>();
+        assert!(!capabilities.contains(&"session_file_system"));
+        assert!(!capabilities.contains(&"tool_output_distillation"));
+        assert!(!capabilities.contains(&"tool_output_persistence"));
+        assert!(!capabilities.contains(&"memory"));
     }
 
     #[test]

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -603,16 +603,18 @@ mod tests {
             .iter()
             .map(|cap| cap.capability_id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(
-            chat_cap_ids,
-            vec![
-                "platform",
-                "btw",
-                "loop_detection",
-                "error_disclosure",
-                "compaction"
-            ]
-        );
+        // Derive from the definition rather than a second literal: the list is
+        // already pinned by `platform_chat_has_a_focused_tool_surface`, and this
+        // test's job is that provisioning persists it verbatim and in order.
+        let expected_chat_cap_ids = harnesses()
+            .into_iter()
+            .find(|definition| definition.name == "platform-chat")
+            .expect("platform-chat definition")
+            .capabilities
+            .iter()
+            .map(|capability| capability.capability_id().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(chat_cap_ids, expected_chat_cap_ids);
     }
 
     #[tokio::test]

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -3886,6 +3886,13 @@ async fn test_chat_harness_includes_platform_capability() {
         vec![
             "platform",
             "btw",
+            "human_intent",
+            "current_time",
+            "message_metadata",
+            "parallel_tool_calls",
+            "stateless_todo_list",
+            "prompt_caching",
+            "tool_call_repair",
             "loop_detection",
             "error_disclosure",
             "compaction"

--- a/knowledge/harnesses/harness-types.md
+++ b/knowledge/harnesses/harness-types.md
@@ -100,17 +100,32 @@ The recommended default harness. Bundles the core capabilities needed for genera
 
 ### Platform Chat
 
-Conversational harness for the global chat interface. Inherits Generic capabilities, adds `platform`, and is tagged separately to support the per-user singleton session pattern.
+Conversational harness for the global chat interface. Parents on Base and declares an explicit,
+focused capability set, so its effective surface is exactly what it lists. It is tagged separately to
+support the per-user singleton session pattern.
 
 | Property | Value |
 |----------|-------|
 | Name | `platform-chat` |
 | Display Name | Platform Chat |
-| Parent | `generic` |
+| Parent | `base` |
 | System Prompt | See `crates/server/src/harnesses/platform_chat.rs` for full prompt |
 | Tags | `chat`, `built-in` |
 
-**Effective capabilities:** Inherits Generic harness capabilities and adds local `platform`.
+**Effective capabilities:** Base contributes none, so the effective set is the local list in
+`crates/server/src/harnesses/platform_chat.rs` — pinned by
+`platform_chat_has_a_focused_tool_surface`. It grants platform catalog access, the UI-facing
+affordances the chat surface renders (tool narration, timestamps, todo lists), conversational
+robustness (loop detection, tool-call repair, detailed error disclosure, proactive compaction), and
+prompt caching for long operator threads.
+
+**Deliberately excluded:** no file system, shell, or web fetch — the chat stays grounded in platform
+state rather than becoming a coding agent. That exclusion transitively rules out
+`tool_output_distillation`, `tool_output_persistence`, and `memory`, which all depend on
+`session_file_system`; `memory` additionally needs `mounts[]` naming per-org `mem_` IDs that a
+built-in definition cannot know. `session_schedule` is excluded because recurring work belongs on an
+Agent Trigger, never on the chat session itself. Guarded by
+`platform_chat_omits_vfs_dependent_capabilities`.
 
 **Authorization rule:** Do not remove `platform` from Platform Chat to paper over authorization bugs. Platform tools must reload the session owner and enforce that caller's permissions via the normal command/policy path.
 


### PR DESCRIPTION
## What changed

Platform Chat — the harness behind the operator chat surface — ran on five capabilities: `platform`, `btw`, `loop_detection`, `error_disclosure`, `compaction`. Its parent is Base, which contributes nothing, so that was the entire effective surface.

Seven capabilities added:

| Capability | Why it matters in chat |
|---|---|
| `human_intent` | Model-authored tool narration. This is the one harness whose tool calls a human watches live, and it was the one without it. |
| `current_time` | No clock at all previously — "which sessions ran today" was ungrounded. |
| `message_metadata` | Message timestamps, pairs with the above. |
| `parallel_tool_calls` (`prefer`) | The system prompt already mandates one bounded pass over five authoritative list views; serial calls fought that instruction. |
| `stateless_todo_list` | Multi-step platform mutations become visible progress in the thread. |
| `prompt_caching` | Long operator threads re-send a ~6 KB system prompt every turn. |
| `tool_call_repair` | Recovers a malformed tool call instead of surfacing a parse error mid-operation. |

Also corrects `knowledge/harnesses/harness-types.md`, which documented Platform Chat as parenting on `generic` and inheriting Generic's capabilities. It parents on `base`; its effective set is exactly its local list. The doc described a harness that does not exist.

No migration needed: `reconcile_built_in_harnesses` syncs capabilities for existing orgs on startup.

## Why

The chat surface was missing affordances the UI already renders, and had no way to answer a relative-time question about platform state. The stale knowledge entry is what made the gap hard to see — reading the doc, Platform Chat looked like it already had everything Generic has.

## Before / After

Effective capability list (pinned by `platform_chat_has_a_focused_tool_surface`):

**Before**
```
platform, btw, loop_detection, error_disclosure, compaction
```

**After**
```
platform, btw, human_intent, current_time, message_metadata,
parallel_tool_calls, stateless_todo_list, prompt_caching,
tool_call_repair, loop_detection, error_disclosure, compaction
```

```
$ cargo test -p everruns-server --lib harnesses::
test harnesses::platform_chat::tests::platform_chat_has_a_focused_tool_surface ... ok
test harnesses::platform_chat::tests::platform_chat_omits_vfs_dependent_capabilities ... ok
test harnesses::platform_chat::tests::platform_chat_requires_authoritative_resource_preflight ... ok
test harnesses::platform_chat::tests::platform_chat_routes_plaintext_credentials_to_write_only_setup ... ok
test result: ok. 21 passed; 0 failed
```

`just pre-push`: 22/22 passed.

## Risk

- Low
- Every added capability is already in production use on Generic or Data Analyst, and none declares a dependency that would pull additional tools into the harness (verified against `dependencies()` for all seven). The widest behavioral change is `parallel_tool_calls: prefer`, which requests concurrency the local scheduler already performs by class. Worst case is more tokens per turn from narration and timestamps, offset by prompt caching.

## Security

- Threat categories reviewed: TM-AUTH. `platform` is untouched, so the authorization path is unchanged — permission enforcement stays in the platform tool execution path, per the standing rule on this harness. No capability added grants file system, shell, network egress, or credential access. `stateless_todo_list` keeps state in conversation history only.
- Findings and resolutions: none.

## Follow-ups

Two capabilities considered and deliberately excluded, both blocked on the same thing:

- `tool_output_distillation` depends on `session_file_system` and by design never replaces a result unless the full original was persisted to the session VFS.
- `memory` has the same dependency, and is driven by `mounts[]` entries naming concrete per-org `mem_` IDs that a built-in definition cannot know. Built-ins are read-only per org, so mounts cannot be added afterwards either.

Enabling either would resolve a file-system tool surface into the chat harness in exchange for a no-op. Both are recorded as a comment on `definition()` and guarded by `platform_chat_omits_vfs_dependent_capabilities`, so this stays a decision rather than an oversight. Revisiting either means first deciding whether Platform Chat should have a VFS — a separate change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHUak1mTBC6qtGYuJujBpD


---
_Generated by [Claude Code](https://claude.ai/code/session_01WHUak1mTBC6qtGYuJujBpD)_