### PR TITLE
fix(test): adopt discovered models so live workflow tests survive provider bootstrap

### DIFF
--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -284,6 +284,86 @@ fn response_preview(text: &str) -> String {
     text.chars().take(100).collect::<String>()
 }
 
+/// Create a model under a provider, adopting the row the provider's own
+/// credential already produced.
+///
+/// A provider that gains a credential now discovers its catalog and enables a
+/// shortlist of chat models (#3515). For a live provider that lands the exact
+/// models these tests then ask for, so `POST .../models` answers `409
+/// already_exists` instead of `201` and six tests panicked on main — where the
+/// live keys are, and where discovery therefore actually runs. On a pull
+/// request the same tests skip, so nothing caught it before the merge.
+///
+/// Who inserted the row is not what any of these tests are about, so adopt it
+/// and bring it to the state the test needs: enabled, under the name the test
+/// expects. Creating it outright stays the normal path.
+async fn ensure_model(
+    client: &reqwest::Client,
+    provider_id: &str,
+    model_id: &str,
+    display_name: &str,
+) -> Model {
+    let response = client
+        .post(format!("{API_BASE_URL}/v1/providers/{provider_id}/models"))
+        .json(&json!({
+            "model_id": model_id,
+            "display_name": display_name,
+            "enabled": true,
+        }))
+        .send()
+        .await
+        .expect("Failed to create model");
+
+    let status = response.status();
+    if status == 201 {
+        return response.json().await.expect("Failed to parse model");
+    }
+    if status != 409 {
+        let body = response.text().await.unwrap_or_default();
+        panic!("Failed to create model {model_id}: status={status}, body={body}");
+    }
+
+    // 409 means discovery got there first. Find that row by its provider-scoped
+    // model_id — the only identifier the test knows.
+    let listed: Value = client
+        .get(format!("{API_BASE_URL}/v1/models"))
+        .send()
+        .await
+        .expect("Failed to list models after a create conflict")
+        .json()
+        .await
+        .expect("Failed to parse model list");
+    let existing_id = listed["data"]
+        .as_array()
+        .expect("model list should have a data array")
+        .iter()
+        .find(|model| model["provider_id"] == provider_id && model["model_id"] == model_id)
+        .and_then(|model| model["id"].as_str())
+        .unwrap_or_else(|| {
+            panic!("create said {model_id} already exists, but it is not in the model list")
+        })
+        .to_string();
+
+    // Discovery may have left it disabled, and it carries the catalog's display
+    // name rather than the test's. Both matter: the tests select this model by
+    // id for a real turn, and an assertion may name it.
+    let patched = client
+        .patch(format!("{API_BASE_URL}/v1/models/{existing_id}"))
+        .json(&json!({ "enabled": true, "display_name": display_name }))
+        .send()
+        .await
+        .expect("Failed to adopt the discovered model");
+    let patch_status = patched.status();
+    if patch_status != 200 {
+        let body = patched.text().await.unwrap_or_default();
+        panic!("Failed to adopt model {model_id}: status={patch_status}, body={body}");
+    }
+    patched
+        .json()
+        .await
+        .expect("Failed to parse the adopted model")
+}
+
 #[test]
 fn response_preview_truncates_on_char_boundaries() {
     // A byte slice at 100 panics here: the model's curly apostrophe occupies
@@ -1364,29 +1444,13 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
     println!("Created Anthropic provider: {}", provider.id);
 
     // Create model (claude-haiku-4-5 for cost-effectiveness)
-    let model_response = client
-        .post(format!(
-            "{}/v1/providers/{}/models",
-            API_BASE_URL, provider.id
-        ))
-        .json(&json!({
-            "model_id": LIVE_ANTHROPIC_FAST_MODEL,
-            "display_name": "Anthropic Fast (FS Bash Test)",
-            "enabled": true
-        }))
-        .send()
-        .await
-        .expect("Failed to create model");
-
-    if model_response.status() != 201 {
-        let status = model_response.status();
-        let body = model_response.text().await.unwrap_or_default();
-        panic!(
-            "Failed to create Anthropic model: status={}, body={}",
-            status, body
-        );
-    }
-    let model: Model = model_response.json().await.expect("Failed to parse model");
+    let model = ensure_model(
+        &client,
+        &provider.id.to_string(),
+        LIVE_ANTHROPIC_FAST_MODEL,
+        "Anthropic Fast (FS Bash Test)",
+    )
+    .await;
     println!("Created model: {}", model.id);
 
     // Step 2: Create agent with both session_file_system and bashkit_shell capabilities
@@ -2122,26 +2186,13 @@ async fn test_no_duplicate_tool_calls() {
 
     // Step 2: Create a model configured for tool use
     println!("\nStep 2: Creating model...");
-    let model_response = client
-        .post(format!(
-            "{}/v1/providers/{}/models",
-            API_BASE_URL, provider.id
-        ))
-        .json(&json!({
-            "model_id": "gpt-5.4-mini",
-            "display_name": "GPT-5.4 Mini Test",
-            "enabled": true
-        }))
-        .send()
-        .await
-        .expect("Failed to create model");
-
-    if model_response.status() != 201 {
-        let status = model_response.status();
-        let body = model_response.text().await.unwrap_or_default();
-        panic!("Failed to create model: status={}, body={}", status, body);
-    }
-    let model: Model = model_response.json().await.expect("Failed to parse model");
+    let model = ensure_model(
+        &client,
+        &provider.id.to_string(),
+        "gpt-5.4-mini",
+        "GPT-5.4 Mini Test",
+    )
+    .await;
     println!("Created model: {}", model.id);
 
     // Step 3: Create an agent with current_time capability
@@ -3728,26 +3779,13 @@ async fn test_agent_execution_openai_with_tool_calls() {
     println!("Created OpenAI provider: {}", provider.id);
 
     // Create model (gpt-5.4-mini for cost-effectiveness)
-    let model_response = client
-        .post(format!(
-            "{}/v1/providers/{}/models",
-            API_BASE_URL, provider.id
-        ))
-        .json(&json!({
-            "model_id": "gpt-5.4-mini",
-            "display_name": "GPT-5.4 Mini (Tool Test)",
-            "enabled": true
-        }))
-        .send()
-        .await
-        .expect("Failed to create model");
-
-    if model_response.status() != 201 {
-        let status = model_response.status();
-        let body = model_response.text().await.unwrap_or_default();
-        panic!("Failed to create model: status={}, body={}", status, body);
-    }
-    let model: Model = model_response.json().await.expect("Failed to parse model");
+    let model = ensure_model(
+        &client,
+        &provider.id.to_string(),
+        "gpt-5.4-mini",
+        "GPT-5.4 Mini (Tool Test)",
+    )
+    .await;
     println!("Created model: {} ({})", model.display_name, model.id);
 
     // Step 2: Create dad jokes agent with current_time capability
@@ -3984,26 +4022,13 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     println!("Created Anthropic provider: {}", provider.id);
 
     // Create model (claude-haiku-4-5 for cost-effectiveness)
-    let model_response = client
-        .post(format!(
-            "{}/v1/providers/{}/models",
-            API_BASE_URL, provider.id
-        ))
-        .json(&json!({
-            "model_id": LIVE_ANTHROPIC_FAST_MODEL,
-            "display_name": "Anthropic Fast (Tool Test)",
-            "enabled": true
-        }))
-        .send()
-        .await
-        .expect("Failed to create model");
-
-    if model_response.status() != 201 {
-        let status = model_response.status();
-        let body = model_response.text().await.unwrap_or_default();
-        panic!("Failed to create model: status={}, body={}", status, body);
-    }
-    let model: Model = model_response.json().await.expect("Failed to parse model");
+    let model = ensure_model(
+        &client,
+        &provider.id.to_string(),
+        LIVE_ANTHROPIC_FAST_MODEL,
+        "Anthropic Fast (Tool Test)",
+    )
+    .await;
     println!("Created model: {} ({})", model.display_name, model.id);
 
     // Step 2: Create dad jokes agent with current_time capability
@@ -4891,26 +4916,13 @@ async fn test_anthropic_extended_thinking() {
     println!("Created Anthropic provider: {}", provider.id);
 
     // Create model (the live thinking model supports extended thinking)
-    let model_response = client
-        .post(format!(
-            "{}/v1/providers/{}/models",
-            API_BASE_URL, provider.id
-        ))
-        .json(&json!({
-            "model_id": LIVE_ANTHROPIC_THINKING_MODEL,
-            "display_name": "Anthropic Thinking (Thinking Test)",
-            "enabled": true
-        }))
-        .send()
-        .await
-        .expect("Failed to create model");
-
-    if model_response.status() != 201 {
-        let status = model_response.status();
-        let body = model_response.text().await.unwrap_or_default();
-        panic!("Failed to create model: status={}, body={}", status, body);
-    }
-    let model: Model = model_response.json().await.expect("Failed to parse model");
+    let model = ensure_model(
+        &client,
+        &provider.id.to_string(),
+        LIVE_ANTHROPIC_THINKING_MODEL,
+        "Anthropic Thinking (Thinking Test)",
+    )
+    .await;
     println!("Created model: {} ({})", model.display_name, model.id);
 
     // Step 2: Create agent (no tool calls - tests basic thinking flow)
@@ -5261,26 +5273,13 @@ async fn test_anthropic_extended_thinking_with_tools() {
     println!("Created Anthropic provider: {}", provider.id);
 
     // Create model (the live thinking model supports extended thinking)
-    let model_response = client
-        .post(format!(
-            "{}/v1/providers/{}/models",
-            API_BASE_URL, provider.id
-        ))
-        .json(&json!({
-            "model_id": LIVE_ANTHROPIC_THINKING_MODEL,
-            "display_name": "Anthropic Thinking (Thinking+Tools Test)",
-            "enabled": true
-        }))
-        .send()
-        .await
-        .expect("Failed to create model");
-
-    if model_response.status() != 201 {
-        let status = model_response.status();
-        let body = model_response.text().await.unwrap_or_default();
-        panic!("Failed to create model: status={}, body={}", status, body);
-    }
-    let model: Model = model_response.json().await.expect("Failed to parse model");
+    let model = ensure_model(
+        &client,
+        &provider.id.to_string(),
+        LIVE_ANTHROPIC_THINKING_MODEL,
+        "Anthropic Thinking (Thinking+Tools Test)",
+    )
+    .await;
     println!("Created model: {} ({})", model.display_name, model.id);
 
     // Step 2: Create agent WITH current_time tool


### PR DESCRIPTION
## What changed

Six live-provider workflow tests stopped assuming they are the ones who create their model.
A new `ensure_model` helper replaces six copies of the same create-and-assert-201 block: it
still creates the model on the normal path, and on `409 already_exists` adopts the row that
provider discovery created, bringing it to the state the test needs — enabled, under the
test's display name, since these tests select the model by id for a real turn.

Test-only. The product behavior is intended and untouched.

## Why

**Main is red on `1ed4b3d`.** #3515 made a provider that gains a credential discover its
catalog and enable a shortlist of chat models. For a live provider that inserts the exact
models these tests then ask for, so their create call conflicts instead of returning 201:

```
test result: FAILED. 34 passed; 6 failed; 0 ignored

    test_agent_execution_anthropic_with_tool_calls
    test_agent_execution_openai_with_tool_calls
    test_agent_filesystem_and_bash_workspace_integration
    test_anthropic_extended_thinking
    test_anthropic_extended_thinking_with_tools
    test_no_duplicate_tool_calls
```

each with the same panic:

```
Failed to create model: status=409 Conflict, body={"title":"Conflict","status":409,
"detail":"error returned from database: duplicate key value violates unique constraint
\"idx_models_provider_model\" at line 666","code":"already_exists"}
```

**Why #3515's own CI was green.** `Workflow Tests (Server + Worker)` is skipped on pull
requests — it only runs where the Doppler live keys are, which is `main`. Without a working
key, discovery is a best-effort no-op and nothing conflicts. So this failure mode cannot
appear until after the merge, which is exactly what happened.

That also means **this PR's CI cannot prove the fix** — the job that failed will skip here
too. The proof arrives on main, on the merge commit. Flagging that rather than implying
green CI here means anything.

## Before / After

Before, on `1ed4b3d`
([run 34572483572](https://github.com/everruns/everruns/actions/runs/34572483572)): the six
tests above fail, all on the 409.

After: the conflict is absorbed. The helper is the only behavioral difference; everything
downstream of it in each test is unchanged.

Verified locally as far as this change can be without live keys:

```
$ cargo check -p everruns-server --tests          # compiles
$ cargo clippy -p everruns-server --all-targets --all-features -- -D warnings
    Finished — no warnings
$ just pre-push
✅ All pre-push checks passed.                     # 22/22
```

The helper's API assumptions were checked against the handlers rather than assumed:
`PATCH /v1/models/{id}` accepts `enabled` and `display_name` and returns `WithUrls<Model>`
(flattened, so the existing `Model` deserialization holds); `list_all_models` takes no
limit/offset, so the lookup cannot miss the row behind pagination.

## Risk

- **Low**, and it is already the lower-risk direction: main is red now, and every further
  push to main re-runs these tests and fails again until this lands.
- **The helper could mask a real 409.** It only absorbs `already_exists` for the exact
  `(provider_id, model_id)` the test asked for, and adopting a leftover row from an earlier
  run is the same correct outcome — the FK-violation noise in the failing job's Postgres log
  shows cleanup does sometimes leave rows behind.
- **Concurrent tests using the same model id under different providers.** The lookup filters
  on `provider_id` *and* `model_id`, so each test finds its own row.
- **Synthetic-model sites are untouched** (llmsim, `gpt-5.2`, `test-model`): discovery never
  produces those ids, so they cannot collide and did not need changing.

## Security

- Threat categories reviewed: none apply — this changes test code only. No production path,
  no dependency, no CI permission, no credential handling in the diff.
- Findings and resolutions: none.

## Follow-ups

- **Cleanup in these tests is already lossy and this PR does not fix it.** The failing job's
  Postgres log shows `DELETE FROM models` / `DELETE FROM providers` hitting
  `agents_default_model_id_fkey` and `sessions_model_id_fkey`, because the bootstrap also
  elects an org default model. The tests do not assert on those deletes, so they neither
  failed before nor fail now — it is pre-existing leakage, out of scope for getting main
  green, and worth its own pass.

## Checklist
- [x] Tests added or updated — this is the test change
- [x] Backward compatibility considered — test-only, no contract touched
- [x] Security review performed against relevant threat model categories — not applicable, stated above
- [x] Final CI ran checks affected by this PR — noting that the affected job skips on PRs; proof is on main
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01448ctR6JAiwPe7NwjUJqwB

---
_Generated by [Claude Code](https://claude.ai/code/session_01448ctR6JAiwPe7NwjUJqwB)_