### PR TITLE
feat(examples): prototype OpenAI websocket steering

### DIFF
--- a/.github/workflows/openai-steering.yml
+++ b/.github/workflows/openai-steering.yml
@@ -1,0 +1,38 @@
+name: OpenAI Steering Prototype
+
+on:
+  pull_request:
+    paths:
+      - 'examples/openai-steering/**'
+      - '.github/workflows/openai-steering.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'examples/openai-steering/**'
+      - '.github/workflows/openai-steering.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  steering:
+    name: Steering protocol (Python ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        python: ['3.11', '3.14']
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install isolated transport dependency
+        run: python -m pip install -r examples/openai-steering/requirements.txt
+      - name: Test durable recovery and real local WebSocket flows
+        run: python -m unittest discover -s examples/openai-steering -v

--- a/crates/everruns/examples/README.md
+++ b/crates/everruns/examples/README.md
@@ -2,15 +2,17 @@
 
 These examples use the [`everruns`](../README.md) crate.
 Most use `gpt-5.6-terra` and require `OPENAI_API_KEY`;
-`capability_configuration`, `canonical_events`, `live_session`, `session_work`,
+`capability_configuration`, `canonical_events`, `session_work`,
 `workspace_policy`, and `session_history` run entirely offline.
 `workspace_heads` also runs offline against a local Git repository.
+`live_session` defaults to an offline simulator; add `--features openai` and
+`-- --live` to use GPT-6 Astra with real API credentials.
 
 | Example | What it demonstrates | Run |
 |---|---|---|
 | [`capability_configuration.rs`](capability_configuration.rs) | One open entrypoint for typed Compaction and ToolSearch, a code-defined Definition, and a dynamic vendor reference | `cargo run -p everruns --example capability_configuration` |
 | [`workspace_policy.rs`](workspace_policy.rs) | Safe read/write scopes, default restrictions, and trusted starter files | `cargo run -p everruns --example workspace_policy` |
-| [`live_session.rs`](live_session.rs) | Non-blocking send, automatic steering, and optional waiting | `cargo run -p everruns --example live_session` |
+| [`live_session.rs`](live_session.rs) | Non-blocking send, iteration-boundary corrections, transcript, and optional live OpenAI mode | `cargo run -p everruns --example live_session` |
 | [`hello.rs`](hello.rs) | Minimal agent, typed tool, turn result, and event observation | `cargo run -p everruns --features openai --example hello` |
 | [`production_agent.rs`](production_agent.rs) | Tool safety boundary and production-shaped multi-turn use | `cargo run -p everruns --features openai --example production_agent` |
 | [`github_monitor.rs`](github_monitor.rs) | Host-owned background work that wakes an agent when it finishes | `cargo run -p everruns --features openai --example github_monitor -- --simulate` |

--- a/crates/everruns/examples/live_session.rs
+++ b/crates/everruns/examples/live_session.rs
@@ -1,43 +1,104 @@
-//! Send, steer, and optionally wait on one live Framework session.
+//! Send a correction to a live Framework session, then inspect its transcript.
 //!
+//! Offline (no API key):
 //! ```text
 //! cargo run -p everruns --example live_session
 //! ```
+//! OpenAI (requires OPENAI_API_KEY and API credits):
+//! ```text
+//! cargo run -p everruns --features openai --example live_session -- --live
+//! ```
+//! Optional positional arguments replace the initial request and correction.
+//! Framework steering queues input for the next iteration boundary; it does not
+//! send OpenAI's WebSocket response.steer event.
 
 use std::time::Duration;
 
-use everruns::{Agent, Engine, LlmSimConfig, Model, SendDisposition};
+use everruns::{Agent, Engine, LlmSimConfig, MessageRole, Model, SendDisposition};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let model = Model::simulated_with_config(
-        LlmSimConfig::fixed("Trip planned.").with_response_delay(Duration::from_millis(100)),
-    );
-    let agent = Agent::builder()
-        .instructions("Plan trips and incorporate every user message.")
-        .model(model)
-        .build()?;
-    let session = Engine::new().create(agent.clone());
+    let mut args = std::env::args().skip(1).peekable();
+    let live = args.peek().is_some_and(|arg| arg == "--live");
+    if live {
+        args.next();
+    }
+    let prompt = args
+        .next()
+        .unwrap_or_else(|| "Plan a three-day trip from Paris to Amsterdam.".into());
+    let update = args.next().unwrap_or_else(|| {
+        "Prefer trains, keep the budget under EUR 500, and include a museum.".into()
+    });
+    if args.next().is_some() || prompt.trim().is_empty() || update.trim().is_empty() {
+        return Err("Usage: live_session [--live] [INITIAL_REQUEST [CORRECTION]]".into());
+    }
 
-    let initial = session.send("Plan my trip.").await?;
-    let latest = session.send("Prefer trains.").await?;
-
-    match latest.disposition {
-        SendDisposition::Steered => {
-            println!("latest message joined turn {}", latest.turn_id);
+    let builder = Agent::builder()
+        .name("steering-example")
+        .instructions("Incorporate every user message. Keep the final answer within 150 words.");
+    let agent = if live {
+        #[cfg(feature = "openai")]
+        {
+            println!("OpenAI gpt-6-astra over HTTP; corrections apply at iteration boundaries.");
+            builder
+                .provider(everruns::OpenAI::from_env()?)
+                .model("gpt-6-astra")
+                .build()?
         }
+        #[cfg(not(feature = "openai"))]
+        {
+            return Err("Live mode requires: cargo run -p everruns --features openai --example live_session -- --live".into());
+        }
+    } else {
+        println!("Offline simulator: echoes the latest user input; no model inference.");
+        builder
+            .model(Model::simulated_with_config(
+                LlmSimConfig::echo().with_response_delay(Duration::from_millis(100)),
+            ))
+            .build()?
+    };
+    let engine = Engine::new();
+    let session = engine.create(agent);
+
+    println!("\nInitial request: {prompt}");
+    let initial = session.send(prompt.as_str()).await?;
+    println!("Correction: {update}");
+    // In a UI, call this same method when the user submits another message.
+    // A receipt confirms acceptance, not that the model has applied the update.
+    let latest = session.send(update.as_str()).await?;
+    match latest.disposition {
+        SendDisposition::Steered => println!("Accepted into the active turn."),
         SendDisposition::Started => {
-            println!("latest message started follow-up turn {}", latest.turn_id);
+            println!("The first turn finished; accepted as a follow-up turn.")
         }
         _ => {}
     }
 
-    // This is correct whether the second message steered the first turn or
-    // arrived after it completed and started a follow-up.
+    // Waiting on the latest receipt works even if the first turn finished just
+    // before the correction arrived. Both receipts remain independently waitable.
     let result = latest.wait().await?;
-    println!("{}", result.response);
+    let first = initial.wait().await?;
+    if !result.success || !first.success {
+        return Err(format!(
+            "Session failed: {}",
+            result
+                .error
+                .or(first.error)
+                .unwrap_or_else(|| format!("{:?}", result.stop_reason))
+        )
+        .into());
+    }
+    println!("\nAnswer: {}", result.response);
+    println!("Iterations in the resulting turn: {}", result.iterations);
 
-    // The first receipt remains independently waitable.
-    let _ = initial.wait().await?;
+    let history = session.history().page().await?;
+    println!("\nUser messages retained by the Framework:");
+    for message in history
+        .messages
+        .iter()
+        .filter(|message| message.role == MessageRole::User)
+    {
+        println!("- {}", message.text());
+    }
     Ok(())
 }

--- a/examples/openai-steering/README.md
+++ b/examples/openai-steering/README.md
@@ -1,0 +1,153 @@
+# Owned WebSocket steering prototype
+
+An **opt-in standalone experiment**, not a production worker transport. It runs
+GPT-6 Astra on one owned connection while other local processes submit durable
+user updates. Existing Everruns HTTP providers and default models are unchanged.
+The [architecture contract](../../knowledge/execution/openai-steering-prototype.md)
+explains ownership, recovery tradeoffs, and the bar for distributed integration.
+
+Requires Python 3.11+ on macOS/Linux. SQLite and the ownership lock require a local
+filesystem; do not put the journal on NFS or share it between hosts.
+
+## Run without API credentials
+
+From this directory:
+
+```sh
+python3 -m venv /tmp/everruns-steering-venv
+/tmp/everruns-steering-venv/bin/pip install -r requirements.txt
+/tmp/everruns-steering-venv/bin/python -m unittest -v
+```
+
+The integration test starts a real loopback WebSocket server, launches the CLI in
+a separate process to submit a user update, acknowledges it, requests a tool
+result, and verifies the successor output and combined usage. Other tests cover
+normal and interrupted parents, FIFO updates, rejection, approvals, duplicate
+receipt, ownership exclusion, and recovery with verified history. No billable API
+requests are made by the test suite.
+
+## Run against OpenAI
+
+Set `OPENAI_API_KEY` in the environment. The account needs GPT-6 Astra access and
+credits. Use a fresh journal path; `init` refuses to overwrite an existing file.
+
+```sh
+PY=/tmp/everruns-steering-venv/bin/python
+"$PY" steering.py --db /tmp/steering-session.db init 'Draft a detailed project plan for a task-tracking app.'
+"$PY" steering.py --db /tmp/steering-session.db run
+```
+
+From another terminal, send an actual user correction while it runs:
+
+```sh
+PY=/tmp/everruns-steering-venv/bin/python
+"$PY" steering.py --db /tmp/steering-session.db update 'Keep scope to two weeks for one developer.' --id user-message-1
+"$PY" steering.py --db /tmp/steering-session.db status
+```
+
+Retry delivery with the same `--id` and identical text. Reusing an ID with different
+text is rejected. IDs are local; the wire steering event contains only the three
+fields allowed by OpenAI. Each journal is one isolated session, and updates sent
+after completion become ordinary follow-up Responses on the same connection.
+
+`run` stays available for further user updates until Ctrl+C or its connection
+budget expires. It prints response/intent state changes. `status` includes final
+response outputs, required inputs, errors, durable inbox contents, and aggregate
+usage across all terminal responses. The journal and owner-lock file are created
+with mode 0600; journals contain prompts, results, and provider events. Keep them
+outside the repository.
+
+For a finite, **billable** check that queues a correction for the first live
+response and verifies the successor's marker:
+
+```sh
+"$PY" live_smoke.py --db /tmp/steering-live-check.db
+```
+
+This fails explicitly if steering does not reach a completed successor. It never
+reports acceptance alone as a successful smoke test.
+
+## Tools and approvals
+
+Pass `--settings settings.json` to `init` to provide synchronous function/custom
+tools, MCP tools, instructions, reasoning, or an output-token limit. For example:
+
+```json
+{
+  "instructions": "Read the current project status with get_project_status before planning.",
+  "tools": [{
+    "type": "function",
+    "name": "get_project_status",
+    "description": "Read current project status",
+    "parameters": {"type": "object", "properties": {}, "required": [], "additionalProperties": false},
+    "strict": true
+  }]
+}
+```
+
+The owner does **not** execute tools or decide approvals. A tool worker reads the
+call from `status`, performs it once, and persists its actual result using the
+original call ID. For example, save this as `/tmp/steering-result.json`, replacing
+`ACTUAL_CALL_ID` and the output with the real call's result:
+
+```json
+{"type":"function_call_output","call_id":"ACTUAL_CALL_ID","output":"Design complete; implementation has not started."}
+```
+
+```sh
+"$PY" steering.py --db /tmp/steering-session.db result /tmp/steering-result.json
+```
+
+An approval result uses `type: "mcp_approval_response"`, the actual
+`approval_request_id`, and an explicit boolean `approve` from the normal approval
+flow. Missing decisions and unrelated IDs are rejected. Save results before
+retrying delivery; conflicting results for the same call are rejected. Accepted
+steering never cancels a tool already running, and the owner never reruns it.
+
+The owner waits for all required results and sends one continuation with saved
+settings. The accepted correction is not repeated: OpenAI prepends it. This
+prototype accepts string function/custom tool outputs and MCP approval decisions;
+other required input types remain visible and blocked. Native async tools and
+configuration updates are outside this experiment.
+
+## Recover
+
+Stop the old owner before recovering. The exclusive lock enforces this, including
+when an old process is paused rather than dead.
+
+```sh
+"$PY" steering.py --db /tmp/steering-session.db recover
+"$PY" steering.py --db /tmp/steering-session.db resume
+```
+
+Recovery retrieves known nonterminal responses over HTTP. If the known response
+is still running, retry recovery after it finishes. It cannot be steered from a
+new connection. Completed responses contribute usage once, and saved tool results
+can continue from their parent without reexecuting the tool.
+
+A sent or accepted correction without an observed successor becomes `uncertain`.
+It is retained and **never automatically replayed**. OpenAI has no documented
+successor-discovery endpoint or steering idempotency key. If an operator obtains
+the successor ID from provider history, supply it:
+
+```sh
+"$PY" steering.py --db /tmp/steering-session.db recover --successor-id resp_ACTUAL_SUCCESSOR
+"$PY" steering.py --db /tmp/steering-session.db resume
+```
+
+The owner fetches that response and paginated input history, checks session
+metadata and parent, and requires exactly the expected additional user input and
+saved results before committing local state. A guessed ID, absent input, or
+duplicate input fails reconciliation. If the successor cannot be identified, the
+journal remains blocked for investigation; absence from the parent alone cannot
+prove that replay is safe. This prototype does not silently restart the prompt or
+claim exactly-once automatic recovery across that ambiguity.
+
+## Validation recorded on 2026-09-05
+
+The local suite exercises the protocol end to end through a real WebSocket and
+the producer CLI. A live GPT-6 Astra request reached `response.created`,
+`response.in_progress`, and `response.steer.accepted`, then returned
+`credit_balance_exhausted`. The unresolved input was preserved without replay.
+Live successor completion remains unverified; rerun the optional smoke check with
+an account that has credits. No UI was changed.

--- a/examples/openai-steering/README.md
+++ b/examples/openai-steering/README.md
@@ -6,6 +6,38 @@ user updates. Existing Everruns HTTP providers and default models are unchanged.
 The [architecture contract](../../knowledge/execution/openai-steering-prototype.md)
 explains ownership, recovery tradeoffs, and the bar for distributed integration.
 
+## Start with the Everruns Framework
+
+For an application using real `Agent`, `Engine`, and `Session` APIs, run the
+[Framework live-session example](../../crates/everruns/examples/live_session.rs):
+
+```sh
+# From the repository root. Offline and free; echoes the correction.
+cargo run -p everruns --example live_session
+
+# Real OpenAI model; requires OPENAI_API_KEY and API credits.
+cargo run -p everruns --features openai --example live_session -- --live \
+  'Plan a three-day trip from Paris to Amsterdam.' \
+  'Prefer trains and keep the budget under EUR 500.'
+```
+
+The Framework example uses `session.send()` for both the initial request and a
+correction, waits on the returned receipts, and prints the answer and retained
+user messages. Replace its second `send()` with your UI's message-submit handler.
+If the turn is still active, the correction joins it; if it finished, a follow-up
+turn starts. Acceptance is distinct from completion; wait on the latest receipt
+for the result that includes the correction.
+
+**These are two different mechanisms.** Framework steering currently queues user
+input for the next reasoning/tool boundary over ordinary HTTP. This Python
+experiment sends `response.steer` on an active OpenAI WebSocket. It is a prototype
+because the connection owner, recovery journal, and status projection are not
+integrated with Framework sessions or distributed workers. The Framework example
+does not claim that in-flight WebSocket capability or the Python journal's
+recovery guarantees; its session lives in memory.
+
+## Python WebSocket experiment
+
 Requires Python 3.11+ on macOS/Linux. SQLite and the ownership lock require a local
 filesystem; do not put the journal on NFS or share it between hosts.
 

--- a/examples/openai-steering/README.md
+++ b/examples/openai-steering/README.md
@@ -24,7 +24,8 @@ a separate process to submit a user update, acknowledges it, requests a tool
 result, and verifies the successor output and combined usage. Other tests cover
 normal and interrupted parents, FIFO updates, rejection, approvals, duplicate
 receipt, ownership exclusion, and recovery with verified history. No billable API
-requests are made by the test suite.
+requests are made by the test suite. The path-scoped OpenAI Steering Prototype CI
+workflow runs this suite on Python 3.11 and 3.14 for PRs and main.
 
 ## Run against OpenAI
 

--- a/examples/openai-steering/live_smoke.py
+++ b/examples/openai-steering/live_smoke.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Optional billable live check. OPENAI_API_KEY and GPT-6 Astra access required."""
+
+import argparse
+import asyncio
+import json
+import os
+
+from steering import Journal, run_owner, usage_totals
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db", required=True, help="New private journal to retain as evidence"
+    )
+    args = parser.parse_args()
+    journal = Journal.create(
+        args.db,
+        "Draft a detailed implementation plan for a task-tracking app.",
+        {"max_output_tokens": 3000},
+    )
+    try:
+        journal.enqueue(
+            "smoke-update-1",
+            "Keep scope to two weeks for one developer. End with STEERING_CONFIRMED.",
+        )
+        asyncio.run(
+            run_owner(
+                journal, os.environ["OPENAI_API_KEY"], stop_when_idle=True, timeout=120
+            )
+        )
+        state = journal.load()
+        if state["phase"] != "complete" or state["intents"][0]["status"] != "applied":
+            raise RuntimeError(
+                f"Live check did not complete: {state['phase']}; {state['error']}"
+            )
+        output = state["responses"][state["current"]]["output"]
+        text = "".join(
+            part["text"]
+            for item in output
+            if item["type"] == "message"
+            for part in item["content"]
+            if part["type"] == "output_text"
+        )
+        if "STEERING_CONFIRMED" not in text:
+            raise RuntimeError("Successor did not include the requested marker")
+        print(
+            json.dumps(
+                {
+                    "result": "passed",
+                    "responses": list(state["responses"]),
+                    "usage": usage_totals(state),
+                    "text": text,
+                },
+                indent=2,
+            )
+        )
+    finally:
+        journal.db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/openai-steering/requirements.txt
+++ b/examples/openai-steering/requirements.txt
@@ -1,0 +1,1 @@
+websockets==15.0.1

--- a/examples/openai-steering/steering.py
+++ b/examples/openai-steering/steering.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""Opt-in, single-host Responses steering owner. See README.md for the boundary.
+
+The socket never leaves its owner. Producers only append durable commands. There
+is deliberately no automatic replay across the send/ack crash window: OpenAI
+provides neither a client steering idempotency key nor successor discovery.
+"""
+
+import argparse
+import asyncio
+import fcntl
+import json
+import os
+import sqlite3
+import sys
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+TERMINAL = {"completed", "incomplete", "failed", "cancelled"}
+UNCOMMITTED = {"sending", "accepted", "pending", "uncertain"}
+OUTPUT_TYPES = {
+    "function_call": "function_call_output",
+    "custom_tool_call": "custom_tool_call_output",
+    "mcp_approval_request": "mcp_approval_response",
+}
+
+
+def result_key(item):
+    return item["type"] + ":" + item.get("call_id", item.get("approval_request_id", ""))
+
+
+def required_from(response):
+    required = []
+    for item in response.get("output", []):
+        if item["type"] in OUTPUT_TYPES:
+            stub = {"type": OUTPUT_TYPES[item["type"]]}
+            if item["type"] == "mcp_approval_request":
+                stub["approval_request_id"] = item["id"]
+            else:
+                stub["call_id"] = item["call_id"]
+            required.append(stub)
+    return required
+
+
+def validate_result(item, required):
+    if result_key(item) not in {result_key(r) for r in required}:
+        raise ValueError("Result does not match an outstanding tool or approval")
+    if item["type"] == "mcp_approval_response":
+        if type(item.get("approve")) is not bool:
+            raise ValueError("Approval requires an explicit boolean approve")
+        allowed = {"type", "approval_request_id", "approve", "reason"}
+    elif item["type"] in {"function_call_output", "custom_tool_call_output"}:
+        if not isinstance(item.get("output"), str):
+            raise ValueError("This prototype accepts string tool outputs")
+        allowed = {"type", "call_id", "output"}
+    else:
+        raise ValueError("Unsupported required input; preserved for operator handling")
+    if set(item) - allowed:
+        raise ValueError("Unexpected result fields")
+
+
+def initial_state(prompt, settings):
+    # Keep the experiment on the documented compatible surface. Normal HTTP
+    # drivers and globally configured models never consult this example.
+    allowed = {"instructions", "tools", "reasoning", "max_output_tokens"}
+    if set(settings) - allowed:
+        raise ValueError(
+            "Settings must be instructions, tools, reasoning, max_output_tokens"
+        )
+    if settings.get("reasoning", {}).get("effort", "medium") not in {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    }:
+        raise ValueError("Unsupported reasoning effort for this prototype")
+    for tool in settings.get("tools", []):
+        if tool.get("type") not in {"function", "custom", "mcp"} or tool.get("async"):
+            raise ValueError(
+                "Only synchronous function/custom tools and MCP are supported"
+            )
+    return {
+        "session": str(uuid.uuid4()),
+        "prompt": prompt,
+        "settings": {
+            "model": "gpt-6-astra",
+            "store": True,
+            "reasoning": {"effort": "medium"},
+            **settings,
+        },
+        "phase": "new",
+        "current": None,
+        "responses": {},
+        "intents": [],
+        "required": [],
+        "create": None,
+        "error": None,
+        "owner": None,
+    }
+
+
+class Journal:
+    def __init__(self, path):
+        self.path = Path(path).resolve()
+        self.db = sqlite3.connect(self.path, timeout=10)
+        self.db.execute("PRAGMA synchronous=FULL")
+
+    @classmethod
+    def create(cls, path, prompt, settings):
+        state = initial_state(prompt, settings)
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.close(fd)
+        journal = cls(path)
+        with journal.db:
+            journal.db.executescript("""
+                CREATE TABLE state (id INTEGER PRIMARY KEY CHECK(id=1), value TEXT NOT NULL);
+                CREATE TABLE inbox (id TEXT PRIMARY KEY, text TEXT NOT NULL, consumed INTEGER DEFAULT 0);
+                CREATE TABLE results (id TEXT PRIMARY KEY, value TEXT NOT NULL);
+                CREATE TABLE events (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+            """)
+            journal.db.execute("INSERT INTO state VALUES (1, ?)", (json.dumps(state),))
+        return journal
+
+    def load(self):
+        return json.loads(
+            self.db.execute("SELECT value FROM state WHERE id=1").fetchone()[0]
+        )
+
+    def save(self, state, event=None):
+        with self.db:
+            self.db.execute("UPDATE state SET value=? WHERE id=1", (json.dumps(state),))
+            if event is not None:
+                self.db.execute(
+                    "INSERT INTO events(value) VALUES (?)", (json.dumps(event),)
+                )
+
+    def enqueue(self, local_id, text):
+        if not text.strip():
+            raise ValueError("Update must not be empty")
+        with self.db:
+            self.db.execute(
+                "INSERT OR IGNORE INTO inbox(id,text) VALUES (?,?)", (local_id, text)
+            )
+            existing = self.db.execute(
+                "SELECT text FROM inbox WHERE id=?", (local_id,)
+            ).fetchone()[0]
+            if existing != text:
+                raise ValueError("Input id already belongs to a different update")
+
+    def drain(self, state):
+        with self.db:
+            for local_id, text in self.db.execute(
+                "SELECT id,text FROM inbox WHERE consumed=0 ORDER BY rowid"
+            ).fetchall():
+                state["intents"].append(
+                    {"id": local_id, "text": text, "status": "queued"}
+                )
+                self.db.execute("UPDATE inbox SET consumed=1 WHERE id=?", (local_id,))
+            self.db.execute("UPDATE state SET value=? WHERE id=1", (json.dumps(state),))
+
+    def submit_result(self, item):
+        key = result_key(item)
+        existing = self.db.execute(
+            "SELECT value FROM results WHERE id=?", (key,)
+        ).fetchone()
+        if existing:
+            if json.loads(existing[0]) != item:
+                raise ValueError("A different result was already saved for this call")
+            return
+        validate_result(item, self.load()["required"])
+        with self.db:
+            self.db.execute(
+                "INSERT OR IGNORE INTO results VALUES (?,?)", (key, json.dumps(item))
+            )
+            saved = json.loads(
+                self.db.execute(
+                    "SELECT value FROM results WHERE id=?", (key,)
+                ).fetchone()[0]
+            )
+            if saved != item:
+                raise ValueError("A different result was already saved for this call")
+
+    def results(self, required):
+        items = []
+        for stub in required:
+            row = self.db.execute(
+                "SELECT value FROM results WHERE id=?", (result_key(stub),)
+            ).fetchone()
+            if row is None:
+                return None
+            items.append(json.loads(row[0]))
+        return items
+
+    @contextmanager
+    def ownership(self):
+        # An OS lock does not expire under a paused owner. Same-host workers can
+        # submit via SQLite, but a second owner cannot open another live socket.
+        fd = os.open(str(self.path) + ".owner", os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            yield
+        finally:
+            os.close(fd)
+
+
+class Owner:
+    def __init__(self, journal):
+        self.journal = journal
+        self.state = journal.load()
+
+    def save(self, event=None):
+        self.journal.save(self.state, event)
+
+    def uncommitted(self):
+        return [i for i in self.state["intents"] if i["status"] in UNCOMMITTED]
+
+    def create(self, inputs, parent=None, intent=None):
+        request = {
+            **self.state["settings"],
+            "type": "response.create",
+            "input": inputs,
+            "metadata": {"everruns_steering_session": self.state["session"]},
+        }
+        if parent:
+            request["previous_response_id"] = parent
+        self.state["create"] = {"parent": parent, "intent": intent}
+        self.state["phase"] = "creating"
+        # Persist before send. A crash here is ambiguous, never a reason to retry.
+        self.save({"outbound": request})
+        return request
+
+    def next_request(self):
+        s = self.state
+        self.journal.drain(s)
+        if s["phase"] == "new":
+            return self.create(s["prompt"])
+        if s["phase"] in {"reconcile", "failed", "creating"}:
+            return None
+        current = s["responses"].get(s["current"], {})
+        if current.get("status") in TERMINAL and s["required"]:
+            # Wait for the pending event if a steer is awaiting acknowledgement.
+            if any(i["status"] in {"sending", "accepted"} for i in self.uncommitted()):
+                return None
+            results = self.journal.results(s["required"])
+            if results is not None:
+                return self.create(results, s["current"])
+            return None
+        if self.uncommitted():
+            return None
+        queued = next((i for i in s["intents"] if i["status"] == "queued"), None)
+        if queued is None:
+            return None
+        if s["phase"] == "active":
+            queued.update(status="sending", parent=s["current"])
+            request = {
+                "type": "response.steer",
+                "previous_response_id": s["current"],
+                "input": queued["text"],
+            }
+            self.save({"outbound": request, "local_id": queued["id"]})
+            return request
+        if s["phase"] == "complete":
+            queued.update(status="sending", parent=s["current"])
+            return self.create(
+                [{"role": "user", "content": queued["text"]}],
+                s["current"],
+                queued["id"],
+            )
+        return None
+
+    def event(self, event):
+        s = self.state
+        kind = event["type"]
+        if event.get("stream_id"):
+            raise ValueError(
+                "Unexpected named lane on dedicated default-lane connection"
+            )
+        if kind == "response.created":
+            response = event["response"]
+            rid = response["id"]
+            if rid in s["responses"]:
+                return  # A repeated event must not commit a newly queued update.
+            parent = response.get("previous_response_id")
+            expected = s["create"]
+            if parent != s["current"] or (expected and parent != expected["parent"]):
+                raise ValueError("Successor does not belong to this response chain")
+            if parent and s["responses"][parent].get("status") not in TERMINAL:
+                raise ValueError("Overlapping responses on the owned lane")
+            if not expected and not self.uncommitted():
+                raise ValueError("Unexpected automatic successor")
+            for intent in self.uncommitted():
+                if intent.get("parent") == parent:
+                    if intent["status"] == "sending" and not (
+                        expected and expected["intent"] == intent["id"]
+                    ):
+                        raise ValueError(
+                            "Successor arrived before steering acknowledgement"
+                        )
+                    intent.update(status="applied", successor=rid)
+            s["responses"][rid] = response
+            s.update(current=rid, phase="active", required=[], create=None)
+        elif kind.startswith("response.steer."):
+            steer = event["steer"]
+            candidates = [
+                i
+                for i in s["intents"]
+                if steer.get("id") and i.get("steer_id") == steer["id"]
+            ]
+            if not candidates:
+                candidates = [
+                    i
+                    for i in s["intents"]
+                    if i["status"] == "sending"
+                    and i.get("parent") == steer["previous_response_id"]
+                ]
+            if len(candidates) != 1:
+                raise ValueError("Cannot correlate steering acknowledgement")
+            intent = candidates[0]
+            if kind == "response.steer.accepted":
+                if intent["status"] == "sending":
+                    intent.update(status="accepted", steer_id=steer["id"])
+            elif kind == "response.steer.pending":
+                if intent["status"] not in {"accepted", "pending"}:
+                    raise ValueError("Pending event without accepted input")
+                intent["status"] = "pending"
+                s["required"] = list(
+                    {result_key(r): r for r in event["required_input"]}.values()
+                )
+                s["phase"] = "waiting"
+            elif kind == "response.steer.failed":
+                if steer["input"] != intent["text"] or intent["status"] == "applied":
+                    raise ValueError(
+                        "Failed input differs from the uncommitted submission"
+                    )
+                intent.update(status="failed", error=event["error"])
+                self.finish_if_ready()
+        elif kind in {"response.completed", "response.incomplete", "response.failed"}:
+            response = event["response"]
+            if response["id"] not in s["responses"]:
+                raise ValueError("Terminal event for an unknown response")
+            # Replace by response id, never add terminal usage on event receipt.
+            s["responses"][response["id"]] = response
+            if response["id"] == s["current"]:
+                s["required"] = required_from(response)
+                self.finish_if_ready()
+        elif kind == "error":
+            s.update(phase="reconcile", error=event["error"])
+        self.save(event)
+
+    def finish_if_ready(self):
+        s = self.state
+        response = s["responses"].get(s["current"], {})
+        status = response.get("status")
+        if status not in TERMINAL:
+            return
+        steered = (
+            response.get("incomplete_details", {}).get("reason") == "steered"
+            if response.get("incomplete_details")
+            else False
+        )
+        if status in {"failed", "cancelled"} or (
+            status == "incomplete" and not steered
+        ):
+            s.update(
+                phase="waiting" if self.uncommitted() else "failed",
+                error=response.get("error") or response.get("incomplete_details"),
+            )
+        elif self.uncommitted() or s["required"]:
+            s["phase"] = "waiting"
+        elif steered:
+            s.update(
+                phase="reconcile", error="Steered response without a known successor"
+            )
+        else:
+            s["phase"] = "complete"
+
+    def disconnected(self, reason):
+        s = self.state
+        s["owner"] = None
+        if s["phase"] not in {"new", "complete", "failed"} or self.uncommitted():
+            for intent in self.uncommitted():
+                intent["status"] = "uncertain"
+            s.update(phase="reconcile", error=s["error"] or str(reason))
+        self.save({"disconnected": str(reason)})
+
+
+def usage_totals(state):
+    def add(target, source):
+        for key, value in source.items():
+            if isinstance(value, dict):
+                add(target.setdefault(key, {}), value)
+            elif isinstance(value, (int, float)):
+                target[key] = target.get(key, 0) + value
+
+    total = {}
+    for response in state["responses"].values():
+        if response.get("status") in TERMINAL:
+            add(total, response.get("usage") or {})
+    return total
+
+
+def get_json(path, key, base="https://api.openai.com/v1"):
+    request = Request(base + path, headers={"Authorization": "Bearer " + key})
+    with urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def input_items(rid, key, base):
+    items, after = [], ""
+    while True:
+        page = get_json(
+            "/responses/"
+            + quote(rid, safe="")
+            + "/input_items?order=asc&limit=100"
+            + after,
+            key,
+            base,
+        )
+        items.extend(page["data"])
+        if not page.get("has_more"):
+            return items
+        after = "&after=" + quote(page["last_id"], safe="")
+
+
+def user_texts(items):
+    values = []
+    for item in items:
+        if item.get("role") == "user":
+            content = item["content"]
+            values.append(
+                content
+                if isinstance(content, str)
+                else "".join(p["text"] for p in content if p["type"] == "input_text")
+            )
+    return values
+
+
+def reconcile(owner, key, successor_id=None, base="https://api.openai.com/v1"):
+    """Recover only provider-proven history. Absence of a successor is not proof."""
+    s = owner.state
+    if successor_id:
+        child = get_json("/responses/" + quote(successor_id, safe=""), key, base)
+        parent = s["current"]
+        if (
+            child.get("id") != successor_id
+            or child.get("previous_response_id") != parent
+            or child.get("metadata", {}).get("everruns_steering_session")
+            != s["session"]
+        ):
+            raise ValueError("Recovery response has wrong parent or session")
+        pending = owner.uncommitted()
+        expected_create = s["create"]
+        old = user_texts(input_items(parent, key, base)) if parent else []
+        history = input_items(successor_id, key, base)
+        new = user_texts(history)
+        expected = [i["text"] for i in pending]
+        if expected_create and parent is None:
+            expected = [s["prompt"]]
+        if (not pending and not expected_create) or new != old + expected:
+            raise ValueError(
+                "History does not prove exactly one copy of each unresolved input"
+            )
+        if expected_create and s["required"]:
+            saved = owner.journal.results(s["required"])
+            if saved is None:
+                raise ValueError(
+                    "Missing saved results for the interrupted continuation"
+                )
+            for result in saved:
+                matches = [
+                    item
+                    for item in history
+                    if item.get("type") == result["type"]
+                    and result_key(item) == result_key(result)
+                ]
+                if len(matches) != 1 or any(
+                    matches[0].get(k) != v for k, v in result.items()
+                ):
+                    raise ValueError(
+                        "History does not prove commitment of saved tool results"
+                    )
+        for intent in pending:
+            intent.update(status="applied", successor=successor_id)
+        s["responses"][successor_id] = child
+        s.update(current=successor_id, create=None)
+        owner.save({"reconciled_successor": successor_id})
+    if owner.uncommitted() or s["create"]:
+        s.update(
+            phase="reconcile",
+            error="Unknown send/commit outcome; supply a verified successor id. No input replayed.",
+        )
+        owner.save()
+        return False
+    for rid, response in list(s["responses"].items()):
+        if response.get("status") not in TERMINAL:
+            fresh = get_json("/responses/" + quote(rid, safe=""), key, base)
+            if fresh["id"] != rid:
+                raise ValueError("Recovery response id mismatch")
+            s["responses"][rid] = fresh
+    response = s["responses"].get(s["current"], {})
+    if response.get("status") not in TERMINAL:
+        s.update(
+            phase="reconcile",
+            error="Known response still running; poll recovery. Cannot steer it from a new socket.",
+        )
+        owner.save()
+        return False
+    s["required"] = required_from(response)
+    s.update(phase="waiting", error=None)
+    owner.finish_if_ready()
+    owner.save({"recovered": s["current"]})
+    return s["phase"] != "reconcile"
+
+
+async def run_owner(
+    journal,
+    key,
+    endpoint="wss://api.openai.com/v1/responses",
+    stop_when_idle=False,
+    timeout=3500,
+):
+    with journal.ownership():
+        owner = Owner(journal)
+        if owner.state["phase"] != "new":
+            raise ValueError("Use recover before resume, or init a fresh journal")
+        await connected_owner(owner, key, endpoint, stop_when_idle, timeout)
+
+
+async def connected_owner(owner, key, endpoint, stop_when_idle, timeout):
+    from websockets.asyncio.client import connect
+
+    owner.state["owner"] = {"pid": os.getpid(), "connection": str(uuid.uuid4())}
+    owner.save()
+    try:
+        async with (
+            asyncio.timeout(timeout),
+            connect(
+                endpoint,
+                additional_headers={"Authorization": "Bearer " + key},
+                open_timeout=10,
+                max_size=16 * 1024 * 1024,
+            ) as socket,
+        ):
+            while True:
+                request = owner.next_request()
+                if request:
+                    await socket.send(json.dumps(request))
+                if owner.state["phase"] in {"failed", "reconcile"}:
+                    return
+                if (
+                    stop_when_idle
+                    and owner.state["phase"] == "complete"
+                    and not any(i["status"] == "queued" for i in owner.state["intents"])
+                ):
+                    return
+                try:
+                    raw = await asyncio.wait_for(socket.recv(), 0.1)
+                except TimeoutError:
+                    continue
+                event = json.loads(raw)
+                owner.event(event)
+                print(
+                    json.dumps(
+                        {
+                            "event": event["type"],
+                            "phase": owner.state["phase"],
+                            "response": owner.state["current"],
+                            "intents": [
+                                {"id": i["id"], "status": i["status"]}
+                                for i in owner.state["intents"]
+                            ],
+                        }
+                    ),
+                    flush=True,
+                )
+    finally:
+        owner.disconnected("Owner stopped; inspect journal before recovery")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", required=True)
+    commands = parser.add_subparsers(dest="command", required=True)
+    init = commands.add_parser("init")
+    init.add_argument("prompt")
+    init.add_argument(
+        "--settings",
+        help="JSON file: synchronous tools, instructions, reasoning, limits",
+    )
+    update = commands.add_parser("update")
+    update.add_argument("text")
+    update.add_argument(
+        "--id", required=True, help="Stable user-message id for producer retries"
+    )
+    result = commands.add_parser("result")
+    result.add_argument(
+        "json_file", help="Completed tool output or explicit approval JSON"
+    )
+    commands.add_parser("status")
+    commands.add_parser("run")
+    recover = commands.add_parser("recover")
+    recover.add_argument("--successor-id")
+    commands.add_parser("resume")
+    args = parser.parse_args()
+    if args.command == "init":
+        settings = json.loads(Path(args.settings).read_text()) if args.settings else {}
+        Journal.create(args.db, args.prompt, settings).db.close()
+        return
+    if not Path(args.db).is_file():
+        raise ValueError("Journal does not exist; run init")
+    journal = Journal(args.db)
+    try:
+        if args.command == "update":
+            journal.enqueue(args.id, args.text)
+        elif args.command == "result":
+            journal.submit_result(json.loads(Path(args.json_file).read_text()))
+        elif args.command == "status":
+            state = journal.load()
+            state["usage_totals"] = usage_totals(state)
+            state["inbox"] = journal.db.execute(
+                "SELECT id,text,consumed FROM inbox ORDER BY rowid"
+            ).fetchall()
+            print(json.dumps(state, indent=2))
+        elif args.command == "run":
+            asyncio.run(run_owner(journal, os.environ["OPENAI_API_KEY"]))
+        else:
+            with journal.ownership():
+                owner = Owner(journal)
+                recovered = reconcile(
+                    owner,
+                    os.environ["OPENAI_API_KEY"],
+                    getattr(args, "successor_id", None),
+                )
+                if (
+                    args.command == "resume"
+                    and recovered
+                    and owner.state["phase"] != "failed"
+                ):
+                    asyncio.run(
+                        connected_owner(
+                            owner,
+                            os.environ["OPENAI_API_KEY"],
+                            "wss://api.openai.com/v1/responses",
+                            False,
+                            3500,
+                        )
+                    )
+                print(
+                    json.dumps(
+                        {"phase": owner.state["phase"], "error": owner.state["error"]}
+                    )
+                )
+    finally:
+        journal.db.close()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, BlockingIOError, KeyError) as error:
+        sys.exit(str(error))

--- a/examples/openai-steering/test_steering.py
+++ b/examples/openai-steering/test_steering.py
@@ -1,0 +1,615 @@
+import asyncio
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from steering import Journal, Owner, reconcile, run_owner, usage_totals
+from websockets.exceptions import WebSocketException
+
+
+def response(
+    rid, parent=None, status="in_progress", output=None, tokens=0, reason=None
+):
+    value = {
+        "id": rid,
+        "previous_response_id": parent,
+        "status": status,
+        "output": output or [],
+        "usage": {
+            "input_tokens": tokens,
+            "output_tokens": tokens,
+            "input_tokens_details": {"cached_tokens": tokens // 2},
+        },
+    }
+    if reason:
+        value["incomplete_details"] = {"reason": reason}
+    return value
+
+
+def created(rid, parent=None):
+    return {"type": "response.created", "response": response(rid, parent)}
+
+
+def terminal(rid, parent=None, status="completed", **kwargs):
+    return {
+        "type": "response." + status,
+        "response": response(rid, parent, status, **kwargs),
+    }
+
+
+def steer(kind, parent="r1", sid="s1", **kwargs):
+    return {
+        "type": "response.steer." + kind,
+        "steer": {"id": sid, "previous_response_id": parent},
+        **kwargs,
+    }
+
+
+class StateTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.db = str(Path(self.temp.name) / "session.db")
+        self.journal = Journal.create(
+            self.db, "Draft a plan", {"instructions": "Be concise"}
+        )
+        self.owner = Owner(self.journal)
+        self.owner.next_request()
+        self.owner.event(created("r1"))
+
+    def tearDown(self):
+        self.journal.db.close()
+        self.temp.cleanup()
+
+    def send_update(self, text="Two weeks only", local_id="u1"):
+        self.journal.enqueue(local_id, text)
+        request = self.owner.next_request()
+        self.assertEqual(
+            request,
+            {"type": "response.steer", "previous_response_id": "r1", "input": text},
+        )
+        return request
+
+    def test_acceptance_is_not_application_and_usage_is_per_response(self):
+        self.send_update()
+        self.owner.event(steer("accepted"))
+        self.assertEqual(self.owner.state["intents"][0]["status"], "accepted")
+        end = terminal("r1", status="incomplete", reason="steered", tokens=10)
+        self.owner.event(end)
+        self.assertIsNone(self.owner.next_request())
+        self.owner.event(created("r2", "r1"))
+        self.assertEqual(self.owner.state["intents"][0]["status"], "applied")
+        self.owner.event(terminal("r2", "r1", tokens=20))
+        self.owner.event(end)
+        self.owner.event(terminal("r2", "r1", tokens=20))
+        self.assertEqual(self.owner.state["phase"], "complete")
+        self.assertEqual(
+            usage_totals(self.owner.state),
+            {
+                "input_tokens": 30,
+                "output_tokens": 30,
+                "input_tokens_details": {"cached_tokens": 15},
+            },
+        )
+
+    def test_completed_parent_waits_for_automatic_successor_and_next_update(self):
+        self.send_update()
+        self.journal.enqueue("u2", "Use bullets")
+        self.owner.event(terminal("r1"))  # Terminal may race the acknowledgement.
+        self.assertIsNone(self.owner.next_request())
+        self.owner.event(steer("accepted"))
+        self.assertIsNone(self.owner.next_request())
+        self.owner.event(created("r2", "r1"))
+        self.assertEqual(self.owner.next_request()["previous_response_id"], "r2")
+        self.owner.event(created("r2", "r1"))
+        self.assertEqual(self.owner.state["intents"][1]["status"], "sending")
+
+    def test_pending_tools_and_approval_use_saved_results_once(self):
+        self.send_update()
+        self.owner.event(steer("accepted"))
+        calls = [
+            {
+                "type": "function_call",
+                "call_id": "c1",
+                "name": "lookup",
+                "arguments": "{}",
+            },
+            {"type": "mcp_approval_request", "id": "a1", "name": "read"},
+        ]
+        self.owner.event(terminal("r1", output=calls))
+        required = [
+            {"type": "function_call_output", "call_id": "c1", "name": "lookup"},
+            {"type": "mcp_approval_response", "approval_request_id": "a1"},
+        ]
+        self.owner.event(
+            steer(
+                "pending", reason="waiting_for_required_input", required_input=required
+            )
+        )
+        self.assertIsNone(self.owner.next_request())
+        result = {
+            "type": "function_call_output",
+            "call_id": "c1",
+            "output": "Saved result",
+        }
+        self.journal.submit_result(result)
+        self.assertIsNone(self.owner.next_request())
+        approval = {
+            "type": "mcp_approval_response",
+            "approval_request_id": "a1",
+            "approve": False,
+        }
+        self.journal.submit_result(approval)
+        self.journal.submit_result(result)
+        with self.assertRaises(ValueError):
+            self.journal.submit_result({**result, "output": "Rerun result"})
+        request = self.owner.next_request()
+        self.assertEqual(request["input"], [result, approval])
+        self.assertNotIn("Two weeks only", json.dumps(request))
+        self.assertEqual(request["instructions"], "Be concise")
+        self.assertIsNone(self.owner.next_request())
+        self.owner.event(created("r2", "r1"))
+        self.journal.submit_result(result)  # Producer retry after successor commitment.
+        self.assertEqual(self.owner.state["intents"][0]["status"], "applied")
+
+    def test_failures_before_and_after_acceptance_are_preserved(self):
+        self.send_update()
+        failed = steer("failed", error={"code": "invalid_input"})
+        failed["steer"].pop("id")
+        failed["steer"]["input"] = "Two weeks only"
+        self.owner.event(failed)
+        self.assertEqual(self.owner.state["intents"][0]["status"], "failed")
+        self.journal.enqueue("u2", "Use bullets")
+        self.owner.next_request()
+        self.owner.event(steer("accepted", sid="s2"))
+        failed = steer("failed", sid="s2", error={"code": "successor_creation_failed"})
+        failed["steer"]["input"] = "Use bullets"
+        self.owner.event(failed)
+        self.assertEqual(
+            self.owner.state["intents"][1]["error"]["code"], "successor_creation_failed"
+        )
+        self.assertIsNone(self.owner.next_request())
+
+    def test_nonsteered_incomplete_is_failure_and_keeps_usage(self):
+        self.owner.event(
+            terminal("r1", status="incomplete", reason="max_output_tokens", tokens=11)
+        )
+        self.assertEqual(self.owner.state["phase"], "failed")
+        self.assertEqual(usage_totals(self.owner.state)["output_tokens"], 11)
+
+    def test_send_and_accept_crash_windows_never_replay(self):
+        for acknowledge in [False, True]:
+            with self.subTest(acknowledge=acknowledge):
+                if not acknowledge:
+                    self.send_update()
+                else:
+                    self.owner.state["intents"][0]["status"] = "sending"
+                    self.owner.event(steer("accepted"))
+                self.owner.disconnected("network lost")
+                recovered = Owner(self.journal)
+                with patch("steering.get_json") as get:
+                    self.assertFalse(reconcile(recovered, "test"))
+                    get.assert_not_called()
+                self.assertIsNone(recovered.next_request())
+                self.assertEqual(
+                    recovered.state["intents"][0]["text"], "Two weeks only"
+                )
+                self.assertEqual(recovered.state["intents"][0]["status"], "uncertain")
+
+    def test_reconcile_verified_successor_then_resume_without_duplicate_input(self):
+        self.send_update()
+        self.owner.event(steer("accepted"))
+        self.owner.disconnected("lost successor event")
+        child = response("r2", "r1", "completed", tokens=20)
+        child["metadata"] = {"everruns_steering_session": self.owner.state["session"]}
+        parent = response("r1", status="incomplete", tokens=10, reason="steered")
+        with (
+            patch("steering.get_json", side_effect=[child, parent]),
+            patch(
+                "steering.input_items",
+                side_effect=[
+                    [{"role": "user", "content": "Draft a plan"}],
+                    [
+                        {"role": "user", "content": "Draft a plan"},
+                        {"role": "user", "content": "Two weeks only"},
+                    ],
+                ],
+            ),
+        ):
+            self.assertTrue(reconcile(self.owner, "test", "r2"))
+        self.assertEqual(self.owner.state["intents"][0]["status"], "applied")
+        self.assertEqual(usage_totals(self.owner.state)["input_tokens"], 30)
+        self.assertIsNone(self.owner.next_request())
+        self.journal.enqueue("u2", "Continue")
+        next_request = self.owner.next_request()
+        self.assertEqual(next_request["type"], "response.create")
+        self.assertEqual(
+            next_request["input"], [{"role": "user", "content": "Continue"}]
+        )
+
+    def test_reconcile_rejects_missing_or_duplicate_input_and_wrong_lineage(self):
+        self.send_update()
+        self.owner.disconnected("lost acknowledgement")
+        child = response("r2", "r1", "completed")
+        child["metadata"] = {"everruns_steering_session": self.owner.state["session"]}
+        for texts in [[], ["Two weeks only", "Two weeks only"]]:
+            with (
+                patch("steering.get_json", return_value=child),
+                patch(
+                    "steering.input_items",
+                    side_effect=[
+                        [],
+                        [{"role": "user", "content": text} for text in texts],
+                    ],
+                ),
+                self.assertRaises(ValueError),
+            ):
+                reconcile(self.owner, "test", "r2")
+        with (
+            patch(
+                "steering.get_json",
+                return_value={**child, "previous_response_id": "foreign"},
+            ),
+            self.assertRaises(ValueError),
+        ):
+            reconcile(self.owner, "test", "r2")
+        self.assertEqual(self.owner.state["intents"][0]["status"], "uncertain")
+
+    def test_parent_failure_drains_steering_failure_before_stopping(self):
+        self.send_update()
+        self.owner.event(steer("accepted"))
+        self.owner.event(terminal("r1", status="failed", tokens=4))
+        self.assertEqual(self.owner.state["phase"], "waiting")
+        failure = steer("failed", error={"code": "successor_creation_failed"})
+        failure["steer"]["input"] = "Two weeks only"
+        self.owner.event(failure)
+        self.assertEqual(self.owner.state["phase"], "failed")
+        self.assertEqual(self.owner.state["intents"][0]["status"], "failed")
+        self.assertEqual(usage_totals(self.owner.state)["output_tokens"], 4)
+
+    def test_quota_error_and_uncommitted_input_survive_disconnect(self):
+        self.send_update()
+        self.owner.event(steer("accepted"))
+        error = {"code": "credit_balance_exhausted", "message": "No credits remaining"}
+        self.owner.event({"type": "error", "error": error})
+        self.owner.disconnected("Owner stopped")
+        self.assertEqual(self.journal.load()["error"], error)
+        self.assertEqual(self.journal.load()["intents"][0]["status"], "uncertain")
+
+    def test_lost_initial_create_receipt_can_be_reconciled(self):
+        self.owner.state = self.journal.load()
+        self.owner.state.update(current=None, responses={}, phase="new", create=None)
+        self.owner.next_request()
+        self.owner.disconnected("lost initial response id")
+        child = response("r1", status="completed", tokens=3)
+        child["metadata"] = {"everruns_steering_session": self.owner.state["session"]}
+        with (
+            patch("steering.get_json", return_value=child),
+            patch(
+                "steering.input_items",
+                return_value=[{"role": "user", "content": "Draft a plan"}],
+            ),
+        ):
+            self.assertTrue(reconcile(self.owner, "test", "r1"))
+        self.assertIsNone(self.owner.next_request())
+        self.assertEqual(self.owner.state["phase"], "complete")
+
+    def test_recovery_of_known_successor_waiting_for_tools(self):
+        self.send_update()
+        self.owner.event(steer("accepted"))
+        self.owner.event(
+            terminal("r1", status="incomplete", reason="steered", tokens=2)
+        )
+        self.owner.event(created("r2", "r1"))
+        self.owner.disconnected("lost terminal event")
+        child = response(
+            "r2",
+            "r1",
+            "completed",
+            tokens=3,
+            output=[
+                {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                }
+            ],
+        )
+        with patch("steering.get_json", return_value=child):
+            self.assertTrue(reconcile(self.owner, "test"))
+        self.assertEqual(self.owner.state["phase"], "waiting")
+        output = {
+            "type": "function_call_output",
+            "call_id": "c1",
+            "output": "Already ran",
+        }
+        self.journal.submit_result(output)
+        request = self.owner.next_request()
+        self.assertEqual(request["input"], [output])
+        self.assertEqual(request["previous_response_id"], "r2")
+        self.assertEqual(usage_totals(self.owner.state)["output_tokens"], 5)
+
+    def test_recovery_of_tool_create_requires_saved_result_evidence(self):
+        self.owner.event(
+            terminal(
+                "r1",
+                output=[
+                    {
+                        "type": "function_call",
+                        "call_id": "c1",
+                        "name": "lookup",
+                        "arguments": "{}",
+                    }
+                ],
+            )
+        )
+        output = {
+            "type": "function_call_output",
+            "call_id": "c1",
+            "output": "Already ran",
+        }
+        self.journal.submit_result(output)
+        self.owner.next_request()
+        self.owner.disconnected("lost tool continuation receipt")
+        child = response("r2", "r1", "completed")
+        child["metadata"] = {"everruns_steering_session": self.owner.state["session"]}
+        with (
+            patch("steering.get_json", return_value=child),
+            patch("steering.input_items", side_effect=[[], []]),
+            self.assertRaises(ValueError),
+        ):
+            reconcile(self.owner, "test", "r2")
+        with (
+            patch("steering.get_json", return_value=child),
+            patch("steering.input_items", side_effect=[[], [output]]),
+        ):
+            self.assertTrue(reconcile(self.owner, "test", "r2"))
+        self.assertEqual(self.owner.state["phase"], "complete")
+
+    def test_required_approval_is_never_inferred(self):
+        self.owner.event(
+            terminal("r1", output=[{"type": "mcp_approval_request", "id": "a1"}])
+        )
+        with self.assertRaises(ValueError):
+            self.journal.submit_result(
+                {"type": "mcp_approval_response", "approval_request_id": "a1"}
+            )
+        with self.assertRaises(ValueError):
+            self.journal.submit_result(
+                {
+                    "type": "mcp_approval_response",
+                    "approval_request_id": "foreign",
+                    "approve": True,
+                }
+            )
+        self.assertIsNone(self.owner.next_request())
+
+    def test_producer_retries_and_second_owner_are_fenced(self):
+        producer = Journal(self.db)
+        try:
+            producer.enqueue("u1", "hello")
+            producer.enqueue("u1", "hello")
+            with self.assertRaises(ValueError):
+                producer.enqueue("u1", "changed")
+            self.owner.next_request()
+            self.assertEqual(len(self.owner.state["intents"]), 1)
+            with (
+                self.journal.ownership(),
+                self.assertRaises(BlockingIOError),
+                producer.ownership(),
+            ):
+                self.fail("Two owners acquired the same journal")
+        finally:
+            producer.db.close()
+
+
+class WireTests(unittest.IsolatedAsyncioTestCase):
+    async def test_automatic_successor_on_original_socket_for_both_parent_endings(self):
+        from websockets.asyncio.server import serve
+
+        for status in ["completed", "incomplete"]:
+            with self.subTest(status=status), tempfile.TemporaryDirectory() as tmp:
+                journal = Journal.create(str(Path(tmp) / "session.db"), "Plan", {})
+                journal.enqueue("u1", "Two weeks only")
+                errors = []
+
+                async def server(socket, ending=status, failures=errors):
+                    try:
+                        self.assertEqual(
+                            json.loads(await socket.recv())["type"], "response.create"
+                        )
+                        await socket.send(json.dumps(created("r1")))
+                        self.assertEqual(
+                            json.loads(await socket.recv())["type"], "response.steer"
+                        )
+                        await socket.send(json.dumps(steer("accepted")))
+                        await socket.send(
+                            json.dumps(
+                                terminal(
+                                    "r1",
+                                    status=ending,
+                                    reason="steered"
+                                    if ending == "incomplete"
+                                    else None,
+                                    tokens=4,
+                                )
+                            )
+                        )
+                        with self.assertRaises(TimeoutError):
+                            await asyncio.wait_for(socket.recv(), 0.05)
+                        await socket.send(json.dumps(created("r2", "r1")))
+                        await socket.send(json.dumps(terminal("r2", "r1", tokens=5)))
+                        await socket.wait_closed()
+                    except (
+                        AssertionError,
+                        OSError,
+                        ValueError,
+                        WebSocketException,
+                    ) as error:
+                        failures.append(error)
+
+                try:
+                    async with serve(server, "127.0.0.1", 0) as listener:
+                        port = listener.sockets[0].getsockname()[1]
+                        with redirect_stdout(io.StringIO()):
+                            await run_owner(
+                                journal, "test", f"ws://127.0.0.1:{port}", True, 5
+                            )
+                    if errors:
+                        raise errors[0]
+                    self.assertEqual(journal.load()["phase"], "complete")
+                    self.assertEqual(journal.load()["intents"][0]["status"], "applied")
+                    self.assertEqual(usage_totals(journal.load())["output_tokens"], 9)
+                finally:
+                    journal.db.close()
+
+    async def test_real_websocket_and_independent_producer_tool_continuation(self):
+        from websockets.asyncio.server import serve
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "journal.db")
+            journal = Journal.create(path, "Draft a plan", {})
+            producer = Journal(path)
+            received = []
+            errors = []
+
+            async def server(socket):
+                try:
+                    received.append(json.loads(await socket.recv()))
+                    self.assertEqual(received[-1]["type"], "response.create")
+                    await socket.send(json.dumps(created("r1")))
+                    process = await asyncio.create_subprocess_exec(
+                        sys.executable,
+                        str(Path(__file__).with_name("steering.py")),
+                        "--db",
+                        path,
+                        "update",
+                        "Two weeks only",
+                        "--id",
+                        "human-update-1",
+                    )
+                    self.assertEqual(await process.wait(), 0)
+                    received.append(json.loads(await socket.recv()))
+                    self.assertEqual(
+                        received[-1],
+                        {
+                            "type": "response.steer",
+                            "previous_response_id": "r1",
+                            "input": "Two weeks only",
+                        },
+                    )
+                    await socket.send(json.dumps(steer("accepted")))
+                    await socket.send(
+                        json.dumps(
+                            terminal(
+                                "r1",
+                                tokens=7,
+                                output=[
+                                    {
+                                        "type": "function_call",
+                                        "call_id": "c1",
+                                        "name": "lookup",
+                                        "arguments": "{}",
+                                    }
+                                ],
+                            )
+                        )
+                    )
+                    await socket.send(
+                        json.dumps(
+                            steer(
+                                "pending",
+                                reason="waiting_for_required_input",
+                                required_input=[
+                                    {
+                                        "type": "function_call_output",
+                                        "call_id": "c1",
+                                        "name": "lookup",
+                                    }
+                                ],
+                            )
+                        )
+                    )
+                    for _ in range(100):
+                        if producer.load()["required"]:
+                            break
+                        await asyncio.sleep(0.01)
+                    producer.submit_result(
+                        {
+                            "type": "function_call_output",
+                            "call_id": "c1",
+                            "output": "Design ready",
+                        }
+                    )
+                    received.append(json.loads(await socket.recv()))
+                    self.assertEqual(
+                        received[-1]["input"],
+                        [
+                            {
+                                "type": "function_call_output",
+                                "call_id": "c1",
+                                "output": "Design ready",
+                            }
+                        ],
+                    )
+                    await socket.send(json.dumps(created("r2", "r1")))
+                    await socket.send(
+                        json.dumps(
+                            terminal(
+                                "r2",
+                                "r1",
+                                tokens=9,
+                                output=[
+                                    {
+                                        "type": "message",
+                                        "role": "assistant",
+                                        "content": [
+                                            {
+                                                "type": "output_text",
+                                                "text": "Two-week plan",
+                                            }
+                                        ],
+                                    }
+                                ],
+                            )
+                        )
+                    )
+                    await socket.wait_closed()
+                except (
+                    AssertionError,
+                    OSError,
+                    ValueError,
+                    WebSocketException,
+                ) as error:
+                    errors.append(error)
+
+            try:
+                async with serve(server, "127.0.0.1", 0) as listener:
+                    port = listener.sockets[0].getsockname()[1]
+                    with redirect_stdout(io.StringIO()):
+                        await run_owner(
+                            journal, "test-key", f"ws://127.0.0.1:{port}", True, 5
+                        )
+                if errors:
+                    raise errors[0]
+                self.assertEqual(len(received), 3)
+                state = journal.load()
+                self.assertEqual(state["phase"], "complete")
+                self.assertEqual(state["intents"][0]["status"], "applied")
+                self.assertEqual(usage_totals(state)["input_tokens"], 16)
+                self.assertEqual(
+                    state["responses"]["r2"]["output"][0]["content"][0]["text"],
+                    "Two-week plan",
+                )
+            finally:
+                producer.db.close()
+                journal.db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/knowledge/execution/index.md
+++ b/knowledge/execution/index.md
@@ -23,3 +23,4 @@
 * [Command Tree Specification](command-tree.md) - The `everruns <noun> <verb>` surface shared by scripted MCP, session shells, and Framework hosts.
 * [Bashkit Requirements for Custom FileSystem Adapters](bashkit-requirements.md) - Bash sandbox capabilities and requirements.
 * [Lua Execution Capability (experimental)](lua-execution.md) - Experimental Lua execution capability (sandboxed VFS scripting; aims to supersede bashkit_shell).
+* [OpenAI Steering Prototype](openai-steering-prototype.md) - Owned WebSocket experiment, durable updates, and recovery tradeoffs.

--- a/knowledge/execution/openai-steering-prototype.md
+++ b/knowledge/execution/openai-steering-prototype.md
@@ -24,6 +24,16 @@ production provider, alter default models, consume production session messages,
 or replace the normal HTTP path. This boundary allows testing the protocol and
 failure semantics before changing the distributed runtime contract.
 
+## Framework example boundary
+
+The [Framework live-session example](../../crates/everruns/examples/live_session.rs)
+provides the supported application path: both initial requests and corrections
+use `Session::send`, receipts distinguish active-turn steering from a follow-up,
+and history retains the user messages. It runs offline or against OpenAI.
+This is iteration-boundary steering over the existing provider transport, not a
+Framework implementation of `response.steer`. The in-memory session does not
+inherit this experiment's SQLite persistence or recovery contract.
+
 ## Ownership and delivery contract
 
 A single owner holds an OS lock for the journal's lifetime and owns one socket,

--- a/knowledge/execution/openai-steering-prototype.md
+++ b/knowledge/execution/openai-steering-prototype.md
@@ -1,0 +1,102 @@
+---
+type: Specification
+title: OpenAI Steering Prototype
+description: A bounded experiment for durable user updates on an explicitly owned OpenAI WebSocket connection.
+tags:
+  - everruns
+  - execution
+  - openai
+---
+
+# OpenAI Steering Prototype
+
+## Why revisit WebSockets
+
+Mid-turn user corrections are a concrete benefit unavailable through the current
+HTTP reason activity. The normal worker consumes persisted user-message wakes at
+activity boundaries (see [the worker boundary](../../crates/worker/src/unified_worker.rs)
+and [durable runner](../../crates/worker/src/durable_runner.rs)). A socket cannot
+follow arbitrary activity placement across stateless workers.
+
+The [runnable prototype](../../examples/openai-steering/README.md) therefore has
+an explicit, single-host owner process and durable inbox. It does not register a
+production provider, alter default models, consume production session messages,
+or replace the normal HTTP path. This boundary allows testing the protocol and
+failure semantics before changing the distributed runtime contract.
+
+## Ownership and delivery contract
+
+A single owner holds an OS lock for the journal's lifetime and owns one socket,
+one default lane, and one response chain. Independent producer processes submit
+user updates and completed tool results to SQLite; they never acquire a socket.
+Producer retries use stable local message IDs. A paused owner retains its lock,
+so another process cannot take over while the old connection remains alive.
+This is a same-host worker experiment, not a distributed SQLite deployment.
+
+The owner durably records each submission before sending it. Only one steering
+submission awaits commitment at a time; further user updates queue locally.
+Acceptance is not application. The successor's creation commits accepted input;
+the original may end incomplete because it was steered or complete normally.
+Neither event alone completes the logical work while steering is outstanding.
+Terminal responses and their usage remain keyed by response ID, so interrupted
+parents and successors contribute once each. Raw provider events and final
+outputs remain in the private journal for inspection.
+
+Client-owned tools and approvals keep accepted steering queued. The owner waits
+for saved results and sends one explicit continuation with the original settings,
+without repeating accepted input. Tools execute outside the owner: steering does
+not cancel or rerun them. The prototype supports synchronous function/custom
+results and explicit MCP approval decisions. Unsupported required input remains
+visible and blocked; it must not be guessed or auto-approved.
+
+## Recovery and its irreducible ambiguity
+
+Stored response IDs allow HTTP retrieval after owner failure. A known successor
+can be reconciled and its terminal usage recovered before continuing on a new
+socket. A supplied successor must belong to the recorded session and parent;
+its retrieved user-input history must prove the unresolved update appears exactly
+once. A failure event preserves the rejected update and error for a user's next
+decision. It does not silently discard or automatically retry invalid input.
+
+There is no steering client idempotency key and no documented lookup of an
+unknown successor by parent. A send without acknowledgement, or acceptance
+without a durably observed successor, is therefore ambiguous after a disconnect.
+Absence from the parent response is not evidence of rejection: the accepted
+queue is connection-local. The prototype preserves these intentions as uncertain,
+blocks replay, and exposes the need for reconciliation. It deliberately cannot
+promise automatic progress through that crash window. This trades availability
+for avoiding silent loss or duplicate application. Provider support for successor
+discovery or durable steering receipts would materially improve recovery.
+
+## Production adoption bar
+
+A production path needs a separately fenced distributed owner service (or a
+long-lived leased activity), durable inbox/outbox operations over the existing
+control-plane store, authenticated session-scoped routing from message ingress,
+and result/event projection back into the runtime. The existing boundary consumer
+must exclude inputs committed by steering, otherwise the next reason activity
+would replay them. An owner replacement must reconcile before claiming work;
+expiring a lease alone does not prevent the old socket from sending.
+
+Also required: multi-host failure tests, integration with existing tool execution
+and approval policy, billing projection across successor responses, bounded event
+retention, and a user-visible unresolved-delivery state. These are promotion
+requirements, not capabilities claimed by the isolated prototype.
+
+## Evidence and references
+
+[Executable tests](../../examples/openai-steering/test_steering.py) cover event
+sequences, saved tool/approval continuation, producer deduplication, ownership,
+usage aggregation, and recovery. The example includes an optional billable
+[live smoke check](../../examples/openai-steering/live_smoke.py).
+
+Official API contracts verified on 2026-09-05:
+
+- [GPT-6 Astra](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra)
+- [Steering](https://developers.openai.com/api/docs/guides/steering)
+- [WebSocket events](https://developers.openai.com/api/reference/resources/responses/websocket-events)
+- [WebSocket recovery](https://developers.openai.com/api/docs/guides/websocket-mode#reconnect-and-recover)
+
+The current WebSocket guide supports concurrent named lanes, superseding the
+historical single-in-flight-per-connection limitation. This experiment intentionally
+keeps a single lane; multiplexing does not solve ownership or ambiguous delivery.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -49,6 +49,13 @@
   hundreds of commands had to forbid it. See
   [Command Tree](execution/command-tree.md).
 
+## 2026-09-08
+
+* The Framework live-session example now offers offline and live OpenAI modes,
+  configurable corrections, and transcript inspection. Its iteration-boundary
+  `Session::send` behavior remains distinct from the isolated WebSocket steering
+ experiment. See [the steering boundary](execution/openai-steering-prototype.md).
+
 ## 2026-09-05
 
 * Astra reasoning changes preserve the initial request effort, persist effective

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -62,6 +62,12 @@
   connector registration from the Framework dependency graph. See
   [Framework application boundaries](framework/application-api.md).
 
+* **Mid-turn correction justifies revisiting socket ownership.** The isolated
+  OpenAI steering prototype uses a durable inbox and explicit single-host owner.
+  Acceptance remains queued until a successor is created; ambiguous disconnects
+  block replay until history proves commitment. Normal workers continue over
+  HTTP. See `knowledge/execution/openai-steering-prototype.md`.
+
 ## 2026-09-01
 
 * **A model switch is a conversation event, not a setting.** Changing the model

--- a/knowledge/project/dismissed-options.md
+++ b/knowledge/project/dismissed-options.md
@@ -134,7 +134,7 @@ execution keys.
 
 ## OpenAI WebSocket Transport
 
-**Status**: Dismissed (Phase 1 plumbing retained)
+**Status**: Revisited for an isolated mid-turn steering prototype; HTTP remains production transport
 
 **What it was**: OpenAI's Responses API supports a WebSocket transport (`wss://api.openai.com/v1/responses`) that eliminates per-request HTTP overhead and enables incremental input across multi-turn tool-calling workflows by keeping a persistent connection.
 
@@ -144,7 +144,7 @@ execution keys.
 - **Horizontal scaling conflict**: Workers are stateless (`SKIP LOCKED`, no affinity). Activities within a turn can land on different workers. WebSocket connections are inherently stateful and pinned to a single process, contradicting the architecture.
 - **`store=true` already works cross-worker**: With `previous_response_id` over HTTP (Phase 1), OpenAI hydrates cached context from disk. This gives the same latency benefit (skip re-encoding) without requiring connection affinity.
 - **Operational complexity**: Connection lifecycle management (60-min limit, reconnection, error fallback), connection pooling, and worker-affinity routing add significant complexity for marginal latency gain.
-- **Single concurrent response per connection**: Each WebSocket connection supports only one in-flight response, limiting throughput per connection.
+- **Historical concurrency limit**: The original evaluation assumed one in-flight response per connection. The current API supports concurrent named lanes; the single-lane ordering constraint remains. Multiplexing does not solve cross-worker ownership.
 
 **What we use instead**: `previous_response_id` threading over standard HTTP (Responses API with `store=true`):
 - Response IDs flow through `ReasonResult` → turn loop → `ReasonInput` → `LlmCallConfig` → `ResponsesRequest`
@@ -152,10 +152,12 @@ execution keys.
 - OpenAI server-side context caching reduces re-encoding cost
 - No additional infrastructure or connection management needed
 
-**May revisit when**:
-- Worker affinity routing is implemented for other reasons
-- WebSocket transport supports multiple concurrent responses
-- Benchmarks show HTTP connection overhead is a meaningful bottleneck
+**What changed**: GPT-6 Astra supports user corrections while a response is running,
+a feature benefit beyond transport latency. The [steering prototype](../execution/openai-steering-prototype.md)
+uses an explicit same-host owner and durable inbox to test delivery, tool/approval
+continuation, accounting, and disconnect reconciliation. It does not change normal
+worker routing or global defaults. That concept owns the production adoption bar
+and the unresolved send/ack recovery limitation.
 
 ## Lowering `codegen-units` for smaller rlibs
 


### PR DESCRIPTION
## What changed

Add an opt-in GPT-6 Astra WebSocket steering prototype with a single owner, durable local inbox, saved tool and approval continuation, usage accounting, recovery checks, and CI coverage. Add a runnable Everruns Framework session example showing the supported iteration-boundary correction flow.

## Why

Users can correct a running workflow without waiting for a final answer. The standalone prototype validates OpenAI's `response.steer` protocol while the Framework example gives application authors a supported path today.

## Before / After

Before: no runnable owned WebSocket steering experiment existed, and the Framework live-session example only used a fixed simulated request.

After: the standalone test suite runs a real loopback socket and a separate CLI producer, exercises accepted/pending/failed steering, tool and approval continuation, recovery, and successor usage. The Framework example accepts a request and correction through `Session::send`, prints the answer and saved transcript, and supports an opt-in GPT-6 Astra mode.

Evidence:

```text
cargo run -p everruns --example live_session -- 'Draft a release plan.' 'Keep scope to one feature.'
Accepted into the active turn.
Answer: Echo: Keep scope to one feature.
Iterations in the resulting turn: 2

PYTHONPATH=/private/tmp/everruns-websocket-deps-20260911 python3 -m unittest discover -s examples/openai-steering -v
Ran 17 tests
OK

just pre-push
All pre-push checks passed.
```

The OpenAI-enabled Framework example builds. Live OpenAI successor completion remains unverified: the recorded live attempt received `response.steer.accepted`, then the account returned `credit_balance_exhausted`. No UI changed.

## Risk

- Medium for the opt-in prototype; it does not change the normal HTTP driver or global defaults.
- Unacknowledged sends or unknown successors are retained as uncertain and never replayed automatically.
- The prototype is same-host only. Distributed ownership, Framework session integration, and durable event projection require a separate design and implementation.

## Security

- Threat categories reviewed: TM-FS, TM-SQL, TM-LLM, TM-TOOL, TM-DOS.
- Findings and resolutions: owner-only journal and lock permissions; parameterized SQLite values; API keys are read from the environment and never journaled; tools are not executed or rerun by the owner; approvals require matching IDs and an explicit boolean; duplicate inputs/results are rejected; the socket has exclusive ownership and a message-size bound. The CI workflow uses read-only contents permission and no API credentials.

## Follow-ups

No in-scope implementation follow-ups. Re-run the optional live smoke test when credits are available. Production distributed ownership, session ingress, and billing/event projection need a separately scoped feature.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
