### PR TITLE
docs(evals): record Astra behavior comparison

### DIFF
--- a/evals/generic/README.md
+++ b/evals/generic/README.md
@@ -209,13 +209,15 @@ before creation and execution after confirmation.
 ### Acceptance status
 
 The candidate follows [official Astra prompting guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra)
-(reviewed 2026-09-05). Production adoption requires live behavioral comparison;
-local deterministic tests establish runtime/scorer correctness only. Automatic
-approval review blocked sending the internal harness prompts to OpenAI Astra,
-even after confirming the selected eleven fixtures are synthetic and contain no
-attachments. No live scores or Astra acceptance are claimed.
+(reviewed 2026-09-05). A live comparison on 2026-09-12 ran GPT-6 Astra at low
+effort for three trials of every behavior case: both baseline and candidate
+passed 42/42 scored trials. The candidate used 83 tool calls and 131 iterations,
+versus the baseline's 76 and 124, and consumed more input and output tokens.
+It therefore does not justify production adoption. Local deterministic tests
+remain the proof of runtime and scorer correctness; the live result is the
+acceptance decision for this candidate.
 
 The full unshipped production-prompt proposal is preserved on local branch
 `codex/astra-harness-behavior`, commit `db74ce86d`. It remains an open objective:
-obtain explicit authorization for the prompt payload and destination, run the
-paired comparison, inspect regressions, then review production adoption separately.
+revise the candidate to produce a measurable behavioral improvement, then run
+the paired comparison and review production adoption separately.


### PR DESCRIPTION
## What changed
Records the completed GPT-6 Astra behavior comparison and keeps the experimental prompt out of production because it did not improve the measured outcome.

## Why
The evaluation documentation previously stated that live comparison was still required. The completed run provides the evidence needed to close that acceptance decision.

## Before / After
Before: no live Astra score was available, so the candidate's production status was unknown.

After: three trials of all behavior cases scored 42/42 for both profiles. The candidate used 83 tool calls and 131 iterations, compared with 76 and 124 for the baseline, so it is not adopted.

## Risk
- Low
- Documentation could report the result inaccurately; the run report is retained locally at `evals/generic/results/20260912T203442Z-261c` and the values were checked from its JSON output.

## Security
- Threat categories reviewed: No security-relevant code changes; this updates evaluation documentation only.
- Findings and resolutions: No security findings.

## Follow-ups
- Revise the candidate only after identifying a measurable behavioral improvement; the current candidate adds overhead without improving the study score.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
