### PR TITLE
refactor(platform): trim the dead legacy CRUD from PlatformStore

### DIFF
--- a/crates/everruns/src/local/backends.rs
+++ b/crates/everruns/src/local/backends.rs
@@ -139,11 +139,9 @@ impl LocalBackends {
     /// (org, session); the runner is the source of truth for local session
     /// state, so no extra store handles are required.
     pub fn with_platform_runner(mut self, runner: Arc<dyn LocalSessionRunner>) -> Self {
-        let base_url = self.profile.base_url.clone();
         let factory: PlatformStoreFactory =
             Arc::new(move |_org_id: i64, _session_id: SessionId| {
-                Arc::new(LocalPlatformStore::new(runner.clone(), base_url.clone()))
-                    as Arc<dyn PlatformStore>
+                Arc::new(LocalPlatformStore::new(runner.clone())) as Arc<dyn PlatformStore>
             });
         self.runtime_backends = self.runtime_backends.with_platform_store_factory(factory);
         self

--- a/crates/everruns/src/local/platform_store.rs
+++ b/crates/everruns/src/local/platform_store.rs
@@ -2,27 +2,26 @@
 //
 // Scope (EVE-594): implement the subagent-critical core honestly, backed by a
 // caller-supplied `LocalSessionRunner` (the embedder wires this to its
-// `InProcessRuntime` so `create_session` / `send_message` / `wait_for_idle`
-// actually create and drive real local sessions, and `get_messages` /
-// `get_session_by_id` / `list_sessions` read real local state). The
-// platform-management-only operations (harness/agent/app CRUD, publish,
-// channels, capability listing, delete/context-report) return an explicit
-// unsupported error rather than half-implementing them — local embedded hosts
-// manage those entities in code, not through this tool surface.
+// `InProcessRuntime` so `create_session_with_options` / `send_message` /
+// `wait_for_idle` actually create and drive real local sessions, and
+// `get_messages` / `get_session_by_id` read real local state).
+//
+// The platform-management-only operations this file used to reject one by one
+// were removed from `PlatformStore` itself with the `platform_management`
+// retirement (EVE-953), so there is nothing left to stub out. `get_harness`
+// stays an explicit unsupported error: it is still on the trait for hosted
+// delegation, and a local embedder has no stored harness catalog to answer
+// from.
 
 use async_trait::async_trait;
-use everruns_core::capability_dto::CapabilityInfo;
 use everruns_core::session::ExecutionSession;
 use everruns_platform::Agent;
 use everruns_platform::Harness;
-use everruns_platform::app::{App, AppChannel, ChannelType};
 use everruns_platform::{PlatformCreateSessionRequest, PlatformMessage, PlatformStore};
 use everruns_platform::{Session, SessionParticipant};
 use everruns_provider::error::{AgentLoopError, Result};
 use everruns_provider::typed_id::PrincipalId;
-use everruns_provider::typed_id::{
-    AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, SessionId,
-};
+use everruns_provider::typed_id::{AgentId, HarnessId, SessionId};
 use std::sync::Arc;
 
 /// Drives real local sessions for the platform store. An embedder implements
@@ -115,16 +114,15 @@ fn unsupported(op: &str) -> AgentLoopError {
 #[derive(Clone)]
 pub struct LocalPlatformStore {
     runner: Arc<dyn LocalSessionRunner>,
-    base_url: String,
 }
 
 impl LocalPlatformStore {
     /// Bind a platform-store adapter to an embedder's session runner.
-    pub fn new(runner: Arc<dyn LocalSessionRunner>, base_url: impl Into<String>) -> Self {
-        Self {
-            runner,
-            base_url: base_url.into(),
-        }
+    ///
+    /// No longer takes a base URL: it existed only to build UI links for the
+    /// retired `platform_management` tool results (EVE-953).
+    pub fn new(runner: Arc<dyn LocalSessionRunner>) -> Self {
+        Self { runner }
     }
 
     /// Lift the runner's portable execution view into the stored platform
@@ -139,26 +137,6 @@ impl LocalPlatformStore {
 #[async_trait]
 impl PlatformStore for LocalPlatformStore {
     // ---- Honestly implemented: subagent-critical core -----------------------
-
-    async fn create_session(
-        &self,
-        harness_id: HarnessId,
-        agent_id: Option<AgentId>,
-        title: Option<&str>,
-        locale: Option<&str>,
-        blueprint_id: Option<&str>,
-        _blueprint_config: Option<&serde_json::Value>,
-        parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
-        if blueprint_id.is_some() {
-            return Err(unsupported("create_session(blueprint)"));
-        }
-        Ok(self.lift(
-            self.runner
-                .create_session(harness_id, agent_id, title, locale, parent_session_id)
-                .await?,
-        ))
-    }
 
     async fn create_session_with_options(
         &self,
@@ -186,20 +164,6 @@ impl PlatformStore for LocalPlatformStore {
         Err(unsupported("add_agent_session_participant"))
     }
 
-    async fn list_sessions(
-        &self,
-        limit: Option<usize>,
-        agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
-        Ok(self
-            .runner
-            .list_sessions(limit, agent_id)
-            .await?
-            .into_iter()
-            .map(|session| self.lift(session))
-            .collect())
-    }
-
     async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
         self.runner.send_message(session_id, content).await
     }
@@ -225,148 +189,12 @@ impl PlatformStore for LocalPlatformStore {
             .ok_or_else(|| AgentLoopError::session_not_found(session_id))
     }
 
-    fn base_url(&self) -> &str {
-        &self.base_url
-    }
-
     // ---- Platform-management-only: explicit unsupported ---------------------
 
-    async fn list_harnesses(&self) -> Result<Vec<Harness>> {
-        Err(unsupported("list_harnesses"))
-    }
     async fn get_harness(&self, _id: HarnessId) -> Result<Option<Harness>> {
         Err(unsupported("get_harness"))
     }
-    async fn create_harness(
-        &self,
-        _name: &str,
-        _display_name: Option<&str>,
-        _description: Option<&str>,
-        _system_prompt: Option<&str>,
-        _parent_harness_id: Option<HarnessId>,
-        _capabilities: &[String],
-    ) -> Result<Harness> {
-        Err(unsupported("create_harness"))
-    }
-    async fn update_harness(
-        &self,
-        _id: HarnessId,
-        _name: Option<&str>,
-        _display_name: Option<&str>,
-        _description: Option<&str>,
-        _system_prompt: Option<&str>,
-        _parent_harness_id: Option<Option<HarnessId>>,
-    ) -> Result<Harness> {
-        Err(unsupported("update_harness"))
-    }
-    async fn delete_harness(&self, _id: HarnessId) -> Result<()> {
-        Err(unsupported("delete_harness"))
-    }
-    async fn copy_harness(&self, _id: HarnessId, _new_name: Option<&str>) -> Result<Harness> {
-        Err(unsupported("copy_harness"))
-    }
-    async fn list_agents(&self) -> Result<Vec<Agent>> {
-        Err(unsupported("list_agents"))
-    }
     async fn get_agent_by_id(&self, _id: AgentId) -> Result<Option<Agent>> {
         Err(unsupported("get_agent_by_id"))
-    }
-    async fn create_agent(
-        &self,
-        _name: &str,
-        _display_name: Option<&str>,
-        _description: Option<&str>,
-        _system_prompt: &str,
-        _capabilities: &[String],
-    ) -> Result<Agent> {
-        Err(unsupported("create_agent"))
-    }
-    async fn update_agent(
-        &self,
-        _id: AgentId,
-        _name: Option<&str>,
-        _display_name: Option<&str>,
-        _description: Option<&str>,
-        _system_prompt: Option<&str>,
-    ) -> Result<Agent> {
-        Err(unsupported("update_agent"))
-    }
-    async fn delete_agent(&self, _id: AgentId) -> Result<()> {
-        Err(unsupported("delete_agent"))
-    }
-    async fn list_apps(&self, _search: Option<&str>, _include_archived: bool) -> Result<Vec<App>> {
-        Err(unsupported("list_apps"))
-    }
-    async fn get_app(&self, _id: AppId) -> Result<Option<App>> {
-        Err(unsupported("get_app"))
-    }
-    async fn create_app(
-        &self,
-        _name: &str,
-        _description: Option<&str>,
-        _harness_id: HarnessId,
-        _agent_id: Option<AgentId>,
-        _agent_identity_id: Option<AgentIdentityId>,
-        _channel_type: Option<ChannelType>,
-        _channel_config: Option<&serde_json::Value>,
-    ) -> Result<App> {
-        Err(unsupported("create_app"))
-    }
-    async fn update_app(
-        &self,
-        _id: AppId,
-        _name: Option<&str>,
-        _description: Option<&str>,
-        _harness_id: Option<HarnessId>,
-        _agent_id: Option<AgentId>,
-        _agent_identity_id: Option<Option<AgentIdentityId>>,
-    ) -> Result<App> {
-        Err(unsupported("update_app"))
-    }
-    async fn delete_app(&self, _id: AppId) -> Result<()> {
-        Err(unsupported("delete_app"))
-    }
-    async fn destroy_app(&self, _id: AppId) -> Result<()> {
-        Err(unsupported("destroy_app"))
-    }
-    async fn publish_app(&self, _id: AppId) -> Result<App> {
-        Err(unsupported("publish_app"))
-    }
-    async fn unpublish_app(&self, _id: AppId) -> Result<App> {
-        Err(unsupported("unpublish_app"))
-    }
-    async fn add_app_channel(
-        &self,
-        _app_id: AppId,
-        _channel_type: ChannelType,
-        _channel_config: Option<&serde_json::Value>,
-        _enabled: Option<bool>,
-    ) -> Result<AppChannel> {
-        Err(unsupported("add_app_channel"))
-    }
-    async fn update_app_channel(
-        &self,
-        _app_id: AppId,
-        _channel_id: AppChannelId,
-        _channel_type: Option<ChannelType>,
-        _channel_config: Option<&serde_json::Value>,
-        _enabled: Option<bool>,
-    ) -> Result<AppChannel> {
-        Err(unsupported("update_app_channel"))
-    }
-    async fn delete_app_channel(&self, _app_id: AppId, _channel_id: AppChannelId) -> Result<()> {
-        Err(unsupported("delete_app_channel"))
-    }
-    async fn get_session_context_report(
-        &self,
-        _id: SessionId,
-    ) -> Result<everruns_core::SessionContextReport> {
-        Err(unsupported("get_session_context_report"))
-    }
-    async fn delete_session(&self, _id: SessionId) -> Result<()> {
-        Err(unsupported("delete_session"))
-    }
-    async fn list_capabilities(&self, _search: Option<&str>) -> Result<Vec<CapabilityInfo>> {
-        Err(unsupported("list_capabilities"))
     }
 }

--- a/crates/everruns/src/local/profile.rs
+++ b/crates/everruns/src/local/profile.rs
@@ -16,8 +16,6 @@ pub struct LocalProfile {
     pub data_dir: PathBuf,
     /// Root directory for the session workspace filesystem.
     pub workspace_root: PathBuf,
-    /// Base URL used to build UI links in tool results.
-    pub base_url: String,
     /// Public organization id for created records.
     pub org_public_id: String,
     /// Owning principal stamped on schedules/sessions created locally.
@@ -30,7 +28,6 @@ impl Default for LocalProfile {
         Self {
             workspace_root: data_dir.join("workspace"),
             data_dir,
-            base_url: "http://localhost:9300".to_string(),
             org_public_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
             owner_principal_id: PrincipalId::from_seed(1),
         }
@@ -57,12 +54,6 @@ impl LocalProfile {
     /// Override the directory exposed as the local workspace root.
     pub fn with_workspace_root(mut self, root: impl Into<PathBuf>) -> Self {
         self.workspace_root = root.into();
-        self
-    }
-
-    /// Override the base URL used in locally projected platform records.
-    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
-        self.base_url = base_url.into();
         self
     }
 

--- a/crates/everruns/tests/local_platform_store_test.rs
+++ b/crates/everruns/tests/local_platform_store_test.rs
@@ -2,8 +2,8 @@
 
 use async_trait::async_trait;
 use everruns::local::{LocalPlatformStore, LocalSessionRunner};
-use everruns_core::session::ExecutionSession;
-use everruns_platform::{PlatformMessage, PlatformStore};
+use everruns_core::session::{ExecutionSession, SessionSeedMode};
+use everruns_platform::{PlatformCreateSessionRequest, PlatformMessage, PlatformStore};
 use everruns_provider::error::Result;
 use everruns_provider::typed_id::{AgentId, HarnessId, SessionId};
 use std::sync::Arc;
@@ -71,8 +71,24 @@ impl LocalSessionRunner for FakeRunner {
     }
 }
 
+fn request(harness_id: HarnessId, blueprint_id: Option<&str>) -> PlatformCreateSessionRequest {
+    PlatformCreateSessionRequest {
+        harness_id,
+        agent_id: None,
+        title: Some("child".to_string()),
+        goal: None,
+        locale: None,
+        blueprint_id: blueprint_id.map(str::to_string),
+        blueprint_config: None,
+        parent_session_id: None,
+        forked_from_session_id: None,
+        budget_root_session_id: None,
+        seed: SessionSeedMode::Fresh,
+    }
+}
+
 fn store() -> LocalPlatformStore {
-    LocalPlatformStore::new(Arc::new(FakeRunner::default()), "http://localhost:9300")
+    LocalPlatformStore::new(Arc::new(FakeRunner::default()))
 }
 
 #[tokio::test]
@@ -80,7 +96,7 @@ async fn subagent_core_is_honest() {
     let store = store();
     let harness_id = HarnessId::new();
     let child = store
-        .create_session(harness_id, None, Some("child"), None, None, None, None)
+        .create_session_with_options(request(harness_id, None))
         .await
         .unwrap();
     assert_eq!(child.harness_id, harness_id);
@@ -88,20 +104,18 @@ async fn subagent_core_is_honest() {
     store.send_message(child.id, "go").await.unwrap();
     assert_eq!(store.wait_for_idle(child.id, None).await.unwrap(), "idle");
     assert_eq!(store.get_messages(child.id, None).await.unwrap().len(), 1);
-    assert_eq!(store.base_url(), "http://localhost:9300");
 }
 
+/// The management surface the local store used to reject method-by-method is
+/// gone from `PlatformStore` entirely (EVE-953), so there is nothing left to
+/// call. What still has to hold is that the one creation path the local store
+/// does not support is refused rather than silently ignored.
 #[tokio::test]
-async fn platform_management_ops_are_unsupported() {
+async fn blueprint_sessions_are_unsupported() {
     let store = store();
-    assert!(store.list_harnesses().await.is_err());
-    assert!(store.list_agents().await.is_err());
-    assert!(store.list_apps(None, false).await.is_err());
-    assert!(store.list_capabilities(None).await.is_err());
-    assert!(store.delete_session(SessionId::new()).await.is_err());
     assert!(
         store
-            .create_agent("x", None, None, "prompt", &[])
+            .create_session_with_options(request(HarnessId::new(), Some("bp")))
             .await
             .is_err()
     );

--- a/crates/everruns/tests/local_spawn_agent_runtime_test.rs
+++ b/crates/everruns/tests/local_spawn_agent_runtime_test.rs
@@ -326,13 +326,11 @@ async fn spawn_agent_dispatches_subagent_and_handoff_via_llmsim() {
     );
 
     let runtime_cell: Arc<OnceLock<InProcessRuntime>> = Arc::new(OnceLock::new());
-    let store: Arc<dyn PlatformStore> = Arc::new(LocalPlatformStore::new(
-        Arc::new(RuntimeRunner {
+    let store: Arc<dyn PlatformStore> =
+        Arc::new(LocalPlatformStore::new(Arc::new(RuntimeRunner {
             runtime: runtime_cell.clone(),
             sessions,
-        }),
-        "http://localhost",
-    ));
+        })));
 
     let backends =
         backends.with_platform_store_factory(Arc::new(move |_org, _session| store.clone()));

--- a/crates/llm-tests/tests/subagent_live_test.rs
+++ b/crates/llm-tests/tests/subagent_live_test.rs
@@ -172,13 +172,11 @@ async fn background_spawn_agent_subagent_live_end_to_end() {
     );
 
     let runtime_cell: Arc<OnceLock<InProcessRuntime>> = Arc::new(OnceLock::new());
-    let store: Arc<dyn PlatformStore> = Arc::new(LocalPlatformStore::new(
-        Arc::new(RuntimeRunner {
+    let store: Arc<dyn PlatformStore> =
+        Arc::new(LocalPlatformStore::new(Arc::new(RuntimeRunner {
             runtime: runtime_cell.clone(),
             sessions,
-        }),
-        "http://localhost",
-    ));
+        })));
 
     let backends =
         backends.with_platform_store_factory(Arc::new(move |_org, _session| store.clone()));

--- a/crates/platform/src/platform_store.rs
+++ b/crates/platform/src/platform_store.rs
@@ -1,24 +1,20 @@
-// Platform Store trait for org-scoped management operations
+// Platform Store trait: the hosted seam behind agent delegation.
 //
-// Decision: Single trait covers harness, agent, session CRUD + messaging
-// Decision: Trait lives in core; implementations in server/worker crates
-// Decision: Tool results include UI links via base_url()
+// Decision: Trait lives in this crate; implementations in server/worker crates
 // Decision: PlatformMessage is a simplified view (role + text + timestamp)
+// Decision: scope is the catalog-backed `platform` command surface plus the
+//   narrow session/agent/harness reads delegation needs. The org-scoped CRUD
+//   half was retired with `platform_management` (EVE-953); management flows
+//   go through the domain-command catalog instead.
 
 use crate::agent::Agent;
-use crate::app::{App, AppChannel, ChannelType};
 use crate::harness::{Harness, resolve_execution_harness};
 use async_trait::async_trait;
-use everruns_core::SessionContextReport;
-use everruns_core::capability_dto::CapabilityInfo;
-use everruns_core::session::SessionSeedMode;
 use everruns_provider::error::Result;
 use everruns_provider::typed_id::SessionParticipantId;
 
 use crate::session::{Session, SessionParticipant};
-use everruns_provider::typed_id::{
-    AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, SessionId,
-};
+use everruns_provider::typed_id::{AgentId, HarnessId, SessionId};
 use std::collections::HashSet;
 
 // The narrow session-delegation DTOs live in `everruns-core` (they are part of
@@ -63,9 +59,6 @@ pub trait PlatformStore: Send + Sync {
     // Harness Operations
     // =========================================================================
 
-    /// List all harnesses in the organization.
-    async fn list_harnesses(&self) -> Result<Vec<Harness>>;
-
     /// Get a harness by ID.
     async fn get_harness(&self, id: HarnessId) -> Result<Option<Harness>>;
 
@@ -96,194 +89,31 @@ pub trait PlatformStore: Send + Sync {
         Ok(chain)
     }
 
-    /// Create a new harness.
-    ///
-    /// `system_prompt` is optional: `None` creates a harness with no base
-    /// prompt of its own (it inherits from the parent harness, if any, and
-    /// composes with agent/session/capability layers at runtime).
-    async fn create_harness(
-        &self,
-        name: &str,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-        parent_harness_id: Option<HarnessId>,
-        capabilities: &[String],
-    ) -> Result<Harness>;
-
-    /// Update a harness (only provided fields are changed).
-    async fn update_harness(
-        &self,
-        id: HarnessId,
-        name: Option<&str>,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-        parent_harness_id: Option<Option<HarnessId>>,
-    ) -> Result<Harness>;
-
-    /// Delete (archive) a harness.
-    async fn delete_harness(&self, id: HarnessId) -> Result<()>;
-
-    /// Copy a harness, optionally with a new name.
-    async fn copy_harness(&self, id: HarnessId, new_name: Option<&str>) -> Result<Harness>;
-
     // =========================================================================
     // Agent Operations
     // =========================================================================
 
-    /// List all agents in the organization.
-    async fn list_agents(&self) -> Result<Vec<Agent>>;
-
     /// Get an agent by public ID.
     async fn get_agent_by_id(&self, id: AgentId) -> Result<Option<Agent>>;
-
-    /// Create a new agent.
-    async fn create_agent(
-        &self,
-        name: &str,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: &str,
-        capabilities: &[String],
-    ) -> Result<Agent>;
-
-    /// Update an agent (only provided fields are changed).
-    async fn update_agent(
-        &self,
-        id: AgentId,
-        name: Option<&str>,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-    ) -> Result<Agent>;
-
-    /// Delete (archive) an agent.
-    async fn delete_agent(&self, id: AgentId) -> Result<()>;
 
     // =========================================================================
     // App Operations
     // =========================================================================
 
-    /// List all apps in the organization.
-    async fn list_apps(&self, search: Option<&str>, include_archived: bool) -> Result<Vec<App>>;
-
-    /// Get an app by ID.
-    async fn get_app(&self, id: AppId) -> Result<Option<App>>;
-
-    /// Create a new app.
-    #[allow(clippy::too_many_arguments)]
-    async fn create_app(
-        &self,
-        name: &str,
-        description: Option<&str>,
-        harness_id: HarnessId,
-        agent_id: Option<AgentId>,
-        agent_identity_id: Option<AgentIdentityId>,
-        channel_type: Option<ChannelType>,
-        channel_config: Option<&serde_json::Value>,
-    ) -> Result<App>;
-
-    /// Update an app (only provided fields are changed).
-    #[allow(clippy::too_many_arguments)]
-    async fn update_app(
-        &self,
-        id: AppId,
-        name: Option<&str>,
-        description: Option<&str>,
-        harness_id: Option<HarnessId>,
-        agent_id: Option<AgentId>,
-        agent_identity_id: Option<Option<AgentIdentityId>>,
-    ) -> Result<App>;
-
-    /// Archive an app.
-    async fn delete_app(&self, id: AppId) -> Result<()>;
-
-    /// Permanently destroy an archived app.
-    async fn destroy_app(&self, id: AppId) -> Result<()>;
-
-    /// Publish an app.
-    async fn publish_app(&self, id: AppId) -> Result<App>;
-
-    /// Unpublish an app back to draft.
-    async fn unpublish_app(&self, id: AppId) -> Result<App>;
-
-    /// Add a channel to an app.
-    async fn add_app_channel(
-        &self,
-        app_id: AppId,
-        channel_type: ChannelType,
-        channel_config: Option<&serde_json::Value>,
-        enabled: Option<bool>,
-    ) -> Result<AppChannel>;
-
-    /// Update a channel on an app.
-    async fn update_app_channel(
-        &self,
-        app_id: AppId,
-        channel_id: AppChannelId,
-        channel_type: Option<ChannelType>,
-        channel_config: Option<&serde_json::Value>,
-        enabled: Option<bool>,
-    ) -> Result<AppChannel>;
-
-    /// Delete a channel from an app.
-    async fn delete_app_channel(&self, app_id: AppId, channel_id: AppChannelId) -> Result<()>;
-
     // =========================================================================
     // Session Operations
     // =========================================================================
 
-    /// List sessions, optionally filtered by agent.
-    async fn list_sessions(
-        &self,
-        limit: Option<usize>,
-        agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>>;
-
-    /// Create a new session.
+    /// Create a session for delegation (subagents, handoff, A2A).
     ///
-    /// When `blueprint_id` is set, the session runs a blueprint agent instead
-    /// of inheriting from `harness_id`/`agent_id`. `blueprint_config` is
-    /// validated config for the blueprint (JSON, optional).
-    /// `parent_session_id` links child subagent/handoff sessions to their parent
-    /// (used to compute governed subagent delegation depth).
-    #[allow(clippy::too_many_arguments)]
-    async fn create_session(
-        &self,
-        harness_id: HarnessId,
-        agent_id: Option<AgentId>,
-        title: Option<&str>,
-        locale: Option<&str>,
-        blueprint_id: Option<&str>,
-        blueprint_config: Option<&serde_json::Value>,
-        parent_session_id: Option<SessionId>,
-    ) -> Result<Session>;
-
+    /// Required rather than defaulted: the flat `create_session` it used to
+    /// delegate to was legacy CRUD with no remaining callers, and every
+    /// implementation already overrode this method to honour the fields that
+    /// default could not express (goal, lineage, budget root, seed mode).
     async fn create_session_with_options(
         &self,
         request: PlatformCreateSessionRequest,
-    ) -> Result<Session> {
-        if request.goal.is_some()
-            || request.forked_from_session_id.is_some()
-            || request.budget_root_session_id.is_some()
-            || request.seed != SessionSeedMode::Fresh
-        {
-            return Err(everruns_provider::error::AgentLoopError::tool(
-                "platform store does not support goal, lineage, budget-root override, or seeded session creation",
-            ));
-        }
-        self.create_session(
-            request.harness_id,
-            request.agent_id,
-            request.title.as_deref(),
-            request.locale.as_deref(),
-            request.blueprint_id.as_deref(),
-            request.blueprint_config.as_ref(),
-            request.parent_session_id,
-        )
-        .await
-    }
+    ) -> Result<Session>;
 
     /// Get a session by ID.
     async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>>;
@@ -294,12 +124,6 @@ pub trait PlatformStore: Send + Sync {
         session_id: SessionId,
         agent_id: AgentId,
     ) -> Result<SessionParticipant>;
-
-    /// Get the latest estimated context breakdown for a session.
-    async fn get_session_context_report(&self, id: SessionId) -> Result<SessionContextReport>;
-
-    /// Delete (archive) a session.
-    async fn delete_session(&self, id: SessionId) -> Result<()>;
 
     // =========================================================================
     // Messaging
@@ -333,18 +157,9 @@ pub trait PlatformStore: Send + Sync {
     // Capabilities
     // =========================================================================
 
-    /// List all available capabilities (built-in + MCP servers + skills).
-    ///
-    /// Optionally filter by a search query (case-insensitive match against
-    /// name, description, category, and capability ID).
-    async fn list_capabilities(&self, search: Option<&str>) -> Result<Vec<CapabilityInfo>>;
-
     // =========================================================================
     // UI Links
     // =========================================================================
-
-    /// Base URL for constructing UI links (e.g., "http://localhost:9300").
-    fn base_url(&self) -> &str;
 }
 
 /// Typed [`ToolContext`](everruns_core::tool_context::ToolContext) extension carrying the
@@ -439,7 +254,6 @@ impl everruns_core::subagent_delegation::SubagentSessionDelegate for PlatformSto
 pub mod tests {
     use super::*;
     use crate::agent::{Agent, AgentStatus};
-    use crate::app::{App, AppChannel, AppStatus, ChannelType};
     use crate::harness::HarnessStatus;
     use crate::session::{Session, SessionStatus};
     use everruns_capability::CapabilityRef as AgentCapabilityConfig;
@@ -454,8 +268,6 @@ pub mod tests {
         pub harness: Harness,
         pub extra_harnesses: std::sync::Mutex<std::collections::HashMap<HarnessId, Harness>>,
         pub agent: Agent,
-        pub app: App,
-        pub app_channel: AppChannel,
         pub session: Session,
         pub extra_sessions: std::sync::Mutex<std::collections::HashMap<SessionId, Session>>,
         pub joined_participants: std::sync::Mutex<Vec<SessionParticipant>>,
@@ -535,42 +347,6 @@ pub mod tests {
                     archived_at: None,
                     deleted_at: None,
                     usage: None,
-                },
-                app_channel: AppChannel {
-                    public_id: AppChannelId::new(),
-                    internal_id: uuid::Uuid::now_v7(),
-                    channel_type: ChannelType::Webhook,
-                    channel_config: serde_json::json!({
-                        "token": "secret-1",
-                        "session_mode": "shared_session",
-                        "message": "Run checks for {{payload.repo.name}}"
-                    }),
-                    enabled: true,
-                    created_at: chrono::Utc::now(),
-                    updated_at: chrono::Utc::now(),
-                },
-                app: App {
-                    public_id: AppId::new(),
-                    internal_id: uuid::Uuid::now_v7(),
-                    org_id: 1,
-                    name: "test-app".to_string(),
-                    description: Some("test app".to_string()),
-                    harness_id: HarnessId::new(),
-                    agent_id: Some(everruns_provider::typed_id::AgentId::new()),
-                    agent_version_policy: crate::app::AgentVersionPolicy::Default,
-                    agent_version_id: None,
-                    agent_identity_id: Some(everruns_provider::typed_id::AgentIdentityId::new()),
-                    owner_principal_id: everruns_provider::typed_id::PrincipalId::from_seed(1),
-                    resolved_owner_user_id: None,
-                    owner: None,
-                    effective_owner: None,
-                    channels: vec![],
-                    status: AppStatus::Draft,
-                    published_at: None,
-                    created_at: chrono::Utc::now(),
-                    updated_at: chrono::Utc::now(),
-                    archived_at: None,
-                    deleted_at: None,
                 },
                 session: {
                     let session_id = SessionId::new();
@@ -652,9 +428,6 @@ pub mod tests {
             Ok(arguments.to_string())
         }
 
-        async fn list_harnesses(&self) -> Result<Vec<Harness>> {
-            Ok(vec![self.harness.clone()])
-        }
         async fn get_harness(&self, id: HarnessId) -> Result<Option<Harness>> {
             if let Some(harness) = self.extra_harnesses.lock().unwrap().get(&id).cloned() {
                 return Ok(Some(harness));
@@ -667,260 +440,11 @@ pub mod tests {
             harness.id = id;
             Ok(Some(harness))
         }
-        async fn create_harness(
-            &self,
-            name: &str,
-            display_name: Option<&str>,
-            _desc: Option<&str>,
-            _prompt: Option<&str>,
-            parent_harness_id: Option<HarnessId>,
-            _caps: &[String],
-        ) -> Result<Harness> {
-            let mut h = self.harness.clone();
-            h.name = name.to_string();
-            h.display_name = display_name.map(|s| s.to_string());
-            h.parent_harness_id = parent_harness_id;
-            Ok(h)
-        }
-        async fn update_harness(
-            &self,
-            _id: HarnessId,
-            name: Option<&str>,
-            display_name: Option<&str>,
-            _desc: Option<&str>,
-            _prompt: Option<&str>,
-            parent_harness_id: Option<Option<HarnessId>>,
-        ) -> Result<Harness> {
-            let mut h = self.harness.clone();
-            if let Some(n) = name {
-                h.name = n.to_string();
-            }
-            if let Some(dn) = display_name {
-                h.display_name = Some(dn.to_string());
-            }
-            if let Some(parent_harness_id) = parent_harness_id {
-                h.parent_harness_id = parent_harness_id;
-            }
-            Ok(h)
-        }
-        async fn delete_harness(&self, _id: HarnessId) -> Result<()> {
-            Ok(())
-        }
-        async fn copy_harness(&self, _id: HarnessId, new_name: Option<&str>) -> Result<Harness> {
-            let mut h = self.harness.clone();
-            h.id = HarnessId::new();
-            h.name = new_name.unwrap_or("copy").to_string();
-            Ok(h)
-        }
-        async fn list_agents(&self) -> Result<Vec<Agent>> {
-            Ok(vec![self.agent.clone()])
-        }
         async fn get_agent_by_id(
             &self,
             _id: everruns_provider::typed_id::AgentId,
         ) -> Result<Option<Agent>> {
             Ok(Some(self.agent.clone()))
-        }
-        async fn create_agent(
-            &self,
-            name: &str,
-            display_name: Option<&str>,
-            _desc: Option<&str>,
-            _prompt: &str,
-            _caps: &[String],
-        ) -> Result<Agent> {
-            let mut a = self.agent.clone();
-            a.name = name.to_string();
-            a.display_name = display_name.map(|s| s.to_string());
-            Ok(a)
-        }
-        async fn update_agent(
-            &self,
-            _id: everruns_provider::typed_id::AgentId,
-            name: Option<&str>,
-            display_name: Option<&str>,
-            _desc: Option<&str>,
-            _prompt: Option<&str>,
-        ) -> Result<Agent> {
-            let mut a = self.agent.clone();
-            if let Some(n) = name {
-                a.name = n.to_string();
-            }
-            if let Some(dn) = display_name {
-                a.display_name = Some(dn.to_string());
-            }
-            Ok(a)
-        }
-        async fn delete_agent(&self, _id: everruns_provider::typed_id::AgentId) -> Result<()> {
-            Ok(())
-        }
-        async fn list_apps(
-            &self,
-            _search: Option<&str>,
-            _include_archived: bool,
-        ) -> Result<Vec<App>> {
-            let mut app = self.app.clone();
-            app.channels = vec![self.app_channel.clone()];
-            Ok(vec![app])
-        }
-        async fn get_app(&self, _id: AppId) -> Result<Option<App>> {
-            let mut app = self.app.clone();
-            app.channels = vec![self.app_channel.clone()];
-            Ok(Some(app))
-        }
-        async fn create_app(
-            &self,
-            name: &str,
-            description: Option<&str>,
-            harness_id: HarnessId,
-            agent_id: Option<AgentId>,
-            agent_identity_id: Option<AgentIdentityId>,
-            channel_type: Option<ChannelType>,
-            channel_config: Option<&serde_json::Value>,
-        ) -> Result<App> {
-            let mut app = self.app.clone();
-            app.name = name.to_string();
-            app.description = description.map(|value| value.to_string());
-            app.harness_id = harness_id;
-            app.agent_id = agent_id;
-            app.agent_identity_id = agent_identity_id;
-            app.channels = channel_type
-                .map(|channel_type| {
-                    let mut channel = self.app_channel.clone();
-                    channel.channel_type = channel_type;
-                    if let Some(channel_config) = channel_config {
-                        channel.channel_config = channel_config.clone();
-                    }
-                    vec![channel]
-                })
-                .unwrap_or_default();
-            Ok(app)
-        }
-        async fn update_app(
-            &self,
-            _id: AppId,
-            name: Option<&str>,
-            description: Option<&str>,
-            harness_id: Option<HarnessId>,
-            agent_id: Option<AgentId>,
-            agent_identity_id: Option<Option<AgentIdentityId>>,
-        ) -> Result<App> {
-            let mut app = self.app.clone();
-            app.channels = vec![self.app_channel.clone()];
-            if let Some(name) = name {
-                app.name = name.to_string();
-            }
-            if let Some(description) = description {
-                app.description = Some(description.to_string());
-            }
-            if let Some(harness_id) = harness_id {
-                app.harness_id = harness_id;
-            }
-            if let Some(agent_id) = agent_id {
-                app.agent_id = Some(agent_id);
-            }
-            if let Some(agent_identity_id) = agent_identity_id {
-                app.agent_identity_id = agent_identity_id;
-            }
-            Ok(app)
-        }
-        async fn delete_app(&self, _id: AppId) -> Result<()> {
-            Ok(())
-        }
-        async fn destroy_app(&self, _id: AppId) -> Result<()> {
-            Ok(())
-        }
-        async fn publish_app(&self, _id: AppId) -> Result<App> {
-            let mut app = self.app.clone();
-            app.channels = vec![self.app_channel.clone()];
-            app.status = AppStatus::Published;
-            app.published_at = Some(chrono::Utc::now());
-            Ok(app)
-        }
-        async fn unpublish_app(&self, _id: AppId) -> Result<App> {
-            let mut app = self.app.clone();
-            app.channels = vec![self.app_channel.clone()];
-            app.status = AppStatus::Draft;
-            app.published_at = None;
-            Ok(app)
-        }
-        async fn add_app_channel(
-            &self,
-            _app_id: AppId,
-            channel_type: ChannelType,
-            channel_config: Option<&serde_json::Value>,
-            enabled: Option<bool>,
-        ) -> Result<AppChannel> {
-            let mut channel = self.app_channel.clone();
-            channel.channel_type = channel_type;
-            if let Some(channel_config) = channel_config {
-                channel.channel_config = channel_config.clone();
-            }
-            if let Some(enabled) = enabled {
-                channel.enabled = enabled;
-            }
-            Ok(channel)
-        }
-        async fn update_app_channel(
-            &self,
-            _app_id: AppId,
-            _channel_id: AppChannelId,
-            channel_type: Option<ChannelType>,
-            channel_config: Option<&serde_json::Value>,
-            enabled: Option<bool>,
-        ) -> Result<AppChannel> {
-            let mut channel = self.app_channel.clone();
-            if let Some(channel_type) = channel_type {
-                channel.channel_type = channel_type;
-            }
-            if let Some(channel_config) = channel_config {
-                channel.channel_config = channel_config.clone();
-            }
-            if let Some(enabled) = enabled {
-                channel.enabled = enabled;
-            }
-            Ok(channel)
-        }
-        async fn delete_app_channel(
-            &self,
-            _app_id: AppId,
-            _channel_id: AppChannelId,
-        ) -> Result<()> {
-            Ok(())
-        }
-        async fn list_sessions(
-            &self,
-            _limit: Option<usize>,
-            _agent_id: Option<everruns_provider::typed_id::AgentId>,
-        ) -> Result<Vec<Session>> {
-            Ok(vec![self.session.clone()])
-        }
-        async fn create_session(
-            &self,
-            hid: HarnessId,
-            aid: Option<everruns_provider::typed_id::AgentId>,
-            title: Option<&str>,
-            locale: Option<&str>,
-            blueprint_id: Option<&str>,
-            blueprint_config: Option<&serde_json::Value>,
-            parent_session_id: Option<SessionId>,
-        ) -> Result<Session> {
-            if let Ok(mut recorder) = self.created_session_harness_ids.lock() {
-                recorder.push(hid);
-            }
-            let mut s = self.session.clone();
-            s.id = SessionId::new();
-            s.harness_id = hid;
-            s.agent_id = aid;
-            s.title = title.map(|t| t.to_string());
-            s.locale = locale.map(|value| value.to_string());
-            s.blueprint_id = blueprint_id.map(|b| b.to_string());
-            s.blueprint_config = blueprint_config.cloned();
-            s.parent_session_id = parent_session_id;
-            if let Ok(mut sessions) = self.extra_sessions.lock() {
-                sessions.insert(s.id, s.clone());
-            }
-            Ok(s)
         }
         async fn create_session_with_options(
             &self,
@@ -930,17 +454,18 @@ pub mod tests {
                 .lock()
                 .expect("budget root recorder")
                 .push(request.budget_root_session_id);
-            let mut session = self
-                .create_session(
-                    request.harness_id,
-                    request.agent_id,
-                    request.title.as_deref(),
-                    request.locale.as_deref(),
-                    request.blueprint_id.as_deref(),
-                    request.blueprint_config.as_ref(),
-                    request.parent_session_id,
-                )
-                .await?;
+            if let Ok(mut recorder) = self.created_session_harness_ids.lock() {
+                recorder.push(request.harness_id);
+            }
+            let mut session = self.session.clone();
+            session.id = SessionId::new();
+            session.harness_id = request.harness_id;
+            session.agent_id = request.agent_id;
+            session.title = request.title.clone();
+            session.locale = request.locale.clone();
+            session.blueprint_id = request.blueprint_id.clone();
+            session.blueprint_config = request.blueprint_config.clone();
+            session.parent_session_id = request.parent_session_id;
             session.goal = request.goal;
             session.forked_from_session_id = request.forked_from_session_id;
             if let Ok(mut sessions) = self.extra_sessions.lock() {
@@ -984,25 +509,6 @@ pub mod tests {
             }
             Ok(participant)
         }
-        async fn get_session_context_report(&self, id: SessionId) -> Result<SessionContextReport> {
-            Ok(SessionContextReport {
-                session_id: id.to_string(),
-                model: "llmsim".to_string(),
-                context_window_tokens: Some(128_000),
-                estimated_input_tokens: 42,
-                sections: vec![everruns_core::ContextReportSection {
-                    key: "conversation".to_string(),
-                    label: "Conversation".to_string(),
-                    tokens: 42,
-                    items: 1,
-                }],
-                contributions: vec![],
-                cumulative_usage: None,
-            })
-        }
-        async fn delete_session(&self, _id: SessionId) -> Result<()> {
-            Ok(())
-        }
         async fn send_message(&self, id: SessionId, content: &str) -> Result<()> {
             self.sent_messages
                 .lock()
@@ -1030,24 +536,6 @@ pub mod tests {
         }
         async fn wait_for_idle(&self, _id: SessionId, _t: Option<u64>) -> Result<String> {
             Ok(self.wait_for_idle_status.lock().unwrap().clone())
-        }
-        async fn list_capabilities(&self, search: Option<&str>) -> Result<Vec<CapabilityInfo>> {
-            let mut registry = everruns_core::capabilities::CapabilityRegistry::new();
-            everruns_builtins::register_runtime_capabilities(&mut registry)
-                .expect("test portable catalog must have unique capability IDs");
-            let mut caps: Vec<CapabilityInfo> = registry
-                .list()
-                .iter()
-                .map(|c| CapabilityInfo::from_core(c.as_ref()))
-                .collect();
-            if let Some(q) = search {
-                caps.retain(|c| c.matches_search(q));
-            }
-            caps.sort_by(|a, b| a.name.cmp(&b.name));
-            Ok(caps)
-        }
-        fn base_url(&self) -> &str {
-            "http://localhost:9300"
         }
     }
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -55,16 +55,10 @@ use crate::services::{EventService, ProviderResolverService};
 use crate::storage::models::{AgentCapabilityRow, AgentRow, UpdateSession};
 use crate::storage::{EncryptionService, StorageBackend};
 use everruns_durable::WorkflowEventStore;
-use serde::Deserialize;
 
 // Helper to create store errors
 fn store_error(msg: impl Into<String>) -> AgentLoopError {
     AgentLoopError::store(msg)
-}
-
-#[derive(Debug, Deserialize)]
-struct CommandPage<T> {
-    data: Vec<T>,
 }
 
 /// Extract file name from path
@@ -2753,13 +2747,6 @@ impl DirectPlatformStore {
         )
     }
 
-    fn capability_refs_to_configs(capabilities: &[String]) -> Vec<serde_json::Value> {
-        capabilities
-            .iter()
-            .map(|capability| serde_json::json!({ "ref": capability, "config": {} }))
-            .collect()
-    }
-
     async fn resolve_caller(&self) -> everruns_provider::error::Result<Caller> {
         self.resolved_caller
             .get_or_try_init(|| async {
@@ -2983,11 +2970,6 @@ impl everruns_platform::PlatformStore for DirectPlatformStore {
     // Harness Operations
     // =========================================================================
 
-    async fn list_harnesses(&self) -> everruns_provider::error::Result<Vec<Harness>> {
-        self.execute_domain_command("list_harnesses", serde_json::json!({}))
-            .await
-    }
-
     async fn get_harness(
         &self,
         id: HarnessId,
@@ -2996,127 +2978,9 @@ impl everruns_platform::PlatformStore for DirectPlatformStore {
             .await
     }
 
-    async fn create_harness(
-        &self,
-        name: &str,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-        parent_harness_id: Option<HarnessId>,
-        capabilities: &[String],
-    ) -> everruns_provider::error::Result<Harness> {
-        self.execute_domain_command(
-            "create_harness",
-            serde_json::json!({
-                "name": name,
-                "display_name": display_name,
-                "description": description,
-                // Omit when absent so the harness contributes no base prompt.
-                "system_prompt": system_prompt,
-                "parent_harness_id": parent_harness_id.map(|id| id.to_string()),
-                "tags": ["managed"],
-                "initial_files": [],
-                "mcp_servers": {},
-                "capabilities": Self::capability_refs_to_configs(capabilities),
-            }),
-        )
-        .await
-    }
-
-    async fn update_harness(
-        &self,
-        id: HarnessId,
-        name: Option<&str>,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-        parent_harness_id: Option<Option<HarnessId>>,
-    ) -> everruns_provider::error::Result<Harness> {
-        let mut params = serde_json::Map::from_iter([(
-            "id".to_string(),
-            serde_json::Value::String(id.to_string()),
-        )]);
-        if let Some(name) = name {
-            params.insert(
-                "name".to_string(),
-                serde_json::Value::String(name.to_string()),
-            );
-        }
-        if let Some(display_name) = display_name {
-            params.insert(
-                "display_name".to_string(),
-                serde_json::Value::String(display_name.to_string()),
-            );
-        }
-        if let Some(description) = description {
-            params.insert(
-                "description".to_string(),
-                serde_json::Value::String(description.to_string()),
-            );
-        }
-        if let Some(system_prompt) = system_prompt {
-            params.insert(
-                "system_prompt".to_string(),
-                serde_json::Value::String(system_prompt.to_string()),
-            );
-        }
-        match parent_harness_id {
-            Some(Some(parent_id)) => {
-                params.insert(
-                    "parent_harness_id".to_string(),
-                    serde_json::Value::String(parent_id.to_string()),
-                );
-            }
-            Some(None) => {
-                params.insert("parent_harness_id".to_string(), serde_json::Value::Null);
-            }
-            None => {}
-        }
-
-        self.execute_domain_command("update_harness", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn delete_harness(&self, id: HarnessId) -> everruns_provider::error::Result<()> {
-        let _: serde_json::Value = self
-            .execute_domain_command(
-                "delete_harness",
-                serde_json::json!({ "id": id.to_string() }),
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn copy_harness(
-        &self,
-        id: HarnessId,
-        new_name: Option<&str>,
-    ) -> everruns_provider::error::Result<Harness> {
-        let harness: Harness = self
-            .execute_domain_command("copy_harness", serde_json::json!({ "id": id.to_string() }))
-            .await?;
-
-        if let Some(new_name) = new_name {
-            self.update_harness(harness.id, Some(new_name), None, None, None, None)
-                .await
-        } else {
-            Ok(harness)
-        }
-    }
-
     // =========================================================================
     // Agent Operations
     // =========================================================================
-
-    async fn list_agents(&self) -> everruns_provider::error::Result<Vec<Agent>> {
-        let page: CommandPage<Agent> = self
-            .execute_domain_command(
-                "list_agents",
-                serde_json::json!({ "offset": 0, "limit": 1000 }),
-            )
-            .await?;
-        Ok(page.data)
-    }
 
     async fn get_agent_by_id(
         &self,
@@ -3126,381 +2990,13 @@ impl everruns_platform::PlatformStore for DirectPlatformStore {
             .await
     }
 
-    async fn create_agent(
-        &self,
-        name: &str,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: &str,
-        capabilities: &[String],
-    ) -> everruns_provider::error::Result<Agent> {
-        self.execute_domain_command(
-            "create_agent",
-            serde_json::json!({
-                "name": name,
-                "display_name": display_name,
-                "description": description,
-                "system_prompt": system_prompt,
-                "tags": ["managed"],
-                "initial_files": [],
-                "tools": [],
-                "mcp_servers": {},
-                "capabilities": Self::capability_refs_to_configs(capabilities),
-            }),
-        )
-        .await
-    }
-
-    async fn update_agent(
-        &self,
-        id: AgentId,
-        name: Option<&str>,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-    ) -> everruns_provider::error::Result<Agent> {
-        let mut params = serde_json::Map::from_iter([(
-            "id".to_string(),
-            serde_json::Value::String(id.to_string()),
-        )]);
-        if let Some(name) = name {
-            params.insert(
-                "name".to_string(),
-                serde_json::Value::String(name.to_string()),
-            );
-        }
-        if let Some(display_name) = display_name {
-            params.insert(
-                "display_name".to_string(),
-                serde_json::Value::String(display_name.to_string()),
-            );
-        }
-        if let Some(description) = description {
-            params.insert(
-                "description".to_string(),
-                serde_json::Value::String(description.to_string()),
-            );
-        }
-        if let Some(system_prompt) = system_prompt {
-            params.insert(
-                "system_prompt".to_string(),
-                serde_json::Value::String(system_prompt.to_string()),
-            );
-        }
-
-        self.execute_domain_command("update_agent", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn delete_agent(&self, id: AgentId) -> everruns_provider::error::Result<()> {
-        let _: serde_json::Value = self
-            .execute_domain_command("delete_agent", serde_json::json!({ "id": id.to_string() }))
-            .await?;
-        Ok(())
-    }
-
     // =========================================================================
     // App Operations
     // =========================================================================
 
-    async fn list_apps(
-        &self,
-        search: Option<&str>,
-        include_archived: bool,
-    ) -> everruns_provider::error::Result<Vec<everruns_platform::App>> {
-        let mut params = serde_json::Map::new();
-        if let Some(search) = search {
-            params.insert(
-                "search".to_string(),
-                serde_json::Value::String(search.to_string()),
-            );
-        }
-        if include_archived {
-            params.insert(
-                "include_archived".to_string(),
-                serde_json::Value::Bool(true),
-            );
-        }
-        self.execute_domain_command("list_apps", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn get_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-    ) -> everruns_provider::error::Result<Option<everruns_platform::App>> {
-        self.execute_domain_lookup("get_app", serde_json::json!({ "id": id.to_string() }))
-            .await
-    }
-
-    async fn create_app(
-        &self,
-        name: &str,
-        description: Option<&str>,
-        harness_id: HarnessId,
-        agent_id: Option<AgentId>,
-        agent_identity_id: Option<everruns_provider::typed_id::AgentIdentityId>,
-        channel_type: Option<everruns_platform::ChannelType>,
-        channel_config: Option<&serde_json::Value>,
-    ) -> everruns_provider::error::Result<everruns_platform::App> {
-        let mut params = serde_json::Map::from_iter([
-            (
-                "name".to_string(),
-                serde_json::Value::String(name.to_string()),
-            ),
-            (
-                "harness_id".to_string(),
-                serde_json::Value::String(harness_id.to_string()),
-            ),
-        ]);
-        if let Some(description) = description {
-            params.insert(
-                "description".to_string(),
-                serde_json::Value::String(description.to_string()),
-            );
-        }
-        if let Some(agent_id) = agent_id {
-            params.insert(
-                "agent_id".to_string(),
-                serde_json::Value::String(agent_id.to_string()),
-            );
-        }
-        if let Some(agent_identity_id) = agent_identity_id {
-            params.insert(
-                "agent_identity_id".to_string(),
-                serde_json::Value::String(agent_identity_id.to_string()),
-            );
-        }
-        if let Some(channel_type) = channel_type {
-            params.insert(
-                "channel_type".to_string(),
-                serde_json::Value::String(channel_type.to_string()),
-            );
-        }
-        if let Some(channel_config) = channel_config {
-            params.insert("channel_config".to_string(), channel_config.clone());
-        }
-        self.execute_domain_command("create_app", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn update_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-        name: Option<&str>,
-        description: Option<&str>,
-        harness_id: Option<HarnessId>,
-        agent_id: Option<AgentId>,
-        agent_identity_id: Option<Option<everruns_provider::typed_id::AgentIdentityId>>,
-    ) -> everruns_provider::error::Result<everruns_platform::App> {
-        let mut params = serde_json::Map::from_iter([(
-            "id".to_string(),
-            serde_json::Value::String(id.to_string()),
-        )]);
-        if let Some(name) = name {
-            params.insert(
-                "name".to_string(),
-                serde_json::Value::String(name.to_string()),
-            );
-        }
-        if let Some(description) = description {
-            params.insert(
-                "description".to_string(),
-                serde_json::Value::String(description.to_string()),
-            );
-        }
-        if let Some(harness_id) = harness_id {
-            params.insert(
-                "harness_id".to_string(),
-                serde_json::Value::String(harness_id.to_string()),
-            );
-        }
-        if let Some(agent_id) = agent_id {
-            params.insert(
-                "agent_id".to_string(),
-                serde_json::Value::String(agent_id.to_string()),
-            );
-        }
-        match agent_identity_id {
-            Some(Some(agent_identity_id)) => {
-                params.insert(
-                    "agent_identity_id".to_string(),
-                    serde_json::Value::String(agent_identity_id.to_string()),
-                );
-            }
-            Some(None) => {
-                params.insert("agent_identity_id".to_string(), serde_json::Value::Null);
-            }
-            None => {}
-        }
-        self.execute_domain_command("update_app", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn delete_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-    ) -> everruns_provider::error::Result<()> {
-        let _: serde_json::Value = self
-            .execute_domain_command("delete_app", serde_json::json!({ "id": id.to_string() }))
-            .await?;
-        Ok(())
-    }
-
-    async fn destroy_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-    ) -> everruns_provider::error::Result<()> {
-        let _: serde_json::Value = self
-            .execute_domain_command("destroy_app", serde_json::json!({ "id": id.to_string() }))
-            .await?;
-        Ok(())
-    }
-
-    async fn publish_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-    ) -> everruns_provider::error::Result<everruns_platform::App> {
-        self.execute_domain_command("publish_app", serde_json::json!({ "id": id.to_string() }))
-            .await
-    }
-
-    async fn unpublish_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-    ) -> everruns_provider::error::Result<everruns_platform::App> {
-        self.execute_domain_command("unpublish_app", serde_json::json!({ "id": id.to_string() }))
-            .await
-    }
-
-    async fn add_app_channel(
-        &self,
-        app_id: everruns_provider::typed_id::AppId,
-        channel_type: everruns_platform::ChannelType,
-        channel_config: Option<&serde_json::Value>,
-        enabled: Option<bool>,
-    ) -> everruns_provider::error::Result<everruns_platform::AppChannel> {
-        let mut params = serde_json::Map::from_iter([
-            (
-                "app_id".to_string(),
-                serde_json::Value::String(app_id.to_string()),
-            ),
-            (
-                "channel_type".to_string(),
-                serde_json::Value::String(channel_type.to_string()),
-            ),
-        ]);
-        if let Some(channel_config) = channel_config {
-            params.insert("channel_config".to_string(), channel_config.clone());
-        }
-        if let Some(enabled) = enabled {
-            params.insert("enabled".to_string(), serde_json::Value::Bool(enabled));
-        }
-        self.execute_domain_command("add_app_channel", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn update_app_channel(
-        &self,
-        app_id: everruns_provider::typed_id::AppId,
-        channel_id: everruns_provider::typed_id::AppChannelId,
-        channel_type: Option<everruns_platform::ChannelType>,
-        channel_config: Option<&serde_json::Value>,
-        enabled: Option<bool>,
-    ) -> everruns_provider::error::Result<everruns_platform::AppChannel> {
-        let mut params = serde_json::Map::from_iter([
-            (
-                "app_id".to_string(),
-                serde_json::Value::String(app_id.to_string()),
-            ),
-            (
-                "channel_id".to_string(),
-                serde_json::Value::String(channel_id.to_string()),
-            ),
-        ]);
-        if let Some(channel_type) = channel_type {
-            params.insert(
-                "channel_type".to_string(),
-                serde_json::Value::String(channel_type.to_string()),
-            );
-        }
-        if let Some(channel_config) = channel_config {
-            params.insert("channel_config".to_string(), channel_config.clone());
-        }
-        if let Some(enabled) = enabled {
-            params.insert("enabled".to_string(), serde_json::Value::Bool(enabled));
-        }
-        self.execute_domain_command("update_app_channel", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn delete_app_channel(
-        &self,
-        app_id: everruns_provider::typed_id::AppId,
-        channel_id: everruns_provider::typed_id::AppChannelId,
-    ) -> everruns_provider::error::Result<()> {
-        let _: serde_json::Value = self
-            .execute_domain_command(
-                "delete_app_channel",
-                serde_json::json!({
-                    "app_id": app_id.to_string(),
-                    "channel_id": channel_id.to_string(),
-                }),
-            )
-            .await?;
-        Ok(())
-    }
-
     // =========================================================================
     // Session Operations
     // =========================================================================
-
-    async fn list_sessions(
-        &self,
-        limit: Option<usize>,
-        agent_id: Option<AgentId>,
-    ) -> everruns_provider::error::Result<Vec<Session>> {
-        let page: CommandPage<Session> = self
-            .execute_domain_command(
-                "list_sessions",
-                serde_json::json!({
-                    "limit": limit.unwrap_or(20),
-                    "agent_id": agent_id.map(|id| id.to_string()),
-                }),
-            )
-            .await?;
-        Ok(page.data)
-    }
-
-    async fn create_session(
-        &self,
-        harness_id: HarnessId,
-        agent_id: Option<AgentId>,
-        title: Option<&str>,
-        locale: Option<&str>,
-        blueprint_id: Option<&str>,
-        blueprint_config: Option<&serde_json::Value>,
-        parent_session_id: Option<SessionId>,
-    ) -> everruns_provider::error::Result<Session> {
-        self.execute_domain_command(
-            "create_session",
-            serde_json::json!({
-                "harness_id": harness_id.to_string(),
-                "agent_id": agent_id.map(|id| id.to_string()),
-                "title": title,
-                "locale": locale,
-                "tags": ["managed"],
-                "capabilities": [],
-                "tools": [],
-                "mcp_servers": {},
-                "initial_files": [],
-                "blueprint_id": blueprint_id,
-                "blueprint_config": blueprint_config,
-                "parent_session_id": parent_session_id.map(|id| id.to_string()),
-            }),
-        )
-        .await
-    }
 
     async fn create_session_with_options(
         &self,
@@ -3555,27 +3051,6 @@ impl everruns_platform::PlatformStore for DirectPlatformStore {
             }),
         )
         .await
-    }
-
-    async fn get_session_context_report(
-        &self,
-        id: SessionId,
-    ) -> everruns_provider::error::Result<everruns_core::SessionContextReport> {
-        self.execute_domain_command(
-            "get_session_context_report",
-            serde_json::json!({ "session_id": id.to_string() }),
-        )
-        .await
-    }
-
-    async fn delete_session(&self, id: SessionId) -> everruns_provider::error::Result<()> {
-        let _: serde_json::Value = self
-            .execute_domain_command(
-                "delete_session",
-                serde_json::json!({ "session_id": id.to_string() }),
-            )
-            .await?;
-        Ok(())
     }
 
     // =========================================================================
@@ -3701,40 +3176,15 @@ impl everruns_platform::PlatformStore for DirectPlatformStore {
     // Capabilities
     // =========================================================================
 
-    async fn list_capabilities(
-        &self,
-        search: Option<&str>,
-    ) -> everruns_provider::error::Result<Vec<everruns_core::CapabilityInfo>> {
-        let mut params = serde_json::Map::new();
-        params.insert("limit".to_string(), serde_json::json!(200));
-        if let Some(search) = search {
-            params.insert(
-                "search".to_string(),
-                serde_json::Value::String(search.to_string()),
-            );
-        }
-        let page: CommandPage<everruns_core::CapabilityInfo> = self
-            .execute_domain_command("list_capabilities", serde_json::Value::Object(params))
-            .await?;
-        Ok(page.data)
-    }
-
     // =========================================================================
     // UI Links
     // =========================================================================
-
-    fn base_url(&self) -> &str {
-        // Leak a static string from env for lifetime reasons
-        // This is called infrequently and the value is stable
-        Box::leak(Self::base_url_from_env().into_boxed_str())
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::storage::models::CreateHarnessRow;
-    use everruns_platform::PlatformStore;
 
     #[test]
     fn string_to_provider_type_maps_gemini() {
@@ -4093,94 +3543,6 @@ mod tests {
         user.id
     }
 
-    fn test_platform_store(
-        adapters: &DirectWorkerAdapters,
-        org_id: i64,
-        session_id: SessionId,
-    ) -> DirectPlatformStore {
-        DirectPlatformStore::new(
-            org_id,
-            session_id,
-            adapters.db.clone(),
-            DirectPlatformStoreDeps {
-                event_service: adapters.event_service.clone(),
-                runner: None,
-                capability_registry: adapters.capability_registry.clone(),
-                connector_registry: adapters.connector_registry.clone(),
-                encryption: None,
-                workflow_store: None,
-                permission_resolver: adapters.permission_resolver.clone(),
-                egress_service: adapters.egress_service.clone(),
-            },
-        )
-    }
-
-    #[tokio::test]
-    async fn platform_store_update_rejects_built_in_harness() {
-        let adapters = test_adapters();
-        let harness_id = seed_harness_for_platform_store(
-            &adapters.db,
-            everruns_core::DEFAULT_ORG_ID,
-            "built-in",
-            true,
-        )
-        .await;
-        let owner_user_id = seed_platform_owner(
-            &adapters.db,
-            everruns_core::DEFAULT_ORG_ID,
-            "built-in-update-owner@example.com",
-        )
-        .await;
-        let session_id = seed_platform_session(
-            &adapters.db,
-            everruns_core::DEFAULT_ORG_ID,
-            harness_id,
-            Some(owner_user_id),
-        )
-        .await;
-        let store = test_platform_store(&adapters, everruns_core::DEFAULT_ORG_ID, session_id);
-
-        let err = store
-            .update_harness(harness_id, Some("renamed"), None, None, None, None)
-            .await
-            .expect_err("built-in harness updates should be rejected");
-
-        assert!(err.to_string().contains("built-in harness"));
-    }
-
-    #[tokio::test]
-    async fn platform_store_delete_rejects_built_in_harness() {
-        let adapters = test_adapters();
-        let harness_id = seed_harness_for_platform_store(
-            &adapters.db,
-            everruns_core::DEFAULT_ORG_ID,
-            "built-in",
-            true,
-        )
-        .await;
-        let owner_user_id = seed_platform_owner(
-            &adapters.db,
-            everruns_core::DEFAULT_ORG_ID,
-            "built-in-delete-owner@example.com",
-        )
-        .await;
-        let session_id = seed_platform_session(
-            &adapters.db,
-            everruns_core::DEFAULT_ORG_ID,
-            harness_id,
-            Some(owner_user_id),
-        )
-        .await;
-        let store = test_platform_store(&adapters, everruns_core::DEFAULT_ORG_ID, session_id);
-
-        let err = store
-            .delete_harness(harness_id)
-            .await
-            .expect_err("built-in harness deletes should be rejected");
-
-        assert!(err.to_string().contains("built-in harness"));
-    }
-
     #[tokio::test]
     async fn platform_store_uses_session_owner_permissions() {
         use crate::storage::models::{CreateOrganizationRow, CreateUserRow};
@@ -4244,17 +3606,6 @@ mod tests {
             script_error.to_string().contains("forbidden")
                 || script_error.to_string().contains("Access denied"),
             "unexpected authorization error: {script_error}"
-        );
-
-        let err = store
-            .create_harness("forbidden", None, None, Some("prompt"), None, &[])
-            .await
-            .expect_err("member should not manage harnesses via platform tools");
-
-        assert!(
-            err.to_string().contains("Access denied")
-                || err.to_string().contains("Permission denied"),
-            "unexpected error: {err}"
         );
     }
 
@@ -5110,11 +4461,27 @@ mod tests {
         let session_org2 =
             seed_platform_session(&adapters.db, org2.org_id, harness_org2, Some(owner_org2)).await;
 
+        // `list_agents` moved off PlatformStore with the legacy CRUD (EVE-953);
+        // the org boundary it guarded is now enforced on the command surface,
+        // so assert it there instead of dropping the coverage.
         let store_org1 = adapters.platform_store(everruns_core::DEFAULT_ORG_ID, session_org1);
-        let agents_org1 = store_org1.list_agents().await.unwrap();
-        assert!(!agents_org1.is_empty(), "default org should have agents");
+        let agents_org1 = store_org1
+            .platform_query(serde_json::json!({ "commands": "list_agents" }))
+            .await
+            .expect("default org may list its agents");
+        assert!(
+            agents_org1.contains("test-agent"),
+            "default org should see its seeded agent: {agents_org1}"
+        );
+
         let store_org2 = adapters.platform_store(org2.org_id, session_org2);
-        let agents_org2 = store_org2.list_agents().await.unwrap();
-        assert!(agents_org2.is_empty(), "second org should have no agents");
+        let agents_org2 = store_org2
+            .platform_query(serde_json::json!({ "commands": "list_agents" }))
+            .await
+            .expect("second org may list its agents");
+        assert!(
+            !agents_org2.contains("test-agent"),
+            "second org must not see the default org's agent: {agents_org2}"
+        );
     }
 }

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -660,6 +660,8 @@ async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
         .map(everruns_provider::typed_id::HarnessId::from_uuid)
         .expect("harness uuid");
 
+    // Keep a storage handle: `start_grpc_test_server` takes the service by value.
+    let db = service.db.clone();
     let (addr, shutdown_tx, server) = start_grpc_test_server(service).await;
     let client = everruns_worker::GrpcClient::connect(&addr)
         .await
@@ -747,16 +749,35 @@ async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
     assert_eq!(detached.parent_session_id, None);
     assert_eq!(detached.forked_from_session_id, Some(parent_id));
 
-    let target_agent = adapter
-        .create_agent(
-            "grpc-handoff-target",
-            Some("gRPC Handoff Target"),
-            None,
-            "You complete test handoffs.",
-            &[],
+    // Seeded directly rather than through the adapter: `create_agent` left
+    // PlatformStore with the legacy CRUD (EVE-953). This agent is setup for the
+    // handoff assertion below, not the behaviour under test.
+    let target_agent_id = everruns_provider::typed_id::AgentId::new();
+    let target_agent = db
+        .create_agent_with_id(
+            everruns_core::DEFAULT_ORG_ID,
+            target_agent_id,
+            crate::storage::models::CreateAgentRow {
+                public_id: target_agent_id.to_string(),
+                name: "grpc-handoff-target".to_string(),
+                display_name: Some("gRPC Handoff Target".to_string()),
+                description: None,
+                system_prompt: "You complete test handoffs.".to_string(),
+                default_model_id: None,
+                harness_id: parent_harness_id,
+                tags: vec![],
+                initial_files: serde_json::Value::Array(vec![]),
+                tools: serde_json::Value::Array(vec![]),
+                mcp_servers: serde_json::json!({}),
+                max_iterations: None,
+                network_access: None,
+                parallel_tool_calls: None,
+                is_built_in: false,
+            },
         )
         .await
-        .expect("create handoff target agent");
+        .expect("create handoff target agent")
+        .expect("handoff target agent should be created");
     let handoff_config = serde_json::json!({
         "targets": [{
             "id": "target",

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -56,12 +56,6 @@ use crate::grpc_durable_store::GrpcClientAuth;
 
 const COMMAND_API_VERSION_V1: &str = "v1";
 
-#[derive(Debug, serde::Deserialize)]
-struct CommandPage<T> {
-    data: Vec<T>,
-    total: u32,
-}
-
 /// Map a tonic gRPC status to the appropriate AgentLoopError variant.
 ///
 /// Preserves the semantic meaning of gRPC status codes so that callers
@@ -117,13 +111,6 @@ fn grpc_command_error_to_error(error: proto::CommandError) -> AgentLoopError {
         4 => AgentLoopError::store(format!("Conflict: {}", error.message)),
         _ => AgentLoopError::store(error.message),
     }
-}
-
-fn capability_refs_to_configs(capabilities: &[String]) -> Vec<serde_json::Value> {
-    capabilities
-        .iter()
-        .map(|capability| serde_json::json!({ "ref": capability, "config": {} }))
-        .collect()
 }
 
 /// Fetch image binary from a presigned URL and return as base64-encoded ResolvedImage.
@@ -3138,11 +3125,6 @@ impl everruns_platform::PlatformStore for GrpcOrgAdapter {
     // Harness Operations
     // =========================================================================
 
-    async fn list_harnesses(&self) -> Result<Vec<Harness>> {
-        self.execute_platform_command("list_harnesses", serde_json::json!({}))
-            .await
-    }
-
     async fn get_harness(
         &self,
         id: everruns_provider::typed_id::HarnessId,
@@ -3151,511 +3133,22 @@ impl everruns_platform::PlatformStore for GrpcOrgAdapter {
             .await
     }
 
-    async fn create_harness(
-        &self,
-        name: &str,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-        parent_harness_id: Option<everruns_provider::typed_id::HarnessId>,
-        capabilities: &[String],
-    ) -> Result<Harness> {
-        self.execute_platform_command(
-            "create_harness",
-            serde_json::json!({
-                "name": name,
-                "display_name": display_name,
-                "description": description,
-                // Omit when absent so the harness contributes no base prompt.
-                "system_prompt": system_prompt,
-                "parent_harness_id": parent_harness_id.map(|id| id.to_string()),
-                "capabilities": capability_refs_to_configs(capabilities),
-            }),
-        )
-        .await
-    }
-
-    async fn update_harness(
-        &self,
-        id: everruns_provider::typed_id::HarnessId,
-        name: Option<&str>,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-        parent_harness_id: Option<Option<everruns_provider::typed_id::HarnessId>>,
-    ) -> Result<Harness> {
-        let mut params = serde_json::Map::from_iter([(
-            "id".to_string(),
-            serde_json::Value::String(id.to_string()),
-        )]);
-        if let Some(name) = name {
-            params.insert(
-                "name".to_string(),
-                serde_json::Value::String(name.to_string()),
-            );
-        }
-        if let Some(display_name) = display_name {
-            params.insert(
-                "display_name".to_string(),
-                serde_json::Value::String(display_name.to_string()),
-            );
-        }
-        if let Some(description) = description {
-            params.insert(
-                "description".to_string(),
-                serde_json::Value::String(description.to_string()),
-            );
-        }
-        if let Some(system_prompt) = system_prompt {
-            params.insert(
-                "system_prompt".to_string(),
-                serde_json::Value::String(system_prompt.to_string()),
-            );
-        }
-        match parent_harness_id {
-            Some(Some(parent_id)) => {
-                params.insert(
-                    "parent_harness_id".to_string(),
-                    serde_json::Value::String(parent_id.to_string()),
-                );
-            }
-            Some(None) => {
-                params.insert("parent_harness_id".to_string(), serde_json::Value::Null);
-            }
-            None => {}
-        }
-
-        self.execute_platform_command("update_harness", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn delete_harness(&self, id: everruns_provider::typed_id::HarnessId) -> Result<()> {
-        let _: serde_json::Value = self
-            .execute_platform_command(
-                "delete_harness",
-                serde_json::json!({ "id": id.to_string() }),
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn copy_harness(
-        &self,
-        id: everruns_provider::typed_id::HarnessId,
-        new_name: Option<&str>,
-    ) -> Result<Harness> {
-        let harness: Harness = self
-            .execute_platform_command("copy_harness", serde_json::json!({ "id": id.to_string() }))
-            .await?;
-
-        if let Some(new_name) = new_name {
-            self.update_harness(harness.id, Some(new_name), None, None, None, None)
-                .await
-        } else {
-            Ok(harness)
-        }
-    }
-
     // =========================================================================
     // Agent Operations
     // =========================================================================
-
-    async fn list_agents(&self) -> Result<Vec<Agent>> {
-        let mut agents = Vec::new();
-        let mut offset = 0usize;
-        let limit = 100usize;
-
-        loop {
-            let page: CommandPage<Agent> = self
-                .execute_platform_command(
-                    "list_agents",
-                    serde_json::json!({ "offset": offset, "limit": limit }),
-                )
-                .await?;
-            let page_len = page.data.len();
-            let total = page.total as usize;
-            agents.extend(page.data);
-
-            if page_len == 0 || agents.len() >= total {
-                break;
-            }
-
-            offset = agents.len();
-        }
-
-        Ok(agents)
-    }
 
     async fn get_agent_by_id(&self, id: AgentId) -> Result<Option<Agent>> {
         self.execute_platform_lookup("get_agent", serde_json::json!({ "id": id.to_string() }))
             .await
     }
 
-    async fn create_agent(
-        &self,
-        name: &str,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: &str,
-        capabilities: &[String],
-    ) -> Result<Agent> {
-        self.execute_platform_command(
-            "create_agent",
-            serde_json::json!({
-                "name": name,
-                "display_name": display_name,
-                "description": description,
-                "system_prompt": system_prompt,
-                "capabilities": capability_refs_to_configs(capabilities),
-            }),
-        )
-        .await
-    }
-
-    async fn update_agent(
-        &self,
-        id: AgentId,
-        name: Option<&str>,
-        display_name: Option<&str>,
-        description: Option<&str>,
-        system_prompt: Option<&str>,
-    ) -> Result<Agent> {
-        let mut params = serde_json::Map::from_iter([(
-            "id".to_string(),
-            serde_json::Value::String(id.to_string()),
-        )]);
-        if let Some(name) = name {
-            params.insert(
-                "name".to_string(),
-                serde_json::Value::String(name.to_string()),
-            );
-        }
-        if let Some(display_name) = display_name {
-            params.insert(
-                "display_name".to_string(),
-                serde_json::Value::String(display_name.to_string()),
-            );
-        }
-        if let Some(description) = description {
-            params.insert(
-                "description".to_string(),
-                serde_json::Value::String(description.to_string()),
-            );
-        }
-        if let Some(system_prompt) = system_prompt {
-            params.insert(
-                "system_prompt".to_string(),
-                serde_json::Value::String(system_prompt.to_string()),
-            );
-        }
-
-        self.execute_platform_command("update_agent", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn delete_agent(&self, id: AgentId) -> Result<()> {
-        let _: serde_json::Value = self
-            .execute_platform_command("delete_agent", serde_json::json!({ "id": id.to_string() }))
-            .await?;
-        Ok(())
-    }
-
     // =========================================================================
     // App Operations
     // =========================================================================
 
-    async fn list_apps(
-        &self,
-        search: Option<&str>,
-        include_archived: bool,
-    ) -> Result<Vec<everruns_platform::App>> {
-        let mut params = serde_json::Map::new();
-        if let Some(search) = search {
-            params.insert(
-                "search".to_string(),
-                serde_json::Value::String(search.to_string()),
-            );
-        }
-        if include_archived {
-            params.insert(
-                "include_archived".to_string(),
-                serde_json::Value::Bool(true),
-            );
-        }
-        self.execute_platform_command("list_apps", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn get_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-    ) -> Result<Option<everruns_platform::App>> {
-        self.execute_platform_lookup("get_app", serde_json::json!({ "id": id.to_string() }))
-            .await
-    }
-
-    async fn create_app(
-        &self,
-        name: &str,
-        description: Option<&str>,
-        harness_id: everruns_provider::typed_id::HarnessId,
-        agent_id: Option<everruns_provider::typed_id::AgentId>,
-        agent_identity_id: Option<everruns_provider::typed_id::AgentIdentityId>,
-        channel_type: Option<everruns_platform::ChannelType>,
-        channel_config: Option<&serde_json::Value>,
-    ) -> Result<everruns_platform::App> {
-        let mut params = serde_json::Map::from_iter([
-            (
-                "name".to_string(),
-                serde_json::Value::String(name.to_string()),
-            ),
-            (
-                "harness_id".to_string(),
-                serde_json::Value::String(harness_id.to_string()),
-            ),
-        ]);
-        if let Some(description) = description {
-            params.insert(
-                "description".to_string(),
-                serde_json::Value::String(description.to_string()),
-            );
-        }
-        if let Some(agent_id) = agent_id {
-            params.insert(
-                "agent_id".to_string(),
-                serde_json::Value::String(agent_id.to_string()),
-            );
-        }
-        if let Some(agent_identity_id) = agent_identity_id {
-            params.insert(
-                "agent_identity_id".to_string(),
-                serde_json::Value::String(agent_identity_id.to_string()),
-            );
-        }
-        if let Some(channel_type) = channel_type {
-            params.insert(
-                "channel_type".to_string(),
-                serde_json::Value::String(channel_type.to_string()),
-            );
-        }
-        if let Some(channel_config) = channel_config {
-            params.insert("channel_config".to_string(), channel_config.clone());
-        }
-        self.execute_platform_command("create_app", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn update_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-        name: Option<&str>,
-        description: Option<&str>,
-        harness_id: Option<everruns_provider::typed_id::HarnessId>,
-        agent_id: Option<everruns_provider::typed_id::AgentId>,
-        agent_identity_id: Option<Option<everruns_provider::typed_id::AgentIdentityId>>,
-    ) -> Result<everruns_platform::App> {
-        let mut params = serde_json::Map::from_iter([(
-            "id".to_string(),
-            serde_json::Value::String(id.to_string()),
-        )]);
-        if let Some(name) = name {
-            params.insert(
-                "name".to_string(),
-                serde_json::Value::String(name.to_string()),
-            );
-        }
-        if let Some(description) = description {
-            params.insert(
-                "description".to_string(),
-                serde_json::Value::String(description.to_string()),
-            );
-        }
-        if let Some(harness_id) = harness_id {
-            params.insert(
-                "harness_id".to_string(),
-                serde_json::Value::String(harness_id.to_string()),
-            );
-        }
-        if let Some(agent_id) = agent_id {
-            params.insert(
-                "agent_id".to_string(),
-                serde_json::Value::String(agent_id.to_string()),
-            );
-        }
-        match agent_identity_id {
-            Some(Some(agent_identity_id)) => {
-                params.insert(
-                    "agent_identity_id".to_string(),
-                    serde_json::Value::String(agent_identity_id.to_string()),
-                );
-            }
-            Some(None) => {
-                params.insert("agent_identity_id".to_string(), serde_json::Value::Null);
-            }
-            None => {}
-        }
-        self.execute_platform_command("update_app", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn delete_app(&self, id: everruns_provider::typed_id::AppId) -> Result<()> {
-        let _: serde_json::Value = self
-            .execute_platform_command("delete_app", serde_json::json!({ "id": id.to_string() }))
-            .await?;
-        Ok(())
-    }
-
-    async fn destroy_app(&self, id: everruns_provider::typed_id::AppId) -> Result<()> {
-        let _: serde_json::Value = self
-            .execute_platform_command("destroy_app", serde_json::json!({ "id": id.to_string() }))
-            .await?;
-        Ok(())
-    }
-
-    async fn publish_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-    ) -> Result<everruns_platform::App> {
-        self.execute_platform_command("publish_app", serde_json::json!({ "id": id.to_string() }))
-            .await
-    }
-
-    async fn unpublish_app(
-        &self,
-        id: everruns_provider::typed_id::AppId,
-    ) -> Result<everruns_platform::App> {
-        self.execute_platform_command("unpublish_app", serde_json::json!({ "id": id.to_string() }))
-            .await
-    }
-
-    async fn add_app_channel(
-        &self,
-        app_id: everruns_provider::typed_id::AppId,
-        channel_type: everruns_platform::ChannelType,
-        channel_config: Option<&serde_json::Value>,
-        enabled: Option<bool>,
-    ) -> Result<everruns_platform::AppChannel> {
-        let mut params = serde_json::Map::from_iter([
-            (
-                "app_id".to_string(),
-                serde_json::Value::String(app_id.to_string()),
-            ),
-            (
-                "channel_type".to_string(),
-                serde_json::Value::String(channel_type.to_string()),
-            ),
-        ]);
-        if let Some(channel_config) = channel_config {
-            params.insert("channel_config".to_string(), channel_config.clone());
-        }
-        if let Some(enabled) = enabled {
-            params.insert("enabled".to_string(), serde_json::Value::Bool(enabled));
-        }
-        self.execute_platform_command("add_app_channel", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn update_app_channel(
-        &self,
-        app_id: everruns_provider::typed_id::AppId,
-        channel_id: everruns_provider::typed_id::AppChannelId,
-        channel_type: Option<everruns_platform::ChannelType>,
-        channel_config: Option<&serde_json::Value>,
-        enabled: Option<bool>,
-    ) -> Result<everruns_platform::AppChannel> {
-        let mut params = serde_json::Map::from_iter([
-            (
-                "app_id".to_string(),
-                serde_json::Value::String(app_id.to_string()),
-            ),
-            (
-                "channel_id".to_string(),
-                serde_json::Value::String(channel_id.to_string()),
-            ),
-        ]);
-        if let Some(channel_type) = channel_type {
-            params.insert(
-                "channel_type".to_string(),
-                serde_json::Value::String(channel_type.to_string()),
-            );
-        }
-        if let Some(channel_config) = channel_config {
-            params.insert("channel_config".to_string(), channel_config.clone());
-        }
-        if let Some(enabled) = enabled {
-            params.insert("enabled".to_string(), serde_json::Value::Bool(enabled));
-        }
-        self.execute_platform_command("update_app_channel", serde_json::Value::Object(params))
-            .await
-    }
-
-    async fn delete_app_channel(
-        &self,
-        app_id: everruns_provider::typed_id::AppId,
-        channel_id: everruns_provider::typed_id::AppChannelId,
-    ) -> Result<()> {
-        let _: serde_json::Value = self
-            .execute_platform_command(
-                "delete_app_channel",
-                serde_json::json!({
-                    "app_id": app_id.to_string(),
-                    "channel_id": channel_id.to_string(),
-                }),
-            )
-            .await?;
-        Ok(())
-    }
-
     // =========================================================================
     // Session Operations
     // =========================================================================
-
-    async fn list_sessions(
-        &self,
-        limit: Option<usize>,
-        agent_id: Option<AgentId>,
-    ) -> Result<Vec<Session>> {
-        let page: CommandPage<Session> = self
-            .execute_platform_command(
-                "list_sessions",
-                serde_json::json!({
-                    "limit": limit.unwrap_or(20),
-                    "agent_id": agent_id.map(|id| id.to_string()),
-                }),
-            )
-            .await?;
-        Ok(page.data)
-    }
-
-    async fn create_session(
-        &self,
-        harness_id: everruns_provider::typed_id::HarnessId,
-        agent_id: Option<AgentId>,
-        title: Option<&str>,
-        locale: Option<&str>,
-        blueprint_id: Option<&str>,
-        blueprint_config: Option<&serde_json::Value>,
-        parent_session_id: Option<SessionId>,
-    ) -> Result<Session> {
-        self.execute_platform_command(
-            "create_session",
-            serde_json::json!({
-                "harness_id": harness_id.to_string(),
-                "agent_id": agent_id.map(|id| id.to_string()),
-                "title": title,
-                "locale": locale,
-                "tags": ["managed"],
-                "capabilities": [],
-                "tools": [],
-                "mcp_servers": {},
-                "initial_files": [],
-                "blueprint_id": blueprint_id,
-                "blueprint_config": blueprint_config,
-                "parent_session_id": parent_session_id.map(|id| id.to_string()),
-            }),
-        )
-        .await
-    }
 
     async fn create_session_with_options(
         &self,
@@ -3707,27 +3200,6 @@ impl everruns_platform::PlatformStore for GrpcOrgAdapter {
             }),
         )
         .await
-    }
-
-    async fn get_session_context_report(
-        &self,
-        id: SessionId,
-    ) -> Result<everruns_core::SessionContextReport> {
-        self.execute_platform_command(
-            "get_session_context_report",
-            serde_json::json!({ "session_id": id.to_string() }),
-        )
-        .await
-    }
-
-    async fn delete_session(&self, id: SessionId) -> Result<()> {
-        let _: serde_json::Value = self
-            .execute_platform_command(
-                "delete_session",
-                serde_json::json!({ "session_id": id.to_string() }),
-            )
-            .await?;
-        Ok(())
     }
 
     // =========================================================================
@@ -3844,40 +3316,9 @@ impl everruns_platform::PlatformStore for GrpcOrgAdapter {
     // Capabilities
     // =========================================================================
 
-    async fn list_capabilities(
-        &self,
-        search: Option<&str>,
-    ) -> Result<Vec<everruns_core::CapabilityInfo>> {
-        let mut params = serde_json::Map::new();
-        params.insert("limit".to_string(), serde_json::json!(200));
-        if let Some(search) = search {
-            params.insert(
-                "search".to_string(),
-                serde_json::Value::String(search.to_string()),
-            );
-        }
-
-        let page: CommandPage<everruns_core::CapabilityInfo> = self
-            .execute_platform_command("list_capabilities", serde_json::Value::Object(params))
-            .await?;
-        Ok(page.data)
-    }
-
     // =========================================================================
     // UI Links
     // =========================================================================
-
-    fn base_url(&self) -> &str {
-        // Cache the base_url as a leaked static to satisfy the &str lifetime
-        // Called infrequently, value stable across runtime
-        static BASE_URL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-        BASE_URL.get_or_init(|| {
-            everruns_core::config::env_string_any(
-                &["PUBLIC_APP_URL", "FRONTEND_URL", "APP_URL"],
-                "http://localhost:9300",
-            )
-        })
-    }
 }
 
 // ============================================================================
@@ -4749,19 +4190,6 @@ mod tests {
         let err = grpc_missing_field("No session in response");
         assert!(matches!(err, AgentLoopError::MessageStore(_)));
         assert!(err.to_string().contains("No session in response"));
-    }
-
-    #[test]
-    fn test_capability_refs_to_configs_wraps_ids() {
-        let configs = capability_refs_to_configs(&["session".to_string(), "platform".to_string()]);
-
-        assert_eq!(
-            configs,
-            vec![
-                serde_json::json!({ "ref": "session", "config": {} }),
-                serde_json::json!({ "ref": "platform", "config": {} }),
-            ]
-        );
     }
 
     #[test]

--- a/knowledge/execution/capabilities.md
+++ b/knowledge/execution/capabilities.md
@@ -1314,9 +1314,14 @@ The `PlatformStore` trait and its management capabilities live in
 `everruns-platform`. `DirectPlatformStore` (in `everruns-server`) implements it
 using the existing `StorageBackend` and `SessionService`; core carries only the
 type-keyed extension boundary and the narrow neutral subagent delegate contract.
-Its legacy org-scoped CRUD methods outlived `platform_management` because
-`subagents`, `agent_handoff`, and `a2a_agent_delegation` still call parts of
-them; the unused remainder is a follow-up cleanup.
+Its legacy org-scoped CRUD methods outlived `platform_management`; the unused
+remainder was removed in EVE-953. What is left is the catalog-backed
+`platform_discover`/`platform_query`/`platform_execute` surface plus exactly the
+reads and writes delegation needs: `get_harness`, `get_harness_chain`,
+`get_agent_by_id`, `create_session_with_options`, `get_session_by_id`,
+`add_agent_session_participant`, `send_message`, `get_messages`, and
+`wait_for_idle`. Management flows go through the command catalog, not this
+trait; anything that wants harness/agent/app/session CRUD belongs there.
 
 ### Experimental Capabilities
 


### PR DESCRIPTION
## What changed

`PlatformStore` drops the org-scoped CRUD that outlived the retired `platform_management` capability. ~34 methods become 12, and each removal is four implementations lighter: `DirectPlatformStore`, the worker's `GrpcOrgAdapter`, `LocalPlatformStore`, and the test mock.

Removed: harness `create`/`update`/`delete`/`copy`/`list`, agent `create`/`update`/`delete`/`list`, the entire app family including channels, `list_sessions`, `create_session`, `delete_session`, `get_session_context_report`, `list_capabilities`, and `base_url`.

What survives is the catalog-backed `platform_discover`/`platform_query`/`platform_execute` surface plus exactly what delegation (`subagents`, `agent_handoff`, `a2a_agent_delegation`) calls: `get_harness`, `get_harness_chain`, `get_agent_by_id`, `create_session_with_options`, `get_session_by_id`, `add_agent_session_participant`, `send_message`, `get_messages`, `wait_for_idle`.

Two contract changes fall out of that:

- **`create_session_with_options` is now required.** It defaulted to the flat `create_session`, which silently rejected goal, lineage, budget-root override and seed mode. Every implementation already overrode it, so nothing loses behaviour.
- **`base_url` is gone.** It existed only to build UI links in `platform_management` tool results. `LocalPlatformStore::new` no longer takes one, and `LocalProfile` drops the field and `with_base_url`.

## Why

Follow-up from the `platform_management` retirement, deliberately kept out of that PR. Management flows go through the authoritative domain-command catalog now; the handwritten store surface was a second, drifting copy that four implementations had to keep honest — mostly by returning "unsupported".

## Before / After

No observable behaviour change: every removed method had no non-test caller. The one behavioural note is in the opposite direction — `create_session_with_options` can no longer silently fall back to a default that drops fields, because that default is gone.

The issue's inventory of "unused" methods had already drifted, so the set was re-derived with the compiler rather than trusted:

- `get_harness_chain` is listed there as unused, but it is what `PlatformStoreSubagentDelegate::get_harness` calls for inheritance-resolved harness lookup. Kept.
- `LocalSessionRunner` is a *separate* public trait that happens to share method names (`create_session`, `list_sessions`). Untouched.

```
11 files changed, 131 insertions(+), 1995 deletions(-)
```

## Risk

- Low
- The removals are compiler-verified: a missed caller is a build failure, not a runtime surprise. `just pre-push` is green and clippy runs `-D warnings` across all targets and features.
- The real risk is the public API break in the 0.x `everruns` crate: `LocalPlatformStore::new` loses its `base_url` argument, and `LocalProfile` loses `base_url`/`with_base_url`. No caller exists in this repo, examples included. The alternative — a constructor parameter that is silently ignored and a config field documented to do something it no longer does — is worse than the break.

## Security

- Threat categories reviewed: TM-AUTHZ, TM-TENANT, TM-API, TM-TOOL.
- Findings and resolutions: none. The removed methods were *callers* of permission checks, so deleting them removes callable surface and cannot weaken any surviving path. No HTTP handler, migration, or SQL is touched, and no `THREAT[...]` marker is added or removed. `platform_store_agent_count_isolated_per_org` kept its tenancy coverage by asserting the org boundary through `platform_query` — the surface that still enforces it — rather than being deleted along with `list_agents`.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Fixes EVE-953

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvEF7W9UNZEE8tfPLjw5Ji)_