### PR TITLE
chore(tooling): remove repo-local Linear MCP config

### DIFF
--- a/.agents/skills/process-issues/SKILL.md
+++ b/.agents/skills/process-issues/SKILL.md
@@ -73,4 +73,4 @@ doppler run -- env | rg 'LINEAR_API_KEY|GITHUB_TOKEN'
 doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
 ```
 
-The Linear MCP server must be configured in `.mcp.json`.
+The Linear MCP server must be configured in the agent environment (global config).

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "linear": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.linear.app/sse"]
-    }
-  }
-}

--- a/knowledge/project/issue-tracking.md
+++ b/knowledge/project/issue-tracking.md
@@ -18,7 +18,7 @@ We use [Linear](https://linear.app) for issue tracking. All issues for this repo
 
 ## Prerequisites
 
-- Linear MCP server configured (`.mcp.json`)
+- Linear MCP server configured (agent global config)
 - `LINEAR_API_KEY` available via Doppler
 - GitHub CLI authenticated: `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'`
 


### PR DESCRIPTION
## Summary

Agents use their own global Linear MCP configuration, so the repo-root
`.mcp.json` (linear `mcp-remote`) only caused confusion. This deletes
it and points the two Linear setup pointers at the agent global config:

- `.agents/skills/process-issues/SKILL.md`
- `knowledge/project/issue-tracking.md`

Generic `.mcp.json` format docs (plugin spec, coding-CLI, CLI allowlist)
are untouched — they describe the file shape, not this repo's wiring.

## Testing

- `just check-okf` passes (346 concepts, 81 index files).
- `just pre-push` — all 22 guards pass (note: requires a Python >= 3.11
  first on PATH; system Python 3.9 trips the crate-docs guard on
  `tomllib`, unrelated to this change).
- Docs/config-only change, no runtime code; no smoke test needed.

## Notes

Security: removes a repo-pinned `npx mcp-remote` tool invocation in
favor of each agent's own managed global config — smaller supply-chain
surface, no secrets touched (`LINEAR_API_KEY` via Doppler unchanged).

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)