### PR TITLE
fix(tests): delete sessions in the live-provider workflow teardowns

### DIFF
--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -1667,6 +1667,14 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
 
     // Cleanup
     println!("\nCleaning up...");
+    // `sessions.model_id` pins the model, so the session goes first or the
+    // model/provider delete is refused (EVE-955).
+    cleanup_delete(
+        &client,
+        format!("{}/v1/sessions/{}", API_BASE_URL, session.id),
+        "session",
+    )
+    .await;
     cleanup_agent(&client, &agent.public_id).await;
 
     cleanup_delete(
@@ -2231,6 +2239,12 @@ async fn test_post_message_wait_returns_completed_turn() {
         .await
         .expect("Failed to create LlmSim model");
     assert_eq!(model_create.status(), 201);
+    // Keep the platform model id: `model_id` above is the provider-side model
+    // string, which the delete endpoint does not accept.
+    let model: Model = model_create
+        .json()
+        .await
+        .expect("Failed to parse LlmSim model");
 
     let agent_name = "wait-test-agent";
     let agent_response = client
@@ -2288,6 +2302,29 @@ async fn test_post_message_wait_returns_completed_turn() {
     let messages = body["messages"].as_array().expect("messages array");
     assert!(!messages.is_empty(), "waited turn returns assistant output");
     println!("✓ POST /messages?wait=true returns completed turn");
+
+    // Cleanup: this test created a provider, a model, an agent and a session,
+    // and cleaned up none of them — so a second run against the same database
+    // failed on a 409 for the agent name it had already taken (EVE-955).
+    cleanup_delete(
+        &client,
+        format!("{}/v1/sessions/{}", API_BASE_URL, session.id),
+        "session",
+    )
+    .await;
+    cleanup_agent(&client, &agent.public_id).await;
+    cleanup_delete(
+        &client,
+        format!("{}/v1/models/{}", API_BASE_URL, model.id),
+        "model",
+    )
+    .await;
+    cleanup_delete(
+        &client,
+        format!("{}/v1/providers/{}", API_BASE_URL, provider.id),
+        "provider",
+    )
+    .await;
 }
 
 /// Test that tool calls are not duplicated during workflow execution.
@@ -2539,6 +2576,14 @@ async fn test_no_duplicate_tool_calls() {
 
     // Cleanup
     println!("\nCleaning up...");
+    // `sessions.model_id` pins the model, so the session goes first or the
+    // model/provider delete is refused (EVE-955).
+    cleanup_delete(
+        &client,
+        format!("{}/v1/sessions/{}", API_BASE_URL, session.id),
+        "session",
+    )
+    .await;
     cleanup_agent(&client, &agent.public_id).await;
     cleanup_delete(
         &client,
@@ -4120,6 +4165,14 @@ async fn test_agent_execution_openai_with_tool_calls() {
 
     // Cleanup first before assertions
     println!("\nCleaning up...");
+    // `sessions.model_id` pins the model, so the session goes first or the
+    // model/provider delete is refused (EVE-955).
+    cleanup_delete(
+        &client,
+        format!("{}/v1/sessions/{}", API_BASE_URL, session.id),
+        "session",
+    )
+    .await;
     cleanup_agent(&client, &agent.public_id).await;
     cleanup_delete(
         &client,
@@ -4374,6 +4427,14 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
 
     // Cleanup first before assertions
     println!("\nCleaning up...");
+    // `sessions.model_id` pins the model, so the session goes first or the
+    // model/provider delete is refused (EVE-955).
+    cleanup_delete(
+        &client,
+        format!("{}/v1/sessions/{}", API_BASE_URL, session.id),
+        "session",
+    )
+    .await;
     cleanup_agent(&client, &agent.public_id).await;
     cleanup_delete(
         &client,
@@ -5406,6 +5467,14 @@ async fn test_anthropic_extended_thinking() {
 
     // Cleanup
     println!("\nCleaning up...");
+    // `sessions.model_id` pins the model, so the session goes first or the
+    // model/provider delete is refused (EVE-955).
+    cleanup_delete(
+        &client,
+        format!("{}/v1/sessions/{}", API_BASE_URL, session.id),
+        "session",
+    )
+    .await;
     cleanup_agent(&client, &agent.public_id).await;
     cleanup_delete(
         &client,
@@ -5773,6 +5842,14 @@ async fn test_anthropic_extended_thinking_with_tools() {
 
     // Cleanup
     println!("\nCleaning up...");
+    // `sessions.model_id` pins the model, so the session goes first or the
+    // model/provider delete is refused (EVE-955).
+    cleanup_delete(
+        &client,
+        format!("{}/v1/sessions/{}", API_BASE_URL, session.id),
+        "session",
+    )
+    .await;
     cleanup_agent(&client, &agent.public_id).await;
     cleanup_delete(
         &client,


### PR DESCRIPTION
## What changed

Seven more workflow tests now delete the session they create, before deleting the model and provider it pins.

**This fixes a red `main`.** #3543 made teardown assert instead of silently swallowing refused deletes; that surfaced seven tests it had missed, six of them live-provider tests that only run in the push-only `Workflow Tests (Server + Worker)` job — so they were invisible on the PR and on my local run, which had no provider credentials and executed 40 tests where CI executes 41.

CI's failure was the same FK every time:

```
ERROR: update or delete on table "models" violates foreign key constraint
       "sessions_model_id_fkey" on table "sessions"
DETAIL: Key (id)=(...) is still referenced from table "sessions".
```

Each test deletes its agent, model and provider but leaves the session:

- `test_agent_execution_anthropic_with_tool_calls`
- `test_agent_execution_openai_with_tool_calls`
- `test_agent_filesystem_and_bash_workspace_integration`
- `test_anthropic_extended_thinking`
- `test_anthropic_extended_thinking_with_tools`
- `test_no_duplicate_tool_calls`
- `test_post_message_wait_returns_completed_turn`

The last one is **not** in CI's failure list. It arrived with #3541 and cleaned up nothing at all, so it also took the `wait-test-agent` name permanently and could not run twice against one database. It now releases its session, agent, model and provider. Capturing the created model is what makes that possible: the `model_id` already in scope is the provider-side model string, which the delete endpoint does not accept.

## Why #3543 missed them

The scan behind it was wrong twice over. It counted `"{}/v1/sessions/{}/messages"` and a `.get()` poll on `"{}/v1/sessions/{}"` as evidence that a test deleted its session. The scan now looks only inside `cleanup_delete` calls, and reports **zero** remaining tests that create a session without deleting it.

## Before / After

Reproducing CI's configuration exactly this time — live server and worker, provider credentials from Doppler, `EVERRUNS_REQUIRE_LIVE_TESTS=1`, so all 41 tests execute rather than the 40 my earlier run reached.

| | before (CI, run 11587) | after (local, live) |
|---|---|---|
| result | 35 passed, **6 failed** | **41 passed, 0 failed** |
| FK errors | 6 | **0** |

Second run against that same database: 0 FK errors, 0 leaked sessions, 0 leaked test providers.

`just pre-push` green (22/22).

## Risk

- Low
- Test-only. No production code, migration, or endpoint is touched.
- The six live tests now genuinely exercise the path CI runs, verified against real Anthropic and OpenAI credentials rather than inferred.

## Security

- No security-relevant code changes: this adds teardown calls to existing tests and captures one already-returned response body. No production surface involved.

## Follow-ups

- The one failure on the second consecutive run is `test_mcp_server_crud`, which is EVE-964 and unrelated to this FK: `DELETE /v1/mcp-servers/{id}` disables rather than removes, and the name uniqueness check counts disabled rows. CI starts from a fresh database, so it does not hit this.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvEF7W9UNZEE8tfPLjw5Ji)_