### PR TITLE
fix(ui): render tool timeline rows as one-liners

### DIFF
--- a/apps/ui/src/__tests__/tool-activity-timeline-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-timeline-group.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { ToolActivityTimelineGroup } from "@/components/chat/tool-activity-timeline-group";
 import { LocaleProvider } from "@/providers/locale-provider";
@@ -103,5 +103,49 @@ describe("ToolActivityTimelineGroup", () => {
     );
     expect(screen.queryByText("sk-live-secret")).not.toBeInTheDocument();
     expect(screen.getByText(/value: \[hidden\]/)).toBeInTheDocument();
+  });
+
+  it("renders label, preview, and details toggle on one line", () => {
+    renderWithLocale(
+      <ToolActivityTimelineGroup
+        headline="Read secret"
+        completedHeadline="Read secret"
+        rows={[
+          {
+            id: "tool-1",
+            label: "Read secret",
+            state: "completed",
+            result: {
+              tool_call_id: "call-1",
+              tool_name: "secret_store",
+              success: true,
+              status: "success",
+              result: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    operation: "get",
+                    name: "OPENAI_API_KEY",
+                    found: true,
+                  }),
+                },
+              ],
+            },
+          },
+        ]}
+      />,
+    );
+
+    const label = screen.getByText("Read secret");
+    const preview = screen.getByText("OPENAI_API_KEY found");
+    const toggle = screen.getByRole("button", { name: /details/i });
+    // Label, preview, and toggle share a single line container.
+    expect(preview.parentElement).toBe(label.parentElement);
+    expect(toggle.parentElement).toBe(label.parentElement);
+
+    // Expanding hides the one-line preview and reveals the details.
+    fireEvent.click(toggle);
+    expect(screen.queryByText("OPENAI_API_KEY found")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /hide/i })).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
@@ -54,34 +54,40 @@ function TimelineRow({ row }: { row: TimelineToolRow }) {
         </div>
 
         <div className="min-w-0 flex-1">
-          <div className="text-[15px] text-muted-foreground">{row.label}</div>
+          <div className="flex min-w-0 items-baseline gap-x-1.5">
+            <span className="min-w-0 flex-1 truncate text-[15px] text-muted-foreground">
+              {row.label}
+            </span>
 
-          {preview && !expanded && (
-            <div className="mt-0.5 truncate text-xs text-muted-foreground/75">{preview}</div>
-          )}
+            {preview && !expanded && (
+              <span className="max-w-[50%] shrink-0 truncate text-xs text-muted-foreground/75">
+                {preview}
+              </span>
+            )}
+
+            {hasDetails && (
+              <button
+                type="button"
+                onClick={() => setExpanded((current) => !current)}
+                className="inline-flex shrink-0 items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70 transition-colors hover:text-foreground"
+                aria-expanded={expanded}
+                aria-controls={detailsId}
+              >
+                {expanded ? (
+                  <ChevronDown className="h-3 w-3" />
+                ) : (
+                  <ChevronRight className="h-3 w-3" />
+                )}
+                {expanded ? t("hide_details") : t("details")}
+              </button>
+            )}
+          </div>
 
           {row.result?.error && (
             <div className="mt-0.5 text-xs text-red-600 dark:text-red-400">{row.result.error}</div>
           )}
 
           <McpAppResourceList resources={mcpAppResources} />
-
-          {hasDetails && (
-            <button
-              type="button"
-              onClick={() => setExpanded((current) => !current)}
-              className="mt-1 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70 transition-colors hover:text-foreground"
-              aria-expanded={expanded}
-              aria-controls={detailsId}
-            >
-              {expanded ? (
-                <ChevronDown className="h-3 w-3" />
-              ) : (
-                <ChevronRight className="h-3 w-3" />
-              )}
-              {expanded ? t("hide_details") : t("details")}
-            </button>
-          )}
 
           <div
             id={detailsId}


### PR DESCRIPTION
## What changed

Collapsed each tool-activity timeline row to a single baseline line: label, result preview ("12 operations"), and the details toggle now share one flex row instead of stacking on three lines. Errors, resource lists, and expanded details still render below the line. Added a regression test asserting label, preview, and toggle share one container and that expanding hides the preview.

## Why

Completed tool calls took three vertical lines each (label / preview / DETAILS), making long runs hard to scan. One-liners keep the same information density per row while preserving expandable details.

## Breaking changes

None.

## Before/After

Before (stacked rows):

![Before — stacked timeline rows](https://github.com/user-attachments/assets/c9585097-c0f1-491c-a174-12040519925d)

After (one-liner rows, expanded state opens below the line):

![After — one-liner timeline rows](https://github.com/user-attachments/assets/dc099fc4-bd49-4120-9f01-76c8eae98cf1)

Note: the After capture is a static preview using the exact new markup/classes, not the running app.

## Risk

Low. Presentational only; no data flow, grouping, redaction, or i18n-key changes. Collapsed and expanded states covered by unit tests.

## Security

No security-relevant changes. Preview uses mock data; no secrets in evidence.

## Other Notes

None.

## Testing

- [x] Tested locally (unit/integration)
- [ ] Tested locally (manual UI)
- [x] Added/updated tests
- [x] Lint/format checks
- [x] Screenshots attached (if UI changed)

## Follow-ups

- [x] No follow-ups

## Related Issues

None.

Produced by [yolop](https://everruns.com/yolop)
