### PR TITLE
chore(release): prepare v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,93 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-09-13
+
+### Highlights
+
+- **PDF input with file attachments** - Agents can now accept PDF documents as file attachments alongside text input ([#3535](https://github.com/everruns/everruns/pull/3535)).
+- **Muse image model** - A new Muse image-generation model with a configurable fallback ([#3523](https://github.com/everruns/everruns/pull/3523)).
+- **Quick-connect provider grid** - Connecting an LLM provider is now a one-click grid in the UI ([#3526](https://github.com/everruns/everruns/pull/3526)).
+- **Native async tool execution on durable workers** - Long-running tool calls execute natively on durable workers instead of blocking a turn ([#3466](https://github.com/everruns/everruns/pull/3466)).
+- **Synchronous wait-for-completion** - A non-streaming wait-for-completion path spanning drivers, the sessions API, and the framework ([#3541](https://github.com/everruns/everruns/pull/3541)).
+- **Agent discovery documents** - The server serves agent discovery documents, and create_agent/session/message descriptions surface their argument constraints ([#3533](https://github.com/everruns/everruns/pull/3533), [#3530](https://github.com/everruns/everruns/pull/3530)).
+
+### What's Changed
+
+- feat(image-gen): add Muse image model with configurable fallback ([#3523](https://github.com/everruns/everruns/pull/3523)) by [@chaliy](https://github.com/chaliy)
+- test(builtins): exercise runtime capability configuration ([#3484](https://github.com/everruns/everruns/pull/3484)) by [@chaliy](https://github.com/chaliy)
+- test(test-support): complete fixture and loop unit review ([#3480](https://github.com/everruns/everruns/pull/3480)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): quick-connect grid for LLM providers ([#3526](https://github.com/everruns/everruns/pull/3526)) by [@chaliy](https://github.com/chaliy)
+- fix(server): claim session schedules atomically so replicas cannot double-fire ([#3527](https://github.com/everruns/everruns/pull/3527)) by [@chaliy](https://github.com/chaliy)
+- fix(models): default OpenAI orgs to GPT-5.6 Terra, never an embedding model ([#3528](https://github.com/everruns/everruns/pull/3528)) by [@chaliy](https://github.com/chaliy)
+- fix(discovery): surface argument constraints in create_agent/session/message descriptions ([#3530](https://github.com/everruns/everruns/pull/3530)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): render tool timeline rows as one-liners ([#3531](https://github.com/everruns/everruns/pull/3531)) by [@chaliy](https://github.com/chaliy)
+- refactor(plugins): remove everruns-dev plugin and unify on everruns ([#3529](https://github.com/everruns/everruns/pull/3529)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp-oauth): allow switching accounts on the authorize page ([#3532](https://github.com/everruns/everruns/pull/3532)) by [@chaliy](https://github.com/chaliy)
+- feat(server): serve agent discovery documents ([#3533](https://github.com/everruns/everruns/pull/3533)) by [@chaliy](https://github.com/chaliy)
+- fix(plugins): list only everruns in agent marketplaces ([#3534](https://github.com/everruns/everruns/pull/3534)) by [@chaliy](https://github.com/chaliy)
+- docs(sre): document agent discovery endpoints and the proxy rule they need ([#3537](https://github.com/everruns/everruns/pull/3537)) by [@chaliy](https://github.com/chaliy)
+- fix(openrouter): advertise xhigh reasoning effort in discovery ([#3536](https://github.com/everruns/everruns/pull/3536)) by [@chaliy](https://github.com/chaliy)
+- refactor(openrouter): carry routing as opaque driver option ([#3538](https://github.com/everruns/everruns/pull/3538)) by [@chaliy](https://github.com/chaliy)
+- feat(files): add PDF input support with file attachments ([#3535](https://github.com/everruns/everruns/pull/3535)) by [@chaliy](https://github.com/chaliy)
+- feat(nonstreaming): wait-for-completion across drivers, sessions API, and framework ([#3541](https://github.com/everruns/everruns/pull/3541)) by [@chaliy](https://github.com/chaliy)
+- refactor(platform): trim the dead legacy CRUD from PlatformStore ([#3542](https://github.com/everruns/everruns/pull/3542)) by [@chaliy](https://github.com/chaliy)
+- fix(tests): make live workflow teardown assert, and stop it leaking ([#3543](https://github.com/everruns/everruns/pull/3543)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): report a failed logout instead of rejecting unhandled ([#3544](https://github.com/everruns/everruns/pull/3544)) by [@chaliy](https://github.com/chaliy)
+- fix(tests): delete sessions in the live-provider workflow teardowns ([#3545](https://github.com/everruns/everruns/pull/3545)) by [@chaliy](https://github.com/chaliy)
+- docs(evals): record Astra behavior comparison ([#3546](https://github.com/everruns/everruns/pull/3546)) by [@chaliy](https://github.com/chaliy)
+- feat(compaction): emit structured lifecycle events attempt/skip/install/fail ([#3539](https://github.com/everruns/everruns/pull/3539)) by [@chaliy](https://github.com/chaliy)
+- feat(examples): prototype OpenAI websocket steering ([#3524](https://github.com/everruns/everruns/pull/3524)) by [@chaliy](https://github.com/chaliy)
+- fix(provider): complete Responses unit test review ([#3483](https://github.com/everruns/everruns/pull/3483)) by [@chaliy](https://github.com/chaliy)
+- feat(tools): integrate native async execution with durable workers ([#3466](https://github.com/everruns/everruns/pull/3466)) by [@chaliy](https://github.com/chaliy)
+- fix(builtins): honor timezones and strengthen tool contracts ([#3485](https://github.com/everruns/everruns/pull/3485)) by [@chaliy](https://github.com/chaliy)
+- chore(ui): refresh non-major dependencies ([#3540](https://github.com/everruns/everruns/pull/3540)) by [@warp-factories](https://github.com/apps/warp-factories)
+- fix(provider): omit reasoning include on continuations ([#3550](https://github.com/everruns/everruns/pull/3550)) by [@chaliy](https://github.com/chaliy)
+- docs(framework): turn agent examples into teaching workflows ([#3547](https://github.com/everruns/everruns/pull/3547)) by [@chaliy](https://github.com/chaliy)
+- feat(openai): account for cache writes and enforce Astra limits ([#3525](https://github.com/everruns/everruns/pull/3525)) by [@chaliy](https://github.com/chaliy)
+- chore(tooling): remove repo-local Linear MCP config ([#3553](https://github.com/everruns/everruns/pull/3553)) by [@chaliy](https://github.com/chaliy)
+- refactor(examples): keep agent assets under src ([#3552](https://github.com/everruns/everruns/pull/3552)) by [@chaliy](https://github.com/chaliy)
+
+### Crate Releases
+
+Independently versioned crates published this cycle, classified with `cargo-semver-checks` (computed
+deterministically by `scripts/plan-crate-release.py`). Seven crates took breaking public-contract
+changes and take the breaking **minor** bump (the breaking slot for `0.x`); `everruns-provider`
+carries the routing refactor ([#3538](https://github.com/everruns/everruns/pull/3538)) that removed
+the `OpenRouter*` routing structs/consts and the `openrouter_routing` builder in favor of an opaque
+driver option, plus new variants on exhaustive content/stream enums from PDF input
+([#3535](https://github.com/everruns/everruns/pull/3535)) and native async tool calls
+([#3466](https://github.com/everruns/everruns/pull/3466)); that change ripples up through
+`everruns-core`, `everruns-engine`, `everruns-host`, `everruns-platform`, and the `everruns` facade.
+`everruns-model-profiles` is breaking on its own — cache-write cost accounting
+([#3525](https://github.com/everruns/everruns/pull/3525)) added a `cache_write` field to the
+exhaustively-constructible `ModelCost`/`CostTier` structs. Everything else is additive or a
+compatibility re-pin (patch), including the cone cascade across the wire-protocol drivers and
+integrations.
+
+Breaking (minor), old → new:
+- `everruns-provider` 0.21.0 → 0.22.0
+- `everruns-core` 0.20.0 → 0.21.0
+- `everruns-engine` 0.18.4 → 0.19.0
+- `everruns-host` 0.20.6 → 0.21.0
+- `everruns-platform` 0.20.0 → 0.21.0
+- `everruns` 0.20.1 → 0.21.0
+- `everruns-model-profiles` 0.1.0 → 0.2.0
+
+Additive / behavior (patch), old → new:
+- `everruns-builtins` 0.18.7 → 0.18.8
+- `everruns-capability` 0.18.1 → 0.18.2
+- `everruns-macros` 0.18.1 → 0.18.2
+- `everruns-mcp` 0.19.4 → 0.19.5
+- `everruns-ard` 0.18.3 → 0.18.4
+- `everruns-cli` 0.18.4 → 0.18.5
+- `everruns-test-support` 0.18.6 → 0.18.7
+- `everruns-llmsim` 0.18.6 → 0.18.7
+- Wire-protocol drivers `everruns-anthropic`, `everruns-bedrock`, `everruns-fireworks`, `everruns-gemini`, `everruns-mai`, `everruns-meta`, `everruns-openai`, `everruns-openrouter`, `everruns-turbopuffer` each patch-bumped to `0.18.5`.
+- All `everruns-integrations-*` crates patch-bumped to `0.18.4` (except `-filesystem` `0.18.5`, `-deno` `0.19.1`).
+
+No published crate was deleted or absorbed this cycle.
+
 ## [0.25.0] - 2026-09-11
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,9 +1532,9 @@ checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "01a7799fd6b852db0e61728dde9a204c423b44d689dbd432522543614b490e78"
 dependencies = [
  "cfg-if",
 ]
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-ard"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.7"
+version = "0.18.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "schemars",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.4"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-fireworks"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "eventsource-stream",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.6"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-bashkit"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-lua"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openai-image"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-openrouter-workspace"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "everruns-capability",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-web-fetch"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "chrono",
  "everruns-capability",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mai"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-meta"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-model-profiles"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-platform"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-test-support"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-turbopuffer"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4691,9 +4691,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+checksum = "0ab1baf72f08796de0260609515130699b890ac25f30e610ad894bc5856cafdb"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -4708,18 +4708,19 @@ dependencies = [
 
 [[package]]
 name = "jiff-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+checksum = "5e52fe76043ccecc9005d2305ebaadf7d7fc0cc89ca6baa10a94d6bc68c7128c"
 dependencies = [
  "defmt",
+ "log",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+checksum = "378268a1116ad67ae6228701118ac9f491d78fda38a40a1f1a9e1348de6f7212"
 dependencies = [
  "jiff-core",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -204,27 +204,27 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.2.0"
-everruns-capability = { path = "crates/capability", version = "0.18.1", default-features = false }
-everruns-builtins = { path = "crates/builtins", version = "0.18.7" }
-everruns-core = { path = "crates/core", version = "0.20.0" }
-everruns-engine = { path = "crates/engine", version = "0.18.4" }
-everruns-host = { path = "crates/host", version = "0.20.6" }
-everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.6", default-features = false }
+everruns-capability = { path = "crates/capability", version = "0.18.2", default-features = false }
+everruns-builtins = { path = "crates/builtins", version = "0.18.8" }
+everruns-core = { path = "crates/core", version = "0.21.0" }
+everruns-engine = { path = "crates/engine", version = "0.19.0" }
+everruns-host = { path = "crates/host", version = "0.21.0" }
+everruns-llmsim = { path = "crates/drivers/llmsim", version = "0.18.7", default-features = false }
 everruns-test-support = { path = "crates/test-support", version = "0.18.2", default-features = false }
-everruns-platform = { path = "crates/platform", version = "0.20.0" }
-everruns-provider = { path = "crates/provider", version = "0.21.0", default-features = false }
-everruns-model-profiles = { path = "crates/model-profiles", version = "0.1.0" }
-everruns-mcp = { path = "crates/mcp", version = "0.19.4" }
+everruns-platform = { path = "crates/platform", version = "0.21.0" }
+everruns-provider = { path = "crates/provider", version = "0.22.0", default-features = false }
+everruns-model-profiles = { path = "crates/model-profiles", version = "0.2.0" }
+everruns-mcp = { path = "crates/mcp", version = "0.19.5" }
 everruns-ard = { path = "crates/ard", version = "0.18.0" }
-everruns-openai = { path = "crates/drivers/openai", version = "0.18.4" }
+everruns-openai = { path = "crates/drivers/openai", version = "0.18.5" }
 everruns = { path = "crates/everruns", version = "0.18.0" }
-everruns-macros = { path = "crates/macros", version = "0.18.1" }
-everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.4" }
-everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.18.3" }
-everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.18.3" }
-everruns-integrations-duckduckgo = { path = "integrations/duckduckgo", version = "0.18.3" }
-everruns-integrations-lua = { path = "integrations/lua", version = "0.18.3" }
-everruns-integrations-openrouter-workspace = { path = "integrations/openrouter-workspace", version = "0.18.3" }
+everruns-macros = { path = "crates/macros", version = "0.18.2" }
+everruns-integrations-filesystem = { path = "integrations/filesystem", version = "0.18.5" }
+everruns-integrations-bashkit = { path = "integrations/bashkit", version = "0.18.4" }
+everruns-integrations-web-fetch = { path = "integrations/web-fetch", version = "0.18.4" }
+everruns-integrations-duckduckgo = { path = "integrations/duckduckgo", version = "0.18.4" }
+everruns-integrations-lua = { path = "integrations/lua", version = "0.18.4" }
+everruns-integrations-openrouter-workspace = { path = "integrations/openrouter-workspace", version = "0.18.4" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/ard/Cargo.toml
+++ b/crates/ard/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 name = "everruns-ard"
 readme = "README.md"
-version = "0.18.3"
+version = "0.18.4"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -49,6 +49,6 @@ url = "2"
 ard-live-tests = []
 
 [dev-dependencies]
-everruns-host = { version = "0.20.0", path = "../host", features = ["direct-egress"] }
+everruns-host = { version = "0.21.0", path = "../host", features = ["direct-egress"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 wiremock = "0.6"

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-builtins"
-version = "0.18.7"
+version = "0.18.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ categories = ["development-tools", "asynchronous"]
 # execution values. It owns no host, platform, database, network, process, or
 # interpreter implementation edge.
 everruns-capability.workspace = true
-everruns-core = { path = "../core", version = "0.20.0", default-features = false }
+everruns-core = { path = "../core", version = "0.21.0", default-features = false }
 everruns-provider.workspace = true
 
 async-trait.workspace = true

--- a/crates/capability/Cargo.toml
+++ b/crates/capability/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns-capability"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "everruns-cli"
 readme = "README.md"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-core"
-version = "0.20.0"
+version = "0.21.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/drivers/anthropic/Cargo.toml
+++ b/crates/drivers/anthropic/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-anthropic"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -43,7 +43,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.21.0" }
+everruns-provider = { path = "../../provider", version = "0.22.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/bedrock/Cargo.toml
+++ b/crates/drivers/bedrock/Cargo.toml
@@ -8,7 +8,7 @@ name = "everruns-bedrock"
 readme = "README.md"
 keywords = ["agent", "llm", "ai", "bedrock", "aws"]
 categories = ["api-bindings", "asynchronous"]
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -39,7 +39,7 @@ base64.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.21.0" }
+everruns-provider = { path = "../../provider", version = "0.22.0" }
 
 # AWS SDK for Bedrock Runtime
 # Default features include the legacy `rustls` connector (rustls 0.21 +

--- a/crates/drivers/fireworks/Cargo.toml
+++ b/crates/drivers/fireworks/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-fireworks"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -35,7 +35,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { version = "0.21.0", path = "../../provider" }
+everruns-provider = { version = "0.22.0", path = "../../provider" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures discovery requests;

--- a/crates/drivers/gemini/Cargo.toml
+++ b/crates/drivers/gemini/Cargo.toml
@@ -7,7 +7,7 @@ name = "everruns-gemini"
 readme = "README.md"
 keywords = ["agent", "llm", "ai", "gemini", "google"]
 categories = ["api-bindings", "asynchronous"]
-version = "0.18.4"
+version = "0.18.5"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -40,7 +40,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.21.0" }
+everruns-provider = { path = "../../provider", version = "0.22.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/llmsim/Cargo.toml
+++ b/crates/drivers/llmsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-llmsim"
-version = "0.18.6"
+version = "0.18.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/drivers/mai/Cargo.toml
+++ b/crates/drivers/mai/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "everruns-mai"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { version = "0.21.0", path = "../../provider" }
+everruns-provider = { version = "0.22.0", path = "../../provider" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver/token requests;

--- a/crates/drivers/meta/Cargo.toml
+++ b/crates/drivers/meta/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "everruns-meta"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -24,7 +24,7 @@ serde.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.21.0" }
+everruns-provider = { path = "../../provider", version = "0.22.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/openai/Cargo.toml
+++ b/crates/drivers/openai/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-openai"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -41,7 +41,7 @@ tracing.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.21.0" }
+everruns-provider = { path = "../../provider", version = "0.22.0" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/drivers/openrouter/Cargo.toml
+++ b/crates/drivers/openrouter/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-openrouter"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -34,7 +34,7 @@ chrono.workspace = true
 # Provider SPI only (EVE-874): wire-protocol crates never depend on
 # everruns-core. Intentional optional features of everruns-provider (`openapi`
 # schema derives, `sqlx` TypedId codecs) stay off; default features are empty.
-everruns-provider = { path = "../../provider", version = "0.21.0" }
+everruns-provider = { path = "../../provider", version = "0.22.0" }
 
 [dev-dependencies]
 # tokio powers `#[tokio::test]`; wiremock captures driver requests; futures

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "everruns-engine"
-version = "0.18.4"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/everruns/Cargo.toml
+++ b/crates/everruns/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "everruns"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/everruns/tests/fixtures/external-consumer/Cargo.lock
+++ b/crates/everruns/tests/fixtures/external-consumer/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.7"
+version = "0.18.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "schemars",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.4"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.6"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,14 +587,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-model-profiles"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "everruns-provider"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "everruns-host"
-version = "0.20.6"
+version = "0.21.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -9,7 +9,7 @@
 
 [package]
 name = "everruns-macros"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-mcp"
-version = "0.19.4"
+version = "0.19.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/model-profiles/Cargo.toml
+++ b/crates/model-profiles/Cargo.toml
@@ -11,7 +11,7 @@
 
 [package]
 name = "everruns-model-profiles"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "everruns-platform"
-version = "0.20.0"
+version = "0.21.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "everruns-provider"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "everruns-test-support"
-version = "0.18.6"
+version = "0.18.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -44,7 +44,7 @@ fixtures = ["dep:everruns-platform"]
 host = ["dep:everruns-host", "sim", "everruns-llmsim/host"]
 
 [dependencies]
-everruns-core = { path = "../core", version = "0.20.0", default-features = false }
+everruns-core = { path = "../core", version = "0.21.0", default-features = false }
 everruns-engine.workspace = true
 everruns-capability.workspace = true
 everruns-provider.workspace = true

--- a/crates/turbopuffer/Cargo.toml
+++ b/crates/turbopuffer/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-turbopuffer"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/evals/generic/Cargo.lock
+++ b/evals/generic/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.1",
  "bigdecimal",
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bzip2",
  "chrono",
  "chrono-tz",
@@ -219,9 +219,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "block-buffer"
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "01a7799fd6b852db0e61728dde9a204c423b44d689dbd432522543614b490e78"
 dependencies = [
  "cfg-if",
 ]
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -695,10 +695,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.7"
+version = "0.18.8"
 dependencies = [
  "async-trait",
  "chrono",
+ "chrono-tz",
  "everruns-capability",
  "everruns-core",
  "everruns-provider",
@@ -712,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "schemars",
@@ -722,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -752,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.4"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -788,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.6"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -816,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-bashkit"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "async-trait",
  "bashkit",
@@ -832,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -848,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -861,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -870,14 +871,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-model-profiles"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "everruns-openai"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -891,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openrouter"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -903,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-provider"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1537,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+checksum = "0ab1baf72f08796de0260609515130699b890ac25f30e610ad894bc5856cafdb"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -1554,18 +1555,19 @@ dependencies = [
 
 [[package]]
 name = "jiff-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+checksum = "5e52fe76043ccecc9005d2305ebaadf7d7fc0cc89ca6baa10a94d6bc68c7128c"
 dependencies = [
  "defmt",
+ "log",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+checksum = "378268a1116ad67ae6228701118ac9f491d78fda38a40a1f1a9e1348de6f7212"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -2230,7 +2232,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
 ]
 
 [[package]]
@@ -2382,7 +2384,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2532,7 +2534,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2760,9 +2762,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "socket2"
@@ -2960,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3018,7 +3020,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.2",
  "bytes",
  "futures-util",
  "http",
@@ -3153,9 +3155,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/evals/platform-capability/Cargo.lock
+++ b/evals/platform-capability/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -36,9 +36,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "bumpalo"
@@ -54,9 +54,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -76,9 +76,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -102,7 +102,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -136,9 +136,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "form_urlencoded"
@@ -250,9 +250,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "itoa"
@@ -432,9 +432,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -461,9 +461,9 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -479,9 +479,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "once_cell",
  "ring",
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -822,7 +822,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -874,9 +874,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "socket2"
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -972,7 +972,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1024,14 +1024,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -1154,9 +1154,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1167,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1187,31 +1187,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1404,13 +1404,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "3ded4057c258ba199e2d26386d3af3780957ecaee6c4ef4041c6b4b8b97c0b06"
 
 [[package]]
 name = "block-buffer"
@@ -197,6 +197,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,7 +235,7 @@ checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
- "phf",
+ "phf 0.11.3",
  "winnow 0.7.15",
 ]
 
@@ -324,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "everruns"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -346,10 +356,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-builtins"
-version = "0.18.7"
+version = "0.18.8"
 dependencies = [
  "async-trait",
  "chrono",
+ "chrono-tz",
  "everruns-capability",
  "everruns-core",
  "everruns-provider",
@@ -363,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-capability"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-trait",
  "schemars",
@@ -373,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -403,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-engine"
-version = "0.18.4"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -422,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-host"
-version = "0.20.6"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -448,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-filesystem"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -464,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llmsim"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -477,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -486,14 +497,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-model-profiles"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "everruns-provider"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -1172,7 +1192,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.8",
 ]
 
@@ -1183,7 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1194,6 +1214,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -1534,9 +1563,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "socket2"
@@ -1681,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1793,9 +1822,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "2ef6dac1e96601b4fb3acccccff2139741fcb757cb9a36089bf5be91cfb285ce"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/integrations/bashkit/Cargo.toml
+++ b/integrations/bashkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-bashkit"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/brave-search/Cargo.toml
+++ b/integrations/brave-search/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "everruns-integrations-brave-search"
 readme = "README.md"
-version = "0.18.3"
+version = "0.18.4"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/browserless/Cargo.toml
+++ b/integrations/browserless/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "everruns-integrations-browserless"
 readme = "README.md"
-version = "0.18.3"
+version = "0.18.4"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/cursor/Cargo.toml
+++ b/integrations/cursor/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "everruns-integrations-cursor"
 readme = "README.md"
-version = "0.18.3"
+version = "0.18.4"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/daytona/Cargo.toml
+++ b/integrations/daytona/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "everruns-integrations-daytona"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/deno/Cargo.toml
+++ b/integrations/deno/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "everruns-integrations-deno"
 readme = "README.md"
-version = "0.19.0"
+version = "0.19.1"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/docker/Cargo.toml
+++ b/integrations/docker/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "everruns-integrations-docker"
 readme = "README.md"
-version = "0.18.3"
+version = "0.18.4"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/duckduckgo/Cargo.toml
+++ b/integrations/duckduckgo/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-integrations-duckduckgo"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-e2b"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/filesystem/Cargo.toml
+++ b/integrations/filesystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-filesystem"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "everruns-integrations-github"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/lua/Cargo.toml
+++ b/integrations/lua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-lua"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/openai-image/Cargo.toml
+++ b/integrations/openai-image/Cargo.toml
@@ -7,7 +7,7 @@
 [package]
 name = "everruns-integrations-openai-image"
 readme = "README.md"
-version = "0.18.3"
+version = "0.18.4"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/openrouter-workspace/Cargo.toml
+++ b/integrations/openrouter-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-openrouter-workspace"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -19,7 +19,7 @@ default = []
 [dependencies]
 everruns-core.workspace = true
 everruns-provider.workspace = true
-everruns-openrouter = { version = "0.18.4", path = "../../crates/drivers/openrouter" }
+everruns-openrouter = { version = "0.18.5", path = "../../crates/drivers/openrouter" }
 async-trait.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/integrations/parallel/Cargo.toml
+++ b/integrations/parallel/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "everruns-integrations-parallel"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/integrations/sprites/Cargo.toml
+++ b/integrations/sprites/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "everruns-integrations-sprites"
 readme = "README.md"
-version = "0.18.3"
+version = "0.18.4"
 rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/integrations/web-fetch/Cargo.toml
+++ b/integrations/web-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "everruns-integrations-web-fetch"
-version = "0.18.3"
+version = "0.18.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/release-card.yml
+++ b/release-card.yml
@@ -1,19 +1,19 @@
-version: 0.25.0
-date: 2026-09-11
+version: 0.26.0
+date: 2026-09-13
 headline:
-  - Context in place,
-  - chat for everyone.
+  - Files in,
+  - models up.
 summary:
-  - AGENTS.md resolves as conversation context,
-  - a pinned Platform Chat for every user,
-  - and a capability deprecation lifecycle.
+  - PDF attachments reach agents,
+  - a new Muse image model with fallback,
+  - and one-click provider connect.
 highlights:
-  - title: Hierarchical AGENTS.md context
-    description: Instructions resolve AGENTS.md hierarchically, kept below harness safety instructions.
-    source: "#3501"
-  - title: Platform Chat for every user
-    description: A precreated, pinned Platform Chat thread with a widened capability set.
-    source: "#3508"
-  - title: Capability deprecation lifecycle
-    description: Capabilities can be Deprecated or Retired; platform_management is retired.
-    source: "#3513"
+  - title: PDF input with attachments
+    description: Agents accept PDF documents as file attachments alongside text.
+    source: "#3535"
+  - title: Muse image model
+    description: A new Muse image-generation model with a configurable fallback.
+    source: "#3523"
+  - title: Quick-connect provider grid
+    description: Connecting an LLM provider is now a one-click grid in the UI.
+    source: "#3526"


### PR DESCRIPTION
## What changed

Cuts the **v0.26.0** product release (from v0.25.0), rebuilt on top of the latest `main` so it captures all **33** commits since v0.25.0. Bumps `workspace.package.version` and `apps/ui/package.json` to `0.26.0`, adds the CHANGELOG entry, updates `release-card.yml`, and refreshes lockfiles. On merge the `chore(release): prepare v` commit auto-tags `v0.26.0` and drives the GitHub Release, Docker images, and CLI binaries.

User-facing highlights:
- PDF input with file attachments (#3535)
- Muse image model with configurable fallback (#3523)
- Quick-connect provider grid in the UI (#3526)
- Native async tool execution on durable workers (#3466)
- Synchronous (non-streaming) wait-for-completion across drivers/API/framework (#3541)
- Agent discovery documents (#3533, #3530)

Full commit list is in `CHANGELOG.md`.

## Why

Regular product release covering the 33 commits merged to `main` since v0.25.0.

## Crate release audit

Mandatory per-release audit computed by `scripts/plan-crate-release.py` and verified with `scripts/check-semver-bumps.py` (cargo-semver-checks 0.50.0, the CI-pinned version) against fresh crates.io baselines. **Seven crates took breaking public-contract changes** → breaking **minor** bump (the `0.x` breaking slot):

- `everruns-provider` 0.21.0 → 0.22.0 — routing refactor (#3538) removed the `OpenRouter*` routing structs/consts and the `openrouter_routing` builder for an opaque driver option; plus new variants on exhaustive content/stream enums from PDF input (#3535) and native async tool calls (#3466).
- `everruns-core` 0.20.0 → 0.21.0, `everruns-engine` 0.18.4 → 0.19.0, `everruns-host` 0.20.6 → 0.21.0, `everruns-platform` 0.20.0 → 0.21.0, `everruns` (facade) 0.20.1 → 0.21.0 — the cone above provider.
- `everruns-model-profiles` 0.1.0 → 0.2.0 — cache-write cost accounting (#3525) added a `cache_write` field to the exhaustively-constructible `ModelCost`/`CostTier` structs.

Everything else is additive or a compatibility re-pin (patch) — see the CHANGELOG **Crate Releases** section. No crate was deleted or absorbed. Cone closed to a fixpoint; `check-publish-cone` passes.

## Before / After

Release-metadata change only; no runtime behavior changes in this PR. `apps/docs` release-card validation passes locally (`release card v0.26.0 is valid`). Migration ordering verified (`migrations sequential (001..130)`). Latest `integration-live-sweep.yml` run on `main` is green.

## Risk
- Low
- Version/changelog/lockfile metadata only. Auto-tagging and publishing follow on merge.

## Security
- Threat categories reviewed: No security-relevant code changes — release metadata, changelog, and lockfiles only.
- Findings and resolutions: none.

## Follow-ups
- `scripts/sync-publish-pin-versions.py` does not update the one internal `everruns-host` pin in `crates/ard/Cargo.toml` that carries a `features` array (fixed by hand here); worth teaching the script to handle feature-carrying path pins so a future breaking host bump doesn't strand that pin.

## Checklist
- [x] Tests added or updated (n/a — release metadata)
- [x] Backward compatibility considered (breaking crate bumps classified and cone closed)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)