### PR TITLE
fix(discovery): surface argument constraints in create_agent/session/message descriptions

### DIFF
--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -265,7 +265,7 @@ impl Command for CreateAgent {
         CommandMeta {
             name: "create_agent",
             category: "agents",
-            description: "Create a new agent with a name, system prompt, and optional capabilities.",
+            description: "Create a new agent with a name, system prompt, and optional capabilities. Agent name must contain only lowercase letters, digits, and hyphens (e.g. joke-telling-agent).",
             method: "POST",
             path: "/v1/agents",
         }

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -36,7 +36,7 @@ impl Command for CreateMessage {
         CommandMeta {
             name: "create_message",
             category: "messages",
-            description: "Create a user message in a session and start the next run.",
+            description: "Create a user message in a session and start the next run. The message content is an array of content parts, e.g. --content '[{\"type\":\"text\",\"text\":\"Tell me a short, family-friendly joke.\"}]'.",
             method: "POST",
             path: "/v1/sessions/{session_id}/messages",
         }

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -65,7 +65,7 @@ impl Command for CreateSession {
         CommandMeta {
             name: "create_session",
             category: "sessions",
-            description: "Create a new session. Optionally assign an agent and harness.",
+            description: "Create a new session. Optionally assign an agent and harness. Assign the agent with --agent_id or --agent_name (the everruns CLI spelling of this flag is --agent).",
             method: "POST",
             path: "/v1/sessions",
         }

--- a/crates/server/src/services/platform_command_surface.rs
+++ b/crates/server/src/services/platform_command_surface.rs
@@ -537,6 +537,33 @@ mod tests {
     }
 
     #[test]
+    fn discovery_descriptions_carry_argument_constraints() {
+        // Each op below caused a failed first agent attempt (agent-name casing,
+        // --agent vs --agent_id, string vs content array), so its description
+        // carries the constraint inline. Exact-name lookups mirror the agent flow:
+        // a broad discover pass, then fetching the single op before invoking it.
+        let cases = [
+            ("create_agent", "lowercase letters, digits, and hyphens"),
+            ("create_session", "--agent_id or --agent_name"),
+            ("create_message", "array of content parts"),
+        ];
+        for (query, hint) in cases {
+            let output = discover_for_test(&serde_json::json!({ "query": query }))
+                .expect("discover JSON output");
+            let value: Value = serde_json::from_str(&output).expect("discover JSON");
+            let operations = value["operations"].as_array().unwrap();
+            assert!(
+                operations.iter().any(|operation| {
+                    operation["description"]
+                        .as_str()
+                        .is_some_and(|description| description.contains(hint))
+                }),
+                "discover '{query}' must surface the hint '{hint}': {value}"
+            );
+        }
+    }
+
+    #[test]
     fn a_flat_command_still_carries_its_usage() {
         // No `cli` spelling means no `--help` to defer to, so discovery stays
         // the only place its flags are written down.


### PR DESCRIPTION
## What changed
Discover descriptions for the three operations agents use to spin up a chat flow now carry their argument constraints inline: lowercase-hyphen agent names (`create_agent`), `--agent_id` / `--agent_name` vs the CLI `--agent` spelling (`create_session`), and content as an array of parts with an example payload (`create_message`). Plus a regression test asserting discover output surfaces all three hints.

## Why
Luna built tool calls from discover output and failed three times on guessable args: display-case agent name, `--agent` passed to the tool (a CLI-only spelling), and a bare string where the tool wants a content array. Schemas alone did not prevent it; the hints now ride in the descriptions agents actually read.

## Before / After
Before: `create_agent` — 'Create a new agent with a name, system prompt, and optional capabilities.' After: appends 'Agent name must contain only lowercase letters, digits, and hyphens (e.g. joke-telling-agent).' Same pattern for the session flag disambiguation and the message content-array example. Verified via new test `discovery_descriptions_carry_argument_constraints` (15/15 module tests pass) and `just pre-push` green.

## Risk
- Low
- What can break: discover/MCP description text only; no behavior, schema, or auth changes.

## Security
- No security-relevant code changes: description-string edits served as JSON data, no shell interpolation, no secrets, no flow changes.
- Findings and resolutions: none.

## Follow-ups
- Broad-query recall: a natural-language discover query like 'agent' truncates at 12 ops and can omit `create_agent`; exact-name lookup works. Relevance ranking is a separate change if agent traces show misses.
- `create_message` is a flat builtin with no CLI spelling, so its fix rides entirely on the description; CLI `chat` examples untouched.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Produced by [yolop](https://everruns.com/yolop)