### PR TITLE
fix(server): claim session schedules atomically so replicas cannot double-fire

### DIFF
--- a/crates/server/migrations/127_session_schedule_claim_lease.sql
+++ b/crates/server/migrations/127_session_schedule_claim_lease.sql
@@ -1,0 +1,20 @@
+-- Session schedule claim lease: make the poller safe to run on more than one
+-- server instance.
+--
+-- `claim_due_session_schedules` selected due rows with `FOR UPDATE SKIP LOCKED`
+-- but ran the statement straight on the pool, so its implicit transaction
+-- committed and released the row locks before the caller had advanced
+-- `next_trigger_at`. Nothing recorded that a row had been picked up, so a
+-- second instance polling in that window saw the same schedules as still due
+-- and fired them again: duplicate agent turns and duplicate monitor probes.
+--
+-- These columns let the claim be a single atomic statement that both selects
+-- and stamps the row, the same shape `durable_schedules` already uses. A claim
+-- is a lease rather than a permanent mark, so an instance that dies mid-fire
+-- releases its schedules once the lease ages out instead of stranding them.
+--
+-- No index is added: idx_session_schedules_polling already covers the
+-- (enabled, next_trigger_at) predicate this claim filters on.
+ALTER TABLE session_schedules
+    ADD COLUMN claimed_by TEXT,
+    ADD COLUMN claimed_at TIMESTAMPTZ;

--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -74,6 +74,11 @@ pub fn spawn_session_scheduler(
     probe_tool_registry: Option<Arc<ToolRegistry>>,
     poll_interval: Duration,
 ) -> JoinHandle<()> {
+    // One identity per process, stamped on every schedule this instance claims.
+    // Servers do not coordinate outside the database, so the claim lease is the
+    // only thing stopping two instances from firing the same schedule.
+    let scheduler_id = format!("session-scheduler-{}", uuid::Uuid::now_v7());
+
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(poll_interval);
         // Skip the immediate first tick — let the server finish starting.
@@ -81,6 +86,7 @@ pub fn spawn_session_scheduler(
 
         tracing::info!(
             poll_interval_secs = poll_interval.as_secs(),
+            scheduler_id = %scheduler_id,
             "Started session schedule poller"
         );
 
@@ -92,6 +98,7 @@ pub fn spawn_session_scheduler(
             interval.tick().await;
             if let Err(e) = poll_and_trigger(
                 &db,
+                &scheduler_id,
                 &schedule_service,
                 &event_service,
                 &runner,
@@ -119,6 +126,7 @@ pub fn spawn_session_scheduler(
 /// One iteration of the poll loop.
 async fn poll_and_trigger(
     db: &Arc<StorageBackend>,
+    scheduler_id: &str,
     schedule_service: &Arc<SessionScheduleService>,
     event_service: &Arc<EventService>,
     runner: &Arc<dyn AgentRunner>,
@@ -130,7 +138,7 @@ async fn poll_and_trigger(
     let task_registry =
         DbSessionTaskRegistry::new(db.clone()).with_event_emitter(event_service.clone());
 
-    let due = db.claim_due_session_schedules(10).await?;
+    let due = db.claim_due_session_schedules(scheduler_id, 10).await?;
     if due.is_empty() {
         return Ok(());
     }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3635,8 +3635,12 @@ impl StorageBackend {
         dispatch!(self, count_active_org_session_schedules, org_id)
     }
 
-    pub async fn claim_due_session_schedules(&self, limit: i32) -> Result<Vec<SessionScheduleRow>> {
-        dispatch!(self, claim_due_session_schedules, limit)
+    pub async fn claim_due_session_schedules(
+        &self,
+        scheduler_id: &str,
+        limit: i32,
+    ) -> Result<Vec<SessionScheduleRow>> {
+        dispatch!(self, claim_due_session_schedules, scheduler_id, limit)
     }
 
     // ============================================

--- a/crates/server/src/storage/memory/schedules.rs
+++ b/crates/server/src/storage/memory/schedules.rs
@@ -37,6 +37,8 @@ impl InMemoryDatabase {
             next_trigger_at: input.next_trigger_at,
             last_triggered_at: None,
             trigger_count: 0,
+            claimed_by: None,
+            claimed_at: None,
             created_at: now,
             updated_at: now,
         };
@@ -83,6 +85,8 @@ impl InMemoryDatabase {
             next_trigger_at: input.next_trigger_at,
             last_triggered_at: None,
             trigger_count: 0,
+            claimed_by: None,
+            claimed_at: None,
             created_at: now,
             updated_at: now,
         };
@@ -179,16 +183,39 @@ impl InMemoryDatabase {
         Ok(count as u32)
     }
 
-    pub async fn claim_due_session_schedules(&self, limit: i32) -> Result<Vec<SessionScheduleRow>> {
+    /// Claim due session schedules, stamping a lease exactly as the Postgres
+    /// backend does so the two cannot diverge in behaviour.
+    pub async fn claim_due_session_schedules(
+        &self,
+        scheduler_id: &str,
+        limit: i32,
+    ) -> Result<Vec<SessionScheduleRow>> {
         let now = Self::now();
-        let schedules = self.session_schedules.read();
+        let lease_cutoff =
+            now - chrono::Duration::seconds(SESSION_SCHEDULE_CLAIM_LEASE_SECONDS as i64);
+
+        let mut schedules = self.session_schedules.write();
         let mut due: Vec<_> = schedules
             .values()
-            .filter(|r| r.enabled && r.next_trigger_at.is_some_and(|t| t <= now))
+            .filter(|r| {
+                r.enabled
+                    && r.next_trigger_at.is_some_and(|t| t <= now)
+                    && (r.claimed_by.is_none() || r.claimed_at.is_none_or(|at| at < lease_cutoff))
+            })
             .cloned()
             .collect();
         due.sort_by_key(|schedule| schedule.next_trigger_at);
         due.truncate(limit as usize);
+
+        for schedule in &mut due {
+            schedule.claimed_by = Some(scheduler_id.to_string());
+            schedule.claimed_at = Some(now);
+            if let Some(stored) = schedules.get_mut(&schedule.id) {
+                stored.claimed_by = schedule.claimed_by.clone();
+                stored.claimed_at = schedule.claimed_at;
+            }
+        }
+
         Ok(due)
     }
 

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -2341,6 +2341,15 @@ pub struct CreateAgentIdentityConnectionRow {
 // Session Schedule models
 // ============================================
 
+/// How long a session schedule claim is honoured before another instance may
+/// take it over.
+///
+/// Short on purpose: the claim only has to survive until the poller advances
+/// `next_trigger_at`, which is the first thing it does with a claimed row. A
+/// long lease would instead mean an instance that died mid-fire stranded its
+/// schedules for that long.
+pub const SESSION_SCHEDULE_CLAIM_LEASE_SECONDS: i32 = 30;
+
 #[derive(Debug, Clone, FromRow, serde::Serialize)]
 pub struct SessionScheduleRow {
     pub id: ScheduleId,
@@ -2358,6 +2367,14 @@ pub struct SessionScheduleRow {
     pub next_trigger_at: Option<DateTime<Utc>>,
     pub last_triggered_at: Option<DateTime<Utc>>,
     pub trigger_count: i32,
+    /// Scheduler instance holding the current claim lease, if any.
+    #[sqlx(default)]
+    pub claimed_by: Option<String>,
+    /// When the current claim was taken. A claim older than the claim lease
+    /// (see `SESSION_SCHEDULE_CLAIM_LEASE_SECONDS`) is reclaimable by any
+    /// instance, so an instance that dies mid-fire does not strand a schedule.
+    #[sqlx(default)]
+    pub claimed_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/crates/server/src/storage/repositories/schedules.rs
+++ b/crates/server/src/storage/repositories/schedules.rs
@@ -202,19 +202,51 @@ impl Database {
 
     /// Claim due session schedules for processing.
     /// Uses SELECT FOR UPDATE SKIP LOCKED for multi-instance safety.
-    pub async fn claim_due_session_schedules(&self, limit: i32) -> Result<Vec<SessionScheduleRow>> {
+    /// Claim due session schedules for this instance.
+    ///
+    /// Selecting and stamping in ONE statement is the whole point. The previous
+    /// implementation ran a bare `SELECT ... FOR UPDATE SKIP LOCKED` straight on
+    /// the pool: its implicit transaction committed as soon as the query
+    /// returned, releasing the row locks long before the caller advanced
+    /// `next_trigger_at`, and nothing recorded that a row had been picked up. A
+    /// second server instance polling in that window saw the same schedules as
+    /// still due and fired them again -- duplicate agent turns and duplicate
+    /// model spend. Mirrors the durable scheduler's claim in
+    /// `crates/durable/src/persistence/postgres.rs`.
+    ///
+    /// The claim is a lease, not a permanent mark: an instance that dies between
+    /// claiming and firing releases its schedules once the lease ages out.
+    pub async fn claim_due_session_schedules(
+        &self,
+        scheduler_id: &str,
+        limit: i32,
+    ) -> Result<Vec<SessionScheduleRow>> {
         let rows = sqlx::query_as::<_, SessionScheduleRow>(
             r#"
-            SELECT * FROM session_schedules
-            WHERE enabled = true
-              AND next_trigger_at IS NOT NULL
-              AND next_trigger_at <= NOW()
-            ORDER BY next_trigger_at ASC
-            LIMIT $1
-            FOR UPDATE SKIP LOCKED
+            WITH due AS (
+                SELECT id FROM session_schedules
+                WHERE enabled = true
+                  AND next_trigger_at IS NOT NULL
+                  AND next_trigger_at <= NOW()
+                  AND (
+                      claimed_by IS NULL
+                      OR claimed_at IS NULL
+                      OR claimed_at < NOW() - ($3 * INTERVAL '1 second')
+                  )
+                ORDER BY next_trigger_at ASC
+                LIMIT $2
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE session_schedules s
+            SET claimed_by = $1, claimed_at = NOW()
+            FROM due d
+            WHERE s.id = d.id
+            RETURNING s.*
             "#,
         )
+        .bind(scheduler_id)
         .bind(limit)
+        .bind(SESSION_SCHEDULE_CLAIM_LEASE_SECONDS)
         .fetch_all(&self.pool)
         .await?;
 

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -4231,3 +4231,173 @@ async fn eval_case_results_detach_from_deleted_sessions() {
         "eval_case_results.session_id must be ON DELETE SET NULL, not restricting"
     );
 }
+
+// ============================================
+// Session Schedule Claim Lease
+// ============================================
+
+/// Create a session plus `count` schedules that are already overdue.
+///
+/// `next_trigger_at` is set far in the past so these rows sort ahead of any
+/// other due schedule left behind by another test, which keeps them inside the
+/// first claim batch regardless of what else is in the table.
+async fn seed_overdue_schedules(
+    backend: &StorageBackend,
+    label: &str,
+    count: usize,
+) -> Vec<everruns_provider::typed_id::ScheduleId> {
+    let owner_principal_id = create_test_principal(backend, TEST_ORG_ID).await;
+    let session = backend
+        .create_session(CreateSessionRow {
+            source: everruns_platform::SessionSource::Api,
+            workspace_id: None,
+            org_id: TEST_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: None,
+            agent_version_id: None,
+            agent_config_hash: None,
+            agent_identity_id: None,
+            owner_principal_id,
+            resolved_owner_user_id: None,
+            title: Some(format!("{label}-{}", Uuid::now_v7())),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            parallel_tool_calls: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+            budget_root_session_id: None,
+        })
+        .await
+        .expect("Failed to create test session");
+
+    let mut ids = Vec::with_capacity(count);
+    for index in 0..count {
+        let schedule = backend
+            .create_session_schedule(CreateSessionScheduleRow {
+                org_id: TEST_ORG_ID,
+                session_id: session.id,
+                owner_principal_id,
+                resolved_owner_user_id: None,
+                description: format!("{label}-{index}-{}", Uuid::now_v7()),
+                cron_expression: Some("0 * * * *".to_string()),
+                scheduled_at: None,
+                timezone: "UTC".to_string(),
+                next_trigger_at: Some(Utc::now() - chrono::Duration::days(3650)),
+            })
+            .await
+            .expect("Failed to create overdue schedule");
+        ids.push(schedule.id);
+    }
+    ids
+}
+
+/// A schedule handed to one instance must not also be handed to another.
+///
+/// The poller runs inside the server process, so two server replicas poll the
+/// same table with no coordination outside the database. Before the claim
+/// lease, `claim_due_session_schedules` selected with `FOR UPDATE SKIP LOCKED`
+/// but ran on the pool, so the implicit transaction committed and dropped the
+/// row locks before the caller advanced `next_trigger_at` -- and both instances
+/// fired the same schedule. That is a duplicate agent turn and duplicate
+/// (customer-funded) model spend, so it is asserted directly.
+///
+/// Sequential calls are enough: the defect is the absence of any recorded
+/// claim, not a narrow interleaving.
+#[tokio::test]
+async fn claim_due_session_schedules_is_exclusive_across_instances_pg() {
+    use std::collections::HashSet;
+
+    let backend = create_test_backend().await;
+    let seeded: HashSet<_> = seed_overdue_schedules(&backend, "claim-exclusive", 3)
+        .await
+        .into_iter()
+        .collect();
+
+    let first: HashSet<_> = backend
+        .claim_due_session_schedules("instance-a", 500)
+        .await
+        .expect("first claim failed")
+        .into_iter()
+        .map(|row| row.id)
+        .filter(|id| seeded.contains(id))
+        .collect();
+    assert_eq!(
+        first.len(),
+        seeded.len(),
+        "the first instance should claim every overdue schedule this test seeded"
+    );
+
+    let second: Vec<_> = backend
+        .claim_due_session_schedules("instance-b", 500)
+        .await
+        .expect("second claim failed")
+        .into_iter()
+        .map(|row| row.id)
+        .filter(|id| first.contains(id))
+        .collect();
+
+    assert!(
+        second.is_empty(),
+        "schedules {second:?} were claimed by two instances at once; each would fire \
+         its session turn twice"
+    );
+}
+
+/// A claim is a lease, not a permanent mark.
+///
+/// An instance that dies between claiming a schedule and firing it must not
+/// strand that schedule forever. Once the lease ages out, another instance
+/// takes it over.
+#[tokio::test]
+async fn expired_session_schedule_claim_is_reclaimable_pg() {
+    let backend = create_test_backend().await;
+    let pool = create_test_pool().await;
+    let seeded = seed_overdue_schedules(&backend, "claim-lease-expiry", 1).await;
+    let schedule_id = seeded[0];
+
+    let claimed: Vec<_> = backend
+        .claim_due_session_schedules("instance-a", 500)
+        .await
+        .expect("first claim failed")
+        .into_iter()
+        .map(|row| row.id)
+        .filter(|id| *id == schedule_id)
+        .collect();
+    assert_eq!(claimed.len(), 1, "the schedule should be claimed once");
+
+    // Simulate an instance that took the claim and then died.
+    sqlx::query(
+        "UPDATE session_schedules SET claimed_at = NOW() - INTERVAL '1 hour' WHERE id = $1",
+    )
+    .bind(schedule_id)
+    .execute(&pool)
+    .await
+    .expect("failed to age the claim");
+
+    let reclaimed: Vec<_> = backend
+        .claim_due_session_schedules("instance-b", 500)
+        .await
+        .expect("reclaim failed")
+        .into_iter()
+        .map(|row| row.id)
+        .filter(|id| *id == schedule_id)
+        .collect();
+
+    assert_eq!(
+        reclaimed.len(),
+        1,
+        "a schedule whose claim lease expired must be reclaimable, or an instance \
+         that died mid-fire strands it forever"
+    );
+}

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,20 @@
 
 ## 2026-09-11
 
+* **Session schedules are now safe to poll from more than one server
+  instance.** `claim_due_session_schedules` selected due rows with
+  `FOR UPDATE SKIP LOCKED` but ran the statement on the pool, so the implicit
+  transaction committed and released the row locks before the caller advanced
+  `next_trigger_at`, and nothing recorded that a row had been picked up. Two
+  instances both saw the same schedules as due and both fired them: duplicate
+  agent turns, duplicate monitor probes, duplicate model spend. `mark_triggered`
+  was no backstop either, being an unguarded read-then-write with no
+  compare-and-swap. The claim is now a single atomic statement that stamps
+  `claimed_by`/`claimed_at`, the shape `durable_schedules` already used, and it
+  is a lease so an instance that dies mid-fire does not strand its schedules.
+  Both storage backends implement it. Found while validating a downstream
+  zero-downtime rollout that wanted two server replicas.
+
 * **Test fixtures live with the crate that owns them, and never ship.** The
   root `testdata/` and `tests/` trees each held a single fixture set. Plugin
   marketplace fixtures moved to `crates/core/testdata/plugins/` (core owns the

--- a/knowledge/runtime-resources/session-tasks.md
+++ b/knowledge/runtime-resources/session-tasks.md
@@ -204,6 +204,39 @@ or the API cancel endpoint), the session scheduler's periodic reconciliation swe
 (`state_detail: "schedule canceled"`). Prefer `cancel_task` or `POST …/cancel`
 when both atomicity and immediacy matter.
 
+## Session scheduler multi-instance safety
+
+The session schedule poller runs inside the server process, so every server
+instance polls the same `session_schedules` table and they coordinate only
+through the database. A schedule firing twice is not a cosmetic duplicate: it
+starts a second agent turn or re-runs a monitor probe, and the model spend is
+the operator's or tenant's.
+
+Exclusivity therefore rests on one property: a due schedule is selected and
+stamped in a **single** statement, which sets `claimed_by` to the polling
+instance's identity and `claimed_at` to now. `FOR UPDATE SKIP LOCKED` alone is
+not enough — run on a pool rather than inside an open transaction, its row
+locks release as soon as the statement commits, which is before the poller has
+advanced `next_trigger_at`. A second instance polling in that window sees the
+same rows as still due. This is the shape
+[the durable execution engine](../operations/durable-execution-engine.md)
+already uses for `durable_schedules`.
+
+The claim is a **lease**, not a permanent mark. An instance that claims a
+schedule and then dies must not strand it, so a claim older than
+`SESSION_SCHEDULE_CLAIM_LEASE_SECONDS` is reclaimable by any instance. The
+lease is deliberately short, because a claim only has to survive until the
+poller advances `next_trigger_at` — the first thing it does with a claimed row.
+Once `next_trigger_at` moves into the future the row is no longer due and the
+stale claim is inert.
+
+Both storage backends implement the lease, so the in-memory backend cannot
+drift from Postgres semantics under test. Exclusivity and lease takeover are
+covered by `claim_due_session_schedules_is_exclusive_across_instances_pg` and
+`expired_session_schedule_claim_is_reclaimable_pg`; the equivalent contract for
+durable schedules is
+[TC008](../test-cases/api/scheduled_tasks/TC008_horizontal_scaling.md).
+
 ## Results and artifacts
 
 Results are modeled apart from status:


### PR DESCRIPTION
## What changed

Running the server on more than one instance no longer fires every due session schedule once per instance. A due schedule is now selected and stamped in a single atomic statement, so exactly one instance gets it.

The claim is a **lease**, not a permanent mark: an instance that claims a schedule and then dies releases it once the lease ages out, instead of stranding it. Each server process stamps its own identity, mirroring the durable scheduler.

Both storage backends implement the lease, so the in-memory backend cannot drift from Postgres semantics under test.

## Why

`claim_due_session_schedules` did not actually claim. It selected due rows with `FOR UPDATE SKIP LOCKED` but ran the statement straight on the pool:

```rust
.bind(limit)
.fetch_all(&self.pool)   // no transaction
.await?;
```

`FOR UPDATE SKIP LOCKED` only excludes concurrent readers while the locking transaction is open. `fetch_all(&self.pool)` runs in its own implicit transaction, which commits the moment the query returns — so the row locks were released before the caller had done anything with the rows. The caller then advanced the trigger in a *separate* round trip, and `session_schedules` had no `claimed_by`/`claimed_at` columns, so nothing recorded that a row had been picked up. A second instance polling in that window saw the same schedules as still due and fired them too.

That is not a cosmetic duplicate: it starts a second agent turn or re-runs a monitor probe, and the model spend is the operator's or tenant's.

`mark_triggered` was not a backstop either — it is an unguarded read-then-write (`get_session_schedule` then `update_session_schedule`) with no compare-and-swap on `next_trigger_at`, so both instances wrote and both incremented `trigger_count`.

This shape already exists and is already correct one crate over. `crates/durable/src/persistence/postgres.rs` claims `durable_schedules` with one statement that selects and stamps a 30s lease, and `crates/durable/src/scheduler/mod.rs` documents "Multi-instance coordination via `SELECT ... FOR UPDATE SKIP LOCKED`". `session_schedules` never got the same treatment. This PR brings it in line.

## Before / After

The new test seeds three overdue schedules and has two instances claim in turn. Against the previous implementation, both instances get all three:

```
$ cargo test -p everruns-server --test repository_integration_test -- claim
test claim_due_session_schedules_is_exclusive_across_instances_pg ... FAILED

panicked at crates/server/tests/repository_integration_test.rs:4350:
schedules [ScheduleIdMarker(sched_01a092da1c4872d993c7f5781fd1e170),
           ScheduleIdMarker(sched_01a092da1c4a700ab9f98d917e0f2343),
           ScheduleIdMarker(sched_01a092da1c5071a8a83e7345ea32dc4c)]
were claimed by two instances at once; each would fire its session turn twice
```

After:

```
$ cargo test -p everruns-server --test repository_integration_test -- claim
test claim_due_session_schedules_is_exclusive_across_instances_pg ... ok
test expired_session_schedule_claim_is_reclaimable_pg ... ok
test result: ok. 2 passed; 0 failed
```

Full suite for the touched surface, and the repo gate:

```
$ cargo test -p everruns-server --test repository_integration_test -- --test-threads=1
test result: ok. 41 passed; 0 failed; 0 ignored

$ ./scripts/lib/pre-push.sh
   ✅ cargo fmt
   ✅ clippy
   ✅ migrations sequential (001..127)
   ✅ existing migrations unchanged
   ✅ knowledge: OKF v0.2 conformant (345 concepts, 81 index files, 1 log files)
   … 19 checks green …
✅ All pre-push checks passed.
```

Sequential calls are enough to demonstrate the defect — it is the absence of any recorded claim, not a narrow interleaving — which also makes the test deterministic rather than timing-dependent.

## Risk

- **Low.** One query replaced by an equivalent that additionally stamps two new nullable columns, plus one added parameter threaded through the backend dispatch and the poller.
- **Single-instance behaviour is unchanged in effect.** One poller claims its own rows and immediately advances `next_trigger_at`; the stale claim is then inert because the row is no longer due.
- **The lease bounds the worst case.** If an instance dies after claiming, its schedules are delayed by at most the lease rather than lost. A too-short lease could in principle let a second instance take a schedule while the first is still firing it; the window is bounded by the time between the claim and `mark_triggered`, which is the first thing the poller does with a claimed row.
- **Migration is additive** — two nullable columns, no backfill, no rewrite. No new index: `idx_session_schedules_polling` already covers the `(enabled, next_trigger_at)` predicate the claim filters on.
- The in-memory backend now also stamps claims, so a test asserting that repeated claims return the same rows would change behaviour. None does; the full repository suite passes.

## Security

- Threat categories reviewed: no new external surface. No auth, authorization, API, or network boundary changes; the added parameter is a process-local scheduler identity, never user input. The change **narrows** an availability/correctness failure that let duplicate agent turns and duplicate tenant-funded model spend be triggered by running a second replica.
- Findings and resolutions: none.

## Follow-ups

No follow-ups. The equivalent contract for durable schedules is already covered by [TC008](knowledge/test-cases/api/scheduled_tasks/TC008_horizontal_scaling.md); session schedules had no such coverage, which is why the gap survived, and the two new tests close it.

## Checklist
- [x] Tests added or updated — exclusivity test written first and confirmed failing against the old implementation, plus lease-takeover coverage
- [x] Backward compatibility considered — additive nullable columns, no backfill; single-instance behaviour effectively unchanged
- [x] Security review performed against relevant threat model categories — no security-relevant surface; the change removes a duplicate-spend failure mode
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code)_