### PR TITLE
ci: shard compile-bound jobs across matrix legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,10 +398,20 @@ jobs:
   # calls may carry that attribute -- see knowledge/project/release-process.md.
   semver-bumps:
     name: Crate Semver Bumps
-    runs-on: ubuntu-latest
+    # Opt-in larger runners via the CI_RUNNER_LABEL repo variable
+    # (e.g. ubuntu-latest-8-core); defaults to standard runners.
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     timeout-minutes: 45
+
+    # Sharded: one check-release over ~28 candidates was ~45 min of serial
+    # rustdoc builds (current + baseline per crate). Four legs partition the
+    # sorted candidate list deterministically; fail-fast stops the burn on red.
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: [0, 1, 2, 3]
 
     steps:
       - uses: actions/checkout@v7
@@ -444,7 +454,7 @@ jobs:
 
       - name: Check released crates are bumped large enough
         if: steps.plan.outputs.found == 'true'
-        run: python3 scripts/check-semver-bumps.py
+        run: python3 scripts/check-semver-bumps.py --shard ${{ matrix.shard }}/4
 
   msrv:
     name: Published Crate MSRV
@@ -753,11 +763,21 @@ jobs:
   # Keeps server compilation in the integration job that already builds it.
   unit-test:
     name: Unit Tests (Pure)
-    runs-on: ubuntu-latest
+    # Opt-in larger runners via the CI_RUNNER_LABEL repo variable
+    # (e.g. ubuntu-latest-8-core); defaults to standard runners.
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     timeout-minutes: 30
 
+
+    # Sharded: ~27 sequential `cargo test` invocations were ~20 min of
+    # compilation on one runner (tests themselves are seconds). Four legs
+    # split by compile weight; the shared rust-cache key keeps dep reuse.
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: [llm-core, provider-engine, host-mcp, facade-cli]
     steps:
       - uses: actions/checkout@v7
 
@@ -781,8 +801,11 @@ jobs:
         with:
           shared-key: "test"
 
-      - name: Run pure unit tests
+      - name: Run pure unit tests (${{ matrix.shard }})
+        shell: bash
         run: |
+          case "${{ matrix.shard }}" in
+            llm-core)
           # Driver suites include local HTTP contracts. Credentialed live cases
           # are explicitly ignored; ordinary cargo test never executes them.
           cargo test -p everruns-anthropic -p everruns-openai -p everruns-gemini \
@@ -801,6 +824,8 @@ jobs:
           # Production-safe deterministic simulator plus its optional host
           # extension. Pure llmsim; no credentials or network.
           cargo test -p everruns-llmsim --all-features
+              ;;
+            provider-engine)
           # The provider SPI and the crates below reach CI here for the first
           # time: none of them had ever appeared in a `cargo test -p` line in
           # any workflow, so their tests/ files had never run. everruns-provider
@@ -820,6 +845,8 @@ jobs:
           # Test-support (EVE-875): in-memory loop, test doubles, fixture
           # capabilities, and llmsim-driven suites that moved out of core.
           cargo test -p everruns-test-support --all-features
+              ;;
+            host-mcp)
           # mcp: whole crate (lib + http_transport + stdio_transport + doctests).
           # Was not tested in CI at all. --all-features enables the `stdio` transport
           # (off in hosted builds) so its transport test runs here. All in-process,
@@ -840,6 +867,8 @@ jobs:
           # the feature-specific MCP target runs immediately afterward.
           cargo test -p everruns-host --features lua,bashkit -- --test-threads=1
           cargo test -p everruns-host --features mcp --test mcp_runtime_test -- --test-threads=1
+              ;;
+            facade-cli)
           # everruns facade (EVE-830): whole crate across every optional facade
           # feature, including local history/resume acceptance paths, plus a
           # bare-facade compile so public configuration cannot accidentally
@@ -864,6 +893,8 @@ jobs:
           cargo test -p everruns-integrations-github
           cargo test -p everruns-integrations-sprites
 
+              ;;
+          esac
   # Durable-worker PR coverage. Catches regressions in the worker crate's
   # durable execution paths (act/reason/input task handling, DLQ emission,
   # session.idled, org_id roundtripping, task error mapping) before merge.
@@ -1068,10 +1099,20 @@ jobs:
   # Tests API endpoints, repositories, and durable execution against real database
   integration-test:
     name: Integration Tests (PostgreSQL)
-    runs-on: ubuntu-latest
+    # Opt-in larger runners via the CI_RUNNER_LABEL repo variable
+    # (e.g. ubuntu-latest-8-core); defaults to standard runners.
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.postgres_integration == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
     timeout-minutes: 40
+
+    # Sharded: 8 sequential test steps were ~26 min on one runner with a
+    # warm cache. Three legs split by suite; each leg gets its own
+    # postgres service and runs migrations against it.
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: [server, domain, durable]
     services:
       postgres:
         image: postgres:17-alpine
@@ -1129,14 +1170,17 @@ jobs:
         run: sqlx migrate run --source crates/server/migrations
 
       - name: Run server unit tests (require DB for storage layer)
+        if: ${{ matrix.shard == 'server' }}
         run: cargo test -p everruns-server --lib
 
       - name: Run server integration tests (API + repository)
+        if: ${{ matrix.shard == 'server' }}
         run: cargo test -p everruns-server --test api_integration_test --test repository_integration_test --test repository_conformance_test -- --test-threads=1
 
       # These contracts use in-memory TestServer instances, but share the server
       # compilation above instead of rebuilding it in the pure-test job.
       - name: Run in-memory server API contracts
+        if: ${{ matrix.shard == 'server' }}
         run: cargo test -p everruns-server --test mcp_url_consent_test --test mcp_url_elicitation_test --test sse_replay_test
 
       # Blob-offload suite against the in-memory object_store backend (no S3
@@ -1146,6 +1190,7 @@ jobs:
       # The dedicated `s3-integration-test` job re-runs the
       # identical suite with STORAGE_BLOB_BACKEND=s3 against SeaweedFS.
       - name: Run blob offload integration tests (in-memory backend)
+        if: ${{ matrix.shard == 'domain' }}
         run: cargo test -p everruns-server --test blob_offload_integration_test -- --test-threads=1
 
       # Domain-focused integration tests that previously only ran manually.
@@ -1153,6 +1198,7 @@ jobs:
       # exercises a cohesive slice (auth, org lifecycle, schedules, git sessions,
       # evals, ag_ui, client-side tools, llm defaults, org isolation).
       - name: Run domain integration tests
+        if: ${{ matrix.shard == 'domain' }}
         run: |
           cargo test -p everruns-server \
             --test ag_ui_integration_test \
@@ -1183,6 +1229,7 @@ jobs:
       # (EVE-667). The Test Enumeration job enforces that every crate test
       # file is either run here or explicitly allowlisted.
       - name: Run previously-unenumerated domain integration tests
+        if: ${{ matrix.shard == 'domain' }}
         run: |
           cargo test -p everruns-server \
             --test app_api_integration_test \
@@ -1206,35 +1253,37 @@ jobs:
             -- --test-threads=1
 
       - name: Run durable integration tests
+        if: ${{ matrix.shard == 'durable' }}
         run: cargo test -p everruns-durable --test postgres_integration_test --test postgres_repository_test --features postgres-tests -- --test-threads=1
 
       # `agent_reliability_test` was audited for EVE-349 but still fails on a
       # clean PostgreSQL-backed run; keep it out of required CI until its
       # restart/reclaim scenarios are stabilized.
       - name: Run durable failpoint tests
+        if: ${{ matrix.shard == 'durable' }}
         run: cargo test -p everruns-durable --test failure_injection_test --features "failpoints,postgres-tests" -- --test-threads=1
 
       # Slack live tests need DOPPLER_TOKEN. Restrict to push events so the
       # token is never instantiated in a fork-PR context where untrusted
       # code (build.rs, proc-macros, test bodies) would see it via env.
       - name: Install Doppler CLI
+        if: ${{ matrix.shard == 'durable' && github.event_name == 'push' }}
         id: doppler_install
         # Absorbs one transient installer failure; see
         # scripts/test-doppler-install-retry.sh for why.
         continue-on-error: true
-        if: github.event_name == 'push'
         uses: dopplerhq/cli-action@v4
 
       - name: Pause before Doppler CLI retry
-        if: steps.doppler_install.outcome == 'failure'
+        if: ${{ matrix.shard == 'durable' && steps.doppler_install.outcome == 'failure' }}
         run: sleep 15
 
       - name: Install Doppler CLI (retry)
-        if: steps.doppler_install.outcome == 'failure'
+        if: ${{ matrix.shard == 'durable' && steps.doppler_install.outcome == 'failure' }}
         uses: dopplerhq/cli-action@v4
 
       - name: Run Slack integration tests (real API via Doppler)
-        if: github.event_name == 'push'
+        if: ${{ matrix.shard == 'durable' && github.event_name == 'push' }}
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --preserve-env="DATABASE_URL" -- cargo test -p everruns-server --test slack_integration_test -- --test-threads=1
@@ -1454,7 +1503,9 @@ jobs:
   # Build release binaries and upload as artifacts for E2E jobs and openapi-check
   build-binaries:
     name: Build Release Binaries
-    runs-on: ubuntu-latest
+    # Opt-in larger runners via the CI_RUNNER_LABEL repo variable
+    # (e.g. ubuntu-latest-8-core); defaults to standard runners.
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     timeout-minutes: 40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1275,11 +1275,11 @@ jobs:
         uses: dopplerhq/cli-action@v4
 
       - name: Pause before Doppler CLI retry
-        if: ${{ matrix.shard == 'durable' && steps.doppler_install.outcome == 'failure' }}
+        if: steps.doppler_install.outcome == 'failure'
         run: sleep 15
 
       - name: Install Doppler CLI (retry)
-        if: ${{ matrix.shard == 'durable' && steps.doppler_install.outcome == 'failure' }}
+        if: steps.doppler_install.outcome == 'failure'
         uses: dopplerhq/cli-action@v4
 
       - name: Run Slack integration tests (real API via Doppler)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1098,7 +1098,7 @@ jobs:
   # Integration tests requiring PostgreSQL
   # Tests API endpoints, repositories, and durable execution against real database
   integration-test:
-    name: Integration Tests (PostgreSQL)
+    name: Integration Tests (PostgreSQL Shards)
     # Opt-in larger runners via the CI_RUNNER_LABEL repo variable
     # (e.g. ubuntu-latest-8-core); defaults to standard runners.
     runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}
@@ -1303,6 +1303,31 @@ jobs:
   # Doppler vault via env (build.rs, proc-macros, test bodies) — the same
   # TM-CI-001/TM-CI-002 boundary the step carried before the split. PR coverage
   # of the LLM matrix is still mocked in `unit-test`.
+
+  integration-test-gate:
+    # Reports the bare required-check name. Matrix legs report as
+    # "Integration Tests (PostgreSQL Shards) (server|domain|durable)",
+    # which never satisfies the branch rule expecting exactly
+    # "Integration Tests (PostgreSQL)" (it waits forever: "Expected --
+    # Waiting for status to be reported"). This gate mirrors the aggregate
+    # leg result under that name: success/skipped pass, anything else fails.
+    name: Integration Tests (PostgreSQL)
+    needs: [integration-test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate integration shard results
+        run: |
+          case "${{ needs.integration-test.result }}" in
+            success|skipped)
+              echo "Integration shards: ${{ needs.integration-test.result }}"
+              ;;
+            *)
+              echo "Integration shards result: ${{ needs.integration-test.result }}"
+              exit 1
+              ;;
+          esac
   live-provider-matrix:
     name: Live Provider Matrix
     runs-on: ubuntu-latest

--- a/scripts/check-publish-cone.py
+++ b/scripts/check-publish-cone.py
@@ -40,6 +40,7 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 
 
 def index_path(name: str) -> str:
@@ -113,9 +114,14 @@ def find_strands(current: dict[str, str], pre_merge: bool) -> list[str]:
     being bumped in this change (workspace version != latest published), because
     that republish heals it.
     """
+    # Baselines are independent crates.io index reads: fetch them
+    # concurrently (pool.map preserves order, so output stays sorted).
+    names = sorted(current)
+    with ThreadPoolExecutor(max_workers=min(10, len(names) or 1)) as pool:
+        baselines = dict(zip(names, pool.map(latest_published, names)))
     strands: list[str] = []
-    for name in sorted(current):
-        latest = latest_published(name)
+    for name in names:
+        latest = baselines[name]
         if not latest:
             continue  # never published: cannot strand a consumer yet
         if pre_merge and current[name] != latest["vers"]:
@@ -202,6 +208,7 @@ def self_test() -> int:
         expect("pre-merge ignores bumped filesystem", pre_healed, [])
         strict_healed = find_strands(healed, pre_merge=False)
         expect("strict still flags until republished", any("filesystem" in s for s in strict_healed), True)
+        expect("concurrent scan is deterministic", find_strands(workspace, pre_merge=True), pre)
     finally:
         latest_published = real
 

--- a/scripts/check-semver-bumps.py
+++ b/scripts/check-semver-bumps.py
@@ -38,6 +38,7 @@ import tarfile
 import tempfile
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 
 
 def index_path(name: str) -> str:
@@ -136,6 +137,16 @@ def index_records(name: str) -> list[tuple[str, bool]]:
     ]
 
 
+INDEX_WORKERS = 10
+
+
+def fetch_many(names: list[str], fetch) -> dict:
+    """Fetch per-crate index data concurrently (order-preserving)."""
+    names = list(names)
+    with ThreadPoolExecutor(max_workers=min(INDEX_WORKERS, len(names) or 1)) as pool:
+        return dict(zip(names, pool.map(fetch, names)))
+
+
 def latest_published_version(records: list[tuple[str, bool]]) -> str | None:
     """Highest non-yanked version -- the baseline cargo-semver-checks uses."""
     best: str | None = None
@@ -222,7 +233,7 @@ def manifest_dirs() -> dict[str, str]:
     return _manifest_dirs
 
 
-def identical_to_baseline(name: str) -> tuple[bool, str]:
+def identical_to_baseline(name: str, records=None) -> tuple[bool, str]:
     """Whether a candidate's source is identical to its published baseline.
 
     Downloads the baseline .crate and compares trees. Returns (True, reason)
@@ -231,7 +242,9 @@ def identical_to_baseline(name: str) -> tuple[bool, str]:
     crate gets the full semver check. This function must never turn the gate
     green by itself.
     """
-    baseline = latest_published_version(index_records(name))
+    if records is None:
+        records = index_records(name)
+    baseline = latest_published_version(records)
     if baseline is None:
         return False, "no published baseline to compare against"
     try:
@@ -295,7 +308,7 @@ def run_semver_checks(packages: list[str]) -> int:
 
 def run_check(plan_only: bool, candidates_only: bool, shard=None) -> int:
     current = workspace_versions()
-    published = {name: published_versions(name) for name in current}
+    published = fetch_many(current, published_versions)
     packages, skipped = plan(current, published)
 
     if candidates_only:
@@ -328,8 +341,9 @@ def run_check(plan_only: bool, candidates_only: bool, shard=None) -> int:
     # baseline cannot have changed API; anything else (including any
     # comparison failure) falls through to the full check below.
     remaining: list[str] = []
+    baselines = fetch_many(packages, index_records)
     for name in packages:
-        identical, reason = identical_to_baseline(name)
+        identical, reason = identical_to_baseline(name, baselines[name])
         if identical:
             print(f"  - {name} (skipped: {reason})")
         else:
@@ -445,6 +459,11 @@ def self_test() -> int:
         "prerelease below release",
         parse_version_tuple("1.2.3") > parse_version_tuple("1.2.3-alpha"),
         True,
+    )
+    expect(
+        "fetch_many keeps order",
+        fetch_many(["b", "a"], lambda n: n.upper()),
+        {"b": "B", "a": "A"},
     )
 
     before = '[package]\nname = "demo"\nversion = "0.18.2"\nedition = "2021"\n'

--- a/scripts/check-semver-bumps.py
+++ b/scripts/check-semver-bumps.py
@@ -29,9 +29,13 @@ network access, so the gate's own correctness is guarded deterministically.
 from __future__ import annotations
 
 import argparse
+import io
 import json
+import os
 import subprocess
 import sys
+import tarfile
+import tempfile
 import urllib.error
 import urllib.request
 
@@ -98,6 +102,166 @@ def plan(
     return check, skipped
 
 
+def shard_slice(packages: list[str], index: int, total: int) -> list[str]:
+    """The INDEX-th deterministic slice of TOTAL over the sorted candidates."""
+    return sorted(packages)[index::total]
+
+
+def parse_version_tuple(version: str):
+    """Comparable key: numeric release tuple, pre-releases sort below the release."""
+    core = version.split("+", 1)[0]
+    base, dash, _pre = core.partition("-")
+    try:
+        nums = tuple(int(part) for part in base.split("."))
+    except ValueError:
+        return (0, ())
+    return ((2, nums) if not dash else (1, nums))
+
+
+def index_records(name: str) -> list[tuple[str, bool]]:
+    """(version, yanked) pairs from the sparse index; [] when never published."""
+    try:
+        body = urllib.request.urlopen(
+            f"https://index.crates.io/{index_path(name)}", timeout=30
+        ).read().decode()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return []
+        raise
+    return [
+        (entry["vers"], bool(entry.get("yanked")))
+        for line in body.splitlines()
+        if line.strip()
+        for entry in [json.loads(line)]
+    ]
+
+
+def latest_published_version(records: list[tuple[str, bool]]) -> str | None:
+    """Highest non-yanked version -- the baseline cargo-semver-checks uses."""
+    best: str | None = None
+    for version, yanked in records:
+        if yanked:
+            continue
+        if best is None or parse_version_tuple(version) > parse_version_tuple(best):
+            best = version
+    return best
+
+
+def normalize_package_version(text: str) -> str:
+    """Neutralize only the `[package] version = ...` line (a pure bump)."""
+    out, section = [], None
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("["):
+            section = stripped.strip("[]").split()[0]
+        if section == "package" and stripped.startswith("version") and "=" in stripped:
+            out.append('version = "0.0.0"\n')
+        else:
+            out.append(line)
+    return "".join(out)
+
+
+def trees_equal(workspace_dir: str, baseline_dir: str) -> bool:
+    """True when the packaged baseline tree matches the workspace crate.
+
+    Every file shipped in the .crate must match (with only the package
+    version line neutralized); any content difference, or any extra
+    workspace file outside target/, means "not equal" and the crate falls
+    through to the full semver check. Cargo.toml.orig / .cargo_vcs_info.json
+    exist only in the packaged tree and are ignored.
+    """
+    packaged_only = {"Cargo.toml.orig", ".cargo_vcs_info.json"}
+    baseline_files: set[str] = set()
+    for root, _dirs, files in os.walk(baseline_dir):
+        for name in files:
+            rel = os.path.relpath(os.path.join(root, name), baseline_dir)
+            if rel not in packaged_only:
+                baseline_files.add(rel)
+    workspace_files: set[str] = set()
+    for root, dirs, files in os.walk(workspace_dir):
+        dirs[:] = [d for d in dirs if d != "target"]
+        for name in files:
+            workspace_files.add(os.path.relpath(os.path.join(root, name), workspace_dir))
+    if baseline_files - workspace_files:
+        return False
+    if workspace_files - baseline_files - packaged_only:
+        return False
+    for rel in baseline_files:
+        with open(os.path.join(baseline_dir, rel), "rb") as fh:
+            baseline_bytes = fh.read()
+        with open(os.path.join(workspace_dir, rel), "rb") as fh:
+            workspace_bytes = fh.read()
+        if rel == "Cargo.toml":
+            try:
+                baseline_text = normalize_package_version(baseline_bytes.decode("utf-8"))
+                workspace_text = normalize_package_version(workspace_bytes.decode("utf-8"))
+            except UnicodeDecodeError:
+                return False
+            if baseline_text != workspace_text:
+                return False
+        elif baseline_bytes != workspace_bytes:
+            return False
+    return True
+
+
+_manifest_dirs: dict[str, str] | None = None
+
+
+def manifest_dirs() -> dict[str, str]:
+    """Workspace package name -> crate directory (one cached cargo metadata)."""
+    global _manifest_dirs
+    if _manifest_dirs is None:
+        meta = json.loads(
+            subprocess.check_output(
+                ["cargo", "metadata", "--no-deps", "--format-version", "1"], text=True
+            )
+        )
+        _manifest_dirs = {
+            p["name"]: os.path.dirname(p["manifest_path"]) for p in meta["packages"]
+        }
+    return _manifest_dirs
+
+
+def identical_to_baseline(name: str) -> tuple[bool, str]:
+    """Whether a candidate's source is identical to its published baseline.
+
+    Downloads the baseline .crate and compares trees. Returns (True, reason)
+    only on a byte-level match (modulo the package version line); every other
+    outcome -- including any infrastructure failure -- returns False so the
+    crate gets the full semver check. This function must never turn the gate
+    green by itself.
+    """
+    baseline = latest_published_version(index_records(name))
+    if baseline is None:
+        return False, "no published baseline to compare against"
+    try:
+        crate_dir = manifest_dirs()[name]
+    except KeyError:
+        return False, "crate not in workspace metadata"
+    url = f"https://static.crates.io/crates/{name}/{name}-{baseline}.crate"
+    try:
+        request = urllib.request.Request(url)
+        with tempfile.TemporaryDirectory(prefix="semver-baseline-") as tmp:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                payload = response.read()
+            with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+                try:
+                    archive.extractall(tmp, filter="data")
+                except TypeError:
+                    # Python < 3.12 predates the filter= parameter; the
+                    # tarball comes from crates.io over TLS, so plain
+                    # extraction is acceptable here.
+                    archive.extractall(tmp)
+            unpacked = os.path.join(tmp, f"{name}-{baseline}")
+            if not os.path.isdir(unpacked):
+                return False, "baseline archive layout unexpected"
+            if trees_equal(crate_dir, unpacked):
+                return True, f"source identical to published {name} {baseline}"
+            return False, f"source differs from published {name} {baseline}"
+    except Exception as exc:  # noqa: BLE001 -- fail open by design
+        return False, f"baseline comparison unavailable ({exc}); running full check"
+
+
 def run_semver_checks(packages: list[str]) -> int:
     """Run cargo-semver-checks over the release candidates in one invocation.
 
@@ -129,7 +293,7 @@ def run_semver_checks(packages: list[str]) -> int:
     return subprocess.call(argv)
 
 
-def run_check(plan_only: bool, candidates_only: bool) -> int:
+def run_check(plan_only: bool, candidates_only: bool, shard=None) -> int:
     current = workspace_versions()
     published = {name: published_versions(name) for name in current}
     packages, skipped = plan(current, published)
@@ -158,6 +322,27 @@ def run_check(plan_only: bool, candidates_only: bool) -> int:
     for name in packages:
         print(f"  - {name} {current[name]}")
     if plan_only:
+        return 0
+
+    # Crates whose packaged source is byte-identical to the published
+    # baseline cannot have changed API; anything else (including any
+    # comparison failure) falls through to the full check below.
+    remaining: list[str] = []
+    for name in packages:
+        identical, reason = identical_to_baseline(name)
+        if identical:
+            print(f"  - {name} (skipped: {reason})")
+        else:
+            if not reason.startswith("source differs"):
+                print(f"  - {name}: {reason}")
+            remaining.append(name)
+    packages = remaining
+    if shard is not None:
+        index, total = shard
+        packages = shard_slice(packages, index, total)
+        print(f"Shard {index}/{total}: checking {len(packages)} candidate(s).")
+    if not packages:
+        print("No candidates left to check in this shard; nothing to do.")
         return 0
 
     code = run_semver_checks(packages)
@@ -231,6 +416,75 @@ def self_test() -> int:
     expect("3-char shard", index_path("abc"), "3/a/abc")
     expect("4+-char shard", index_path("everruns-host"), "ev/er/everruns-host")
 
+    expect("shard 0/2", shard_slice(["c", "a", "b", "d", "e"], 0, 2), ["a", "c", "e"])
+    expect("shard 1/2", shard_slice(["c", "a", "b", "d", "e"], 1, 2), ["b", "d"])
+    expect("empty shard", shard_slice(["a"], 1, 4), [])
+    expect(
+        "shards partition",
+        sorted(
+            shard_slice(["a", "b", "c", "d"], 0, 4)
+            + shard_slice(["a", "b", "c", "d"], 1, 4)
+            + shard_slice(["a", "b", "c", "d"], 2, 4)
+            + shard_slice(["a", "b", "c", "d"], 3, 4)
+        ),
+        ["a", "b", "c", "d"],
+    )
+
+    expect(
+        "latest skips yanked",
+        latest_published_version([("0.2.0", True), ("0.1.0", False)]),
+        "0.1.0",
+    )
+    expect(
+        "latest picks max",
+        latest_published_version([("0.1.0", False), ("0.2.0", False)]),
+        "0.2.0",
+    )
+    expect("no baseline", latest_published_version([]), None)
+    expect(
+        "prerelease below release",
+        parse_version_tuple("1.2.3") > parse_version_tuple("1.2.3-alpha"),
+        True,
+    )
+
+    before = '[package]\nname = "demo"\nversion = "0.18.2"\nedition = "2021"\n'
+    after = '[package]\nname = "demo"\nversion = "0.19.0"\nedition = "2021"\n'
+    expect(
+        "pure bump compares equal",
+        normalize_package_version(before) == normalize_package_version(after),
+        True,
+    )
+    dep_change = '[package]\nname = "demo"\nversion = "0.19.0"\n[dependencies]\nfoo = "3"\n'
+    dep_same = '[package]\nname = "demo"\nversion = "0.18.2"\n[dependencies]\nfoo = "2"\n'
+    expect(
+        "dep requirement change is visible",
+        normalize_package_version(dep_change) == normalize_package_version(dep_same),
+        False,
+    )
+
+    with tempfile.TemporaryDirectory() as work, tempfile.TemporaryDirectory() as base:
+        os.makedirs(os.path.join(work, "src"))
+        os.makedirs(os.path.join(base, "src"))
+        with open(os.path.join(work, "Cargo.toml"), "w") as fh:
+            fh.write(after)
+        with open(os.path.join(base, "Cargo.toml"), "w") as fh:
+            fh.write(before)
+        with open(os.path.join(base, "Cargo.toml.orig"), "w") as fh:
+            fh.write("orig\n")
+        with open(os.path.join(work, "src", "lib.rs"), "w") as fh:
+            fh.write("pub fn f() {}\n")
+        with open(os.path.join(base, "src", "lib.rs"), "w") as fh:
+            fh.write("pub fn f() {}\n")
+        expect("identical trees", trees_equal(work, base), True)
+        with open(os.path.join(base, "src", "lib.rs"), "w") as fh:
+            fh.write("pub fn g() {}\n")
+        expect("content change detected", trees_equal(work, base), False)
+        with open(os.path.join(base, "src", "lib.rs"), "w") as fh:
+            fh.write("pub fn f() {}\n")
+        with open(os.path.join(work, "extra.rs"), "w") as fh:
+            fh.write("// new\n")
+        expect("extra workspace file detected", trees_equal(work, base), False)
+
     for failure in failures:
         print(f"  FAIL {failure}")
     if failures:
@@ -257,10 +511,27 @@ def main() -> int:
         action="store_true",
         help="run the network-free checks of the planning logic",
     )
+    parser.add_argument(
+        "--shard",
+        default=None,
+        metavar="INDEX/COUNT",
+        help="check only the INDEX-th slice (0-based) of COUNT candidate shards",
+    )
     args = parser.parse_args()
     if args.self_test:
         return self_test()
-    return run_check(plan_only=args.plan, candidates_only=args.candidates)
+    shard = None
+    if args.shard:
+        try:
+            index_s, count_s = args.shard.split("/")
+            shard = (int(index_s), int(count_s))
+        except ValueError:
+            print(f"--shard must look like INDEX/COUNT, got {args.shard!r}", file=sys.stderr)
+            return 2
+        if not 0 <= shard[0] < shard[1]:
+            print(f"--shard index out of range: {args.shard!r}", file=sys.stderr)
+            return 2
+    return run_check(plan_only=args.plan, candidates_only=args.candidates, shard=shard)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

CI wall on full-code runs is ~27-46 min, dominated by serial compilation
on single 4-vCPU runners with a warm cache (measured on run
34556825690: unit tests 26.5 min with ~19.8 min of compilation across
29 builds, tests themselves seconds; PG integration 26.1 min).

- **unit-test**: 4 matrix legs (llm-core, provider-engine, host-mcp,
  facade-cli), shared rust-cache key, fail-fast.
- **integration-test**: 3 matrix legs (server, domain, durable), each
  with its own postgres service + migrations; Doppler-gated Slack stays
  on the durable leg.
- **semver-bumps**: 4 package shards (`--shard INDEX/COUNT`, fail-fast)
  plus an identical-source skip: candidates byte-identical to the
  published baseline (modulo the package version line) skip the
  rustdoc double-build; any comparison failure falls through to the
  full check. Self-test extended and passing.
- Pole-job runner labels gated on the `CI_RUNNER_LABEL` repo variable
  (default `ubuntu-latest`): no behavior change until the variable is set.

Job IDs are unchanged, so the `ci-success` gate and the test-enumeration
pre-push check (8/22, passing) are unaffected. actionlint reports no new
findings (remaining warnings pre-exist on main).

## Deliberately not included

- **cargo-nextest**: probed 0.9.113 locally — `nextest run` skips
  doctests (1 test run vs 2 under cargo) and this workload is
  compile-bound with cargo already running targets in parallel, so the
  expected gain is ~0 against real semantic risk.
- **Baseline rustdoc-JSON cache**: v0.50.0 only reuses baselines via a
  single-file `--baseline-rustdoc` (no multi-package mapping); the
  identical-source skip above captures the larger share of that saving.
- **cargo-public-api snapshots**: needs a release-process decision
  (snapshot blessing per API change), not just CI plumbing.
- **Build gating**: already exists via the `ci:skip-slow-rust` label.

## Validation

- `python3 scripts/check-semver-bumps.py --self-test` passes (incl. a
  live baseline comparison against crates.io for `everruns`).
- actionlint clean for touched regions; touched run blocks pass `bash -n`.
- `just pre-push` 21/22 locally; the single failure is the published-docs
  check importing `tomllib` under the worktree's python3.9 (passes with
  homebrew python3.14) — pre-existing environment issue, unrelated.

Produced by [yolop](https://everruns.com/yolop)