### PR TITLE
fix(models): adopt a discovered model instead of conflicting on explicit create

### DIFF
--- a/crates/server/src/domains/models/service.rs
+++ b/crates/server/src/domains/models/service.rs
@@ -113,6 +113,38 @@ impl ModelService {
         let provider = self.get_provider(caller.org_id, provider_id).await?;
         Self::require_unmanaged_provider(&provider)?;
 
+        // Discovery populates a provider's catalog the moment it gains a
+        // credential, so an explicit create now routinely names a model the
+        // system itself just wrote. The caller means "this model should exist
+        // with these settings", so adopt the discovered row instead of
+        // answering 409 for something they never created. A collision with a
+        // row the user added themselves is a real duplicate and still conflicts
+        // on the unique index.
+        if let Some(discovered) = self
+            .db
+            .list_models_for_provider(caller.org_id, provider_id)
+            .await?
+            .into_iter()
+            .find(|row| row.model_id == req.model_id && row.source == "discovered")
+        {
+            let update = UpdateModel {
+                display_name: Some(req.display_name),
+                // An omitted `capabilities` must not blank what discovery
+                // learned from the provider — resolution depends on it.
+                capabilities: (!req.capabilities.is_empty()).then_some(req.capabilities),
+                enabled: Some(req.enabled),
+                is_favorite: Some(req.is_favorite),
+                ..Default::default()
+            };
+            let row = self
+                .db
+                .update_model(caller.org_id, discovered.id.uuid(), update)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("discovered model vanished while being adopted"))?;
+            self.invalidate_resolver_cache(caller.org_id).await;
+            return Ok(Self::row_to_model(&row));
+        }
+
         let input = CreateModelRow {
             provider_id: provider.id,
             model_id: req.model_id,
@@ -762,6 +794,94 @@ mod tests {
 
     fn assert_managed_policy_error(err: anyhow::Error) {
         assert!(err.downcast_ref::<PolicyError>().is_some(), "{err:#}");
+    }
+
+    /// Regression: provider creation now discovers a catalog inline, so an
+    /// explicit `POST /v1/providers/{id}/models` naming a discovered model used
+    /// to hit the `(provider_id, model_id)` unique index and 409. Six live
+    /// workflow tests do exactly that. The caller's settings must win, and the
+    /// capabilities discovery learned must survive an omitted field.
+    #[tokio::test]
+    async fn create_adopts_a_discovered_model_instead_of_conflicting() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = ModelService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let provider_id = create_provider(&db, DEFAULT_ORG_ID).await;
+        let discovered = db
+            .create_model(
+                DEFAULT_ORG_ID,
+                CreateModelRow {
+                    provider_id,
+                    model_id: "test-model".to_string(),
+                    display_name: "test-model".to_string(),
+                    capabilities: vec!["chat".to_string()],
+                    enabled: false,
+                    is_favorite: false,
+                    source: "discovered".to_string(),
+                    provider_metadata: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let created = service
+            .create(
+                &caller,
+                provider_id.uuid(),
+                CreateModelRequest {
+                    model_id: "test-model".to_string(),
+                    display_name: "Chosen Name".to_string(),
+                    capabilities: vec![],
+                    enabled: true,
+                    is_favorite: true,
+                },
+            )
+            .await
+            .expect("an explicit create must adopt the discovered row");
+
+        assert_eq!(created.id, discovered.id, "adopted, not duplicated");
+        assert_eq!(created.display_name, "Chosen Name");
+        assert!(created.enabled);
+        assert!(created.is_favorite);
+        assert_eq!(
+            created.capabilities,
+            vec!["chat".to_string()],
+            "an omitted capabilities list must not blank what discovery found"
+        );
+        assert_eq!(
+            db.list_models_for_provider(DEFAULT_ORG_ID, provider_id.uuid())
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "adoption must not leave a second row"
+        );
+    }
+
+    /// A second explicit create of the same id is a genuine duplicate and must
+    /// still fail — adoption only ever absorbs a system-discovered row.
+    #[tokio::test]
+    async fn create_still_rejects_a_duplicate_of_a_manual_model() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = ModelService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let provider_id = create_provider(&db, DEFAULT_ORG_ID).await;
+        service
+            .create(&caller, provider_id.uuid(), build_create_request())
+            .await
+            .unwrap();
+
+        let err = service
+            .create(&caller, provider_id.uuid(), build_create_request())
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("duplicate")
+                || err.to_string().contains("already")
+                || err.to_string().contains("Unique"),
+            "expected a duplicate error, got: {err:#}"
+        );
     }
 
     // --- first-run intelligence bootstrap ---


### PR DESCRIPTION
## What changed

An explicit `POST /v1/providers/{id}/models` that names a model the system already **discovered** now adopts that row and applies the request to it, instead of answering `409 Conflict` on the `(provider_id, model_id)` unique index. A collision with a row the user created themselves is a genuine duplicate and still conflicts.

An omitted `capabilities` list no longer blanks what discovery learned from the provider — model resolution depends on it, so the discovered value survives.

## Why

**Main is red.** #3515 made provider creation discover the model catalog inline, which means an explicit create now routinely names a row the system itself just wrote. Six live workflow tests do exactly that — create a provider with a key, then create the specific model they want — and all six started failing with:

```
Failed to create model: status=409 Conflict,
body={"detail":"duplicate key value violates unique constraint \"idx_models_provider_model\"","code":"already_exists"}
```

This is a real contract break rather than a test artifact: any caller that creates a provider and then names the model it wants hits it. Fixing the tests would have papered over the regression, so the API behaviour is what changed here.

**Why PR CI didn't catch it:** `Workflow Tests (Server + Worker)` is gated on `if: github.event_name == 'push'`, so it never runs on a pull request. #3515 was green on all 44 checks a PR can run.

## Before / After

Before, on main (`1ed4b3d`):

```
test test_agent_execution_anthropic_with_tool_calls ... FAILED
test test_agent_execution_openai_with_tool_calls ... FAILED
test test_agent_filesystem_and_bash_workspace_integration ... FAILED
test test_anthropic_extended_thinking ... FAILED
test test_anthropic_extended_thinking_with_tools ... FAILED
test test_no_duplicate_tool_calls ... FAILED
test result: FAILED. 34 passed; 6 failed
```

After, the adoption path is covered directly:

```
test create_adopts_a_discovered_model_instead_of_conflicting ... ok
test create_still_rejects_a_duplicate_of_a_manual_model ... ok
test result: ok. 2286 passed; 0 failed; 2 ignored
```

The first asserts the adopted row keeps its id (no duplicate row), takes the caller's `display_name`, `enabled` and `is_favorite`, and keeps the discovered `capabilities` when the request omits them. The second asserts a second explicit create of the same id still fails, so adoption only ever absorbs a system-discovered row.

The six live workflow tests cannot run here — they need live provider credentials and only run on `push` — so their green is expected from this merge, not demonstrated in advance.

## Risk

- **Low / Medium**
- `POST /v1/providers/{id}/models` no longer returns `409` for a discovered model id; it returns the adopted model. A caller relying on `409` to detect "this model is already in the catalog" sees a success instead. That is the intended change, and the status stays `201`.
- Adoption leaves `source` as `discovered`, so the row stays subject to normal stale detection. Changing it to `manual` would need a new `UpdateModel` field and is deliberately out of scope.
- Create now does one extra org-scoped read (`list_models_for_provider`) before inserting.

## Security

- **Threat categories reviewed:** TM-TENANT, TM-AUTHZ.
- **Findings and resolutions:**
  - *TM-TENANT.* The new lookup and update are org-scoped (`list_models_for_provider(caller.org_id, provider_id)`, `update_model(caller.org_id, ..)`), and only rows already belonging to the named provider in the caller's org can be adopted.
  - *TM-AUTHZ.* `require_unmanaged_provider` still runs before anything else, so a host-managed catalog cannot be modified through this path. The managed-catalog tests are unchanged and still pass.
- No `THREAT[...]` marker near the touched code changed meaning; no threat-model update warranted.

## Follow-ups

- No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnnwddPmTMnTNCxFm7uRQe)_