### PR TITLE
fix(openrouter): advertise xhigh reasoning effort in discovery

### DIFF
--- a/crates/drivers/openrouter/src/types.rs
+++ b/crates/drivers/openrouter/src/types.rs
@@ -239,10 +239,11 @@ fn openrouter_price_per_million(value: &str) -> Option<f64> {
         .filter(|price| price.is_finite() && *price >= 0.0)
 }
 
-/// Standard low/medium/high effort config for OpenRouter reasoning models.
+/// Standard effort config for OpenRouter reasoning models.
 ///
-/// OpenRouter normalizes `reasoning.effort` ∈ {low, medium, high} across upstream
-/// providers, so we expose those three with `medium` as the default.
+/// The gateway forwards `reasoning.effort` through to the upstream provider,
+/// which accepts `xhigh` on reasoning-capable models, so we expose
+/// low/medium/high/xhigh with `medium` as the default.
 fn openrouter_effort_config() -> everruns_provider::model::ReasoningEffortConfig {
     use everruns_provider::model::*;
     ReasoningEffortConfig {
@@ -258,6 +259,10 @@ fn openrouter_effort_config() -> everruns_provider::model::ReasoningEffortConfig
             ReasoningEffortValue {
                 value: ReasoningEffort::High,
                 name: "High".into(),
+            },
+            ReasoningEffortValue {
+                value: ReasoningEffort::Xhigh,
+                name: "Extra High".into(),
             },
         ],
         default: ReasoningEffort::Medium,
@@ -318,7 +323,7 @@ mod openrouter_tests {
                 "tool_call":true,"structured_output":true,"open_weights":false,
                 "limits":{"context":262144,"output":262144},
                 "modalities":{"input":["text"],"output":["text"]},
-                "reasoning_effort":{"values":[{"value":"low","name":"Low"},{"value":"medium","name":"Medium"},{"value":"high","name":"High"}],"default":"medium"},
+                "reasoning_effort":{"values":[{"value":"low","name":"Low"},{"value":"medium","name":"Medium"},{"value":"high","name":"High"},{"value":"xhigh","name":"Extra High"}],"default":"medium"},
                 "tool_search":false,"supports_phases":false,
                 "supported_parameters":["include_reasoning","max_tokens","reasoning","response_format","structured_outputs","temperature","tool_choice","tools","top_p"]
             })


### PR DESCRIPTION
## Summary

OpenRouter discovery advertised only low/medium/high reasoning efforts behind a stale comment claiming the gateway normalizes to those three. The request path already forwards `reasoning_effort` verbatim (verified live: `xhigh` is sent as `reasoning: {"effort": "xhigh", "exclude": true}` and returns 200), so discovery was the only place hiding `xhigh`.

- Adds `Xhigh` ("Extra High", matching the first-party preset naming) to `openrouter_effort_config`; default stays `medium`.
- Updates the stale doc comment and the catalog snapshot test.

## Risk

Low. Discovery metadata only; the wire path is untouched. Picking `xhigh` on a model whose upstream doesn't support it surfaces a provider error through existing handling, same as any other value.

## Validation

- Updated the catalog snapshot test first: failed with 3 values actual vs 4 expected, then passed after the fix.
- `cargo test -p everruns-openrouter`: 80 lib + 13 wire tests green (includes the None/explicit-effort reasoning edge cases).
- `just pre-push` green; full PR CI green.

## Docs

None needed — internal discovery metadata; no public contract change.

## Security

No security-relevant change. Static allowlist strings only; no input handling, auth, secrets, or execution surface touched.

## Follow-ups

No follow-ups. `Minimal`/`None`/`Max` intentionally left out — provider-specific extremes, not proven gateway-wide.

Produced by [yolop](https://everruns.com/yolop)