### PR TITLE
fix(ui): report a failed logout instead of rejecting unhandled

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -835,4 +835,53 @@ describe("Create Organization dialog", () => {
     });
     expect(warningBtn).not.toBeInTheDocument();
   });
+
+  // Sentry EVERRUNS-1Z: a rejected logout escaped the async click handler, so
+  // nothing rendered, the user stayed on an authenticated page, and the
+  // rejection was reported to Sentry as unhandled.
+  describe("logout failure", () => {
+    const renderMenuWithFailingLogout = (reason: unknown) => {
+      const logout = jest.fn().mockRejectedValue(reason);
+      mockUseAuth.mockReturnValue({
+        user: { email: "test@example.com", name: "Test User" },
+        requiresAuth: true,
+        isAuthenticated: true,
+        config: { mode: "builtin" },
+        isLoading: false,
+        logout,
+        logoutPending: false,
+        createOrganization: undefined,
+      });
+      render(<Sidebar />);
+      fireEvent.click(screen.getByRole("button", { name: /test user/i }));
+      fireEvent.click(screen.getByText("Sign out"));
+      return logout;
+    };
+
+    it("navigates to /login and reports the failure instead of rejecting unhandled", async () => {
+      const unhandled = jest.fn();
+      window.addEventListener("unhandledrejection", unhandled);
+      const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const logout = renderMenuWithFailingLogout(new Error("Logout failed"));
+
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/login"));
+      expect(logout).toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith("Logout failed", expect.any(Error));
+      expect(unhandled).not.toHaveBeenCalled();
+
+      consoleError.mockRestore();
+      window.removeEventListener("unhandledrejection", unhandled);
+    });
+
+    it("still navigates when the rejection is not an Error", async () => {
+      const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      renderMenuWithFailingLogout("boom");
+
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/login"));
+
+      consoleError.mockRestore();
+    });
+  });
 });

--- a/apps/ui/src/__tests__/use-auth.test.tsx
+++ b/apps/ui/src/__tests__/use-auth.test.tsx
@@ -436,6 +436,34 @@ describe("Auth Hooks", () => {
       expect(localStorage.getItem("everruns_current_org")).toBeNull();
     });
 
+    // Sentry EVERRUNS-1Z: the cache clear used to hang off `onSuccess`, so a
+    // logout that failed server-side left every org-sensitive query in memory
+    // for whoever logged in next — on the one path where the user had already
+    // declared they were done.
+    it("clears cached data even when the logout request fails", async () => {
+      queryClient.setQueryData(authKeys.user(), {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test User",
+        roles: ["user"],
+        email_verified: true,
+      });
+      queryClient.setQueryData(["durable", "workflows"], [{ id: "wf-1" }]);
+      localStorage.setItem("everruns_current_org", "org_123");
+
+      mockLogout.mockRejectedValueOnce(new Error("Logout failed"));
+
+      const { result } = renderHook(() => useLogout(), { wrapper });
+
+      await act(async () => {
+        await expect(result.current.mutateAsync()).rejects.toThrow("Logout failed");
+      });
+
+      expect(queryClient.getQueryData(authKeys.user())).toBeUndefined();
+      expect(queryClient.getQueryData(["durable", "workflows"])).toBeUndefined();
+      expect(localStorage.getItem("everruns_current_org")).toBeNull();
+    });
+
     it("should clear user cache even if user was previously set", async () => {
       // Set initial user
       queryClient.setQueryData(authKeys.user(), {

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -65,7 +65,20 @@ export function SidebarUserMenu({
   const navigate = (href: string) => router.push(href);
 
   const handleLogout = async () => {
-    await logout();
+    // A rejected logout must not escape the click handler. It used to reject
+    // unhandled: nothing rendered, the user stayed on an authenticated page,
+    // and Sentry recorded it as an unhandled promise rejection (EVERRUNS-1Z).
+    //
+    // The navigation happens either way. The user asked to leave, and the
+    // logout mutation clears the client-side cache in `onSettled`, so a
+    // server-side failure does not strand them holding another user's data.
+    // `logout` may be a fork-supplied override, so the reason is whatever that
+    // implementation threw.
+    try {
+      await logout();
+    } catch (error) {
+      console.error("Logout failed", error);
+    }
     navigate("/login");
   };
 

--- a/apps/ui/src/hooks/use-auth.ts
+++ b/apps/ui/src/hooks/use-auth.ts
@@ -143,7 +143,12 @@ export function useLogout() {
 
   return useMutation({
     mutationFn: logout,
-    onSuccess: () => {
+    // `onSettled`, not `onSuccess`: a logout that fails server-side is exactly
+    // when the client-side cache must still go. Clearing only on success left
+    // every org-sensitive query (durable, admin, sessions) in memory for
+    // whoever logged in next, on the one path where the user had already
+    // declared they were done (EVERRUNS-1Z).
+    onSettled: () => {
       // Clear ALL cached queries to prevent data leaking across users.
       // Selective removal (only auth keys) left org-sensitive data
       // (durable, admin, sessions, etc.) cached for the next user.


### PR DESCRIPTION
## What changed

A logout that fails no longer rejects out of the click handler, and the client-side cache is cleared whether logout succeeded or not.

`handleLogout` awaited `logout()` bare inside an async `onClick`. Any failure rejected out of the event handler: nothing rendered, the user stayed on an authenticated page, `navigate("/login")` never ran, and Sentry recorded it as an unhandled promise rejection.

Same defect class as the Models page in #3521, and the same treatment: catch, report the reason, never let the rejection escape the handler.

## Why

Sentry [EVERRUNS-1Z](https://everruns.sentry.io/issues/EVERRUNS-1Z) — `Error: Logout failed`, 6 events on `app.everruns.com/settings/organization`, `mechanism: auto.browser.global_handlers.onunhandledrejection`, `handled: no`.

Two decisions fall out of it:

- **Navigate either way.** The user asked to leave. Stranding them on an authenticated page with no feedback is the worse outcome.
- **That made the cache-clear timing load-bearing, so it moves too.** `useLogout` cleared the query cache and the persisted org selection in `onSuccess`, so a logout that failed server-side left every org-sensitive query (durable, admin, sessions) in memory for whoever logged in next — on the one path where the user had already declared they were done. `onSettled` clears it on every outcome, which is what makes navigating after a failure safe.

## Before / After

**Before** — rejection escapes, no navigation, Sentry logs it as unhandled, cache survives.

**After** — the reason is reported, `/login` is reached, no `unhandledrejection` fires, cache is gone.

Mutation proof: all three new tests fail against the previous code and pass after.

```
● logout failure › navigates to /login and reports the failure instead of rejecting unhandled
● logout failure › still navigates when the rejection is not an Error
● useLogout › clears cached data even when the logout request fails

Tests: 3 failed, 60 passed   (before the fix)
Tests: 63 passed             (after)
```

One test asserts explicitly that no `unhandledrejection` fires; one covers a non-Error rejection.

Full run: **1475 UI tests green across 188 suites**, format/lint/typecheck clean, `just pre-push` green (22/22).

## Risk

- Low
- Behaviour change is confined to the failure path, which previously did nothing useful. The success path is unchanged.
- The one judgement call is navigating to `/login` after a failed logout. If the server-side session genuinely survived, the login page may bounce the user back — which is still strictly better than the current silent no-op, and the cache clear means they are not holding stale org data either way.

## Security

- Threat categories reviewed: TM-AUTH, TM-WEB.
- Findings and resolutions: no regression; the change strictly *widens* when client-side auth state is discarded. Previously a failed logout kept another user's cached org data in memory — that is now cleared on every outcome. No new endpoint, no change to what the server does on logout, no credential handling touched.

## Follow-ups

- The `"Logout failed"` message itself originates outside this repository — it is a plain `Error`, not an `ApiError`, and the string appears nowhere here, so it comes from the fork-supplied `logoutOverride` in `auth-provider.tsx`. Whether that server-side logout should be failing at all is theirs to answer; this change only stops the client from swallowing it.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvEF7W9UNZEE8tfPLjw5Ji)_