### PR TITLE
feat(harnesses): code-defined icons for built-in harnesses

### DIFF
--- a/apps/ui/src/__tests__/harness-icons.test.tsx
+++ b/apps/ui/src/__tests__/harness-icons.test.tsx
@@ -1,0 +1,23 @@
+import { Shield } from "lucide-react";
+import { getHarnessIcon } from "@/lib/harness-icons";
+
+describe("getHarnessIcon", () => {
+  it("falls back to the neutral harness glyph when no icon is set", () => {
+    expect(getHarnessIcon()).toBe(Shield);
+    expect(getHarnessIcon(null)).toBe(Shield);
+  });
+
+  it("falls back for an icon name the UI does not know", () => {
+    expect(getHarnessIcon("not-a-real-icon")).toBe(Shield);
+  });
+
+  it("resolves built-in harness icon names", () => {
+    expect(getHarnessIcon("everruns")).not.toBe(Shield);
+    expect(getHarnessIcon("box")).not.toBe(Shield);
+    expect(getHarnessIcon("square-dashed")).not.toBe(Shield);
+    expect(getHarnessIcon("bar-chart")).not.toBe(Shield);
+    expect(getHarnessIcon("container")).not.toBe(Shield);
+    expect(getHarnessIcon("terminal")).not.toBe(Shield);
+    expect(getHarnessIcon("daytona")).not.toBe(Shield);
+  });
+});

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -33,7 +33,6 @@ import {
   BarChart3,
   Rocket,
   Terminal,
-  Shield,
 } from "lucide-react";
 import { ResourceStatsPanel } from "@/components/stats/resource-stats-panel";
 import { EntityIdentity } from "@/components/ui/entity-identity";
@@ -52,6 +51,7 @@ import {
 } from "@/components/layout";
 import type { Capability, ModelWithProvider } from "@/lib/api/types";
 import { CapabilityIcon } from "@/lib/capability-icons";
+import { HarnessIcon } from "@/lib/harness-icons";
 import {
   localizedCapabilityDescription,
   localizedCapabilityName,
@@ -160,7 +160,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
       />
 
       <PageMasthead
-        icon={<Shield />}
+        icon={<HarnessIcon icon={harness.icon} />}
         entityId={harness.id}
         title={
           <span className={getEntityNameClassName(harness.status)}>{getDisplayName(harness)}</span>

--- a/apps/ui/src/components/harnesses/example-card.tsx
+++ b/apps/ui/src/components/harnesses/example-card.tsx
@@ -7,6 +7,8 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Import } from "lucide-react";
 import type { Capability, CapabilityId, HarnessExample } from "@/lib/api/types";
 import { CapabilityIcon } from "@/lib/capability-icons";
+import { HarnessIcon } from "@/lib/harness-icons";
+import { IconTile } from "@/components/layout/page-layout";
 import {
   localizedCapabilityDescription,
   localizedCapabilityName,
@@ -32,6 +34,7 @@ export function HarnessExampleCard({
 
   return (
     <EntityCard
+      icon={<IconTile size="md" icon={<HarnessIcon icon={example.icon} />} />}
       title={example.display_name}
       headerActions={
         example.dev_only && (

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -5,10 +5,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EntityCard, EntityCardFooter } from "@/components/ui/entity-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { GitBranch, Pencil, Shield } from "lucide-react";
+import { GitBranch, Pencil } from "lucide-react";
 import { IconTile } from "@/components/layout/page-layout";
 import type { Harness, Capability, CapabilityId } from "@/lib/api/types";
 import { CapabilityIcon } from "@/lib/capability-icons";
+import { HarnessIcon } from "@/lib/harness-icons";
 import {
   localizedCapabilityDescription,
   localizedCapabilityName,
@@ -59,7 +60,7 @@ export function HarnessCard({
 
   return (
     <EntityCard
-      icon={<IconTile size="md" icon={<Shield />} />}
+      icon={<IconTile size="md" icon={<HarnessIcon icon={harness.icon} />} />}
       title={getDisplayName(harness)}
       href={`/harnesses/${harness.id}`}
       titleClassName={getEntityNameClassName(harness.status)}

--- a/apps/ui/src/lib/api/generated/openapi.ts
+++ b/apps/ui/src/lib/api/generated/openapi.ts
@@ -8097,6 +8097,14 @@ export interface components {
         [key: string]: string;
       };
       /**
+       * @description Display glyph name rendered by the UI (e.g. "message-circle").
+       *
+       *     Built-in harnesses declare it in their definition; custom harnesses
+       *     leave it unset and fall back to the UI's generic harness glyph.
+       * @example message-circle
+       */
+      icon?: string | null;
+      /**
        * @description Unique identifier for the harness (format: harness_{32-hex}).
        * @example harness_01933b5a00007000800000000000001
        */
@@ -8171,6 +8179,8 @@ export interface components {
       dev_only: boolean;
       /** @description Human-readable display name (e.g. `Data Analyst`). */
       display_name: string;
+      /** @description Display glyph name rendered by the UI (e.g. `bar-chart`). */
+      icon?: string | null;
       /** @description Unique slug (e.g. `data-analyst`). */
       name: string;
       /**
@@ -9446,6 +9456,14 @@ export interface components {
           [key: string]: string;
         };
         /**
+         * @description Display glyph name rendered by the UI (e.g. "message-circle").
+         *
+         *     Built-in harnesses declare it in their definition; custom harnesses
+         *     leave it unset and fall back to the UI's generic harness glyph.
+         * @example message-circle
+         */
+        icon?: string | null;
+        /**
          * @description Unique identifier for the harness (format: harness_{32-hex}).
          * @example harness_01933b5a00007000800000000000001
          */
@@ -10677,6 +10695,14 @@ export interface components {
         embedder_metadata?: {
           [key: string]: string;
         };
+        /**
+         * @description Display glyph name rendered by the UI (e.g. "message-circle").
+         *
+         *     Built-in harnesses declare it in their definition; custom harnesses
+         *     leave it unset and fall back to the UI's generic harness glyph.
+         * @example message-circle
+         */
+        icon?: string | null;
         /**
          * @description Unique identifier for the harness (format: harness_{32-hex}).
          * @example harness_01933b5a00007000800000000000001
@@ -17763,6 +17789,14 @@ export interface components {
         [key: string]: string;
       };
       /**
+       * @description Display glyph name rendered by the UI (e.g. "message-circle").
+       *
+       *     Built-in harnesses declare it in their definition; custom harnesses
+       *     leave it unset and fall back to the UI's generic harness glyph.
+       * @example message-circle
+       */
+      icon?: string | null;
+      /**
        * @description Unique identifier for the harness (format: harness_{32-hex}).
        * @example harness_01933b5a00007000800000000000001
        */
@@ -18197,6 +18231,14 @@ export interface components {
       embedder_metadata?: {
         [key: string]: string;
       };
+      /**
+       * @description Display glyph name rendered by the UI (e.g. "message-circle").
+       *
+       *     Built-in harnesses declare it in their definition; custom harnesses
+       *     leave it unset and fall back to the UI's generic harness glyph.
+       * @example message-circle
+       */
+      icon?: string | null;
       /**
        * @description Unique identifier for the harness (format: harness_{32-hex}).
        * @example harness_01933b5a00007000800000000000001

--- a/apps/ui/src/lib/api/legacy-api-types.ts
+++ b/apps/ui/src/lib/api/legacy-api-types.ts
@@ -343,6 +343,8 @@ export interface Harness {
   name: string;
   /** Human-readable display name shown in UI. Falls back to name when absent. */
   display_name: string | null;
+  /** Display glyph name (e.g. "message-circle"). Set for built-in harnesses; absent otherwise. */
+  icon?: string | null;
   description: string | null;
   /** Base system prompt. Null/absent means the harness contributes no base prompt. */
   system_prompt?: string | null;
@@ -409,6 +411,8 @@ export interface HarnessExample {
   name: string;
   display_name: string;
   description: string;
+  /** Display glyph name (e.g. "bar-chart"). */
+  icon?: string | null;
   tags: string[];
   /** Name of the parent harness (e.g. `generic`) the example will inherit from when imported. */
   parent_name?: string;

--- a/apps/ui/src/lib/harness-icons.tsx
+++ b/apps/ui/src/lib/harness-icons.tsx
@@ -1,0 +1,57 @@
+// Harness glyphs: built-in harnesses declare an `icon` name in their backend
+// definition (crates/server/src/harnesses/*.rs). Custom harnesses carry no icon
+// and fall back to the neutral shield used across harness surfaces.
+
+import { forwardRef, type SVGProps } from "react";
+import { BarChart3, Shield, SquareDashed } from "lucide-react";
+import { capabilityIconMap, type IconComponent } from "@/lib/capability-icons";
+
+/**
+ * Everruns mark (monochrome): three rings on the vertices of an equilateral
+ * triangle, centered on their centroid. Geometry mirrors `logo-mono.svg`.
+ */
+const EverrunsIcon = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>((props, ref) => (
+  <svg
+    ref={ref}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 512 512"
+    fill="none"
+    stroke="currentColor"
+    // ~1.3px at a 16px render, matching the lucide siblings' stroke weight.
+    strokeWidth={42}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <circle cx="256" cy="183.64" r="120" />
+    <circle cx="193.33" cy="292.18" r="120" />
+    <circle cx="318.67" cy="292.18" r="120" />
+  </svg>
+));
+EverrunsIcon.displayName = "EverrunsIcon";
+
+/**
+ * Icon names usable by harness definitions. Capability icon names are reused so
+ * a harness can share a glyph with the capability it is built around.
+ */
+export const harnessIconMap: Record<string, IconComponent> = {
+  ...capabilityIconMap,
+  everruns: EverrunsIcon,
+  "square-dashed": SquareDashed,
+  "bar-chart": BarChart3,
+};
+
+/** Resolve a harness icon name, falling back to the neutral harness glyph. */
+export function getHarnessIcon(iconName?: string | null): IconComponent {
+  if (!iconName) return Shield;
+  return harnessIconMap[iconName] ?? Shield;
+}
+
+interface HarnessIconProps extends SVGProps<SVGSVGElement> {
+  icon?: string | null;
+}
+
+export function HarnessIcon({ icon, ...props }: HarnessIconProps) {
+  const Icon = getHarnessIcon(icon);
+  return <Icon {...props} />;
+}

--- a/apps/ui/src/lib/harness-icons.tsx
+++ b/apps/ui/src/lib/harness-icons.tsx
@@ -1,6 +1,11 @@
 // Harness glyphs: built-in harnesses declare an `icon` name in their backend
 // definition (crates/server/src/harnesses/*.rs). Custom harnesses carry no icon
 // and fall back to the neutral shield used across harness surfaces.
+//
+// The stored name is only ever a key into this map; unknown names fall back.
+// Unlike `CapabilityIcon`, this renderer has no embedded-SVG branch, so a
+// database-sourced icon can never put attacker-controlled markup on the page
+// (TM-WEB-001).
 
 import { forwardRef, type SVGProps } from "react";
 import { BarChart3, Shield, SquareDashed } from "lucide-react";

--- a/crates/platform/src/harness.rs
+++ b/crates/platform/src/harness.rs
@@ -464,10 +464,10 @@ mod tests {
 
     fn test_harness(id_seed: u128, system_prompt: &str) -> Harness {
         Harness {
-            icon: None,
             id: HarnessId::from_uuid(uuid::Uuid::from_u128(id_seed)),
             name: format!("harness-{id_seed}"),
             display_name: Some(format!("Harness {id_seed}")),
+            icon: None,
             description: None,
             system_prompt: Some(system_prompt.to_string()),
             parent_harness_id: None,

--- a/crates/platform/src/harness.rs
+++ b/crates/platform/src/harness.rs
@@ -81,6 +81,13 @@ pub struct Harness {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(example = "Generic Harness"))]
     pub display_name: Option<String>,
+    /// Display glyph name rendered by the UI (e.g. "message-circle").
+    ///
+    /// Built-in harnesses declare it in their definition; custom harnesses
+    /// leave it unset and fall back to the UI's generic harness glyph.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = "message-circle"))]
+    pub icon: Option<String>,
     /// Human-readable description of what the harness does.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
@@ -277,6 +284,7 @@ pub fn merge_harness(parent: &Harness, child: &Harness) -> Harness {
         id: child.id,
         name: child.name.clone(),
         display_name: child.display_name.clone(),
+        icon: child.icon.clone(),
         description: child.description.clone(),
         parent_harness_id: child.parent_harness_id,
         tags: child.tags.clone(),
@@ -361,6 +369,8 @@ pub struct BuiltInHarnessDefinition {
     pub display_name: String,
     /// Human-readable description.
     pub description: String,
+    /// Display glyph name rendered by the UI (e.g. "message-circle").
+    pub icon: Option<String>,
     /// Base system prompt for the harness.
     pub system_prompt: String,
     /// Optional parent harness name to inherit from during provisioning.
@@ -385,6 +395,7 @@ impl BuiltInHarnessDefinition {
             name: name.into(),
             display_name: display_name.into(),
             description: description.into(),
+            icon: None,
             system_prompt: system_prompt.into(),
             parent_name: None,
             tags: Vec::new(),
@@ -400,6 +411,12 @@ impl BuiltInHarnessDefinition {
         S: Into<String>,
     {
         self.tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the UI glyph name for the harness.
+    pub fn with_icon(mut self, icon: impl Into<String>) -> Self {
+        self.icon = Some(icon.into());
         self
     }
 
@@ -447,6 +464,7 @@ mod tests {
 
     fn test_harness(id_seed: u128, system_prompt: &str) -> Harness {
         Harness {
+            icon: None,
             id: HarnessId::from_uuid(uuid::Uuid::from_u128(id_seed)),
             name: format!("harness-{id_seed}"),
             display_name: Some(format!("Harness {id_seed}")),

--- a/crates/platform/src/platform_store.rs
+++ b/crates/platform/src/platform_store.rs
@@ -482,6 +482,7 @@ pub mod tests {
         pub fn new() -> Self {
             Self {
                 harness: Harness {
+                    icon: None,
                     id: HarnessId::new(),
                     name: "test-harness".to_string(),
                     display_name: Some("Test Harness".to_string()),

--- a/crates/platform/src/platform_store.rs
+++ b/crates/platform/src/platform_store.rs
@@ -482,10 +482,10 @@ pub mod tests {
         pub fn new() -> Self {
             Self {
                 harness: Harness {
-                    icon: None,
                     id: HarnessId::new(),
                     name: "test-harness".to_string(),
                     display_name: Some("Test Harness".to_string()),
+                    icon: None,
                     description: Some("test harness".to_string()),
                     system_prompt: Some("You are helpful.".to_string()),
                     parent_harness_id: None,

--- a/crates/server/migrations/126_harness_icon.sql
+++ b/crates/server/migrations/126_harness_icon.sql
@@ -1,0 +1,6 @@
+-- Harness icon: display glyph name rendered by the UI.
+--
+-- Built-in harness definitions declare their icon in code and it is synced on
+-- org provisioning. Custom harnesses leave it NULL and fall back to the
+-- generic harness glyph in the UI.
+ALTER TABLE harnesses ADD COLUMN icon VARCHAR(64);

--- a/crates/server/src/api/harness_examples.rs
+++ b/crates/server/src/api/harness_examples.rs
@@ -27,6 +27,9 @@ pub struct HarnessExample {
     pub display_name: String,
     /// Short description.
     pub description: String,
+    /// Display glyph name rendered by the UI (e.g. `bar-chart`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
     /// Tags for categorization.
     pub tags: Vec<String>,
     /// Name of the parent harness this example inherits from when adopted
@@ -46,6 +49,7 @@ fn example_to_dto(ex: &HarnessExampleDef) -> HarnessExample {
         name: ex.definition.name.clone(),
         display_name: ex.definition.display_name.clone(),
         description: ex.definition.description.clone(),
+        icon: ex.definition.icon.clone(),
         tags: ex.definition.tags.clone(),
         parent_name: ex.definition.parent_name.clone(),
         capabilities: ex

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -1478,6 +1478,7 @@ mod tests {
                 CreateHarnessRow {
                     name: "generic".to_string(),
                     display_name: Some("Generic".to_string()),
+                    icon: None,
                     description: Some("Generic".to_string()),
                     system_prompt: Some("You are helpful.".to_string()),
                     parent_harness_id: None,

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2097,6 +2097,7 @@ impl DirectWorkerAdapters {
 
             cursor = row.parent_harness_id;
             chain.push(Harness {
+                icon: None,
                 id: row.id,
                 name: row.name,
                 display_name: row.display_name,
@@ -4008,6 +4009,7 @@ mod tests {
             CreateHarnessRow {
                 name: name.to_string(),
                 display_name: None,
+                icon: None,
                 description: None,
                 system_prompt: Some("test prompt".to_string()),
                 parent_harness_id: None,

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2097,10 +2097,10 @@ impl DirectWorkerAdapters {
 
             cursor = row.parent_harness_id;
             chain.push(Harness {
-                icon: None,
                 id: row.id,
                 name: row.name,
                 display_name: row.display_name,
+                icon: None,
                 description: row.description,
                 system_prompt: row.system_prompt,
                 parent_harness_id: row.parent_harness_id,

--- a/crates/server/src/domains/agent_triggers/tests.rs
+++ b/crates/server/src/domains/agent_triggers/tests.rs
@@ -64,6 +64,7 @@ async fn seed_agent(db: &Arc<StorageBackend>) -> (String, everruns_provider::typ
             CreateHarnessRow {
                 name: "trigger-harness".to_string(),
                 display_name: Some("Trigger Harness".to_string()),
+                icon: None,
                 description: None,
                 system_prompt: Some(String::new()),
                 parent_harness_id: None,
@@ -214,6 +215,7 @@ async fn dispatch_trigger_message_uses_preserved_harness() {
             CreateHarnessRow {
                 name: "preserved-app-harness".to_string(),
                 display_name: None,
+                icon: None,
                 description: None,
                 system_prompt: Some(String::new()),
                 parent_harness_id: None,

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -2264,6 +2264,7 @@ mod tests {
             CreateHarnessRow {
                 name: name.to_string(),
                 display_name: Some(name.to_string()),
+                icon: None,
                 description: None,
                 system_prompt: Some("test harness".to_string()),
                 parent_harness_id: None,

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -254,6 +254,7 @@ impl Command for CreateHarness {
         let input = CreateHarnessRow {
             name: req.name,
             display_name: req.display_name,
+            icon: None,
             description: req.description,
             // Normalize an empty/whitespace-only prompt to "no base prompt" so
             // storage matches the documented semantics (the composition layer
@@ -1147,6 +1148,7 @@ mod tests {
             CreateHarnessRow {
                 name: "seeded-system".to_string(),
                 display_name: None,
+                icon: None,
                 description: None,
                 system_prompt: None,
                 parent_harness_id: None,

--- a/crates/server/src/domains/harnesses/queries.rs
+++ b/crates/server/src/domains/harnesses/queries.rs
@@ -307,10 +307,10 @@ pub fn merge_preview_layer(
         return (system_prompt.to_string(), capabilities.to_vec());
     };
     let draft = Harness {
-        icon: None,
         id: HarnessId::new(),
         name: "preview".to_string(),
         display_name: Some("Preview".to_string()),
+        icon: None,
         description: None,
         system_prompt: (!system_prompt.trim().is_empty()).then(|| system_prompt.to_string()),
         parent_harness_id: None,

--- a/crates/server/src/domains/harnesses/queries.rs
+++ b/crates/server/src/domains/harnesses/queries.rs
@@ -24,6 +24,7 @@ pub fn row_to_harness(row: HarnessRow, capabilities: Vec<AgentCapabilityConfig>)
         id: row.id,
         name: row.name,
         display_name: row.display_name,
+        icon: row.icon,
         description: row.description,
         system_prompt: row.system_prompt,
         parent_harness_id: row.parent_harness_id,
@@ -306,6 +307,7 @@ pub fn merge_preview_layer(
         return (system_prompt.to_string(), capabilities.to_vec());
     };
     let draft = Harness {
+        icon: None,
         id: HarnessId::new(),
         name: "preview".to_string(),
         display_name: Some("Preview".to_string()),
@@ -458,6 +460,7 @@ mod tests {
         CreateHarnessRow {
             name: name.to_string(),
             display_name: Some(name.to_string()),
+            icon: None,
             description: None,
             system_prompt: None,
             parent_harness_id,

--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -404,6 +404,7 @@ mod tests {
 
     fn test_harness() -> Harness {
         Harness {
+            icon: None,
             id: HarnessId::new(),
             name: "test-harness".to_string(),
             display_name: None,

--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -404,10 +404,10 @@ mod tests {
 
     fn test_harness() -> Harness {
         Harness {
-            icon: None,
             id: HarnessId::new(),
             name: "test-harness".to_string(),
             display_name: None,
+            icon: None,
             description: None,
             system_prompt: Some("harness".to_string()),
             parent_harness_id: None,

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -486,6 +486,7 @@ mod tests {
                 CreateHarnessRow {
                     name: "routing-harness".to_string(),
                     display_name: None,
+                    icon: None,
                     description: None,
                     system_prompt: Some("You are helpful.".to_string()),
                     parent_harness_id: None,
@@ -640,6 +641,7 @@ mod tests {
                 CreateHarnessRow {
                     name: "platform-chat".to_string(),
                     display_name: Some("Platform Chat".to_string()),
+                    icon: None,
                     description: None,
                     system_prompt: None,
                     parent_harness_id: None,

--- a/crates/server/src/domains/session_sandbox/commands.rs
+++ b/crates/server/src/domains/session_sandbox/commands.rs
@@ -368,6 +368,7 @@ mod tests {
             CreateHarnessRow {
                 name: "sandbox-harness".to_string(),
                 display_name: Some("Sandbox Harness".to_string()),
+                icon: None,
                 description: Some("test".to_string()),
                 system_prompt: Some("test".to_string()),
                 parent_harness_id: None,

--- a/crates/server/src/domains/session_sandbox/service.rs
+++ b/crates/server/src/domains/session_sandbox/service.rs
@@ -559,6 +559,7 @@ mod tests {
             CreateHarnessRow {
                 name: "sandbox-harness".to_string(),
                 display_name: Some("Sandbox Harness".to_string()),
+                icon: None,
                 description: Some("test".to_string()),
                 system_prompt: Some("test".to_string()),
                 parent_harness_id: None,

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -721,6 +721,7 @@ mod tests {
             CreateHarnessRow {
                 name: "base".to_string(),
                 display_name: Some("Base".to_string()),
+                icon: None,
                 description: None,
                 system_prompt: Some(String::new()),
                 parent_harness_id: None,
@@ -1727,6 +1728,7 @@ mod tests {
                 CreateHarnessRow {
                     name: "acl-test-harness".to_string(),
                     display_name: None,
+                    icon: None,
                     description: None,
                     system_prompt: Some(String::new()),
                     parent_harness_id: None,

--- a/crates/server/src/domains/session_tasks/queries.rs
+++ b/crates/server/src/domains/session_tasks/queries.rs
@@ -222,10 +222,10 @@ async fn load_harness_chain(
 
         cursor = row.parent_harness_id;
         chain.push(Harness {
-            icon: None,
             id: row.id,
             name: row.name,
             display_name: row.display_name,
+            icon: None,
             description: row.description,
             system_prompt: row.system_prompt,
             parent_harness_id: row.parent_harness_id,

--- a/crates/server/src/domains/session_tasks/queries.rs
+++ b/crates/server/src/domains/session_tasks/queries.rs
@@ -222,6 +222,7 @@ async fn load_harness_chain(
 
         cursor = row.parent_harness_id;
         chain.push(Harness {
+            icon: None,
             id: row.id,
             name: row.name,
             display_name: row.display_name,

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -4382,6 +4382,7 @@ mod tests {
                 CreateHarnessRow {
                     name: "coding-container".to_string(),
                     display_name: Some("Coding (Container)".to_string()),
+                    icon: None,
                     description: None,
                     system_prompt: Some("coding".to_string()),
                     parent_harness_id: None,
@@ -4438,6 +4439,7 @@ mod tests {
                 CreateHarnessRow {
                     name: "restricted-harness".to_string(),
                     display_name: Some("Restricted Harness".to_string()),
+                    icon: None,
                     description: None,
                     system_prompt: Some("restricted".to_string()),
                     parent_harness_id: None,
@@ -4521,6 +4523,7 @@ mod tests {
                 CreateHarnessRow {
                     name: "declarative-harness".to_string(),
                     display_name: Some("Declarative Harness".to_string()),
+                    icon: None,
                     description: None,
                     system_prompt: Some("declarative".to_string()),
                     parent_harness_id: None,
@@ -5184,6 +5187,7 @@ mod tests {
                 CreateHarnessRow {
                     name: name.to_string(),
                     display_name: Some(name.to_string()),
+                    icon: None,
                     description: None,
                     system_prompt: Some("hooked".to_string()),
                     parent_harness_id: None,

--- a/crates/server/src/harnesses/base.rs
+++ b/crates/server/src/harnesses/base.rs
@@ -8,6 +8,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Empty harness with no capabilities. Provides a blank canvas for custom configurations.",
         "You are a helpful assistant.",
     )
+    .with_icon("square-dashed")
     .with_tags(["base", "built-in"])
     .with_roles([BuiltInHarnessRole::Base])
 }

--- a/crates/server/src/harnesses/coding_container.rs
+++ b/crates/server/src/harnesses/coding_container.rs
@@ -17,6 +17,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Coding harness with self-hosted container sandboxes. Provides real filesystem, full process execution, network access, GitHub Scout subagents, and all Generic capabilities for software development tasks.",
         SYSTEM_PROMPT,
     )
+    .with_icon("container")
     .with_parent_name("generic")
     .with_tags(["coding", "container", "built-in"])
     .with_capabilities([

--- a/crates/server/src/harnesses/coding_daytona.rs
+++ b/crates/server/src/harnesses/coding_daytona.rs
@@ -16,6 +16,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Coding harness with Daytona cloud sandboxes. Provides real filesystem, full process execution, git integration, GitHub Scout subagents, and all Generic capabilities for software development tasks.",
         SYSTEM_PROMPT,
     )
+    .with_icon("daytona")
     .with_parent_name("generic")
     .with_tags(["coding", "daytona", "built-in"])
     .with_capabilities([

--- a/crates/server/src/harnesses/coding_session_sandbox.rs
+++ b/crates/server/src/harnesses/coding_session_sandbox.rs
@@ -11,6 +11,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Coding harness with one managed session-owned sandbox. Uses provider-neutral sandbox tools backed by Daytona and intentionally omits a local shell.",
         SYSTEM_PROMPT,
     )
+    .with_icon("terminal")
     .with_tags(["coding", "sandbox", "managed", "built-in"])
     .with_capabilities([
         BuiltInCapabilityDefinition::new("session_file_system"),

--- a/crates/server/src/harnesses/data_analyst.rs
+++ b/crates/server/src/harnesses/data_analyst.rs
@@ -12,6 +12,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Data analysis harness with SQL databases, persistent memory, interactive charts, and a structured analysis pipeline. Learns from corrections across sessions.",
         SYSTEM_PROMPT,
     )
+    .with_icon("bar-chart")
     .with_parent_name("generic")
     .with_tags(["data", "sql", "analytics", "built-in"])
     .with_capabilities([

--- a/crates/server/src/harnesses/generic.rs
+++ b/crates/server/src/harnesses/generic.rs
@@ -10,6 +10,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, tool output distillation, loop detection, message timestamp annotations, detailed error disclosure, parallel tool calls, agent skills, and claim-level citations with verification. Recommended default for most use cases.",
         SYSTEM_PROMPT,
     )
+    .with_icon("box")
     .with_tags(["generic", "default", "built-in"])
     .with_roles([BuiltInHarnessRole::Default])
     .with_capabilities([

--- a/crates/server/src/harnesses/mod.rs
+++ b/crates/server/src/harnesses/mod.rs
@@ -80,6 +80,23 @@ mod tests {
     }
 
     #[test]
+    fn every_harness_definition_declares_an_icon() {
+        // Icons are code-defined: the UI renders `Harness.icon` and only falls
+        // back to a generic glyph for user-created harnesses.
+        let definitions = built_in_harnesses()
+            .into_iter()
+            .chain(std::iter::once(coding_session_sandbox::definition()))
+            .chain(harness_examples().into_iter().map(|ex| ex.definition));
+        for definition in definitions {
+            assert!(
+                definition.icon.is_some(),
+                "harness {} must declare an icon",
+                definition.name
+            );
+        }
+    }
+
+    #[test]
     fn built_in_list_excludes_example_harnesses() {
         let _lock = lock_env();
         let _env_guard = EnvVarGuard::capture(&[

--- a/crates/server/src/harnesses/platform_chat.rs
+++ b/crates/server/src/harnesses/platform_chat.rs
@@ -10,9 +10,10 @@ pub fn definition() -> BuiltInHarnessDefinition {
     BuiltInHarnessDefinition::new(
         "platform-chat",
         "Platform Chat",
-        "Conversational harness for the global chat interface.",
+        "Conversational harness for the Everruns Platform chat.",
         SYSTEM_PROMPT,
     )
+    .with_icon("everruns")
     .with_parent_name("base")
     .with_tags(["chat", "built-in"])
     .with_roles([BuiltInHarnessRole::Chat])

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -262,6 +262,7 @@ pub async fn initialize_org_harnesses_with_definitions(
         let input = CreateHarnessRow {
             name: harness.name.to_string(),
             display_name: Some(harness.display_name.to_string()),
+            icon: harness.icon.clone(),
             description: Some(harness.description.to_string()),
             system_prompt: Some(harness.system_prompt.to_string()),
             parent_harness_id,
@@ -878,6 +879,7 @@ mod tests {
                 crate::storage::models::CreateHarnessRow {
                     name: "data-analyst".to_string(),
                     display_name: Some("Data Analyst".to_string()),
+                    icon: None,
                     description: Some("legacy".to_string()),
                     system_prompt: Some("legacy prompt".to_string()),
                     parent_harness_id: None,

--- a/crates/server/src/storage/harness_store.rs
+++ b/crates/server/src/storage/harness_store.rs
@@ -86,10 +86,10 @@ impl DbHarnessStore {
 
             cursor = row.parent_harness_id;
             chain.push(Harness {
-                icon: None,
                 id: row.id,
                 name: row.name,
                 display_name: row.display_name,
+                icon: None,
                 description: row.description,
                 system_prompt: row.system_prompt,
                 parent_harness_id: row.parent_harness_id,

--- a/crates/server/src/storage/harness_store.rs
+++ b/crates/server/src/storage/harness_store.rs
@@ -86,6 +86,7 @@ impl DbHarnessStore {
 
             cursor = row.parent_harness_id;
             chain.push(Harness {
+                icon: None,
                 id: row.id,
                 name: row.name,
                 display_name: row.display_name,

--- a/crates/server/src/storage/memory/harnesses.rs
+++ b/crates/server/src/storage/memory/harnesses.rs
@@ -17,6 +17,7 @@ impl InMemoryDatabase {
         let now = Self::now();
         let id = HarnessId::new();
         let row = HarnessRow {
+            icon: input.icon,
             id,
             org_id,
             name: input.name,
@@ -56,6 +57,7 @@ impl InMemoryDatabase {
         if let Some(existing) = harnesses.get(&id) {
             if existing.name == input.name
                 && existing.display_name == input.display_name
+                && existing.icon == input.icon
                 && existing.description == input.description
                 && existing.system_prompt == input.system_prompt
                 && existing.parent_harness_id == input.parent_harness_id
@@ -68,6 +70,7 @@ impl InMemoryDatabase {
             let row = HarnessRow {
                 name: input.name,
                 display_name: input.display_name,
+                icon: input.icon,
                 description: input.description,
                 system_prompt: input.system_prompt,
                 parent_harness_id: input.parent_harness_id,
@@ -83,6 +86,7 @@ impl InMemoryDatabase {
         }
 
         let row = HarnessRow {
+            icon: input.icon,
             id,
             org_id,
             name: input.name,

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -610,6 +610,7 @@ async fn test_session_aggregate_stats_by_agent_and_harness() {
             CreateHarnessRow {
                 name: "stats-harness".to_string(),
                 display_name: Some("Stats Harness".to_string()),
+                icon: None,
                 description: None,
                 system_prompt: Some(String::new()),
                 parent_harness_id: None,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -671,6 +671,9 @@ pub struct HarnessRow {
     pub name: String,
     #[sqlx(default)]
     pub display_name: Option<String>,
+    /// Display glyph name rendered by the UI. Set from built-in definitions.
+    #[sqlx(default)]
+    pub icon: Option<String>,
     pub description: Option<String>,
     /// Base system prompt. Nullable: a harness may contribute no base prompt
     /// and rely entirely on inheritance, agent, session, and capability layers.
@@ -702,6 +705,8 @@ pub struct HarnessRow {
 pub struct CreateHarnessRow {
     pub name: String,
     pub display_name: Option<String>,
+    /// Display glyph name rendered by the UI.
+    pub icon: Option<String>,
     pub description: Option<String>,
     /// Base system prompt; `None` means the harness contributes no base prompt.
     pub system_prompt: Option<String>,

--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -16,9 +16,9 @@ impl Database {
     pub async fn create_harness(&self, org_id: i64, input: CreateHarnessRow) -> Result<HarnessRow> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            INSERT INTO harnesses (org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 'active')
-            RETURNING id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            INSERT INTO harnesses (org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, icon, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'active')
+            RETURNING id, org_id, name, display_name, icon, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
@@ -34,6 +34,7 @@ impl Database {
         .bind(&input.network_access)
         .bind(&input.embedder_metadata)
         .bind(input.is_built_in)
+        .bind(&input.icon)
         .fetch_one(&self.pool)
         .await?;
 
@@ -52,11 +53,12 @@ impl Database {
     ) -> Result<Option<HarnessRow>> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            INSERT INTO harnesses (id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'active')
+            INSERT INTO harnesses (id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, icon, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, 'active')
             ON CONFLICT (id) DO UPDATE SET
                 name = EXCLUDED.name,
                 display_name = EXCLUDED.display_name,
+                icon = EXCLUDED.icon,
                 description = EXCLUDED.description,
                 system_prompt = EXCLUDED.system_prompt,
                 parent_harness_id = EXCLUDED.parent_harness_id,
@@ -70,6 +72,7 @@ impl Database {
             WHERE
                 harnesses.name IS DISTINCT FROM EXCLUDED.name
                 OR harnesses.display_name IS DISTINCT FROM EXCLUDED.display_name
+                OR harnesses.icon IS DISTINCT FROM EXCLUDED.icon
                 OR harnesses.description IS DISTINCT FROM EXCLUDED.description
                 OR harnesses.system_prompt IS DISTINCT FROM EXCLUDED.system_prompt
                 OR harnesses.parent_harness_id IS DISTINCT FROM EXCLUDED.parent_harness_id
@@ -79,7 +82,7 @@ impl Database {
                 OR harnesses.network_access IS DISTINCT FROM EXCLUDED.network_access
                 OR harnesses.embedder_metadata IS DISTINCT FROM EXCLUDED.embedder_metadata
                 OR harnesses.is_built_in IS DISTINCT FROM EXCLUDED.is_built_in
-            RETURNING id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            RETURNING id, org_id, name, display_name, icon, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(id.uuid())
@@ -96,6 +99,7 @@ impl Database {
         .bind(&input.network_access)
         .bind(&input.embedder_metadata)
         .bind(input.is_built_in)
+        .bind(&input.icon)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -120,7 +124,7 @@ impl Database {
     pub async fn get_harness(&self, org_id: i64, id: HarnessId) -> Result<Option<HarnessRow>> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            SELECT id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            SELECT id, org_id, name, display_name, icon, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             FROM harnesses
             WHERE org_id = $1 AND id = $2
             "#,
@@ -152,7 +156,7 @@ impl Database {
                 JOIN ancestry_ids ancestry ON ancestry.id = child.id
                 WHERE parent.org_id = $1
             )
-            SELECT h.id, h.org_id, h.name, h.display_name, h.description, h.system_prompt,
+            SELECT h.id, h.org_id, h.name, h.display_name, h.icon, h.description, h.system_prompt,
                    h.parent_harness_id, h.default_model_id, h.tags, h.status,
                    h.created_at, h.updated_at, h.archived_at, h.deleted_at,
                    h.initial_files, h.mcp_servers, h.network_access, h.embedder_metadata, h.is_built_in
@@ -169,7 +173,7 @@ impl Database {
     pub async fn get_harness_by_name(&self, org_id: i64, name: &str) -> Result<Option<HarnessRow>> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            SELECT id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            SELECT id, org_id, name, display_name, icon, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             FROM harnesses
             WHERE org_id = $1 AND name = $2 AND status != 'deleted'
             "#,
@@ -199,7 +203,7 @@ impl Database {
             " AND status = 'active'"
         };
         let sql = format!(
-            r#"SELECT id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            r#"SELECT id, org_id, name, display_name, icon, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
                 FROM harnesses
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
@@ -253,7 +257,7 @@ impl Database {
                 status = COALESCE($17, status),
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
-            RETURNING id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            RETURNING id, org_id, name, display_name, icon, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
@@ -308,7 +312,7 @@ impl Database {
     ) -> Result<Vec<HarnessRow>> {
         Ok(sqlx::query_as::<_, HarnessRow>(
             r#"
-            SELECT id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            SELECT id, org_id, name, display_name, icon, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, mcp_servers, network_access, embedder_metadata, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             FROM harnesses
             WHERE org_id = $1 AND parent_harness_id = $2 AND status != 'deleted'
             ORDER BY created_at DESC

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -448,6 +448,7 @@ async fn seed_agent(ctx: &Ctx, name: &str) -> AgentId {
             CreateHarnessRow {
                 name: format!("harness-{name}"),
                 display_name: None,
+                icon: None,
                 description: None,
                 system_prompt: Some("test prompt".to_string()),
                 parent_harness_id: None,

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -833,6 +833,7 @@ async fn test_session_crud() {
             CreateHarnessRow {
                 name: format!("repo-test-app-harness-{}", Uuid::now_v7()),
                 display_name: Some("Repo Test App Harness".to_string()),
+                icon: None,
                 description: None,
                 system_prompt: Some("Test".to_string()),
                 parent_harness_id: None,
@@ -937,6 +938,7 @@ async fn test_session_crud() {
             CreateHarnessRow {
                 name: format!("repo-test-harness-{}", &Uuid::now_v7().to_string()[..8]),
                 display_name: Some("Repo Test Harness".to_string()),
+                icon: None,
                 description: None,
                 system_prompt: Some("Test".to_string()),
                 parent_harness_id: None,

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1552,6 +1552,8 @@ fn proto_harness_to_harness(proto_harness: proto::Harness) -> Result<Harness> {
         id: id.into(),
         name: proto_harness.name,
         display_name: proto_harness.display_name,
+        // UI-only presentation field; not carried on the execution proto.
+        icon: None,
         description: non_empty_string(proto_harness.description),
         // proto carries a plain string; empty/whitespace means no base prompt.
         system_prompt: Some(proto_harness.system_prompt).filter(|s| !s.trim().is_empty()),

--- a/crates/worker/tests/resolved_turn_parity_test.rs
+++ b/crates/worker/tests/resolved_turn_parity_test.rs
@@ -26,10 +26,10 @@ fn fixture_records() -> (Harness, Agent, ExecutionSession) {
     // Stored (pre-merged) platform record, as transported by WorkerAdapters
     // (EVE-881): the host itself only ever sees the projected definition.
     let harness = Harness {
-        icon: None,
         id: harness_id,
         name: "hoster".into(),
         display_name: None,
+        icon: None,
         description: None,
         system_prompt: Some("Harness instructions.".into()),
         parent_harness_id: None,

--- a/crates/worker/tests/resolved_turn_parity_test.rs
+++ b/crates/worker/tests/resolved_turn_parity_test.rs
@@ -26,6 +26,7 @@ fn fixture_records() -> (Harness, Agent, ExecutionSession) {
     // Stored (pre-merged) platform record, as transported by WorkerAdapters
     // (EVE-881): the host itself only ever sees the projected definition.
     let harness = Harness {
+        icon: None,
         id: harness_id,
         name: "hoster".into(),
         display_name: None,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -23070,6 +23070,14 @@
               "team": "platform"
             }
           },
+          "icon": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display glyph name rendered by the UI (e.g. \"message-circle\").\n\nBuilt-in harnesses declare it in their definition; custom harnesses\nleave it unset and fall back to the UI's generic harness glyph.",
+            "example": "message-circle"
+          },
           "id": {
             "type": "string",
             "description": "Unique identifier for the harness (format: harness_{32-hex}).",
@@ -23184,6 +23192,13 @@
           "display_name": {
             "type": "string",
             "description": "Human-readable display name (e.g. `Data Analyst`)."
+          },
+          "icon": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display glyph name rendered by the UI (e.g. `bar-chart`)."
           },
           "name": {
             "type": "string",
@@ -25414,6 +25429,14 @@
                     "env": "production",
                     "team": "platform"
                   }
+                },
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Display glyph name rendered by the UI (e.g. \"message-circle\").\n\nBuilt-in harnesses declare it in their definition; custom harnesses\nleave it unset and fall back to the UI's generic harness glyph.",
+                  "example": "message-circle"
                 },
                 "id": {
                   "type": "string",
@@ -27740,6 +27763,14 @@
                             "env": "production",
                             "team": "platform"
                           }
+                        },
+                        "icon": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Display glyph name rendered by the UI (e.g. \"message-circle\").\n\nBuilt-in harnesses declare it in their definition; custom harnesses\nleave it unset and fall back to the UI's generic harness glyph.",
+                          "example": "message-circle"
                         },
                         "id": {
                           "type": "string",
@@ -40260,6 +40291,14 @@
                   "team": "platform"
                 }
               },
+              "icon": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Display glyph name rendered by the UI (e.g. \"message-circle\").\n\nBuilt-in harnesses declare it in their definition; custom harnesses\nleave it unset and fall back to the UI's generic harness glyph.",
+                "example": "message-circle"
+              },
               "id": {
                 "type": "string",
                 "description": "Unique identifier for the harness (format: harness_{32-hex}).",
@@ -40966,6 +41005,14 @@
                       "env": "production",
                       "team": "platform"
                     }
+                  },
+                  "icon": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Display glyph name rendered by the UI (e.g. \"message-circle\").\n\nBuilt-in harnesses declare it in their definition; custom harnesses\nleave it unset and fall back to the UI's generic harness glyph.",
+                    "example": "message-circle"
                   },
                   "id": {
                     "type": "string",

--- a/knowledge/harnesses/harness-types.md
+++ b/knowledge/harnesses/harness-types.md
@@ -27,6 +27,12 @@ Every harness has two name fields:
 | `name` | URL/CLI-friendly addressable identifier | `[a-z0-9]+(-[a-z0-9]+)*`, max 64 chars, unique per org | `deep-research` |
 | `display_name` | Human-readable label shown in UI | Free-form string, max 2 KB | `Deep Research` |
 
+Harnesses also carry an optional `icon`: a glyph name the UI renders on harness cards, detail pages,
+and the example gallery. Icons are code-defined — every built-in and example harness declares one in
+its definition (`crates/server/src/harnesses/*.rs`), and the UI resolves the name against its icon
+map (`apps/ui/src/lib/harness-icons.tsx`). The API does not accept an icon on create/update, so
+user-created harnesses render the neutral fallback glyph.
+
 The `name` field works like a GitHub repository name: lowercase alphanumeric with hyphens, no consecutive hyphens, no leading/trailing hyphens. It is unique per organization (among non-deleted harnesses) and can be used for API lookups, CLI references, and URL routing.
 
 ### Name-based access
@@ -100,7 +106,7 @@ The recommended default harness. Bundles the core capabilities needed for genera
 
 ### Platform Chat
 
-Conversational harness for the global chat interface. Parents on Base and declares an explicit,
+Conversational harness for the Everruns Platform chat. Parents on Base and declares an explicit,
 focused capability set, so its effective surface is exactly what it lists. It is tagged separately to
 support the per-user singleton session pattern.
 


### PR DESCRIPTION
## What changed

Harnesses now carry an optional `icon`, so the harness surfaces stop rendering the same shield for
everything. Built-in and example harness definitions declare a glyph name in code; it is persisted
on the harness row, synced into every org on provisioning, served on `Harness` and `HarnessExample`,
and resolved by the UI against an icon map. Platform Chat gets the monochrome Everruns mark, Generic
a box, Base a dashed square, the coding harnesses a container/terminal/Daytona mark, Data Analyst a
bar chart. User-created harnesses carry no icon and keep the neutral shield.

The API does not accept `icon` on create/update: icons stay code-defined, which also keeps the
field out of user control.

Platform Chat's description now reads "Conversational harness for the Everruns Platform chat."
instead of "…for the global chat interface."

## Why

Every harness card, detail masthead, and gallery entry rendered an identical shield, so the list
read as undifferentiated rows and the built-ins users rely on (Platform Chat, Generic, Base) were
indistinguishable at a glance. The old Platform Chat description also still pointed at the retired
"global chat interface" wording.

## Before / After

Live stack (everruns-server + built UI against local PostgreSQL, `AUTH_MODE=none`), freshly
provisioned org:

Before — `GET /api/v1/harnesses` on main:

```
platform-chat   (no icon field)   Conversational harness for the global chat interface.
generic         (no icon field)   General-purpose harness with file system, bash, web fetch, …
base            (no icon field)   Empty harness with no capabilities. …
```

After — same request on this branch:

```
platform-chat   icon=everruns        Conversational harness for the Everruns Platform chat.
generic         icon=box             General-purpose harness with file system, bash, web fetch, …
base            icon=square-dashed   Empty harness with no capabilities. …
```

`GET /api/v1/harness-examples`:

```
coding-daytona   icon=daytona
data-analyst     icon=bar-chart
```

Database, after org provisioning against a migrated database:

```
 name          | icon          | description
---------------+---------------+------------------------------------------------------
 base          | square-dashed | Empty harness with no capabilities. …
 generic       | box           | General-purpose harness with file system, bash, …
 platform-chat | everruns      | Conversational harness for the Everruns Platform chat.
 repo-test-…   |               |   (user-created rows stay NULL → shield fallback)
```

UI, driven in Chromium against that stack:

- `/harnesses` — Platform Chat card renders the Everruns rings, Generic the box, Base the dashed
  square, with the new Platform Chat description.
- `/harnesses/{platform-chat}` — masthead renders the Everruns mark beside the title.
- `/harnesses/examples` — Coding (Daytona) renders the Daytona mark, Data Analyst the bar chart.

Screenshots could not be attached: this sandbox's egress proxy rejects binary uploads to
`uploads.github.com` (415, "Request bodies must declare Content-Type: application/json"), and no
Crabbox client is available here. The API/DB output above is reproducible with the commands in the
evidence list.

## Risk

- Low
- Adds a nullable `VARCHAR(64)` column and one field to harness read paths. A stale UI simply
  ignores the field; a harness with an unknown or absent icon name falls back to the shield.
  Provisioning treats `icon` as part of the built-in "changed?" comparison, so the first
  reconciliation after deploy updates existing built-in rows once.

## Security

- Threat categories reviewed: TM-WEB, TM-SQL, TM-TENANT, TM-API, TM-DOS.
- Findings and resolutions:
  - TM-WEB-001 (XSS via stored content): the icon is a database-sourced string, so the renderer
    matters. `HarnessIcon` uses the name only as a key into a fixed component map and falls back to
    the shield; unlike `CapabilityIcon` it has no embedded-SVG (`data:image/svg+xml`) branch, so
    attacker-controlled markup can never reach the page. Recorded as a comment in
    `apps/ui/src/lib/harness-icons.tsx`.
  - TM-SQL: no new query construction; `icon` rides existing parameterized statements as a bound
    value and a projected column.
  - TM-TENANT: no query lost its `org_id` scope; the column adds no new access path.
  - TM-API: read-only field. `CreateHarnessRequest`/`UpdateHarnessRequest` are unchanged, so the
    value is not settable through the API and only code-defined names can reach the database.
  - TM-DOS: bounded column (64 chars), no new unbounded work or allocations.
- No threat-model update needed: no new threat and no changed mitigation.

## Follow-ups

- Adopting an example harness (`POST /v1/harnesses/import?from-example=…`) creates an org-owned
  harness without the example's icon, so it renders the shield. Carrying it over needs a
  user-writable icon on create, which is deliberately out of scope for this change (icons stay
  code-defined); the gallery itself shows the icon.
- The Everruns mark reads dense at 14–16px where the three rings overlap; it is used at 22px on
  every current surface, so no change made now.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)