### PR TITLE
feat(ui): precreate and pin a Platform Chat thread for every user

### DIFF
--- a/apps/ui/src/__tests__/new-chat-form.test.tsx
+++ b/apps/ui/src/__tests__/new-chat-form.test.tsx
@@ -108,7 +108,7 @@ describe("NewChatForm", () => {
 
     await waitFor(() =>
       expect(mutateAsync).toHaveBeenCalledWith({
-        request: { agent_id: "agent_1", tags: ["chat"] },
+        request: { agent_id: "agent_1", source: "chat", tags: ["chat"] },
       }),
     );
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/chats/sess_new"));
@@ -124,7 +124,7 @@ describe("NewChatForm", () => {
 
     await waitFor(() =>
       expect(mutateAsync).toHaveBeenCalledWith({
-        request: { harness_name: "platform-chat", tags: ["chat"] },
+        request: { harness_name: "platform-chat", source: "chat", tags: ["chat"] },
       }),
     );
   });
@@ -150,7 +150,7 @@ describe("NewChatForm", () => {
 
     await waitFor(() =>
       expect(mutateAsync).toHaveBeenCalledWith({
-        request: { harness_name: "generic", tags: ["chat"] },
+        request: { harness_name: "generic", source: "chat", tags: ["chat"] },
       }),
     );
   });

--- a/apps/ui/src/__tests__/org-setup-page.test.tsx
+++ b/apps/ui/src/__tests__/org-setup-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import OrgSetupPage from "@/app/(main)/orgs/[orgId]/setup/page";
@@ -45,6 +45,12 @@ jest.mock("@/hooks/use-providers", () => ({
   }),
 }));
 
+// The Done step links to the precreated Platform Chat thread; its own suite
+// covers how the thread is ensured.
+jest.mock("@/hooks/use-platform-chat-thread", () => ({
+  usePlatformChatThread: () => ({ thread: { id: "ses_platform_chat" }, isLoading: false }),
+}));
+
 jest.mock("@/providers/org-provider", () => ({
   useOrg: () => ({
     currentOrg: { public_id: "org_test123", name: "Test Org", role: "owner" },
@@ -87,5 +93,16 @@ describe("OrgSetupPage", () => {
     // The breadth strip mentions Azure OpenAI as plain text, but it must not
     // be a selectable card during setup.
     expect(screen.queryByRole("button", { name: /Azure OpenAI/ })).not.toBeInTheDocument();
+  });
+
+  it("ends onboarding in the precreated Platform Chat thread", async () => {
+    render(<OrgSetupPage />, { wrapper });
+
+    // Skipping the provider form is the shortest route to the Done step.
+    const skip = await screen.findByRole("button", { name: "Skip for now" });
+    fireEvent.click(skip);
+
+    const open = await screen.findByRole("link", { name: /Open Platform Chat/ });
+    expect(open).toHaveAttribute("href", "/chats/ses_platform_chat");
   });
 });

--- a/apps/ui/src/__tests__/platform-chat-thread.test.tsx
+++ b/apps/ui/src/__tests__/platform-chat-thread.test.tsx
@@ -82,6 +82,7 @@ test("creates and pins a Platform Chat thread when the user has none", async () 
   await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
   expect(mockCreate).toHaveBeenCalledWith({
     request: {
+      source: "chat",
       harness_name: "platform-chat",
       title: "Platform Chat",
       tags: [CHAT_THREAD_TAG],

--- a/apps/ui/src/__tests__/platform-chat-thread.test.tsx
+++ b/apps/ui/src/__tests__/platform-chat-thread.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * The Platform Chat thread is precreated and pinned so a new user lands in a
+ * conversation rather than an empty Chats list — and is adopted, never
+ * duplicated, when one already exists.
+ */
+import { render, waitFor } from "@testing-library/react";
+import { useChatThreads } from "@/hooks/use-chat-threads";
+import { usePlatformChatThread } from "@/hooks/use-platform-chat-thread";
+import { CHAT_THREAD_TAG } from "@/lib/chat-threads";
+import type { Session } from "@/lib/api/types";
+
+const mockCreate = jest.fn();
+const mockPin = jest.fn();
+
+jest.mock("@/hooks/use-chat-threads", () => ({
+  useChatThreads: jest.fn(),
+}));
+
+jest.mock("@/hooks", () => ({
+  useHarnesses: () => ({
+    data: [
+      { id: "harness_generic", name: "generic" },
+      { id: "harness_platform", name: "platform-chat" },
+    ],
+    isLoading: false,
+  }),
+}));
+
+jest.mock("@/hooks/use-sessions", () => ({
+  useCreateSession: () => ({ mutateAsync: mockCreate }),
+  usePinSession: () => ({ mutateAsync: mockPin }),
+}));
+
+// The ensure guard is keyed by org and lives for the page load, so each test
+// runs against its own org — the same isolation a fresh page load gives.
+let currentOrgId = "org_1";
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({ currentOrg: { public_id: currentOrgId, name: "Acme", role: "owner" } }),
+}));
+
+let orgCounter = 0;
+
+const mockUseChatThreads = useChatThreads as jest.MockedFunction<typeof useChatThreads>;
+
+function thread(overrides: Partial<Session>): Session {
+  return {
+    id: "ses_existing",
+    organization_id: currentOrgId,
+    harness_id: "harness_platform",
+    agent_id: null,
+    owner_principal_id: "user_1",
+    title: "Platform Chat",
+    tags: [CHAT_THREAD_TAG],
+    model_id: null,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    started_at: null,
+    finished_at: null,
+    ...overrides,
+  } as Session;
+}
+
+function Probe({ ensure }: { ensure?: boolean }) {
+  const { thread: found } = usePlatformChatThread({ ensure });
+  return <span data-testid="thread">{found?.id ?? "none"}</span>;
+}
+
+beforeEach(() => {
+  orgCounter += 1;
+  currentOrgId = `org_${orgCounter}`;
+  jest.clearAllMocks();
+  mockCreate.mockResolvedValue({ id: "ses_new" });
+  mockPin.mockResolvedValue(undefined);
+});
+
+test("creates and pins a Platform Chat thread when the user has none", async () => {
+  mockUseChatThreads.mockReturnValue({ threads: [], isLoading: false, error: null });
+
+  render(<Probe ensure />);
+
+  await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+  expect(mockCreate).toHaveBeenCalledWith({
+    request: {
+      harness_name: "platform-chat",
+      title: "Platform Chat",
+      tags: [CHAT_THREAD_TAG],
+    },
+  });
+  await waitFor(() => expect(mockPin).toHaveBeenCalledWith({ sessionId: "ses_new" }));
+});
+
+test("adopts an existing Platform Chat thread instead of creating a second", async () => {
+  mockUseChatThreads.mockReturnValue({
+    threads: [thread({})],
+    isLoading: false,
+    error: null,
+  });
+
+  const { getByTestId } = render(<Probe ensure />);
+
+  expect(getByTestId("thread")).toHaveTextContent("ses_existing");
+  await waitFor(() => expect(mockCreate).not.toHaveBeenCalled());
+});
+
+test("does not recreate a thread the user archived", async () => {
+  mockUseChatThreads.mockReturnValue({
+    threads: [thread({ archived_at: "2026-02-01T00:00:00Z" })],
+    isLoading: false,
+    error: null,
+  });
+
+  render(<Probe ensure />);
+
+  await waitFor(() => expect(mockCreate).not.toHaveBeenCalled());
+});
+
+test("ignores threads bound to another harness or to an agent", async () => {
+  mockUseChatThreads.mockReturnValue({
+    threads: [
+      thread({ id: "ses_generic", harness_id: "harness_generic" }),
+      thread({ id: "ses_agent", agent_id: "agent_1" }),
+    ],
+    isLoading: false,
+    error: null,
+  });
+
+  const { getByTestId } = render(<Probe ensure />);
+
+  expect(getByTestId("thread")).toHaveTextContent("none");
+  await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+});
+
+test("reads without creating when ensure is off", async () => {
+  mockUseChatThreads.mockReturnValue({ threads: [], isLoading: false, error: null });
+
+  render(<Probe />);
+
+  await waitFor(() => expect(mockCreate).not.toHaveBeenCalled());
+});
+
+test("waits for the thread list before deciding to create", async () => {
+  mockUseChatThreads.mockReturnValue({ threads: [], isLoading: true, error: null });
+
+  render(<Probe ensure />);
+
+  await waitFor(() => expect(mockCreate).not.toHaveBeenCalled());
+});

--- a/apps/ui/src/__tests__/sidebar-chat-threads.test.tsx
+++ b/apps/ui/src/__tests__/sidebar-chat-threads.test.tsx
@@ -19,6 +19,12 @@ jest.mock("@/hooks/use-chat-threads", () => ({
   useChatThreads: jest.fn(),
 }));
 
+// The Platform Chat thread is ensured here (see the component's header); its
+// own suite covers that behaviour.
+jest.mock("@/hooks/use-platform-chat-thread", () => ({
+  usePlatformChatThread: () => ({ thread: undefined, isLoading: false }),
+}));
+
 const mockUseChatThreads = jest.mocked(useChatThreads);
 
 function thread(id: string, title: string): Session {

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -8,7 +8,12 @@
 // Done: shown after the provider form is submitted OR skipped (replaces the old
 //   redirect straight to /chats). The Done subline is conditional — it only
 //   claims a provider is connected when one actually exists; a skip shows a
-//   gentle nudge instead. The user proceeds from Done into a real first action.
+//   gentle nudge instead. The user proceeds from Done into a real first action,
+//   and that action is the Platform Chat thread: onboarding ends in a
+//   conversation that can do the next steps (create an agent, add a provider)
+//   for the user, not on an empty form. The thread is ensured here because the
+//   onboarding surfaces render without the sidebar that ensures it everywhere
+//   else.
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
@@ -22,6 +27,7 @@ import {
   ArrowRight,
   Plus,
   LayoutGrid,
+  MessageCircle,
   Users,
   BookOpen,
 } from "lucide-react";
@@ -37,6 +43,7 @@ import { usePageTitle } from "@/hooks";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrg } from "@/providers/org-provider";
+import { usePlatformChatThread } from "@/hooks/use-platform-chat-thread";
 import { OnboardingShell } from "@/components/onboarding/onboarding-shell";
 import { useOnboardingArc } from "@/components/onboarding/onboarding-arc-context";
 import type { ApiError } from "@/lib/api/client";
@@ -119,6 +126,8 @@ export default function OrgSetupPage() {
   // (e.g. SaaS with a prepended "Verify") shifts indices/labels via context so
   // the stepper stays continuous across the whole journey.
   const arc = useOnboardingArc();
+  // Precreated, pinned Platform Chat thread — the landing place after Done.
+  const { thread: platformChatThread } = usePlatformChatThread({ ensure: true });
 
   const {
     data: org,
@@ -341,23 +350,35 @@ export default function OrgSetupPage() {
               )}
             </p>
 
+            {/* Land in the chat. Falls back to the Chats list while the thread
+                is still being created — it is pinned at the top there. */}
             <Link
-              href="/agents/new"
+              href={platformChatThread ? `/chats/${platformChatThread.id}` : "/chats"}
               className="mt-6 flex items-center gap-3.5 bg-primary px-5 py-4 text-primary-foreground transition-colors hover:bg-primary/90"
             >
               <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center border border-accent/50 bg-accent/[0.15] text-accent">
-                <Plus className="icon-sharp h-[18px] w-[18px]" strokeWidth={2} />
+                <MessageCircle className="icon-sharp h-[18px] w-[18px]" strokeWidth={2} />
               </span>
               <span className="flex-1">
-                <span className="block text-[15px] font-semibold">Create your first agent</span>
+                <span className="block text-[15px] font-semibold">Open Platform Chat</span>
                 <span className="block text-xs text-primary-foreground/60">
-                  Start from a template or a blank harness
+                  Ask it to create your first agent, or just start talking
                 </span>
               </span>
               <ArrowRight className="icon-sharp h-[18px] w-[18px] text-accent" strokeWidth={2} />
             </Link>
 
             <div className="mt-3.5 flex gap-2.5">
+              <Link
+                href="/agents/new"
+                className="flex flex-1 flex-col gap-2 border p-3.5 text-foreground transition-colors hover:bg-muted"
+              >
+                <Plus
+                  className="icon-sharp h-[18px] w-[18px] text-muted-foreground"
+                  strokeWidth={1.8}
+                />
+                <span className="text-[13px] font-medium">Create an agent</span>
+              </Link>
               <Link
                 href="/agents/examples"
                 className="flex flex-1 flex-col gap-2 border p-3.5 text-foreground transition-colors hover:bg-muted"

--- a/apps/ui/src/components/chat/new-chat-form.tsx
+++ b/apps/ui/src/components/chat/new-chat-form.tsx
@@ -62,7 +62,11 @@ export function NewChatForm({
 
     try {
       const session = await createSession.mutateAsync({
-        request: { ...binding, tags: [CHAT_THREAD_TAG] } as CreateSessionRequest,
+        request: {
+          ...binding,
+          source: "chat",
+          tags: [CHAT_THREAD_TAG],
+        } as CreateSessionRequest,
       });
       router.push(`/chats/${session.id}`);
     } catch (e) {

--- a/apps/ui/src/components/layout/sidebar-chat-threads.tsx
+++ b/apps/ui/src/components/layout/sidebar-chat-threads.tsx
@@ -6,6 +6,12 @@
  * bounded. And the order is frozen while the pointer or keyboard focus is inside
  * the list, so an arriving turn cannot re-sort a row out from under a click;
  * the pending order is adopted as soon as the user leaves.
+ *
+ * This is also where the user's pinned Platform Chat thread is ensured: the
+ * list is rendered on every app route in both the OSS app and its wrappers, so
+ * a user who never passes through onboarding (an invited member, say) still
+ * finds the thread waiting. The onboarding surfaces, which render without the
+ * sidebar, ensure it themselves.
  */
 "use client";
 
@@ -13,6 +19,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Pin, Plus } from "lucide-react";
 import { useChatThreads } from "@/hooks/use-chat-threads";
+import { usePlatformChatThread } from "@/hooks/use-platform-chat-thread";
 import { SIDEBAR_THREAD_LIMIT, threadTitle } from "@/lib/chat-threads";
 import type { Session } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
@@ -36,6 +43,7 @@ function useFrozen<T>(value: T, frozen: boolean): T {
 
 export function SidebarChatThreads({ pathname }: { pathname: string }) {
   const { threads, isLoading } = useChatThreads();
+  usePlatformChatThread({ ensure: true });
   const [interacting, setInteracting] = useState(false);
   const stableThreads = useFrozen<Session[]>(threads, interacting);
   const visible = stableThreads.slice(0, SIDEBAR_THREAD_LIMIT);

--- a/apps/ui/src/hooks/use-chat-threads.ts
+++ b/apps/ui/src/hooks/use-chat-threads.ts
@@ -28,6 +28,11 @@ export interface UseChatThreadsOptions {
   /** Widen the list to archived threads too. Off by default: archiving a thread
    *  is the user asking for it to stop showing up. */
   includeArchived?: boolean;
+  /** Keep the list fresh on a timer. On by default for surfaces that display
+   *  threads; a caller that only needs to read the list once (e.g. deciding
+   *  whether a thread exists) turns it off so it does not add a second poll of
+   *  the same endpoint. */
+  poll?: boolean;
 }
 
 /** This user's chat threads, pinned first and then ordered by recent activity. */
@@ -37,6 +42,7 @@ export function useChatThreads(options: UseChatThreadsOptions = {}): UseChatThre
   const org = currentOrg?.public_id;
   const enabled = !!org && (options.enabled ?? true);
   const includeArchived = options.includeArchived ?? false;
+  const poll = options.poll ?? true;
 
   const query = useQuery({
     // Still under the `["sessions"]` prefix, so a create/update invalidation of
@@ -50,7 +56,7 @@ export function useChatThreads(options: UseChatThreadsOptions = {}): UseChatThre
     ),
     queryFn: () => listSessions({ offset: 0, limit: THREAD_SCAN_LIMIT, includeArchived }),
     enabled,
-    refetchInterval: THREAD_POLL_MS,
+    refetchInterval: poll ? THREAD_POLL_MS : false,
   });
 
   const threads = useMemo(

--- a/apps/ui/src/hooks/use-chat-threads.ts
+++ b/apps/ui/src/hooks/use-chat-threads.ts
@@ -28,6 +28,11 @@ export interface UseChatThreadsOptions {
   /** Widen the list to archived threads too. Off by default: archiving a thread
    *  is the user asking for it to stop showing up. */
   includeArchived?: boolean;
+  /** Ask the server for this user's sessions only. The client-side owner
+   *  filter runs either way; this narrows the page the server returns, so a
+   *  busy org's other sessions cannot push the user's threads out of the
+   *  scanned window. */
+  mine?: boolean;
   /** Keep the list fresh on a timer. On by default for surfaces that display
    *  threads; a caller that only needs to read the list once (e.g. deciding
    *  whether a thread exists) turns it off so it does not add a second poll of
@@ -43,6 +48,7 @@ export function useChatThreads(options: UseChatThreadsOptions = {}): UseChatThre
   const enabled = !!org && (options.enabled ?? true);
   const includeArchived = options.includeArchived ?? false;
   const poll = options.poll ?? true;
+  const mine = options.mine ?? false;
 
   const query = useQuery({
     // Still under the `["sessions"]` prefix, so a create/update invalidation of
@@ -50,11 +56,11 @@ export function useChatThreads(options: UseChatThreadsOptions = {}): UseChatThre
     // separate cache entry because it is a different server-side predicate.
     queryKey: queryKeys.sessions.filtered(
       org,
-      includeArchived ? "threads+archived" : "threads",
+      `${mine ? "my-threads" : "threads"}${includeArchived ? "+archived" : ""}`,
       0,
       THREAD_SCAN_LIMIT,
     ),
-    queryFn: () => listSessions({ offset: 0, limit: THREAD_SCAN_LIMIT, includeArchived }),
+    queryFn: () => listSessions({ offset: 0, limit: THREAD_SCAN_LIMIT, includeArchived, mine }),
     enabled,
     refetchInterval: poll ? THREAD_POLL_MS : false,
   });

--- a/apps/ui/src/hooks/use-platform-chat-thread.ts
+++ b/apps/ui/src/hooks/use-platform-chat-thread.ts
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * The user's Platform Chat thread: precreated, pinned, and the place a new
+ * user lands.
+ *
+ * Chats is the unconditional landing route
+ * (knowledge/ui/information-architecture.md), so a fresh account must find a
+ * conversation already waiting there rather than an empty list and a picker.
+ * The thread is an ordinary session bound to the built-in `platform-chat`
+ * harness and tagged as a chat thread — nothing about it is special except
+ * that the app creates it instead of the user, and pins it so it stays at the
+ * top of the list.
+ *
+ * Ensuring is per user and per org (pins are per-user state), idempotent, and
+ * one-shot per entry: if the thread already exists it is adopted, and a failed
+ * attempt is simply retried the next time the app is entered. A thread the
+ * user archived is *not* recreated — archiving is the user saying they do not
+ * want it.
+ *
+ * The guard against a second thread is module-level rather than per-component,
+ * because the hook can be mounted more than once at a time (the desktop and
+ * mobile sidebars both render the thread list) and the created thread is only
+ * visible to the others once the sessions list has refetched.
+ */
+
+import { useEffect } from "react";
+import { useHarnesses } from "@/hooks";
+import { useChatThreads } from "@/hooks/use-chat-threads";
+import { useCreateSession, usePinSession } from "@/hooks/use-sessions";
+import { useOrg } from "@/providers/org-provider";
+import { CHAT_THREAD_TAG, PLATFORM_CHAT_HARNESS_NAME } from "@/lib/chat-threads";
+import type { Session } from "@/lib/api/types";
+
+/** Title given to the precreated thread. Users may rename it afterwards; the
+ *  thread is recognised by its harness binding, not by this string. */
+export const PLATFORM_CHAT_THREAD_TITLE = "Platform Chat";
+
+/** Orgs this page load has already created the thread for. Survives the
+ *  remounts and parallel mounts a single page load produces; a full reload
+ *  starts over, by which time the created thread is in the sessions list. */
+const ensuredOrgIds = new Set<string>();
+
+export interface UsePlatformChatThreadOptions {
+  /** Create the thread when the user has none. Read-only when false. */
+  ensure?: boolean;
+}
+
+export interface UsePlatformChatThreadResult {
+  /** The user's Platform Chat thread, once it exists. */
+  thread?: Session;
+  /** True until the existing threads and harnesses have been read. */
+  isLoading: boolean;
+}
+
+export function usePlatformChatThread(
+  options: UsePlatformChatThreadOptions = {},
+): UsePlatformChatThreadResult {
+  const { ensure = false } = options;
+  const { currentOrg } = useOrg();
+  const orgId = currentOrg?.public_id;
+  // Archived threads count as existing: a user who put the thread away must not
+  // get a fresh one on the next page load.
+  const { threads, isLoading: threadsLoading } = useChatThreads({
+    includeArchived: true,
+    poll: false,
+  });
+  const { data: harnesses = [], isLoading: harnessesLoading } = useHarnesses();
+  const createSession = useCreateSession();
+  const pinSession = usePinSession();
+
+  const platformChat = harnesses.find((harness) => harness.name === PLATFORM_CHAT_HARNESS_NAME);
+  // A thread bound straight to the harness, with no agent in between.
+  const thread = platformChat
+    ? threads.find((candidate) => !candidate.agent_id && candidate.harness_id === platformChat.id)
+    : undefined;
+  const isLoading = threadsLoading || harnessesLoading;
+
+  useEffect(() => {
+    if (!ensure || isLoading || !orgId || !platformChat || thread) return;
+    if (ensuredOrgIds.has(orgId)) return;
+    ensuredOrgIds.add(orgId);
+
+    void (async () => {
+      try {
+        const session = await createSession.mutateAsync({
+          request: {
+            harness_name: PLATFORM_CHAT_HARNESS_NAME,
+            title: PLATFORM_CHAT_THREAD_TITLE,
+            tags: [CHAT_THREAD_TAG],
+          },
+        });
+        await pinSession.mutateAsync({ sessionId: session.id });
+      } catch {
+        // Best-effort: the app works without the precreated thread, and the
+        // next entry tries again.
+        ensuredOrgIds.delete(orgId);
+      }
+    })();
+    // Deliberately not keyed on the mutation objects: they are recreated on
+    // every render, and the attempt guard above is what keeps this one-shot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ensure, isLoading, orgId, platformChat, thread]);
+
+  return { thread, isLoading };
+}

--- a/apps/ui/src/hooks/use-platform-chat-thread.ts
+++ b/apps/ui/src/hooks/use-platform-chat-thread.ts
@@ -63,6 +63,9 @@ export function usePlatformChatThread(
   // get a fresh one on the next page load.
   const { threads, isLoading: threadsLoading } = useChatThreads({
     includeArchived: true,
+    // Scanning the org's sessions would let a busy org hide this user's thread
+    // past the scan window and have the app create a fresh one on every entry.
+    mine: true,
     poll: false,
   });
   const { data: harnesses = [], isLoading: harnessesLoading } = useHarnesses();
@@ -85,6 +88,7 @@ export function usePlatformChatThread(
       try {
         const session = await createSession.mutateAsync({
           request: {
+            source: "chat",
             harness_name: PLATFORM_CHAT_HARNESS_NAME,
             title: PLATFORM_CHAT_THREAD_TITLE,
             tags: [CHAT_THREAD_TAG],

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -4028,6 +4028,10 @@ export interface ResourceStats {
 }
 
 export interface CreateSessionRequest {
+  /** How the session was started. Clients may declare only `chat` (an
+   *  interactive thread) or `api` (the default); every other source is
+   *  server-owned. */
+  source?: SessionSource;
   /** Harness ID for this session. If omitted, the harness is derived from the agent (when one is supplied), else the org default harness. */
   harness_id?: string;
   /** Harness name, resolved within the org. Mutually exclusive with `harness_id`. */

--- a/knowledge/ui/information-architecture.md
+++ b/knowledge/ui/information-architecture.md
@@ -69,6 +69,12 @@ policy and dev-mode gating and stay out of the five groups for the same reason.
 * **Chats is the unconditional landing route.** It is core functionality, requires no feature
   opt-in, is the first thing in the sidebar, and is the default destination for every user with no
   other intent. A fresh organization can open Chats and start a thread without configuration.
+* **Every user starts with a pinned Platform Chat thread.** "Requires no configuration" is
+  not enough if the landing route is an empty list and a counterpart picker: the app creates a
+  thread bound to the built-in `platform-chat` harness on first entry, pins it so it stays at the
+  top, and ends onboarding there. It is an ordinary session, adopted rather than duplicated when
+  one already exists, and never recreated once archived — archiving is the user saying they do
+  not want it.
 * **A thread is bound to exactly one counterpart.** The counterpart may be an Agent or a Harness,
   so users can talk to a configured runtime without creating an otherwise-empty Agent. Switching
   counterparts starts a new thread rather than re-pointing an existing one; the transcript is only

--- a/test_cases/ui/chats/TC016_platform_chat_precreated.md
+++ b/test_cases/ui/chats/TC016_platform_chat_precreated.md
@@ -1,0 +1,40 @@
+# TC016: Chats - Platform Chat Precreated and Pinned
+
+## Description
+
+Verify that a user entering the application for the first time already has a Platform Chat
+thread in Chats, that it is pinned, that onboarding ends in it, and that it is neither
+duplicated on later entries nor recreated after the user archives it.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- A user account that has never entered the application, or a fresh organisation for an
+  existing user
+- Built-in harnesses provisioned for the organisation (org setup completed)
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Sign in as the new user and complete onboarding through the **Done** step
+2. Press **Open Platform Chat** on the Done step and observe the route and the thread header
+3. Navigate to `/chats` and observe the list and the sidebar under **Chats**
+4. Reload the application twice and re-check `/chats`
+5. Send one message in the thread and confirm it answers
+6. Archive the thread from `/chats`, then reload the application and re-check `/chats`
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Precreated | A thread titled **Platform Chat** exists in `/chats` without the user creating one |
+| Counterpart | The thread header shows the built-in **Platform Chat** harness, no agent |
+| Pinned | The thread shows as pinned in `/chats` and carries the pin marker in the sidebar |
+| Ordering | The pinned thread sorts above unpinned threads |
+| Onboarding landing | **Open Platform Chat** on the Done step lands on `/chats/{sessionId}` for that thread |
+| No duplicates | After reloads, exactly one Platform Chat thread exists |
+| Usable | The thread answers a message like any other chat thread |
+| Archive respected | After archiving and reloading, no new Platform Chat thread is created |


### PR DESCRIPTION
## What changed

Every user now finds a **Platform Chat** thread already waiting in Chats, pinned to the top, instead of an empty list and a counterpart picker.

- On first entry the app creates a thread bound to the built-in `platform-chat` harness, tagged as a chat thread, and pins it for that user. The thread is an ordinary session — nothing about it is special except who created it.
- Ensuring happens in the sidebar thread list, which renders on every app route in the OSS app and its wrappers, so a user who never passes through onboarding (an invited member) gets it too. The onboarding surfaces render without the sidebar, so the org setup page ensures it itself.
- Onboarding now ends in that conversation: the Done step's primary action is **Open Platform Chat** → `/chats/{id}`. "Create an agent" moves into the secondary row next to templates, invite, and docs.
- The behavior is idempotent: an existing platform-chat thread is adopted rather than duplicated, and a thread the user archived is never recreated — archiving is the user saying they do not want it. The guard is module-level, because the desktop and mobile sidebars can both be mounted.
- Threads created from the Chats surface now declare `source: "chat"` on `POST /v1/sessions`, which is what `knowledge/runtime-resources/session-source-and-facets.md` specifies and what makes them filterable server-side.

## Why

Chats is the unconditional landing route, but "requires no configuration" was not true in practice: a new user landed on an empty list and had to pick a counterpart before anything could happen. The platform-chat harness can create agents, add providers, and run things conversationally, so it is the right first surface — the user should land in it, not next to it.

## Before / After

Smoke tested end to end against a local stack (`PORT_PREFIX=271 AUTH_MODE=none ./scripts/start-agent-dev.sh`, `/health` → `{"status":"ok","version":"0.24.0","auth_mode":"None"}`), driving the real UI in Chromium.

**Before** — fresh org, no sessions at all:

```
GET /api/v1/sessions?mine=true&include_archived=true&limit=100
{"data":[],"total":0,"offset":0,"limit":100}
```

`/chats` in that state used to render "No chats yet" plus a counterpart picker, and the onboarding Done step pointed at `/agents/new`.

**After** — loading `/chats` once as that user:

```
GET /api/v1/sessions?mine=true&include_archived=true&limit=100
total: 1
{'id': 'session_01a08ed2c54a7f41bc6f4a0db138475c', 'title': 'Platform Chat',
 'harness_id': 'harness_...cfaffcc1'  (= platform-chat), 'agent_id': None,
 'tags': ['chat'], 'source': 'chat', 'is_pinned': True, 'archived_at': None}
```

Rendered state read back from the page (Chromium):

```
sidebar + list rows: ["Platform Chat", "New chat", "New chat", "PC\nPlatform Chat\njust now"]
thread header:       "Platform Chat" / "Platform Chat" harness, actions: Unpin chat · Archive chat · Share · Open session
composer:            "Reply to Platform Chat... (Enter to send)"
```

**No duplicates** — after 7 page loads of `/chats` across two browser sessions, still exactly one session (`total: 1`).

**Onboarding lands there** — driving `/orgs/{org}/setup` through to Done:

```
done CTA count: 1  href: /chats/session_01a08ed2c54a7f41bc6f4a0db138475c
```

The Done step reads "You're all set." with **Open Platform Chat** as the primary action ("Ask it to create your first agent, or just start talking") and Create an agent · Browse templates · Invite your team · Read the docs beneath it.

**Archive is respected** — `PUT /v1/sessions/{id}/archive` (204), then 3 more loads of `/chats`:

```
total after archive + 3 loads: 1
Platform Chat | archived: True | pinned: True
```

i.e. the archived thread was not replaced with a new one.

Screenshots of all three surfaces were captured but could not be attached: this sandbox's egress proxy rejects binary uploads to `uploads.github.com` (HTTP 415), so there is no path to the user-attachments CDN from here. The text assertions above are read from those same page loads.

Local checks: full UI suite 1436 passed / 184 suites, `oxlint` clean, `oxfmt --check` clean, `tsgo --noEmit` clean, `next build` exit 0.

## Risk

- Low / Medium
- The app now performs a write (one session create + pin) on first entry per org. Failure is best-effort and silent: the app works without the thread and retries on the next entry.
- The duplicate-creation hazard is the thing to get right, and it is what the second commit hardens: the existence check asks the server for the caller's own sessions rather than scanning the org's 100 most recent, so a busy org cannot push the user's thread outside the scanned window and have a fresh one created on every page load.
- `useChatThreads` gained `mine` and `poll` options; existing callers keep their previous behavior (`mine: false`, `poll: true`).

## Security

- Threat categories reviewed: **TM-WEB**, **TM-TENANT**, **TM-AUTHZ**, **TM-DOS**.
  - *TM-WEB*: no new rendering of untrusted input. The thread title is a constant; the only interpolation is a server-issued session id into a `next/link` href.
  - *TM-TENANT / TM-AUTHZ*: no new endpoint and no new privilege. Creation, pinning, and listing all go through the existing org-scoped session APIs with the caller's own cookie; org comes from the server-validated cookie, never from the client. Pins are per-user state, so the precreated thread is pinned only for its owner.
  - *TM-DOS*: the one automated write is guarded per org for the page load, and the existence check is now scoped to the caller (see Risk) so it cannot degenerate into one new session per page load. A failed attempt is not retried in a loop — it waits for the next app entry. Verified above: 7 page loads, one session.
- Findings and resolutions: one finding, the org-wide 100-row scan window, found during self-review and fixed in b1ad574 before opening this PR. No threat-model changes needed; no `THREAT[...]` markers are near the diff.

## Follow-ups

- SaaS repo needs no code change — its chats/org-setup routes are re-exports of OSS and its sidebar wraps the OSS one — but it does need an `oss/` submodule bump to pick this up, which can only point at a commit already on OSS main. That bump follows this merge.
- The Platform Chat thread keeps a fixed title, because the `platform-chat` harness does not enable the `session` capability's `auto_title`. Deliberate for now (product call); enabling auto-titling would affect every platform-chat thread, not just this one.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)