### PR TITLE
fix(providers): make a configured provider key actually produce a usable org

### DIFF
--- a/apps/ui/e2e/navigation-prefetch.spec.ts
+++ b/apps/ui/e2e/navigation-prefetch.spec.ts
@@ -88,6 +88,11 @@ const STARTUP_API_ALLOWLIST = new Set([
   "/api/v1/capabilities",
   "/api/v1/models",
   "/api/v1/providers",
+  // Chats reads the provider policy map to decide whether the "no intelligence
+  // available" notice may link to Settings. Only fetched when the org actually
+  // has no usable chat model — which is this suite's mocked state, since the
+  // API mock answers every list with `{ data: [] }`.
+  "/api/v1/providers/config",
   "/api/v1/sessions",
   "/api/v1/sessions/stats",
   "/api/v1/feature-flags",

--- a/apps/ui/src/__tests__/chat-message-list-work-log.test.tsx
+++ b/apps/ui/src/__tests__/chat-message-list-work-log.test.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { render, screen } from "@testing-library/react";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import type { Event } from "@/lib/api/types";
@@ -47,6 +48,40 @@ function event(id: string, type: string, data: Record<string, unknown>): Event {
     sequence: id.length,
   };
 }
+
+function renderEmpty(emptyState?: React.ReactNode) {
+  return render(
+    <ChatMessageList
+      events={[]}
+      chatEvents={[]}
+      sessionId="session-1"
+      toolResultsMap={new Map()}
+      toolProgressMap={new Map()}
+      toolOutputMap={new Map()}
+      eventsLoading={false}
+      hasMoreEvents={false}
+      loadingOlderEvents={false}
+      getMessageText={() => ""}
+      getToolCalls={() => []}
+      emptyState={emptyState}
+    />,
+  );
+}
+
+describe("ChatMessageList empty state", () => {
+  it("invites a first message by default", () => {
+    renderEmpty();
+
+    expect(screen.getByText("no_messages_yet")).toBeInTheDocument();
+  });
+
+  it("replaces that invitation with the override rather than stacking both", () => {
+    renderEmpty(<div>Nothing to chat with</div>);
+
+    expect(screen.getByText("Nothing to chat with")).toBeInTheDocument();
+    expect(screen.queryByText("no_messages_yet")).not.toBeInTheDocument();
+  });
+});
 
 describe("ChatMessageList work-log narration", () => {
   it("routes human reason.item and reason.completed text through the narration renderer", () => {

--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -94,6 +94,19 @@ jest.mock("@/components/session/session-participants-rail", () => ({
   SessionParticipantsRail: () => null,
 }));
 
+// The composer's "no intelligence available" notice reads the model list and the
+// provider policy map straight from `use-providers`, outside the `@/hooks`
+// barrel this suite stubs. A healthy enabled model keeps it hidden here; its own
+// behaviour is covered by no-intelligence-notice.test.tsx.
+jest.mock("@/hooks/use-providers", () => ({
+  useModels: () => ({
+    data: [{ enabled: true, healthy: true, capabilities: ["chat"] }],
+    isLoading: false,
+    isError: false,
+  }),
+  useProvidersConfig: () => ({ data: { policies: {} }, isLoading: false }),
+}));
+
 jest.mock("@/hooks", () => ({
   useModels: () => ({ data: mockModels, isLoading: false }),
   useProviders: () => ({ data: [] }),

--- a/apps/ui/src/__tests__/chats-page.test.tsx
+++ b/apps/ui/src/__tests__/chats-page.test.tsx
@@ -35,6 +35,15 @@ jest.mock("@/hooks", () => ({
   usePageTitle: jest.fn(),
 }));
 
+// The page now decides whether its empty state is "No chats yet" or the
+// no-intelligence message, so it reads intelligence status (org context this
+// suite does not stub). Default to available; the no-intelligence branch has
+// its own coverage.
+const intelligenceStatus = { isLoading: false, available: true, canManage: true };
+jest.mock("@/hooks/use-intelligence", () => ({
+  useIntelligenceStatus: () => intelligenceStatus,
+}));
+
 jest.mock("@/components/chat/new-chat-form", () => ({
   NewChatForm: ({ onStartingChange }: { onStartingChange?: (starting: boolean) => void }) => (
     <button type="button" onClick={() => onStartingChange?.(true)}>
@@ -77,6 +86,9 @@ describe("Chats surface", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseChatThreads.mockReturnValue({ threads: [], isLoading: false, error: null });
+    intelligenceStatus.isLoading = false;
+    intelligenceStatus.available = true;
+    intelligenceStatus.canManage = true;
   });
 
   it("renders the empty state without feature-flag configuration", () => {
@@ -91,6 +103,18 @@ describe("Chats surface", () => {
 
     expect(screen.getByText("No chats yet")).toBeInTheDocument();
     expect(screen.getByText("new-chat-form")).toBeInTheDocument();
+  });
+
+  it("swaps the whole empty state for the no-intelligence message", () => {
+    intelligenceStatus.available = false;
+
+    render(<ChatsPageClient />);
+
+    expect(screen.getByText("No intelligence available")).toBeInTheDocument();
+    // One centred message: "No chats yet / pick an agent and start talking"
+    // would be advice that cannot work.
+    expect(screen.queryByText("No chats yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("new-chat-form")).not.toBeInTheDocument();
   });
 
   it("lists threads, linking each to its thread route", () => {

--- a/apps/ui/src/__tests__/new-chat-form.test.tsx
+++ b/apps/ui/src/__tests__/new-chat-form.test.tsx
@@ -14,16 +14,16 @@ jest.mock("@/hooks", () => ({
   useHarnesses: jest.fn(),
 }));
 
-// The form carries the "no intelligence available" notice, which reads the model
-// list and provider policy map from `use-providers` (org context, not stubbed
-// here). Default to a healthy enabled model so the picker renders; one test
-// empties it to cover the no-intelligence branch.
-const intelligenceModels: { enabled: boolean; healthy: boolean; capabilities: string[] }[] = [
-  { enabled: true, healthy: true, capabilities: ["chat"] },
-];
+// ChatMessageList and friends reach `use-providers` for org context this suite
+// does not stub. The form itself no longer reads intelligence state — its hosts
+// do — so a fixed healthy model is enough.
 jest.mock("@/hooks/use-providers", () => ({
-  useModels: () => ({ data: intelligenceModels, isLoading: false, isError: false }),
-  useProvidersConfig: () => ({ data: { policies: { "provider.manage": true } }, isLoading: false }),
+  useModels: () => ({
+    data: [{ enabled: true, healthy: true, capabilities: ["chat"] }],
+    isLoading: false,
+    isError: false,
+  }),
+  useProvidersConfig: () => ({ data: { policies: {} }, isLoading: false }),
 }));
 
 jest.mock("@/hooks/use-sessions", () => ({
@@ -107,23 +107,7 @@ describe("NewChatForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mutateAsync.mockResolvedValue({ id: "sess_new" });
-    intelligenceModels.splice(0, intelligenceModels.length, {
-      enabled: true,
-      healthy: true,
-      capabilities: ["chat"],
-    });
     setup();
-  });
-
-  it("replaces the picker with the no-intelligence message when the org has no model", () => {
-    intelligenceModels.length = 0;
-
-    render(<NewChatForm />);
-
-    expect(screen.getByText("No intelligence available")).toBeInTheDocument();
-    // One message, not two: starting a thread nothing can answer is a dead end.
-    expect(screen.queryByRole("combobox", { name: "Chat counterpart" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Start chat/ })).not.toBeInTheDocument();
   });
 
   it("creates an agent-bound thread and opens it", async () => {

--- a/apps/ui/src/__tests__/new-chat-form.test.tsx
+++ b/apps/ui/src/__tests__/new-chat-form.test.tsx
@@ -16,14 +16,14 @@ jest.mock("@/hooks", () => ({
 
 // The form carries the "no intelligence available" notice, which reads the model
 // list and provider policy map from `use-providers` (org context, not stubbed
-// here). A healthy enabled model keeps it hidden; the notice has its own suite.
+// here). Default to a healthy enabled model so the picker renders; one test
+// empties it to cover the no-intelligence branch.
+const intelligenceModels: { enabled: boolean; healthy: boolean; capabilities: string[] }[] = [
+  { enabled: true, healthy: true, capabilities: ["chat"] },
+];
 jest.mock("@/hooks/use-providers", () => ({
-  useModels: () => ({
-    data: [{ enabled: true, healthy: true, capabilities: ["chat"] }],
-    isLoading: false,
-    isError: false,
-  }),
-  useProvidersConfig: () => ({ data: { policies: {} }, isLoading: false }),
+  useModels: () => ({ data: intelligenceModels, isLoading: false, isError: false }),
+  useProvidersConfig: () => ({ data: { policies: { "provider.manage": true } }, isLoading: false }),
 }));
 
 jest.mock("@/hooks/use-sessions", () => ({
@@ -107,7 +107,23 @@ describe("NewChatForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mutateAsync.mockResolvedValue({ id: "sess_new" });
+    intelligenceModels.splice(0, intelligenceModels.length, {
+      enabled: true,
+      healthy: true,
+      capabilities: ["chat"],
+    });
     setup();
+  });
+
+  it("replaces the picker with the no-intelligence message when the org has no model", () => {
+    intelligenceModels.length = 0;
+
+    render(<NewChatForm />);
+
+    expect(screen.getByText("No intelligence available")).toBeInTheDocument();
+    // One message, not two: starting a thread nothing can answer is a dead end.
+    expect(screen.queryByRole("combobox", { name: "Chat counterpart" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Start chat/ })).not.toBeInTheDocument();
   });
 
   it("creates an agent-bound thread and opens it", async () => {

--- a/apps/ui/src/__tests__/new-chat-form.test.tsx
+++ b/apps/ui/src/__tests__/new-chat-form.test.tsx
@@ -14,6 +14,18 @@ jest.mock("@/hooks", () => ({
   useHarnesses: jest.fn(),
 }));
 
+// The form carries the "no intelligence available" notice, which reads the model
+// list and provider policy map from `use-providers` (org context, not stubbed
+// here). A healthy enabled model keeps it hidden; the notice has its own suite.
+jest.mock("@/hooks/use-providers", () => ({
+  useModels: () => ({
+    data: [{ enabled: true, healthy: true, capabilities: ["chat"] }],
+    isLoading: false,
+    isError: false,
+  }),
+  useProvidersConfig: () => ({ data: { policies: {} }, isLoading: false }),
+}));
+
 jest.mock("@/hooks/use-sessions", () => ({
   useCreateSession: jest.fn(),
 }));

--- a/apps/ui/src/__tests__/new-chat-page-no-intelligence.test.tsx
+++ b/apps/ui/src/__tests__/new-chat-page-no-intelligence.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import NewChatPageClient from "@/app/(main)/chats/new/new-chat-page-client";
+
+const status = { isLoading: false, available: false, canManage: true };
+
+jest.mock("@/hooks/use-intelligence", () => ({
+  useIntelligenceStatus: () => status,
+}));
+
+jest.mock("@/components/chat/new-chat-form", () => ({
+  NewChatForm: () => <div data-testid="new-chat-form" />,
+}));
+
+describe("New chat page", () => {
+  beforeEach(() => {
+    status.isLoading = false;
+    status.available = false;
+    status.canManage = true;
+  });
+
+  it("replaces the whole empty state when the org has no model", () => {
+    render(<NewChatPageClient />);
+
+    expect(screen.getByText("No intelligence available")).toBeInTheDocument();
+    // One centred message, not two: the "New chat / pick a counterpart" frame
+    // and its picker would be advice that cannot work.
+    expect(screen.queryByText("New chat")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("new-chat-form")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /manage providers & models/i })).toHaveAttribute(
+      "href",
+      "/settings/providers",
+    );
+  });
+
+  it("points a member at an admin instead of a link", () => {
+    status.canManage = false;
+
+    render(<NewChatPageClient />);
+
+    expect(screen.queryByRole("link", { name: /manage providers/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/ask an organisation owner or admin/i)).toBeInTheDocument();
+  });
+
+  it("shows the normal picker once a model is available", () => {
+    status.available = true;
+
+    render(<NewChatPageClient />);
+
+    expect(screen.getByText("New chat")).toBeInTheDocument();
+    expect(screen.getByTestId("new-chat-form")).toBeInTheDocument();
+    expect(screen.queryByText("No intelligence available")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/no-intelligence-notice.test.tsx
+++ b/apps/ui/src/__tests__/no-intelligence-notice.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { NoIntelligenceNotice } from "@/components/chat/no-intelligence-notice";
+
+const modelsState = {
+  data: [] as { enabled: boolean; healthy: boolean; capabilities: string[] }[] | undefined,
+  isLoading: false,
+  isError: false,
+};
+const configState = {
+  data: { policies: {} as Record<string, boolean> } as
+    | { policies: Record<string, boolean> }
+    | undefined,
+  isLoading: false,
+};
+
+jest.mock("@/hooks/use-providers", () => ({
+  useModels: () => modelsState,
+  useProvidersConfig: () => configState,
+}));
+
+function chatModel(overrides: Partial<{ enabled: boolean; healthy: boolean }> = {}) {
+  return { enabled: true, healthy: true, capabilities: ["chat"], ...overrides };
+}
+
+describe("NoIntelligenceNotice", () => {
+  beforeEach(() => {
+    modelsState.data = [];
+    modelsState.isLoading = false;
+    modelsState.isError = false;
+    configState.data = { policies: {} };
+    configState.isLoading = false;
+  });
+
+  it("tells the user chat has no model and offers the fix when they may manage providers", () => {
+    configState.data = { policies: { "provider.manage": true } };
+
+    render(<NoIntelligenceNotice />);
+
+    expect(screen.getByText("No intelligence available")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /manage providers & models/i })).toHaveAttribute(
+      "href",
+      "/settings/providers",
+    );
+  });
+
+  it("points a member at an admin instead of a link they cannot act on", () => {
+    configState.data = { policies: { "provider.manage": false } };
+
+    render(<NoIntelligenceNotice />);
+
+    expect(screen.getByText("No intelligence available")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText(/ask an organisation owner or admin/i)).toBeInTheDocument();
+  });
+
+  it("stays silent once an enabled, healthy chat model exists", () => {
+    modelsState.data = [chatModel()];
+
+    render(<NoIntelligenceNotice />);
+
+    expect(screen.queryByText("No intelligence available")).not.toBeInTheDocument();
+  });
+
+  it("still warns when the only models are unhealthy, disabled, or embeddings", () => {
+    modelsState.data = [
+      chatModel({ healthy: false }),
+      chatModel({ enabled: false }),
+      { enabled: true, healthy: true, capabilities: ["embeddings"] },
+    ];
+
+    render(<NoIntelligenceNotice />);
+
+    expect(screen.getByText("No intelligence available")).toBeInTheDocument();
+  });
+
+  it("renders nothing while loading or when the model list could not be read", () => {
+    modelsState.isLoading = true;
+    const { rerender } = render(<NoIntelligenceNotice />);
+    expect(screen.queryByText("No intelligence available")).not.toBeInTheDocument();
+
+    modelsState.isLoading = false;
+    modelsState.isError = true;
+    modelsState.data = undefined;
+    rerender(<NoIntelligenceNotice />);
+    expect(screen.queryByText("No intelligence available")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/chats/chats-page-client.tsx
+++ b/apps/ui/src/app/(main)/chats/chats-page-client.tsx
@@ -7,17 +7,23 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { MessageCircle, Plus } from "lucide-react";
+import { MessageCircle, Plus, Sparkles } from "lucide-react";
 import { AgentAvatar } from "@/components/chat/agent-avatar";
 import { ChatArchiveButton } from "@/components/chat/chat-archive-button";
 import { ChatPinButton } from "@/components/chat/chat-pin-button";
 import { NewChatForm } from "@/components/chat/new-chat-form";
+import {
+  NO_INTELLIGENCE_DESCRIPTION,
+  NO_INTELLIGENCE_TITLE,
+  NoIntelligenceAction,
+} from "@/components/chat/no-intelligence-notice";
 import { EmptyState, PageContainer, PageMasthead } from "@/components/layout";
 import { buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ArchiveFilter } from "@/components/archive-filter";
 import { useAgents, useHarnesses } from "@/hooks";
 import { useChatThreads } from "@/hooks/use-chat-threads";
+import { useIntelligenceStatus } from "@/hooks/use-intelligence";
 import { isArchivedThread, threadTitle } from "@/lib/chat-threads";
 import { formatRelativeTime } from "@/lib/formatting";
 import { cn } from "@/lib/utils";
@@ -75,6 +81,12 @@ export default function ChatsPageClient() {
   const { threads, isLoading } = useChatThreads({ includeArchived: showArchived });
   const { data: agents = [] } = useAgents();
   const { data: harnesses = [] } = useHarnesses();
+  // The empty state is this page's only centred message, so when the org has no
+  // model to chat with it *becomes* that message — "No chats yet / pick an agent
+  // and start talking" would otherwise sit above it giving advice that cannot
+  // work.
+  const intelligence = useIntelligenceStatus();
+  const noIntelligence = !intelligence.isLoading && !intelligence.available;
   // Hold the starting state open once the user commits, so the new thread landing
   // in the list cannot unmount the form mid-navigation.
   const [starting, setStarting] = useState(false);
@@ -111,14 +123,23 @@ export default function ChatsPageClient() {
             <Skeleton key={index} className="h-[58px] w-full" />
           ))}
 
-        {!isLoading && (threads.length === 0 || starting) && (
-          <EmptyState
-            icon={<MessageCircle />}
-            title="No chats yet"
-            description="Pick an agent or harness and start talking. The thread is saved as a session you can come back to."
-            action={<NewChatForm onStartingChange={setStarting} />}
-          />
-        )}
+        {!isLoading &&
+          (threads.length === 0 || starting) &&
+          (noIntelligence ? (
+            <EmptyState
+              icon={<Sparkles />}
+              title={NO_INTELLIGENCE_TITLE}
+              description={NO_INTELLIGENCE_DESCRIPTION}
+              action={<NoIntelligenceAction canManage={intelligence.canManage} />}
+            />
+          ) : (
+            <EmptyState
+              icon={<MessageCircle />}
+              title="No chats yet"
+              description="Pick an agent or harness and start talking. The thread is saved as a session you can come back to."
+              action={<NewChatForm onStartingChange={setStarting} />}
+            />
+          ))}
 
         {!starting &&
           threads.map((thread) => (

--- a/apps/ui/src/app/(main)/chats/new/new-chat-page-client.tsx
+++ b/apps/ui/src/app/(main)/chats/new/new-chat-page-client.tsx
@@ -1,20 +1,43 @@
 "use client";
 
-import { MessageCircle } from "lucide-react";
+// The new-chat surface. Its empty-state frame is the only centred message here,
+// so an org with no model to chat with replaces it outright rather than showing
+// a counterpart picker that cannot lead anywhere.
+
+import { MessageCircle, Sparkles } from "lucide-react";
 import { NewChatForm } from "@/components/chat/new-chat-form";
+import {
+  NO_INTELLIGENCE_DESCRIPTION,
+  NO_INTELLIGENCE_TITLE,
+  NoIntelligenceAction,
+} from "@/components/chat/no-intelligence-notice";
 import { BackLink, EmptyState, PageContainer } from "@/components/layout";
+import { useIntelligenceStatus } from "@/hooks/use-intelligence";
 
 export default function NewChatPageClient() {
+  const intelligence = useIntelligenceStatus();
+  const noIntelligence = !intelligence.isLoading && !intelligence.available;
+
   return (
     <PageContainer>
       <BackLink href="/chats">Chats</BackLink>
-      <EmptyState
-        className="mt-6"
-        icon={<MessageCircle />}
-        title="New chat"
-        description="A thread is bound to one agent or harness for its lifetime. Pick the counterpart you want to talk to."
-        action={<NewChatForm />}
-      />
+      {noIntelligence ? (
+        <EmptyState
+          className="mt-6"
+          icon={<Sparkles />}
+          title={NO_INTELLIGENCE_TITLE}
+          description={NO_INTELLIGENCE_DESCRIPTION}
+          action={<NoIntelligenceAction canManage={intelligence.canManage} />}
+        />
+      ) : (
+        <EmptyState
+          className="mt-6"
+          icon={<MessageCircle />}
+          title="New chat"
+          description="A thread is bound to one agent or harness for its lifetime. Pick the counterpart you want to talk to."
+          action={<NewChatForm />}
+        />
+      )}
     </PageContainer>
   );
 }

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -5,6 +5,9 @@
 //
 // Configure: provisioning checklist + inline LLM provider setup (provider type +
 //   API key). Polling queries drive the checklist; "Skip for now" is preserved.
+//   Creating the provider with a key also discovers its models and elects the
+//   org default model server-side (see `provision_provider_models`), so the key
+//   entered here is enough to leave chat usable — the form waits for that call.
 // Done: shown after the provider form is submitted OR skipped (replaces the old
 //   redirect straight to /chats). The Done subline is conditional — it only
 //   claims a provider is connected when one actually exists; a skip shows a
@@ -619,7 +622,7 @@ export default function OrgSetupPage() {
                     Skip for now
                   </button>
                   <Button onClick={handleContinue} disabled={createProvider.isPending}>
-                    {createProvider.isPending ? "Configuring..." : "Finish setup"}
+                    {createProvider.isPending ? "Discovering models..." : "Finish setup"}
                     {!createProvider.isPending && <ArrowRight className="ml-2 h-4 w-4" />}
                   </Button>
                 </div>

--- a/apps/ui/src/app/dev/chat-components/page.tsx
+++ b/apps/ui/src/app/dev/chat-components/page.tsx
@@ -10,6 +10,7 @@ import {
   makePendingImages,
 } from "@/app/dev/_fixtures/chat-runtime-fixtures";
 import { ChatComposer } from "@/components/chat/chat-composer";
+import { NoIntelligenceMessage } from "@/components/chat/no-intelligence-notice";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { chatSurfaceStyles } from "@/components/chat/chat-surface";
 import type { PendingImage } from "@/lib/api/images";
@@ -86,6 +87,31 @@ export default function DevChatComponentsPage() {
             </p>
           </div>
           <DevChatNavRailPreview />
+        </section>
+
+        <section className="space-y-3">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">No intelligence available</h2>
+            <p className="text-sm text-muted-foreground">
+              Shown on every chat surface when the org has no enabled, healthy chat model: above the
+              composer on a thread, and above the counterpart picker on the new-chat form. The route
+              to Settings only appears for a caller who can manage providers.
+            </p>
+          </div>
+          <div className="grid gap-4 border border-border/70 bg-background p-6 md:grid-cols-2">
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                Can manage providers
+              </p>
+              <NoIntelligenceMessage canManage />
+            </div>
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                Member, view only
+              </p>
+              <NoIntelligenceMessage canManage={false} />
+            </div>
+          </div>
         </section>
 
         <section className="space-y-3 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">

--- a/apps/ui/src/app/dev/chat-components/page.tsx
+++ b/apps/ui/src/app/dev/chat-components/page.tsx
@@ -93,8 +93,10 @@ export default function DevChatComponentsPage() {
           <div className="space-y-1">
             <h2 className="text-lg font-semibold text-foreground">No intelligence available</h2>
             <p className="text-sm text-muted-foreground">
-              Shown on every chat surface when the org has no enabled, healthy chat model: above the
-              composer on a thread, and above the counterpart picker on the new-chat form. The route
+              Shown on every chat surface when the org has no enabled, healthy chat model. It is
+              always the only centred message on the surface: it replaces the transcript&rsquo;s
+              &ldquo;No messages yet&rdquo; card on a fresh thread, sits above the composer once
+              there is history, and replaces the counterpart picker on the new-chat form. The route
               to Settings only appears for a caller who can manage providers.
             </p>
           </div>
@@ -110,6 +112,12 @@ export default function DevChatComponentsPage() {
                 Member, view only
               </p>
               <NoIntelligenceMessage canManage={false} />
+            </div>
+            <div className="space-y-2 md:col-span-2">
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                Plain, inside a host that draws its own frame
+              </p>
+              <NoIntelligenceMessage canManage variant="plain" />
             </div>
           </div>
         </section>

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -92,6 +92,13 @@ interface ChatMessageListProps {
    * keeps its transcript free of run chrome.
    */
   runsByEventId?: Map<string, ChatRun[]>;
+  /**
+   * Replaces the default "No messages yet" card when the transcript is empty.
+   * Used when the surface has something more useful to say than "start typing"
+   * — e.g. the org has no model to chat with, so inviting a first message would
+   * be a second, competing centred message.
+   */
+  emptyState?: ReactNode;
 }
 
 /** A derived join/leave marker interleaved into the transcript by timestamp. */
@@ -163,6 +170,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   getToolCalls,
   participants,
   runsByEventId,
+  emptyState,
 }: ChatMessageListProps) {
   const { locale, t } = useLocale();
   const { data: providers } = useProviders();
@@ -466,6 +474,13 @@ export const ChatMessageList = memo(function ChatMessageList({
   }
 
   if (chatEvents.length === 0) {
+    if (emptyState) {
+      return (
+        <div className="flex flex-col items-center justify-end text-center text-muted-foreground">
+          {emptyState}
+        </div>
+      );
+    }
     return (
       <div className="flex flex-col items-center justify-end text-center text-muted-foreground">
         <div className={chatSurfaceStyles.emptyStateCard}>

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -23,6 +23,7 @@ import { endSessionVoice, startSessionVoice } from "@/lib/api/voice";
 import { useMutation } from "@tanstack/react-query";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 import { ChatComposer } from "@/components/chat/chat-composer";
+import { NoIntelligenceNotice } from "@/components/chat/no-intelligence-notice";
 import { MessageContent } from "@/components/chat/message-content";
 import { SessionTaskChips } from "@/components/session/session-task-chips";
 import { SessionParticipantsRail } from "@/components/session/session-participants-rail";
@@ -572,6 +573,8 @@ export function ChatPanel({ replyToLabel, showRunCards = false }: ChatPanelProps
             basePath={sessionBasePath}
             hasTasksFeature={hasTasksFeature}
           />
+
+          <NoIntelligenceNotice className="mb-3" />
 
           <ChatComposer
             commands={commands}

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -16,6 +16,7 @@ import { getDisplayName } from "@/lib/entity-lifecycle";
 import { getSessionParticipantLabel } from "@/lib/session-participant-label";
 import type { ParticipantMentionOption } from "@/components/chat/participant-mention-autocomplete";
 import { useChatModelSelection } from "@/hooks/use-chat-model-selection";
+import { useIntelligenceStatus } from "@/hooks/use-intelligence";
 import { executeSessionCommand } from "@/lib/api/commands";
 import { ApiError } from "@/lib/api/client";
 import { sendUserMessageWithImages } from "@/lib/api/messages";
@@ -23,7 +24,7 @@ import { endSessionVoice, startSessionVoice } from "@/lib/api/voice";
 import { useMutation } from "@tanstack/react-query";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 import { ChatComposer } from "@/components/chat/chat-composer";
-import { NoIntelligenceNotice } from "@/components/chat/no-intelligence-notice";
+import { NoIntelligenceMessage } from "@/components/chat/no-intelligence-notice";
 import { MessageContent } from "@/components/chat/message-content";
 import { SessionTaskChips } from "@/components/session/session-task-chips";
 import { SessionParticipantsRail } from "@/components/session/session-participants-rail";
@@ -118,6 +119,7 @@ export function ChatPanel({ replyToLabel, showRunCards = false }: ChatPanelProps
     agentId,
     sessionId,
     session,
+    chatEvents,
     llmModel,
     llmModelLoading,
     eventsLoading,
@@ -132,6 +134,12 @@ export function ChatPanel({ replyToLabel, showRunCards = false }: ChatPanelProps
   } = useSessionContext();
 
   const { data: models = [], isLoading: modelsLoading } = useModels();
+  // One message, not two: when the org has no model to chat with, the notice
+  // *replaces* the transcript's "No messages yet" card on a fresh thread, and
+  // only sits above the composer once there is history to sit under.
+  const intelligence = useIntelligenceStatus();
+  const showNoIntelligence = !intelligence.isLoading && !intelligence.available;
+  const transcriptEmpty = chatEvents.length === 0;
   const { data: participants, refetch: refetchParticipants } = useSessionParticipants(sessionId);
   const { data: agents } = useAgents();
   const [inputValue, setInputValue] = useState("");
@@ -548,6 +556,11 @@ export function ChatPanel({ replyToLabel, showRunCards = false }: ChatPanelProps
         <div className="flex min-h-0 flex-1 flex-col">
           <SessionTranscript
             showRunCards={showRunCards}
+            emptyState={
+              showNoIntelligence ? (
+                <NoIntelligenceMessage canManage={intelligence.canManage} />
+              ) : undefined
+            }
             footer={
               <>
                 {submitError && (
@@ -574,7 +587,9 @@ export function ChatPanel({ replyToLabel, showRunCards = false }: ChatPanelProps
             hasTasksFeature={hasTasksFeature}
           />
 
-          <NoIntelligenceNotice className="mb-3" />
+          {showNoIntelligence && !transcriptEmpty && (
+            <NoIntelligenceMessage canManage={intelligence.canManage} className="mb-3" />
+          )}
 
           <ChatComposer
             commands={commands}

--- a/apps/ui/src/components/chat/new-chat-form.tsx
+++ b/apps/ui/src/components/chat/new-chat-form.tsx
@@ -7,6 +7,10 @@
  * A thread is an ordinary session: this posts `POST /v1/sessions` with either
  * an agent or a harness binding. Direct harness chats let users start from a
  * configured runtime without creating an otherwise-empty agent first.
+ *
+ * An org with no model to chat with never reaches this form: both hosts own
+ * their empty-state frame, so they swap the whole frame for the
+ * "no intelligence available" message rather than stacking a second one here.
  */
 "use client";
 
@@ -24,9 +28,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
-import { NoIntelligenceMessage } from "@/components/chat/no-intelligence-notice";
 import { useAgents, useHarnesses } from "@/hooks";
-import { useIntelligenceStatus } from "@/hooks/use-intelligence";
 import { useCreateSession } from "@/hooks/use-sessions";
 import { CHAT_THREAD_TAG } from "@/lib/chat-threads";
 import { getDisplayName } from "@/lib/entity-lifecycle";
@@ -50,7 +52,6 @@ export function NewChatForm({
   const { data: agents = [], isLoading: agentsLoading } = useAgents();
   const { data: harnesses = [], isLoading: harnessesLoading } = useHarnesses();
   const createSession = useCreateSession();
-  const intelligence = useIntelligenceStatus();
   const [selection, setSelection] = useState("");
   const [error, setError] = useState<string | null>(null);
   const optionsLoading = agentsLoading || harnessesLoading;
@@ -77,13 +78,6 @@ export function NewChatForm({
       setError(e instanceof Error ? e.message : "Could not start the chat.");
     }
   };
-
-  // Starting a thread with no model to answer it is a dead end, so the notice
-  // replaces the picker instead of sitting above it — and stays unboxed, since
-  // every host of this form already draws its own empty-state frame.
-  if (!intelligence.isLoading && !intelligence.available) {
-    return <NoIntelligenceMessage canManage={intelligence.canManage} variant="plain" />;
-  }
 
   if (!optionsLoading && agents.length === 0 && harnesses.length === 0) {
     return (

--- a/apps/ui/src/components/chat/new-chat-form.tsx
+++ b/apps/ui/src/components/chat/new-chat-form.tsx
@@ -24,8 +24,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
-import { NoIntelligenceNotice } from "@/components/chat/no-intelligence-notice";
+import { NoIntelligenceMessage } from "@/components/chat/no-intelligence-notice";
 import { useAgents, useHarnesses } from "@/hooks";
+import { useIntelligenceStatus } from "@/hooks/use-intelligence";
 import { useCreateSession } from "@/hooks/use-sessions";
 import { CHAT_THREAD_TAG } from "@/lib/chat-threads";
 import { getDisplayName } from "@/lib/entity-lifecycle";
@@ -49,6 +50,7 @@ export function NewChatForm({
   const { data: agents = [], isLoading: agentsLoading } = useAgents();
   const { data: harnesses = [], isLoading: harnessesLoading } = useHarnesses();
   const createSession = useCreateSession();
+  const intelligence = useIntelligenceStatus();
   const [selection, setSelection] = useState("");
   const [error, setError] = useState<string | null>(null);
   const optionsLoading = agentsLoading || harnessesLoading;
@@ -76,6 +78,13 @@ export function NewChatForm({
     }
   };
 
+  // Starting a thread with no model to answer it is a dead end, so the notice
+  // replaces the picker instead of sitting above it — and stays unboxed, since
+  // every host of this form already draws its own empty-state frame.
+  if (!intelligence.isLoading && !intelligence.available) {
+    return <NoIntelligenceMessage canManage={intelligence.canManage} variant="plain" />;
+  }
+
   if (!optionsLoading && agents.length === 0 && harnesses.length === 0) {
     return (
       <div className="space-y-3">
@@ -89,8 +98,6 @@ export function NewChatForm({
 
   return (
     <div className="space-y-3">
-      <NoIntelligenceNotice />
-
       <div className="flex flex-wrap items-center justify-center gap-2">
         <Select value={selection} onValueChange={setSelection} disabled={optionsLoading}>
           <SelectTrigger className="w-64" aria-label="Chat counterpart">

--- a/apps/ui/src/components/chat/new-chat-form.tsx
+++ b/apps/ui/src/components/chat/new-chat-form.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
+import { NoIntelligenceNotice } from "@/components/chat/no-intelligence-notice";
 import { useAgents, useHarnesses } from "@/hooks";
 import { useCreateSession } from "@/hooks/use-sessions";
 import { CHAT_THREAD_TAG } from "@/lib/chat-threads";
@@ -88,6 +89,8 @@ export function NewChatForm({
 
   return (
     <div className="space-y-3">
+      <NoIntelligenceNotice />
+
       <div className="flex flex-wrap items-center justify-center gap-2">
         <Select value={selection} onValueChange={setSelection} disabled={optionsLoading}>
           <SelectTrigger className="w-64" aria-label="Chat counterpart">

--- a/apps/ui/src/components/chat/no-intelligence-notice.tsx
+++ b/apps/ui/src/components/chat/no-intelligence-notice.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * "This org has no model to think with" — shown on every chat surface when no
+ * enabled, healthy chat model exists.
+ *
+ * Decisions:
+ * - A centred message, not a warning stripe. The chat is unusable, so this is
+ *   the state of the surface rather than an aside about it; weight (bold) and
+ *   position carry the message instead of an alert colour.
+ * - The route out is only rendered for a caller who holds `provider.manage`.
+ *   Everyone else gets a sentence naming who can fix it, because a link they
+ *   cannot act on reads as a dead end.
+ * - Silent while loading and silent on a failed read: a false "no intelligence"
+ *   on a working org is worse than a late one.
+ */
+
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { useIntelligenceStatus } from "@/hooks/use-intelligence";
+import { cn } from "@/lib/utils";
+
+export function NoIntelligenceNotice({ className }: { className?: string }) {
+  const { isLoading, available, canManage } = useIntelligenceStatus();
+
+  if (isLoading || available) return null;
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "mx-auto flex max-w-md flex-col items-center gap-2 border border-border/70 bg-card/60 px-6 py-5 text-center",
+        className,
+      )}
+    >
+      <Sparkles className="icon-sharp size-5 text-muted-foreground" strokeWidth={1.8} />
+      <p className="text-sm font-semibold text-foreground">No intelligence available</p>
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        This organisation has no model available for chat. Connect a provider and enable at least
+        one model to start a conversation.
+      </p>
+      {canManage ? (
+        <Link
+          href="/settings/providers"
+          className={cn(buttonVariants({ variant: "outline", size: "sm" }), "mt-1")}
+        >
+          Manage providers &amp; models
+        </Link>
+      ) : (
+        <p className="mt-1 text-xs text-muted-foreground">
+          Ask an organisation owner or admin to configure a model provider.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/chat/no-intelligence-notice.tsx
+++ b/apps/ui/src/components/chat/no-intelligence-notice.tsx
@@ -28,6 +28,28 @@ import { buttonVariants } from "@/components/ui/button";
 import { useIntelligenceStatus } from "@/hooks/use-intelligence";
 import { cn } from "@/lib/utils";
 
+/** One wording for every surface, so hosts that frame their own empty state
+ *  (the chats list, the new-chat page) say the same thing this message does. */
+export const NO_INTELLIGENCE_TITLE = "No intelligence available";
+export const NO_INTELLIGENCE_DESCRIPTION =
+  "This organisation has no model available for chat. Connect a provider and enable at least one model to start a conversation.";
+
+/** The way out, or who to ask when the caller has no route to Settings. */
+export function NoIntelligenceAction({ canManage }: { canManage: boolean }) {
+  if (!canManage) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Ask an organisation owner or admin to configure a model provider.
+      </p>
+    );
+  }
+  return (
+    <Link href="/settings/providers" className={buttonVariants({ variant: "outline", size: "sm" })}>
+      Manage providers &amp; models
+    </Link>
+  );
+}
+
 export function NoIntelligenceMessage({
   canManage,
   variant = "card",
@@ -49,23 +71,11 @@ export function NoIntelligenceMessage({
       )}
     >
       <Sparkles className="icon-sharp size-5 text-muted-foreground" strokeWidth={1.8} />
-      <p className="text-sm font-semibold text-foreground">No intelligence available</p>
-      <p className="text-xs leading-relaxed text-muted-foreground">
-        This organisation has no model available for chat. Connect a provider and enable at least
-        one model to start a conversation.
-      </p>
-      {canManage ? (
-        <Link
-          href="/settings/providers"
-          className={cn(buttonVariants({ variant: "outline", size: "sm" }), "mt-1")}
-        >
-          Manage providers &amp; models
-        </Link>
-      ) : (
-        <p className="mt-1 text-xs text-muted-foreground">
-          Ask an organisation owner or admin to configure a model provider.
-        </p>
-      )}
+      <p className="text-sm font-semibold text-foreground">{NO_INTELLIGENCE_TITLE}</p>
+      <p className="text-xs leading-relaxed text-muted-foreground">{NO_INTELLIGENCE_DESCRIPTION}</p>
+      <div className="mt-1">
+        <NoIntelligenceAction canManage={canManage} />
+      </div>
     </div>
   );
 }

--- a/apps/ui/src/components/chat/no-intelligence-notice.tsx
+++ b/apps/ui/src/components/chat/no-intelligence-notice.tsx
@@ -13,6 +13,8 @@
  *   cannot act on reads as a dead end.
  * - Silent while loading and silent on a failed read: a false "no intelligence"
  *   on a working org is worse than a late one.
+ * - Split presentational/data-bound so `/dev/chat-components` can show both
+ *   permission variants without a backend.
  */
 
 import Link from "next/link";
@@ -21,11 +23,14 @@ import { buttonVariants } from "@/components/ui/button";
 import { useIntelligenceStatus } from "@/hooks/use-intelligence";
 import { cn } from "@/lib/utils";
 
-export function NoIntelligenceNotice({ className }: { className?: string }) {
-  const { isLoading, available, canManage } = useIntelligenceStatus();
-
-  if (isLoading || available) return null;
-
+export function NoIntelligenceMessage({
+  canManage,
+  className,
+}: {
+  /** Render the route to Settings → Providers. */
+  canManage: boolean;
+  className?: string;
+}) {
   return (
     <div
       role="status"
@@ -54,4 +59,12 @@ export function NoIntelligenceNotice({ className }: { className?: string }) {
       )}
     </div>
   );
+}
+
+export function NoIntelligenceNotice({ className }: { className?: string }) {
+  const { isLoading, available, canManage } = useIntelligenceStatus();
+
+  if (isLoading || available) return null;
+
+  return <NoIntelligenceMessage canManage={canManage} className={className} />;
 }

--- a/apps/ui/src/components/chat/no-intelligence-notice.tsx
+++ b/apps/ui/src/components/chat/no-intelligence-notice.tsx
@@ -8,6 +8,11 @@
  * - A centred message, not a warning stripe. The chat is unusable, so this is
  *   the state of the surface rather than an aside about it; weight (bold) and
  *   position carry the message instead of an alert colour.
+ * - One message per surface. Where a surface already shows a centred empty
+ *   state ("No messages yet", "No chats yet"), this *replaces* it rather than
+ *   stacking under it — two centred cards competing for the same job reads as a
+ *   bug. Hosts that already frame their own box pass `variant="plain"` so the
+ *   message does not land as a card inside a card.
  * - The route out is only rendered for a caller who holds `provider.manage`.
  *   Everyone else gets a sentence naming who can fix it, because a link they
  *   cannot act on reads as a dead end.
@@ -25,17 +30,21 @@ import { cn } from "@/lib/utils";
 
 export function NoIntelligenceMessage({
   canManage,
+  variant = "card",
   className,
 }: {
   /** Render the route to Settings → Providers. */
   canManage: boolean;
+  /** `plain` drops the box, for a host that already draws one. */
+  variant?: "card" | "plain";
   className?: string;
 }) {
   return (
     <div
       role="status"
       className={cn(
-        "mx-auto flex max-w-md flex-col items-center gap-2 border border-border/70 bg-card/60 px-6 py-5 text-center",
+        "mx-auto flex max-w-md flex-col items-center gap-2 text-center",
+        variant === "card" && "border border-border/70 bg-card/60 px-6 py-5",
         className,
       )}
     >
@@ -61,10 +70,16 @@ export function NoIntelligenceMessage({
   );
 }
 
-export function NoIntelligenceNotice({ className }: { className?: string }) {
+export function NoIntelligenceNotice({
+  variant,
+  className,
+}: {
+  variant?: "card" | "plain";
+  className?: string;
+}) {
   const { isLoading, available, canManage } = useIntelligenceStatus();
 
   if (isLoading || available) return null;
 
-  return <NoIntelligenceMessage canManage={canManage} className={className} />;
+  return <NoIntelligenceMessage canManage={canManage} variant={variant} className={className} />;
 }

--- a/apps/ui/src/components/session/session-transcript.tsx
+++ b/apps/ui/src/components/session/session-transcript.tsx
@@ -33,9 +33,12 @@ export function SessionTranscript({
   footer,
   /** Show inline run cards for work the turns started (Chats thread surface). */
   showRunCards = false,
+  /** Replaces the transcript's default empty state (see `ChatMessageList`). */
+  emptyState,
 }: {
   footer?: ReactNode;
   showRunCards?: boolean;
+  emptyState?: ReactNode;
 }) {
   const { t } = useLocale();
   const {
@@ -133,6 +136,7 @@ export function SessionTranscript({
           getToolCalls={getToolCalls}
           participants={participants}
           runsByEventId={runsByEventId}
+          emptyState={emptyState}
         />
 
         {(isThinking || streamingText) && (

--- a/apps/ui/src/hooks/use-intelligence.ts
+++ b/apps/ui/src/hooks/use-intelligence.ts
@@ -13,6 +13,11 @@
  *
  * Every role may read models (`org:providers:view`), so the check itself is not
  * gated; only the fix-it link is, on `provider.manage`.
+ *
+ * The policy map is fetched only once the org is known to have no model. Chats
+ * is the landing surface, so an unconditional fetch would add a request to every
+ * cold start for a case that almost never fires — and `navigation-prefetch.spec`
+ * guards exactly that.
  */
 
 import { useModels, useProvidersConfig } from "@/hooks/use-providers";
@@ -29,7 +34,6 @@ export interface IntelligenceStatus {
 
 export function useIntelligenceStatus(): IntelligenceStatus {
   const { data: models, isLoading: modelsLoading, isError: modelsError } = useModels();
-  const { data: config, isLoading: configLoading } = useProvidersConfig();
 
   // A failed models read is not evidence of a misconfigured org, so treat it as
   // "nothing to say" and leave the chat UI alone.
@@ -38,8 +42,13 @@ export function useIntelligenceStatus(): IntelligenceStatus {
       ? true
       : models.some((model) => model.enabled && model.healthy && isChatModel(model));
 
+  const needsPolicy = !modelsLoading && !available;
+  const { data: config, isLoading: configLoading } = useProvidersConfig({ enabled: needsPolicy });
+
   return {
-    isLoading: modelsLoading || configLoading,
+    // Stay "loading" until the policy lands too, so the notice does not render
+    // the no-permission wording first and swap in the link a moment later.
+    isLoading: modelsLoading || (needsPolicy && configLoading),
     available,
     canManage: config?.policies?.["provider.manage"] ?? false,
   };

--- a/apps/ui/src/hooks/use-intelligence.ts
+++ b/apps/ui/src/hooks/use-intelligence.ts
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * Whether this org can actually run a chat turn, and whether the current user
+ * can do anything about it.
+ *
+ * Decision: readiness is derived from the model list rather than the provider
+ * list. A provider row alone proves nothing — a keyed provider whose models were
+ * never discovered, or whose models are all disabled, resolves to no model and
+ * the turn fails. `healthy` is the server's own derivation (provider active and
+ * credentialed), so this stays in step with `get_default_model`, which also
+ * fails closed on a disabled model or an inactive provider.
+ *
+ * Every role may read models (`org:providers:view`), so the check itself is not
+ * gated; only the fix-it link is, on `provider.manage`.
+ */
+
+import { useModels, useProvidersConfig } from "@/hooks/use-providers";
+import { isChatModel } from "@/lib/model-capabilities";
+
+export interface IntelligenceStatus {
+  /** Still resolving — render nothing rather than a false alarm. */
+  isLoading: boolean;
+  /** At least one enabled, healthy chat model exists. */
+  available: boolean;
+  /** The caller may configure providers and models. */
+  canManage: boolean;
+}
+
+export function useIntelligenceStatus(): IntelligenceStatus {
+  const { data: models, isLoading: modelsLoading, isError: modelsError } = useModels();
+  const { data: config, isLoading: configLoading } = useProvidersConfig();
+
+  // A failed models read is not evidence of a misconfigured org, so treat it as
+  // "nothing to say" and leave the chat UI alone.
+  const available =
+    modelsError || !models
+      ? true
+      : models.some((model) => model.enabled && model.healthy && isChatModel(model));
+
+  return {
+    isLoading: modelsLoading || configLoading,
+    available,
+    canManage: config?.policies?.["provider.manage"] ?? false,
+  };
+}

--- a/apps/ui/src/hooks/use-providers.ts
+++ b/apps/ui/src/hooks/use-providers.ts
@@ -87,6 +87,11 @@ export function useCreateProvider() {
     mutationFn: (data: CreateProviderRequest) => createProvider(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.providers.all });
+      // A provider created with a credential also discovers its models and may
+      // elect the org default model server-side, so the model caches are stale
+      // the moment this resolves.
+      queryClient.invalidateQueries({ queryKey: queryKeys.models.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
     },
   });
 }
@@ -101,6 +106,10 @@ export function useUpdateProvider(providerId: string) {
       queryClient.invalidateQueries({
         queryKey: queryKeys.providers.detail(providerId),
       });
+      // Same as create: a key landing on an existing provider discovers models
+      // and may elect the org default.
+      queryClient.invalidateQueries({ queryKey: queryKeys.models.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
     },
   });
 }
@@ -123,9 +132,11 @@ export function useSyncProviderModels() {
   return useMutation({
     mutationFn: (providerId: string) => syncProviderModels(providerId),
     onSuccess: () => {
-      // Refresh models list after sync
+      // Refresh models list after sync. A sync may also elect the org default
+      // model when none resolved, so org settings are stale too.
       queryClient.invalidateQueries({ queryKey: queryKeys.models.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.providers.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
     },
   });
 }

--- a/apps/ui/src/hooks/use-providers.ts
+++ b/apps/ui/src/hooks/use-providers.ts
@@ -63,14 +63,14 @@ export function useProvider(providerId: string) {
 
 // Per-driver credential schemas (and caller policies), used to render the
 // provider credential forms as discrete typed inputs.
-export function useProvidersConfig() {
+export function useProvidersConfig(options: { enabled?: boolean } = {}) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
   const query = useQuery({
     queryKey: [...queryKeys.providers.all, "config", org],
     queryFn: () => getProvidersConfig(),
-    enabled: !!org,
+    enabled: !!org && (options.enabled ?? true),
     staleTime: 300000,
   });
 

--- a/crates/server/src/api/providers.rs
+++ b/crates/server/src/api/providers.rs
@@ -44,6 +44,11 @@ pub struct AppState {
     pub db: Arc<StorageBackend>,
     pub service: Arc<ProviderService>,
     pub sync_service: Arc<ModelSyncService>,
+    /// Model service, so a provider that gains a credential can bootstrap the
+    /// org's enabled models and default model in the same request. Carries the
+    /// provider resolver when one exists, so the cache is invalidated after the
+    /// bootstrap writes.
+    pub model_service: Arc<crate::domains::models::ModelService>,
     pub auth: AuthState,
     /// Driver registry, used to discover whether a provider's driver declares an
     /// interactive OAuth connect flow.
@@ -60,6 +65,12 @@ impl AppState {
         auth: AuthState,
         provider_resolver: Option<Arc<ProviderResolverService>>,
     ) -> Self {
+        let model_service = match provider_resolver.clone() {
+            Some(resolver) => {
+                crate::domains::models::ModelService::with_resolver(db.clone(), resolver)
+            }
+            None => crate::domains::models::ModelService::new(db.clone()),
+        };
         let service = if let Some(resolver) = provider_resolver {
             ProviderService::with_resolver(db.clone(), encryption.clone(), resolver)
         } else {
@@ -68,6 +79,7 @@ impl AppState {
         Self {
             db: db.clone(),
             service: Arc::new(service),
+            model_service: Arc::new(model_service),
             sync_service: Arc::new(ModelSyncService::new(
                 db,
                 driver_registry.clone(),
@@ -88,6 +100,7 @@ impl AppState {
         )
         .with_provider_service(self.service.clone())
         .with_model_sync_service(self.sync_service.clone())
+        .with_model_service(self.model_service.clone())
     }
 }
 
@@ -1075,6 +1088,41 @@ mod tests {
 #[cfg(test)]
 mod creation_tests {
     use super::*;
+
+    /// The provider command context must carry both the sync service *and* the
+    /// model service: `provision_provider_models` bootstraps the org's enabled
+    /// models and default model through the latter, and its best-effort
+    /// `if let Some(..)` would otherwise skip that silently — discovery would
+    /// run, every model would stay disabled, and chat would still resolve
+    /// nothing. Regression guard for exactly that wiring gap.
+    #[tokio::test]
+    async fn provider_ctx_carries_the_services_provisioning_needs() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let state = AppState::new(
+            db.clone(),
+            None,
+            Arc::new(DriverRegistry::new()),
+            AuthState::builtin(crate::auth::AuthConfig::default(), db),
+            None,
+        );
+        let org = ResolvedOrg {
+            org_id: everruns_core::DEFAULT_ORG_ID,
+            public_id: "org_test".into(),
+            name: "Test".into(),
+            user_id: None,
+            role: everruns_core::OrgRole::Owner,
+            is_platform_user: false,
+            feature_flags: Default::default(),
+        };
+
+        let ctx = state.ctx(&org);
+
+        assert!(
+            ctx.model_sync_service.is_some(),
+            "model sync service missing"
+        );
+        assert!(ctx.model_service.is_some(), "model service missing");
+    }
 
     #[tokio::test]
     async fn create_rejects_invalid_base_urls_as_client_errors() {

--- a/crates/server/src/domains/models/service.rs
+++ b/crates/server/src/domains/models/service.rs
@@ -32,6 +32,51 @@ pub const LLM_MODEL_MANAGE: Policy = Policy {
     rules: &[Rule::UserHasPermission(Permission::OrgProvidersManage)],
 };
 
+/// What [`ModelService::bootstrap_intelligence`] changed. All-zero means the org
+/// was already usable and nothing was touched.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct IntelligenceBootstrap {
+    /// How many of the provider's models were switched on.
+    pub enabled_models: usize,
+    /// How many of them were starred as favourites.
+    pub favorited_models: usize,
+    /// The model elected as the org default, when one was elected.
+    pub default_model_id: Option<Uuid>,
+}
+
+impl IntelligenceBootstrap {
+    pub fn changed(&self) -> bool {
+        self.enabled_models > 0 || self.favorited_models > 0 || self.default_model_id.is_some()
+    }
+}
+
+/// How many of a provider's ranked chat models the bootstrap switches on, and
+/// how many of those it stars. Shortlist sizes, not limits on what a user may
+/// enable afterwards in Settings.
+const BOOTSTRAP_ENABLE_LIMIT: usize = 8;
+const BOOTSTRAP_FAVORITE_LIMIT: usize = 3;
+
+/// Default-model preference order: newest release first, then the model with the
+/// fewest missing agent-relevant traits. Lower sorts better.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ModelRank {
+    /// `Reverse` so a later date — and a known date over an unknown one — wins.
+    release: std::cmp::Reverse<String>,
+    capability_gaps: u8,
+}
+
+impl ModelRank {
+    fn of(profile: &ModelProfile) -> Self {
+        let gaps = u8::from(!profile.reasoning)
+            + u8::from(!profile.attachment)
+            + u8::from(!profile.structured_output);
+        Self {
+            release: std::cmp::Reverse(profile.release_date.clone().unwrap_or_default()),
+            capability_gaps: gaps,
+        }
+    }
+}
+
 pub struct ModelService {
     db: Arc<StorageBackend>,
     provider_resolver: Option<Arc<ProviderResolverService>>,
@@ -364,6 +409,163 @@ impl ModelService {
         Ok(())
     }
 
+    // ============================================================
+    // First-run intelligence bootstrap
+    // ============================================================
+    //
+    // Decision: configuring a provider credential is the moment an org gains
+    // intelligence, so it must also leave the org *usable*. Discovery creates
+    // models disabled and never elects an org default, which left a freshly
+    // onboarded org with a keyed provider, zero selectable models and a chat
+    // that could not resolve a model. Bootstrapping lives here, at the domain
+    // layer, so every entry path (onboarding, Settings, CLI, MCP) behaves the
+    // same.
+    //
+    // It only ever adds: models are enabled solely when the org has no enabled
+    // chat model at all, and the default is elected solely when none resolves.
+    // An org that deliberately disabled everything is left alone.
+
+    /// Make a freshly credentialed provider usable: enable its chat models when
+    /// the org has none, and elect an org default model when none resolves.
+    pub async fn bootstrap_intelligence(
+        &self,
+        org_id: i64,
+        provider_id: Uuid,
+    ) -> Result<IntelligenceBootstrap> {
+        let provider = self.get_provider(org_id, provider_id).await?;
+        let provider_type: DriverId = provider.provider_type.parse().unwrap_or(DriverId::OpenAI);
+        let mut outcome = IntelligenceBootstrap::default();
+
+        // A provider that cannot serve a request bootstraps nothing.
+        if !provider.api_key_set || provider.status != "active" {
+            return Ok(outcome);
+        }
+
+        let org_has_enabled_chat = self
+            .db
+            .list_all_models(org_id)
+            .await?
+            .iter()
+            .any(|row| row.enabled && Self::row_is_chat_model(&row.capabilities));
+
+        if !org_has_enabled_chat {
+            let candidates = self
+                .chat_candidates(org_id, &provider, &provider_type)
+                .await?;
+            // A shortlist, not the whole catalog: the picker stays readable, and
+            // the strongest few are starred so the composer has something to
+            // offer before anyone visits Settings.
+            for (rank, candidate) in candidates.iter().take(BOOTSTRAP_ENABLE_LIMIT).enumerate() {
+                let favorite = rank < BOOTSTRAP_FAVORITE_LIMIT && !candidate.is_favorite;
+                if candidate.enabled && !favorite {
+                    continue;
+                }
+                self.db
+                    .update_model(
+                        org_id,
+                        candidate.id.uuid(),
+                        UpdateModel {
+                            enabled: Some(true),
+                            is_favorite: favorite.then_some(true),
+                            ..Default::default()
+                        },
+                    )
+                    .await?;
+                if !candidate.enabled {
+                    outcome.enabled_models += 1;
+                }
+                if favorite {
+                    outcome.favorited_models += 1;
+                }
+            }
+        }
+
+        // `get_default_model` fails closed on a disabled model or an inactive
+        // provider, so "resolves to nothing" — not merely a NULL setting — is
+        // the condition that makes chat unusable.
+        if self.db.get_default_model(org_id).await?.is_none() {
+            let pick = self
+                .chat_candidates(org_id, &provider, &provider_type)
+                .await?
+                .into_iter()
+                .find(|row| row.enabled);
+            if let Some(pick) = pick {
+                self.db
+                    .upsert_organization_settings(org_id, Some(pick.id.uuid()))
+                    .await?;
+                outcome.default_model_id = Some(pick.id.uuid());
+            }
+        }
+
+        if outcome.changed() {
+            self.invalidate_resolver_cache(org_id).await;
+            tracing::info!(
+                org_id,
+                provider_id = %provider_id,
+                enabled_models = outcome.enabled_models,
+                favorited_models = outcome.favorited_models,
+                default_model_set = outcome.default_model_id.is_some(),
+                "Bootstrapped org intelligence from provider credential"
+            );
+        }
+        Ok(outcome)
+    }
+
+    /// This provider's chat models, best default first.
+    ///
+    /// Only catalog-known models that can call tools are candidates: a provider
+    /// catalog also lists transcription, image and legacy ids that make a poor
+    /// default, and an agent runtime needs tool calling. When the static catalog
+    /// knows none of them — a self-hosted or aggregator endpoint — the single
+    /// best-guess chat model still keeps the org usable.
+    async fn chat_candidates(
+        &self,
+        org_id: i64,
+        provider: &crate::storage::models::ProviderRow,
+        provider_type: &DriverId,
+    ) -> Result<Vec<ModelRow>> {
+        let mut chat: Vec<ModelRow> = self
+            .db
+            .list_models_for_provider(org_id, provider.id.uuid())
+            .await?
+            .into_iter()
+            .filter(|row| Self::row_is_chat_model(&row.capabilities))
+            .collect();
+
+        let mut known: Vec<(ModelRank, ModelRow)> = chat
+            .iter()
+            .filter_map(|row| {
+                let profile = get_model_profile(provider_type, &row.model_id)?;
+                profile
+                    .tool_call
+                    .then(|| (ModelRank::of(&profile), row.clone()))
+            })
+            .collect();
+
+        if !known.is_empty() {
+            known.sort_by(|(left_rank, left), (right_rank, right)| {
+                left_rank
+                    .cmp(right_rank)
+                    .then_with(|| left.model_id.cmp(&right.model_id))
+            });
+            return Ok(known.into_iter().map(|(_, row)| row).collect());
+        }
+
+        chat.sort_by(|left, right| left.model_id.cmp(&right.model_id));
+        chat.truncate(1);
+        Ok(chat)
+    }
+
+    /// Mirrors the UI rule (apps/ui/src/lib/model-capabilities.ts): an embedding
+    /// model is the one kind a chat cannot use.
+    fn row_is_chat_model(capabilities: &sqlx::types::JsonValue) -> bool {
+        let capabilities: Vec<String> =
+            serde_json::from_value(capabilities.clone()).unwrap_or_default();
+        !capabilities
+            .iter()
+            .any(|capability| capability.eq_ignore_ascii_case("embeddings"))
+    }
+
     async fn get_provider(
         &self,
         org_id: i64,
@@ -502,6 +704,7 @@ impl ModelService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::models::CreateModelRow;
     use crate::storage::{CreateOrganizationRow, CreateProviderRow};
     use everruns_core::{DEFAULT_ORG_ID, PolicyError};
 
@@ -559,6 +762,184 @@ mod tests {
 
     fn assert_managed_policy_error(err: anyhow::Error) {
         assert!(err.downcast_ref::<PolicyError>().is_some(), "{err:#}");
+    }
+
+    // --- first-run intelligence bootstrap ---
+
+    async fn create_keyed_provider(
+        db: &StorageBackend,
+        org_id: i64,
+    ) -> everruns_provider::typed_id::ProviderId {
+        db.create_provider(
+            org_id,
+            CreateProviderRow {
+                name: "OpenAI".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: Some(b"encrypted".to_vec()),
+                settings: None,
+            },
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    /// Mimics model discovery: catalog rows land disabled and unstarred.
+    async fn discover_model(
+        db: &StorageBackend,
+        org_id: i64,
+        provider_id: everruns_provider::typed_id::ProviderId,
+        model_id: &str,
+        capabilities: &[&str],
+    ) -> ModelRow {
+        db.create_model(
+            org_id,
+            CreateModelRow {
+                provider_id,
+                model_id: model_id.to_string(),
+                display_name: model_id.to_string(),
+                capabilities: capabilities.iter().map(|c| c.to_string()).collect(),
+                enabled: false,
+                is_favorite: false,
+                source: "discovered".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn bootstrap_enables_favourites_and_elects_a_default() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_id = create_second_org(&db).await;
+        let service = ModelService::new(db.clone());
+        let provider_id = create_keyed_provider(&db, org_id).await;
+
+        for model_id in ["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.4-mini"] {
+            discover_model(&db, org_id, provider_id, model_id, &["chat"]).await;
+        }
+        let embedding = discover_model(
+            &db,
+            org_id,
+            provider_id,
+            "text-embedding-3-small",
+            &["embeddings"],
+        )
+        .await;
+
+        // Precondition: discovery alone leaves the org unable to resolve a model.
+        assert!(db.get_default_model(org_id).await.unwrap().is_none());
+
+        let outcome = service
+            .bootstrap_intelligence(org_id, provider_id.uuid())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.enabled_models, 3);
+        assert_eq!(outcome.favorited_models, 3);
+        let default = db
+            .get_default_model(org_id)
+            .await
+            .unwrap()
+            .expect("default elected");
+        assert_eq!(outcome.default_model_id, Some(default.id.uuid()));
+
+        let rows = db
+            .list_models_for_provider(org_id, provider_id.uuid())
+            .await
+            .unwrap();
+        for row in &rows {
+            if row.id == embedding.id {
+                assert!(!row.enabled, "embedding model must stay disabled");
+                assert!(!row.is_favorite);
+            } else {
+                assert!(row.enabled, "{} should be enabled", row.model_id);
+                assert!(row.is_favorite, "{} should be starred", row.model_id);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn bootstrap_leaves_a_configured_org_alone() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_id = create_second_org(&db).await;
+        let service = ModelService::new(db.clone());
+        let provider_id = create_keyed_provider(&db, org_id).await;
+
+        let chosen = discover_model(&db, org_id, provider_id, "gpt-5.6-terra", &["chat"]).await;
+        let other = discover_model(&db, org_id, provider_id, "gpt-5.6-sol", &["chat"]).await;
+        db.update_model(
+            org_id,
+            chosen.id.uuid(),
+            UpdateModel {
+                enabled: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        db.upsert_organization_settings(org_id, Some(chosen.id.uuid()))
+            .await
+            .unwrap();
+
+        let outcome = service
+            .bootstrap_intelligence(org_id, provider_id.uuid())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, IntelligenceBootstrap::default());
+        let rows = db
+            .list_models_for_provider(org_id, provider_id.uuid())
+            .await
+            .unwrap();
+        let other_row = rows.iter().find(|row| row.id == other.id).unwrap();
+        assert!(
+            !other_row.enabled,
+            "a deliberate opt-out must not be overridden"
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_skips_a_provider_without_a_key() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_id = create_second_org(&db).await;
+        let service = ModelService::new(db.clone());
+        let provider_id = create_provider(&db, org_id).await;
+        discover_model(&db, org_id, provider_id, "gpt-5.6-terra", &["chat"]).await;
+
+        let outcome = service
+            .bootstrap_intelligence(org_id, provider_id.uuid())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, IntelligenceBootstrap::default());
+        assert!(db.get_default_model(org_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_falls_back_to_one_model_for_an_unknown_catalog() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_id = create_second_org(&db).await;
+        let service = ModelService::new(db.clone());
+        let provider_id = create_keyed_provider(&db, org_id).await;
+        for model_id in ["house-llm-a", "house-llm-b"] {
+            discover_model(&db, org_id, provider_id, model_id, &["chat"]).await;
+        }
+
+        let outcome = service
+            .bootstrap_intelligence(org_id, provider_id.uuid())
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.enabled_models, 1);
+        let default = db
+            .get_default_model(org_id)
+            .await
+            .unwrap()
+            .expect("default elected");
+        assert_eq!(default.model_id, "house-llm-a");
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/providers/commands.rs
+++ b/crates/server/src/domains/providers/commands.rs
@@ -22,6 +22,62 @@ fn sync_service(
         .ok_or_else(|| CommandError::internal(anyhow::anyhow!("Model sync service not configured")))
 }
 
+/// Make a provider that just gained a credential immediately usable: discover
+/// its models, then bootstrap the org's enabled models and default model.
+///
+/// Best-effort by design. The provider row is already written and valid; a
+/// provider API that is slow, unreachable, or rejects the key must not fail the
+/// create/update. The UI surfaces the resulting state (and a "no intelligence
+/// configured" notice) from the models it can see.
+async fn provision_provider_models(ctx: &Ctx, provider: &Provider) {
+    let provider_uuid = provider.id.uuid();
+
+    if let Some(sync) = ctx.model_sync_service.as_ref() {
+        match tokio::time::timeout(
+            PROVISION_TIMEOUT,
+            sync.sync_provider(ctx.org_id(), provider_uuid),
+        )
+        .await
+        {
+            Ok(Ok(result)) => tracing::info!(
+                org_id = ctx.org_id(),
+                provider_id = %provider.id,
+                ?result,
+                "Synced models for newly credentialed provider"
+            ),
+            Ok(Err(error)) => tracing::warn!(
+                org_id = ctx.org_id(),
+                provider_id = %provider.id,
+                %error,
+                "Model sync after provider credential change failed (non-fatal)"
+            ),
+            Err(_) => tracing::warn!(
+                org_id = ctx.org_id(),
+                provider_id = %provider.id,
+                "Model sync after provider credential change timed out (non-fatal)"
+            ),
+        }
+    }
+
+    if let Some(models) = ctx.model_service.as_ref()
+        && let Err(error) = models
+            .bootstrap_intelligence(ctx.org_id(), provider_uuid)
+            .await
+    {
+        tracing::warn!(
+            org_id = ctx.org_id(),
+            provider_id = %provider.id,
+            %error,
+            "Intelligence bootstrap after provider credential change failed (non-fatal)"
+        );
+    }
+}
+
+/// Upper bound on the inline discovery call a create/update waits for. Long
+/// enough for a cold provider API, short enough that the onboarding request
+/// still returns.
+const PROVISION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateProvider {
     /// Human-readable name. Safe to render in user-facing messages.
@@ -54,7 +110,8 @@ impl Command for CreateProvider {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Provider, CommandError> {
-        q::service(ctx)
+        let has_credential = self.api_key.is_some();
+        let provider = q::service(ctx)
             .create(
                 &ctx.caller,
                 crate::api::providers::CreateProviderRequest {
@@ -70,7 +127,12 @@ impl Command for CreateProvider {
                 },
             )
             .await
-            .map_err(classify_anyhow)
+            .map_err(classify_anyhow)?;
+
+        if has_credential {
+            provision_provider_models(ctx, &provider).await;
+        }
+        Ok(provider)
     }
 }
 
@@ -185,7 +247,8 @@ impl Command for UpdateProvider {
 
     async fn execute(self, ctx: &Ctx) -> Result<Provider, CommandError> {
         let provider_id = q::parse_provider_id(&self.id)?;
-        q::service(ctx)
+        let has_credential = self.api_key.is_some();
+        let provider = q::service(ctx)
             .update(
                 &ctx.caller,
                 provider_id,
@@ -204,7 +267,14 @@ impl Command for UpdateProvider {
             )
             .await
             .map_err(classify_anyhow)?
-            .ok_or_else(|| CommandError::not_found("Provider"))
+            .ok_or_else(|| CommandError::not_found("Provider"))?;
+
+        // A key arriving on an existing provider is the same event as one
+        // arriving with a new provider: the org may only now have intelligence.
+        if has_credential {
+            provision_provider_models(ctx, &provider).await;
+        }
+        Ok(provider)
     }
 }
 
@@ -281,6 +351,22 @@ impl Command for SyncProviderModels {
             .sync_provider(ctx.org_id(), provider_id)
             .await
             .map_err(classify_anyhow)?;
+
+        // A manual refresh is also a chance to make the org usable: an org that
+        // still has no enabled chat model or no resolvable default gets one.
+        if let Some(models) = ctx.model_service.as_ref()
+            && let Err(error) = models
+                .bootstrap_intelligence(ctx.org_id(), provider_id)
+                .await
+        {
+            tracing::warn!(
+                org_id = ctx.org_id(),
+                %provider_id,
+                %error,
+                "Intelligence bootstrap after model sync failed (non-fatal)"
+            );
+        }
+
         match result {
             crate::services::SyncResult::Success {
                 created,

--- a/crates/server/src/domains/providers/commands.rs
+++ b/crates/server/src/domains/providers/commands.rs
@@ -39,6 +39,16 @@ async fn provision_provider_models(ctx: &Ctx, provider: &Provider) {
         )
         .await
         {
+            // A provider-reported failure is a warning, not routine info: the
+            // key may be wrong. Its message is an upstream string, so it is
+            // logged at the same level and shape as any other sync failure
+            // rather than folded into a success line.
+            Ok(Ok(crate::services::SyncResult::Failed { error })) => tracing::warn!(
+                org_id = ctx.org_id(),
+                provider_id = %provider.id,
+                %error,
+                "Provider rejected model discovery after a credential change (non-fatal)"
+            ),
             Ok(Ok(result)) => tracing::info!(
                 org_id = ctx.org_id(),
                 provider_id = %provider.id,

--- a/knowledge/foundations/models.md
+++ b/knowledge/foundations/models.md
@@ -266,6 +266,7 @@ Key design points:
 - Model/provider assignment is editable so an existing model config can be moved to a different configured provider without deleting and recreating it.
 - Organization default model: stored in `organization_settings.default_model_id` (not on the model itself). Auto-elects a new default from enabled models if the current default is disabled or deleted.
 - Stale model detection: `last_seen_at < provider.last_synced_at` means model no longer returned by provider API. Stale models kept (not deleted) to preserve customizations.
+- First-run intelligence bootstrap: a provider gaining a credential (create, update, or a manual model sync) discovers its models and then, when the org has no enabled chat model, switches on a shortlist of the provider's catalog-known tool-calling models, stars the strongest few, and elects `organization_settings.default_model_id` when none resolves. Discovery alone creates models disabled and elects nothing, which left a freshly onboarded org with a keyed provider and a chat that could not resolve a model. The bootstrap only ever adds, so an org that deliberately disabled everything is never overridden. See `ModelService::bootstrap_intelligence` in `crates/server/src/domains/models/service.rs` and `provision_provider_models` in `crates/server/src/domains/providers/commands.rs`.
 
 ### Execution Model Specification
 


### PR DESCRIPTION
## What changed

Configuring a provider credential now leaves the organisation **usable**, and every chat surface says so plainly when it isn't.

**Server.** A provider that gains a credential — on create, on update, or on a manual model sync — discovers its models and then bootstraps the org: it enables a shortlist of the provider's catalog-known, tool-calling chat models, stars the strongest few as favourites, and elects `organization_settings.default_model_id` when none resolves. Discovery runs inline under a 20s timeout and is best-effort, so a slow or key-rejecting provider API never fails the write. The bootstrap only ever *adds*: an org that already has an enabled chat model and a resolvable default is left alone.

**UI.** Every chat surface shows a centred "No intelligence available" message when no enabled, healthy chat model exists — and it is always the *only* centred message: it replaces the transcript's "No messages yet" card on a fresh thread, sits above the composer once there is history, and replaces the whole empty state on the chats list and new-chat page. The route to Settings → Providers renders only for a caller holding `provider.manage`; everyone else is told who can fix it. Silent while loading and on a failed read, so a working org never sees a false alarm.

## Why

Onboarding asked for an API key, stored it, and stopped. Model discovery never ran, so a freshly onboarded org had a keyed provider, zero models, and no default model. Chat could not resolve a model and every turn failed with nothing on screen explaining why.

## Before / After

Reproduced against a real OpenAI key on the canonical local stack (`PORT_PREFIX=271 AUTH_MODE=none ./scripts/start-agent-dev.sh`), in a brand-new organisation.

**Before** — fresh org, then `POST /v1/providers` with a valid key:

```
providers: 0 | models: 0 | org default_model_id: None
POST /v1/providers  ->  HTTP 201
discovered: 89 | enabled: 0 | favourites: 0 | enabled+healthy+chat: 0
org default_model_id: None
```

Discovery ran, every model stayed disabled, and no default was elected — chat still could not resolve a model.

**After** — same steps, same key:

```
providers: 0 | models: 0 | org default_model_id: None
POST /v1/providers  ->  HTTP 201 in 1.65s
discovered: 89 | enabled: 8 | favourites: 3 | enabled+healthy+chat: 8

  gpt-5.5                    favourite=False
  gpt-5.5-2026-04-23         favourite=False
  gpt-5.5-pro                favourite=False
  gpt-5.5-pro-2026-04-23     favourite=False
  gpt-5.6-luna               favourite=True
  gpt-5.6-sol                favourite=True
  gpt-5.6-terra              favourite=False
  gpt-6-astra                favourite=True

org default_model_id -> gpt-6-astra (healthy: True)
```

**A real chat turn in that org**, which is the whole point:

```
user  -> Reply with exactly: SMOKE OK
agent -> SMOKE OK
```

**Bootstrap does not override a configured org.** Adding a second keyed provider (Anthropic) to the same org afterwards:

```
total models: 100 | enabled: 8 | favourites: 3      (unchanged)
anthropic models discovered: 11 | any enabled: False
org default still: gpt-6-astra
```

**UI.** Screenshots of the live stack were captured for the chats list, the new-chat page, the thread composer, and both permission variants. This environment's GitHub proxy rejects binary uploads to the user-attachments CDN (`415`, JSON-only), so they could not be attached here; they were delivered to the author directly. The same states render without a backend at `/dev/chat-components`, which this PR extends with a "No intelligence available" section covering the manage / view-only / plain variants.

## Risk

- **Medium**
- Provider create/update now performs an outbound provider API call inline. Bounded by a 20s timeout and best-effort — a failure or timeout logs a warning and the write still succeeds — but it does make those two endpoints slower (~1.6s against OpenAI) and moves egress that previously only happened on an explicit sync into the create path. Same permission (`provider.manage`) gates both, and `validate_provider_base_url` still runs first.
- The bootstrap writes only when the org has no enabled chat model, or no resolvable default. An org that deliberately disabled everything keeps that state.
- Default-model choice is a heuristic (catalog-known + tool-calling, newest release first). It is a *default*, changeable in Settings.

## Security

- **Threat categories reviewed:** TM-TENANT, TM-AUTHZ, TM-LLM, TM-DOS, TM-WEB.
- **Findings and resolutions:**
  - *TM-TENANT.* Every new read and write is org-scoped (`list_all_models(org_id)`, `get_provider(org_id, ..)`, `update_model(org_id, ..)`, `upsert_organization_settings(org_id, ..)`); the bootstrap only ever acts on `ctx.org_id()`.
  - *TM-AUTHZ.* The bootstrap runs inside commands already gated by `provider.manage`; it adds no new entry point. It does not touch the managed-catalog guards.
  - *TM-LLM.* Credentials are unchanged: the key is encrypted at rest and decrypted only inside the existing sync path. New log lines carry org id, provider id and counts, never key material. A provider-reported sync failure is logged at `warn` with the upstream message rather than folded into a success line; every driver sends its credential in a header, not a URL, and `runtime_provider` redacts URLs in `Debug`.
  - *TM-DOS.* The inline discovery call is bounded by a 20s timeout; the bootstrap writes at most 8 model rows plus one settings row.
  - *TM-WEB.* The new UI renders static copy and an internal link; no user-controlled markup, no new storage.
- No `THREAT[...]` marker near the touched code changed meaning, and no new threat-model entry was warranted.

## Follow-ups

- **The "no intelligence" copy does not distinguish causes.** It reads the same whether the org has no provider, a provider with no key, or models that are all disabled. Deliberate: the fix is the same page in every case, and a more specific message would need the notice to reason about provider state as well as model state. Deferred until there is evidence users need the distinction.
- **The notice on a thread with history sits above the composer**, so on a long thread it is only visible once scrolled to the bottom. The transcript is real content and should not be displaced; pinning it to the composer area is a design call left open.
- Otherwise no follow-ups.

## Note on rebase

Smoke testing this branch also surfaced that a disabled model could not be enabled (`PATCH /v1/models/{id}` returned `404`, because `ModelService::update`/`delete` used the enabled-only resolution lookup), which mattered here because the new notice tells users to go enable a model. That was fixed independently and merged as #3512 while this PR was open. This branch has been rebased onto it and the duplicate implementation, tests, and knowledge edits dropped — the fix now comes from main, not from this PR.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)