### PR TITLE
feat(server): serve agent discovery documents

### DIFF
--- a/crates/server/src/api/agent_discovery.rs
+++ b/crates/server/src/api/agent_discovery.rs
@@ -1,0 +1,281 @@
+// Agent discovery endpoints: MCP Server Card and auth.md.
+//
+// Decision: both are public (no auth). An agent that has no credentials yet is
+//   exactly the caller that needs to read them.
+// Decision: every value is derived from live server config (issuer URL, auth
+//   mode, MCP server name/version) rather than hardcoded, so a self-hosted
+//   deployment describes itself correctly and cannot drift from the running
+//   service.
+// Decision: when the server is not actually protecting anything (AuthMode::None,
+//   local development) the documents say so instead of advertising an OAuth
+//   flow that is not enforced. Publishing discovery metadata for a capability
+//   that does not exist sends agents at endpoints that will reject them.
+//
+// See: SEP-1649 (MCP Server Card), https://isitagentready.com/ authMd check.
+
+use axum::{
+    Json, Router,
+    http::header,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use serde_json::{Value, json};
+
+use crate::auth::config::AuthMode;
+
+#[derive(Clone)]
+pub struct AppState {
+    /// Server root, e.g. `https://app.everruns.com`. Also the OAuth issuer.
+    pub root_url: String,
+    /// API base, e.g. `https://app.everruns.com/api`.
+    pub api_base_url: String,
+    /// Drives whether the documents describe OAuth and personal access tokens
+    /// as available.
+    pub auth_mode: AuthMode,
+    /// MCP server identity, mirroring what `initialize` reports.
+    pub mcp_server_name: String,
+    pub mcp_server_version: String,
+}
+
+impl AppState {
+    pub fn new(
+        root_url: impl Into<String>,
+        api_base_url: impl Into<String>,
+        auth_mode: AuthMode,
+        mcp_server_name: impl Into<String>,
+        mcp_server_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            root_url: root_url.into().trim_end_matches('/').to_string(),
+            api_base_url: api_base_url.into().trim_end_matches('/').to_string(),
+            auth_mode,
+            mcp_server_name: mcp_server_name.into(),
+            mcp_server_version: mcp_server_version.into(),
+        }
+    }
+
+    /// True when credentials are actually enforced, so the discovery documents
+    /// should describe how to obtain them.
+    fn auth_enforced(&self) -> bool {
+        self.auth_mode != AuthMode::None
+    }
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/.well-known/mcp/server-card.json", get(mcp_server_card))
+        .route("/auth.md", get(auth_md))
+        .with_state(state)
+}
+
+/// JSON with permissive CORS. Discovery documents are fetched cross-origin by
+/// browser-based agents, and they contain nothing sensitive.
+fn json_public(body: Value) -> Response {
+    ([(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")], Json(body)).into_response()
+}
+
+/// GET /.well-known/mcp/server-card.json — MCP Server Card (SEP-1649).
+///
+/// Describes the MCP endpoint this server exposes so a client can decide
+/// whether to connect before running an OAuth flow.
+async fn mcp_server_card(axum::extract::State(state): axum::extract::State<AppState>) -> Response {
+    let root = &state.root_url;
+
+    let mut card = json!({
+        "serverInfo": {
+            "name": state.mcp_server_name,
+            "version": state.mcp_server_version,
+        },
+        "endpoint": format!("{root}/mcp"),
+        "transport": "streamable-http",
+        // Mirrors the capabilities advertised by `initialize` in
+        // api/mcp_endpoint: tools and resources, no prompts.
+        "capabilities": {
+            "tools": { "listChanged": false },
+            "resources": {},
+        },
+    });
+
+    if state.auth_enforced() {
+        card["authentication"] = json!({
+            "type": "oauth2",
+            "protectedResourceMetadata":
+                format!("{root}/.well-known/oauth-protected-resource/mcp"),
+            "authorizationServerMetadata":
+                format!("{root}/.well-known/oauth-authorization-server"),
+            "registrationEndpoint": format!("{root}/oauth/register"),
+            "scopesSupported": ["mcp"],
+            "documentation": format!("{root}/auth.md"),
+        });
+    } else {
+        card["authentication"] = json!({ "type": "none" });
+    }
+
+    json_public(card)
+}
+
+/// Markdown with permissive CORS.
+fn markdown_public(body: String) -> Response {
+    (
+        [
+            (header::CONTENT_TYPE, "text/markdown; charset=utf-8"),
+            (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+/// GET /auth.md — how an agent obtains credentials for this server.
+async fn auth_md(axum::extract::State(state): axum::extract::State<AppState>) -> Response {
+    markdown_public(render_auth_md(&state))
+}
+
+fn render_auth_md(state: &AppState) -> String {
+    let root = &state.root_url;
+    let api = &state.api_base_url;
+
+    if !state.auth_enforced() {
+        return format!(
+            "# auth.md\n\n\
+             How an agent obtains credentials for this Everruns server.\n\n\
+             ## No credentials required\n\n\
+             This server runs with authentication disabled (`AUTH_MODE=none`), \
+             a local-development mode in which every request is treated as an \
+             administrator. Call the API at `{api}` and the MCP endpoint at \
+             `{root}/mcp` without any `Authorization` header.\n\n\
+             Do not expose a server in this mode to a network you do not control.\n\n\
+             Documentation: <https://docs.everruns.com/>\n"
+        );
+    }
+
+    format!(
+        "# auth.md\n\n\
+         How an AI agent obtains credentials for this Everruns server.\n\n\
+         Everruns is a durable agent platform. Credentials below are bound to a \
+         human-owned account; there is no anonymous access.\n\n\
+         ## Method 1: MCP over OAuth 2.1 (preferred for agents)\n\n\
+         The MCP endpoint supports OAuth dynamic client registration, so a client \
+         can register itself without a human pre-provisioning it.\n\n\
+         | Field | Value |\n\
+         | --- | --- |\n\
+         | MCP endpoint (resource) | `{root}/mcp` |\n\
+         | Protected resource metadata | `{root}/.well-known/oauth-protected-resource/mcp` |\n\
+         | Authorization server metadata | `{root}/.well-known/oauth-authorization-server` |\n\
+         | Issuer | `{root}` |\n\
+         | Registration endpoint (RFC 7591) | `{root}/oauth/register` |\n\
+         | PKCE | required, `S256` |\n\
+         | Scopes | `mcp` |\n\
+         | Credential presentation | `Authorization: Bearer <access_token>` |\n\n\
+         Fetch the protected resource metadata first, then the authorization \
+         server metadata, and use the endpoints they return rather than the table \
+         above. Register a client, run the authorization code flow with PKCE (a \
+         human approves in a browser), then call `{root}/mcp` with the access \
+         token.\n\n\
+         Access tokens issued by this flow are audience-restricted to `{root}/mcp`. \
+         They are **not** accepted by the REST API; see method 2 for that.\n\n\
+         ## Method 2: Personal access token (REST API)\n\n\
+         For server-to-server use where no browser is available, a human issues a \
+         personal access token from the operator console under \
+         **Settings -> Personal access tokens** and hands it to the agent out of \
+         band.\n\n\
+         | Field | Value |\n\
+         | --- | --- |\n\
+         | API base | `{api}` |\n\
+         | Token format | opaque string prefixed `evr_pat_` |\n\
+         | Credential presentation | `Authorization: Bearer evr_pat_...` |\n\n\
+         ```bash\n\
+         curl -X POST {api}/v1/agents \\\n  \
+         -H \"Authorization: Bearer $EVERRUNS_TOKEN\" \\\n  \
+         -H \"Content-Type: application/json\" \\\n  \
+         -d '{{\"name\":\"Assistant\",\"system_prompt\":\"You are helpful.\"}}'\n\
+         ```\n\n\
+         A personal access token carries the full authority of the account that \
+         issued it. Store it as a secret, never in source control, and rotate it \
+         from the screen that issued it.\n\n\
+         ## Credential handling\n\n\
+         - Send credentials only over TLS, and only to the origin that issued them.\n\
+         - Present tokens in the `Authorization` header, never in a query string.\n\
+         - Refresh access tokens rather than re-running the authorization flow.\n\
+         - On `401`, re-read the protected resource metadata before retrying: \
+         endpoints and scopes can change.\n\n\
+         ## Related discovery documents\n\n\
+         - <{root}/.well-known/mcp/server-card.json> - MCP server card\n\
+         - <{root}/.well-known/oauth-authorization-server> - authorization server metadata\n\
+         - <https://docs.everruns.com/> - full documentation\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(mode: AuthMode) -> AppState {
+        AppState::new(
+            "https://app.example.com/",
+            "https://app.example.com/api/",
+            mode,
+            "everruns",
+            "0.25.0",
+        )
+    }
+
+    #[test]
+    fn trailing_slashes_are_trimmed() {
+        let s = state(AuthMode::Full);
+        assert_eq!(s.root_url, "https://app.example.com");
+        assert_eq!(s.api_base_url, "https://app.example.com/api");
+    }
+
+    #[test]
+    fn auth_md_documents_both_credential_paths_when_enforced() {
+        let md = render_auth_md(&state(AuthMode::External));
+        assert!(md.starts_with("# auth.md"), "H1 must contain auth.md");
+        assert!(md.contains("https://app.example.com/mcp"));
+        assert!(md.contains("/.well-known/oauth-protected-resource/mcp"));
+        assert!(md.contains("evr_pat_"));
+        assert!(md.contains("https://app.example.com/api/v1/agents"));
+    }
+
+    #[test]
+    fn auth_md_states_that_mcp_tokens_do_not_reach_the_rest_api() {
+        // MCP access tokens are audience-bound to `{root}/mcp` and typed
+        // `mcp_access`; the REST API rejects them. An agent that assumes
+        // otherwise burns a full OAuth flow before finding out.
+        let md = render_auth_md(&state(AuthMode::Full));
+        assert!(md.contains("not** accepted by the REST API"));
+    }
+
+    #[test]
+    fn auth_md_does_not_advertise_oauth_when_auth_is_disabled() {
+        let md = render_auth_md(&state(AuthMode::None));
+        assert!(md.contains("No credentials required"));
+        assert!(!md.contains("oauth-protected-resource"));
+        assert!(!md.contains("evr_pat_"));
+    }
+
+    #[tokio::test]
+    async fn server_card_reports_real_identity_and_capabilities() {
+        let body = card_json(AuthMode::External).await;
+        assert_eq!(body["serverInfo"]["name"], "everruns");
+        assert_eq!(body["serverInfo"]["version"], "0.25.0");
+        assert_eq!(body["endpoint"], "https://app.example.com/mcp");
+        assert_eq!(body["capabilities"]["tools"]["listChanged"], false);
+        assert!(body["capabilities"].get("prompts").is_none());
+        assert_eq!(body["authentication"]["type"], "oauth2");
+    }
+
+    #[tokio::test]
+    async fn server_card_reports_no_auth_when_auth_is_disabled() {
+        let body = card_json(AuthMode::None).await;
+        assert_eq!(body["authentication"]["type"], "none");
+    }
+
+    async fn card_json(mode: AuthMode) -> Value {
+        let response = mcp_server_card(axum::extract::State(state(mode))).await;
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        serde_json::from_slice(&bytes).expect("json")
+    }
+}

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -136,8 +136,8 @@ impl JsonRpcResponse {
 // MCP Tool definitions
 // ============================================================================
 
-const MCP_SERVER_NAME: &str = "everruns";
-const MCP_SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const MCP_SERVER_NAME: &str = "everruns";
+pub const MCP_SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const MCP_PROTOCOL_VERSION_FALLBACK: &str = "2025-03-26";
 const MCP_PROTOCOL_VERSION_2025_06: &str = "2025-06-18";
 const MCP_PROTOCOL_VERSION_LATEST: &str = "2026-07-28";

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -6,6 +6,7 @@
 pub mod a2a_signing;
 pub mod ag_ui;
 pub mod agent_credentials;
+pub mod agent_discovery;
 pub mod agent_examples;
 pub mod agent_identities;
 pub mod agent_identity_connections;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1539,6 +1539,15 @@ impl ServerAppBuilder {
             flags: feature_flags.clone(),
         };
 
+        // Agent discovery: MCP server card + auth.md, both derived from the
+        // live auth config so a self-hosted deployment describes itself.
+        let agent_discovery_state = api::agent_discovery::AppState::new(
+            mcp_root_url.clone(),
+            auth_config.base_url.clone(),
+            auth_config.mode.clone(),
+            api::mcp_endpoint::MCP_SERVER_NAME,
+            api::mcp_endpoint::MCP_SERVER_VERSION,
+        );
         let http_signing_keys_state = api::http_signing_keys::AppState::from_env();
 
         if !self.config.api_prefix.is_empty() {
@@ -1779,6 +1788,7 @@ impl ServerAppBuilder {
                 "/api-doc/openapi.json",
                 get(|| async { Json(ApiDoc::openapi()) }),
             )
+            .merge(api::agent_discovery::routes(agent_discovery_state))
             .merge(api::http_signing_keys::routes(http_signing_keys_state))
             .merge(root_routes)
             .merge(build_router_with_prefix(

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -228,6 +228,7 @@ configs:
       #   /oauth/*   -> API
       #   /mcp       -> API
       #   /.well-known/* -> API
+      #   /auth.md   -> API
       #   /api-doc/* -> API
       #   /health    -> API
       #   /*         -> UI
@@ -268,6 +269,9 @@ configs:
           reverse_proxy server:9000
         }
         handle /.well-known/* {
+          reverse_proxy server:9000
+        }
+        handle /auth.md {
           reverse_proxy server:9000
         }
         handle /api-doc/* {

--- a/infra/railway/caddy/Caddyfile
+++ b/infra/railway/caddy/Caddyfile
@@ -29,6 +29,10 @@
 	handle /.well-known/* {
 		reverse_proxy {$SERVER_HOST}:9000
 	}
+	# Agent credential documentation, served by the API (see local/Caddyfile).
+	handle /auth.md {
+		reverse_proxy {$SERVER_HOST}:9000
+	}
 
 	handle /api-doc/* {
 		reverse_proxy {$SERVER_HOST}:9000

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -16,6 +16,7 @@
 #   /oauth/*   -> API server at :API_PORT
 #   /mcp       -> API server at :API_PORT
 #   /.well-known/* -> API server at :API_PORT
+#   /auth.md   -> API server at :API_PORT
 #   /api-doc/* -> API server at :API_PORT
 #   /health    -> API server at :API_PORT
 #   /*         -> UI dev server at :UI_PORT
@@ -63,6 +64,11 @@
 		reverse_proxy localhost:{$API_PORT:9301}
 	}
 	handle /.well-known/* {
+		reverse_proxy localhost:{$API_PORT:9301}
+	}
+	# Agent credential documentation. Served by the API, not the UI: an agent
+	# with no credentials yet is exactly the caller that needs to read it.
+	handle /auth.md {
 		reverse_proxy localhost:{$API_PORT:9301}
 	}
 	handle /api-doc/* {


### PR DESCRIPTION
## What changed

An agent that lands on an Everruns server has no way to learn how to authenticate. The OAuth metadata is published, but only a client that already knows to look for RFC 8414/9728 endpoints finds it, and nothing describes the MCP endpoint or the personal-access-token path at all.

Two new public endpoints, both derived from live server config so a self-hosted deployment describes itself rather than repeating a hardcoded hosted URL:

| Path | Contents |
| --- | --- |
| `/.well-known/mcp/server-card.json` | MCP Server Card (SEP-1649): server identity, transport, capabilities, how to authenticate |
| `/auth.md` | How an agent obtains credentials, covering both real paths |

## Why

Scanned against [isitagentready.com](https://isitagentready.com/), `app.everruns.com` reports **Level 0, "Not Ready"** — the origin an agent must actually authenticate against is less discoverable than the marketing site. This closes the two checks that can be closed honestly at this origin.

## Two things worth a reviewer's attention

**1. `auth.md` states that MCP tokens do not reach the REST API.** This surprised me, so I verified it in the code before documenting it:

- `generate_mcp_access_token` mints `token_type: "mcp_access"` with `aud` bound to the MCP resource (`auth/jwt.rs`)
- `validate_mcp_token` requires `token_type == MCP_ACCESS_TOKEN_TYPE` **and** an exact `aud` match
- the general API path requires `token_type == ACCESS_TOKEN_TYPE` and rejects anything else

So an OAuth access token is audience-restricted to `{root}/mcp` and the REST API will not accept it. An agent that assumes otherwise burns a full authorization-code flow before finding out. There's now a test pinning that sentence in place.

**2. It refuses to advertise auth that isn't enforced.** Under `AUTH_MODE=none` both documents say no credentials are required instead of describing an OAuth flow nothing enforces. Publishing discovery metadata for a capability that does not exist sends agents at endpoints that reject them, which is worse than publishing nothing.

## Deliberately not included

A bare `/.well-known/oauth-protected-resource`. A scanner probes that path, but this server has no protected resource identified by the origin root — the MCP resource is `{root}/mcp`, correctly served at `/.well-known/oauth-protected-resource/mcp` per RFC 9728 §3.1, and the existing code comment says the root alias was removed deliberately. Serving a document there whose `resource` did not match the URL it was fetched from would violate RFC 9728 §3.3 ("If these values are not identical, the data contained in the response MUST NOT be used") — a green check that every compliant client discards.

Making the REST API OAuth-discoverable would first require making it OAuth-*accessible*, which is a product decision, not a metadata change.

## Before / After

**Before:** `GET /auth.md` → 404 from the UI. `GET /.well-known/mcp/server-card.json` → 404.

**After**, verified against a running stack (`PORT_PREFIX=271 AUTH_MODE=none ./scripts/start-agent-dev.sh`):

```
auth.md:     HTTP 200 text/markdown; charset=utf-8
card:        HTTP 200 application/json
health:      200
ui root:     307   (unchanged — the UI still owns /)
```

```json
{
  "authentication": { "type": "none" },
  "capabilities": { "resources": {}, "tools": { "listChanged": false } },
  "endpoint": "http://localhost:27100/mcp",
  "serverInfo": { "name": "everruns", "version": "0.25.0" },
  "transport": "streamable-http"
}
```

The card's capabilities mirror what `initialize` advertises in `api/mcp_endpoint` (tools and resources, no prompts); `MCP_SERVER_NAME`/`MCP_SERVER_VERSION` are now shared with that module rather than duplicated, so the card cannot drift from the handshake.

**A real bug this caught:** on first end-to-end test `/auth.md` returned the UI's 404 even though the axum route was registered — the proxy routes `/.well-known/*` to the API but sent `/auth.md` to the UI. Fixed in all three proxy configs (`local/Caddyfile`, `infra/railway/caddy/Caddyfile`, `examples/docker-compose-full.yaml`). Compile-and-unit-test alone would have shipped an unreachable endpoint.

## Risk

- **Low.** Two additive public GET routes and one proxy rule; no existing route changes behaviour.
- Both documents are public by design: an agent with no credentials is exactly the caller that needs them. Neither exposes anything not already discoverable from the published OAuth metadata.

## Verification

- `cargo check -p everruns-server` — clean
- `cargo clippy -p everruns-server --lib --all-features -- -D warnings` — clean
- `cargo fmt` — clean
- `cargo test -p everruns-server --lib agent_discovery` — 6 passed, covering both auth modes, trailing-slash normalisation, and the MCP-tokens-are-not-API-tokens sentence
- End-to-end against a running stack through the Caddy proxy, as above