### PR TITLE
fix(ui): report failed Models page actions instead of rejecting unhandled

### DIFF
--- a/apps/ui/src/__tests__/models-page.test.tsx
+++ b/apps/ui/src/__tests__/models-page.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import ModelsPage from "@/app/(main)/models/page";
+import { updateModel } from "@/lib/api/providers";
+import { ApiError } from "@/lib/api/client";
 
 const mockUseSearchParams = jest.fn();
 
@@ -423,5 +425,48 @@ describe("ModelsPage", () => {
 
     expect(screen.getByText("Organization Settings")).toBeInTheDocument();
     expect(screen.getByText("Default Model")).toBeInTheDocument();
+  });
+
+  // EVE-954 / Sentry EVERRUNS-1Y: a rejected action used to escape the async
+  // handler unhandled — nothing on screen, the control silently reverting, and
+  // the rejection reported to Sentry as an unhandled promise rejection.
+  it("reports a failed toggle to the operator instead of rejecting unhandled", async () => {
+    const rejection = new ApiError(404, "Not Found", "Model not found");
+    (updateModel as jest.Mock).mockRejectedValueOnce(rejection);
+    const unhandled = jest.fn();
+    window.addEventListener("unhandledrejection", unhandled);
+
+    render(<ModelsPage />, { wrapper });
+    fireEvent.click(screen.getByRole("button", { name: /Disable/i }));
+
+    // The server's own reason reaches the reader — not a generic string.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Failed to disable model: Model not found");
+    expect(unhandled).not.toHaveBeenCalled();
+    window.removeEventListener("unhandledrejection", unhandled);
+  });
+
+  it("clears a previous failure when the next action succeeds", async () => {
+    (updateModel as jest.Mock)
+      .mockRejectedValueOnce(new ApiError(404, "Not Found", "Model not found"))
+      .mockResolvedValueOnce(undefined);
+
+    render(<ModelsPage />, { wrapper });
+    fireEvent.click(screen.getByRole("button", { name: /Disable/i }));
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Disable/i }));
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  });
+
+  it("reports a non-Error rejection without rendering [object Object]", async () => {
+    (updateModel as jest.Mock).mockRejectedValueOnce({ nope: true });
+
+    render(<ModelsPage />, { wrapper });
+    fireEvent.click(screen.getByRole("button", { name: /Disable/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Failed to disable model: Unexpected error",
+    );
   });
 });

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Notice, NoticeDescription } from "@/components/ui/notice";
 import {
   PageContainer,
   PageBreadcrumb,
@@ -36,11 +37,21 @@ import { useModels, useProviders, useDeleteModel } from "@/hooks/use-providers";
 import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
 import { usePageTitle } from "@/hooks";
 import { updateModel } from "@/lib/api/providers";
+import { ApiError } from "@/lib/api/client";
 import { queryKeys } from "@/lib/query-keys";
 import { pluralize } from "@/lib/formatting";
 import { cn } from "@/lib/utils";
 import type { ModelWithProvider } from "@/lib/api/types";
 import { isChatModel } from "@/lib/model-capabilities";
+
+// The operator-readable half of a failed action. `ApiError` already carries the
+// server's Problem Details message; anything else falls back to its own text,
+// and a non-Error rejection to a fixed string rather than "[object Object]".
+function errorDetail(error: unknown): string {
+  if (error instanceof ApiError) return error.message;
+  if (error instanceof Error && error.message) return error.message;
+  return "Unexpected error";
+}
 
 // Order models by release date desc (newest first), then by created_at desc.
 // Models without a release_date in their profile fall to the bottom; this works
@@ -64,6 +75,10 @@ export default function ModelsPage() {
   const deleteModel = useDeleteModel();
   const [addModelOpen, setAddModelOpen] = useState(false);
   const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
+  // Every action on this page can fail against the API. Without somewhere to
+  // put the reason, a rejection escapes the async handler unhandled — invisible
+  // on screen, and noise in Sentry (EVE-954).
+  const [actionError, setActionError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const selectedProviderId = searchParams.get("provider");
   const selectedProvider = useMemo(
@@ -121,33 +136,52 @@ export default function ModelsPage() {
       .sort((a, b) => b.count - a.count);
   }, [models, providers]);
 
+  // Run one page action, reporting the failure instead of letting it reject out
+  // of the handler. Clears any previous failure first, so the notice always
+  // describes the action the operator just took.
+  const runAction = async (summary: string, action: () => Promise<void>) => {
+    setActionError(null);
+    try {
+      await action();
+    } catch (error) {
+      console.error(`${summary}:`, error);
+      setActionError(`${summary}: ${errorDetail(error)}`);
+    }
+  };
+
   const handleDeleteModel = async (id: string) => {
     if (confirm("Are you sure you want to delete this model?")) {
-      await deleteModel.mutateAsync(id);
+      await runAction("Failed to delete model", () => deleteModel.mutateAsync(id).then(() => {}));
     }
   };
 
   const handleToggleEnabled = async (modelId: string, enabled: boolean) => {
     setTogglingModelId(modelId);
     try {
-      await updateModel(modelId, { enabled });
-      await queryClient.invalidateQueries({ queryKey: queryKeys.models.all });
-      if (!enabled) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
-      }
+      await runAction(`Failed to ${enabled ? "enable" : "disable"} model`, async () => {
+        await updateModel(modelId, { enabled });
+        await queryClient.invalidateQueries({ queryKey: queryKeys.models.all });
+        if (!enabled) {
+          await queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
+        }
+      });
     } finally {
       setTogglingModelId(null);
     }
   };
 
   const handleUpdateModel = async (modelId: string, data: Parameters<typeof updateModel>[1]) => {
-    await updateModel(modelId, data);
-    await queryClient.invalidateQueries({ queryKey: queryKeys.models.all });
-    await queryClient.invalidateQueries({ queryKey: queryKeys.providers.all });
+    await runAction("Failed to update model", async () => {
+      await updateModel(modelId, data);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.models.all });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.providers.all });
+    });
   };
 
   const handleSetDefaultModel = async (modelId: string | null) => {
-    await updateOrg.mutateAsync({ default_model_id: modelId });
+    await runAction("Failed to set the default model", () =>
+      updateOrg.mutateAsync({ default_model_id: modelId }).then(() => {}),
+    );
   };
 
   return (
@@ -191,6 +225,12 @@ export default function ModelsPage() {
         <div className="border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
           Failed to load models: {modelsError.message}
         </div>
+      )}
+
+      {actionError && (
+        <Notice variant="destructive" role="alert">
+          <NoticeDescription>{actionError}</NoticeDescription>
+        </Notice>
       )}
 
       <PageControlStrip className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## What changed

Every action on the Models page now tells the operator when it fails, instead of failing
silently and reporting an unhandled promise rejection to Sentry.

All four handlers route through one `runAction` helper that catches, logs, and puts the
reason in a destructive `Notice` above the controls, cleared when the next action succeeds.
`ApiError` already carries the server's Problem Details message, so the operator reads *why*
rather than watching a toggle flip back for no stated reason.

## Why

Sentry [EVERRUNS-1Y](https://everruns.sentry.io/issues/EVERRUNS-1Y): 15 events on
`app.everruns.com/models`, `ApiError: Model not found`, mechanism
`auto.browser.global_handlers.onunhandledrejection`.

The 404 itself was #3512 (`PATCH /v1/models/{id}` 404ing on a disabled model). This is the
half that outlived it — none of the four handlers caught:

| handler | before |
|---|---|
| `handleDeleteModel` | bare `await deleteModel.mutateAsync(id)` |
| `handleToggleEnabled` | `try`/`finally`, **no `catch`** |
| `handleUpdateModel` | three bare awaits |
| `handleSetDefaultModel` | bare `await updateOrg.mutateAsync(...)` |

So any API failure rejected out of an async event handler: nothing rendered, the control
silently reverted, and the rejection landed in Sentry as unhandled. That applies to every
failure mode on the page, not just the 404 that exposed it — which is why fixing the server
side did not fix this.

Sibling pages (`agents/[agentId]/edit`, `agent-identities/[identityId]`,
`observers/[observerId]`) at least `catch` and `console.error`; `observer-form.tsx` already
renders `<Notice variant="destructive">`. The Models page did neither, so this brings it to
the existing convention rather than inventing one.

## Before / After

**Before** — click Disable on a model the API rejects: nothing appears, the row reverts, and
the browser reports an unhandled rejection. **After** — the failure is on screen, carrying
the server's own reason:

```html
<div data-slot="notice" data-variant="destructive" role="alert"
     class="border bg-card/90 px-4 py-3 … border-l-[3px] border-l-destructive block">
  <div class="min-w-0 space-y-1">
    <div data-slot="notice-description" data-variant="destructive"
         class="text-sm leading-6 text-muted-foreground">
      Failed to disable model: Model not found
    </div>
  </div>
</div>
```

That is the real markup the component renders under the real failure, captured from the
regression test below (`ApiError(404, "Not Found", "Model not found")` → click Disable →
`getByRole("alert").outerHTML`), not hand-written.

**No browser screenshot.** The canonical stack needs Doppler, which is not available in this
environment, so I could not photograph it in a running app — flagging that rather than
implying I did. The markup above and the tests are what I can actually show; the visual is
the standard `Notice variant="destructive"` already shipped on the observers page.

```
$ pnpm exec jest src/__tests__/models-page.test.tsx src/__tests__/runtime-errors.test.ts
Test Suites: 2 passed, Tests: 24 passed

$ pnpm run format:check && pnpm run lint && pnpm run typecheck   # all clean
$ just pre-push
✅ All pre-push checks passed.                                    # 22/22
```

Three new tests pin the behaviour: the alert renders with the server's reason **and** no
`unhandledrejection` fires; a following successful action clears it; and a non-`Error`
rejection reports "Unexpected error" rather than `[object Object]`.

## Risk

- **Low.** One page, no API or data-flow change.
- **A failure that was silent is now visible**, which is the point, but it does mean an
  operator who previously saw nothing will now see a notice on a failure that was already
  happening. That is the bug being fixed, not a new one.
- `handleDeleteModel` and `handleSetDefaultModel` wrap `mutateAsync(...).then(() => {})` to
  fit the helper's `Promise<void>`; the mutation's own result was already unused at both
  call sites.

## Security

- Threat categories reviewed: **TM-WEB**. The only new rendered content is an error message
  originating from our own API's Problem Details body, placed as a React text child of
  `NoticeDescription` — auto-escaped, no `dangerouslySetInnerHTML`, no URL or link
  construction, nothing interpolated into markup. `errorDetail` falls back to a fixed string
  for a non-`Error` rejection rather than stringifying arbitrary objects.
- Findings and resolutions: none.

## Follow-ups

No follow-ups for this page. Separately filed while triaging the same Sentry issue:
[EVE-955](https://linear.app/everruns/issue/EVE-955/live-workflow-tests-leak-models-and-providers-when-cleanup-hits-fk) —
live workflow tests silently leak models and providers because their teardown `expect`s only
that the request was sent, not that the delete succeeded. Unrelated code path.

## Checklist
- [x] Tests added or updated — three regression tests, including an explicit `unhandledrejection` assertion
- [x] Backward compatibility considered — UI-only, no contract touched
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Fixes EVE-954

https://claude.ai/code/session_01448ctR6JAiwPe7NwjUJqwB

---
_Generated by [Claude Code](https://claude.ai/code/session_01448ctR6JAiwPe7NwjUJqwB)_