### PR TITLE
fix(provider): omit reasoning include on continuations

### DIFF
--- a/crates/provider/src/openresponses_protocol.rs
+++ b/crates/provider/src/openresponses_protocol.rs
@@ -1243,9 +1243,14 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             });
 
         // Reasoning items are only replayable when the provider hands back
-        // their encrypted payload, and it only does so on request.
-        let include = (reasoning.is_some() || update_state.is_some())
-            .then(|| vec!["reasoning.encrypted_content".to_string()]);
+        // their encrypted payload, and it only does so on request. Stateful
+        // continuations already retain that state server-side; Meta rejects
+        // this include when paired with `previous_response_id`.
+        let include = previous_response_id
+            .is_none()
+            .then_some(reasoning.is_some() || update_state.is_some())
+            .filter(|include| *include)
+            .map(|_| vec!["reasoning.encrypted_content".to_string()]);
 
         // Build metadata for request tracking
         let metadata = if config.metadata.is_empty() {
@@ -3754,7 +3759,7 @@ mod tests {
             temperature: None,
             max_tokens: None,
             tools: vec![],
-            reasoning_effort: None,
+            reasoning_effort: Some(crate::model::ReasoningEffort::High),
             metadata: std::collections::HashMap::new(),
             previous_response_id: Some("resp_tool_turn".to_string()),
             provider_opaque_context: None,
@@ -3781,6 +3786,10 @@ mod tests {
         let first: serde_json::Value = requests[0].body_json().expect("first body");
         let second: serde_json::Value = requests[1].body_json().expect("second body");
         assert_eq!(first["previous_response_id"], "resp_tool_turn");
+        assert!(
+            first.get("include").is_none(),
+            "stateful continuations must not request encrypted reasoning: {first}"
+        );
         assert!(second.get("previous_response_id").is_none());
         let replay = second["input"].as_array().expect("replay input");
         assert!(replay.iter().any(|item| item["type"] == "function_call"));


### PR DESCRIPTION
## What changed
Responses stateful continuations no longer request `reasoning.encrypted_content`.

## Why
The Meta Responses endpoint rejects that field when `previous_response_id` is present, breaking a reasoning-and-tool-call continuation after the first successful turn.

## Before / After
Before: the Meta live matrix failed with HTTP 400: ``reasoning.encrypted_content` cannot be used with `previous_response_id``.

After: stateful continuation requests keep the response ID and omit `include`; non-continuation reasoning requests still request encrypted replay state. The wire-level regression test covers the rejected-continuation recovery path.

## Risk
- Low: only requests with both a server-side continuation ID and reasoning state change.
- Stateless and compact-context paths still request encrypted reasoning replay state when needed.

## Security
- Reviewed TM-API and TM-LLM request-shaping boundaries.
- The change removes an incompatible provider field and does not broaden user input, provider-key exposure, or data retention. Stateful server-side reasoning state remains with the provider; stateless replay behavior is unchanged.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
