### PR TITLE
fix(plugins): list only everruns in agent marketplaces

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -16,18 +16,6 @@
       },
       "category": "Agents",
       "description": "Connects Codex to Everruns over MCP (https://app.everruns.com/mcp) with skills, slash commands, and agents. See plugins/everruns/README.md."
-    },
-    {
-      "name": "resend",
-      "description": "Send transactional email through Resend over MCP. See plugins/resend/README.md.",
-      "source": {
-        "source": "local",
-        "path": "./plugins/resend"
-      },
-      "policy": {
-        "trust": "verified"
-      },
-      "category": "Productivity"
     }
   ],
   "description": "Everruns plugins for Codex"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,26 +26,6 @@
         "harness",
         "llm"
       ]
-    },
-    {
-      "name": "resend",
-      "source": "./plugins/resend",
-      "description": "Send transactional emails through the Resend remote MCP server with OAuth.",
-      "version": "0.1.1",
-      "author": {
-        "name": "Everruns",
-        "url": "https://everruns.com"
-      },
-      "homepage": "https://resend.com",
-      "repository": "https://github.com/everruns/everruns",
-      "license": "MIT",
-      "category": "Productivity",
-      "keywords": [
-        "email",
-        "resend",
-        "mcp",
-        "oauth"
-      ]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -35,25 +35,6 @@
         "harness",
         "llm"
       ]
-    },
-    {
-      "name": "resend",
-      "displayName": "Resend",
-      "description": "Send transactional emails through the Resend remote MCP server from Cursor. Sending, scheduling, audiences, and broadcasts over OAuth.",
-      "source": "./plugins/resend",
-      "version": "0.1.1",
-      "publisher": "Everruns",
-      "license": "MIT",
-      "categories": [
-        "productivity",
-        "developer-tools"
-      ],
-      "keywords": [
-        "resend",
-        "email",
-        "mcp",
-        "oauth"
-      ]
     }
   ]
 }

--- a/scripts/test-plugins.sh
+++ b/scripts/test-plugins.sh
@@ -13,6 +13,10 @@ check_contains() { # check_contains <desc> <file> <pattern>
   local desc="$1" file="$2" pattern="$3"
   if grep -q "$pattern" "$file" 2>/dev/null; then echo "ok   - $desc"; else echo "FAIL - $desc"; fail=1; fi
 }
+check_absent() { # check_absent <desc> <file> <pattern>
+  local desc="$1" file="$2" pattern="$3"
+  if grep -q "$pattern" "$file" 2>/dev/null; then echo "FAIL - $desc"; fail=1; else echo "ok   - $desc"; fi
+}
 
 json_field() { python3 -c "import json,sys; print(json.load(open('$1'))$2)"; }
 
@@ -43,11 +47,11 @@ for m in "$ROOT/.claude-plugin/marketplace.json" "$ROOT/.agents/plugins/marketpl
   check "$(basename "$(dirname "$m")") marketplace is valid JSON" python3 -c "import json; json.load(open('$m'))"
 done
 check_contains "everruns in Claude marketplace" "$ROOT/.claude-plugin/marketplace.json" '"everruns"'
-check_contains "resend in Claude marketplace" "$ROOT/.claude-plugin/marketplace.json" '"resend"'
+check_absent "resend not in Claude marketplace" "$ROOT/.claude-plugin/marketplace.json" '"resend"'
 check_contains "everruns in Codex marketplace" "$ROOT/.agents/plugins/marketplace.json" '"everruns"'
-check_contains "resend in Codex marketplace" "$ROOT/.agents/plugins/marketplace.json" '"resend"'
+check_absent "resend not in Codex marketplace" "$ROOT/.agents/plugins/marketplace.json" '"resend"'
 check_contains "everruns in Cursor marketplace" "$ROOT/.cursor-plugin/marketplace.json" '"everruns"'
-check_contains "resend in Cursor marketplace" "$ROOT/.cursor-plugin/marketplace.json" '"resend"'
+check_absent "resend not in Cursor marketplace" "$ROOT/.cursor-plugin/marketplace.json" '"resend"'
 
 echo "== MCP endpoints =="
 check_contains "everruns host MCP default" "$ROOT/plugins/everruns/.mcp.json" 'https://app.everruns.com/mcp'


### PR DESCRIPTION
## What changed

Removes the `resend` entries from the Claude (`.claude-plugin/marketplace.json`), Codex (`.agents/plugins/marketplace.json`), and Cursor (`.cursor-plugin/marketplace.json`) marketplaces so they list only our `everruns` plugin. `scripts/test-plugins.sh` now asserts `resend` is absent from all three.

## Why

Marketplaces should present only our own plugins. The `plugins/resend/` directory stays in the repo as a compiler test fixture; it is just no longer offered for installation.

## Before / After

Before: every marketplace listed `everruns` + `resend`.

After: every marketplace lists only `everruns`.

```
test-plugins: all checks passed
just pre-push  # pass
```

## Risk

- Low
- Anyone who installed `resend` from one of our marketplaces loses update flow; the plugin directory itself is untouched.

## Security

- No security-relevant code changes (marketplace JSON + test script only).

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Produced by [yolop](https://everruns.com/yolop)