### PR TITLE
fix(tooling): sync version-carrying dev-dependency pins

### DIFF
--- a/knowledge/foundations/code-organization.md
+++ b/knowledge/foundations/code-organization.md
@@ -183,6 +183,13 @@ Two pin conventions follow from package publishability:
   `[workspace.dependencies]`. `scripts/sync-publish-pin-versions.py` discovers
   both packages and edges from Cargo metadata, so there is no release allowlist
   to update when a crate moves or versions diverge.
+- **Dev-dependencies** stay version-less by default: `cargo publish` strips a
+  version-less path dev-dependency, which keeps siblings that dev-depend on each
+  other free of a publish-order deadlock. A dev-dependency that needs features the
+  workspace entry does not carry (`everruns-ard` dev-depends on `everruns-host`
+  with `direct-egress`) spells out its own version and is then synced like any
+  other pin, because a breaking bump would otherwise leave the published crate
+  requesting a version that no longer exists.
 
 ## Formatting
 

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -3,7 +3,9 @@
 
 Published workspace packages own explicit versions. Every path dependency from
 a published package must carry the current version of the package it targets;
-workspace-inherited dependencies obtain that pin from ``Cargo.toml``.
+workspace-inherited dependencies obtain that pin from ``Cargo.toml``. A
+dev-dependency counts only once it declares a version of its own (see
+``dependency_tables``).
 
 The package graph is discovered from Cargo metadata. There are no package or
 dependency allowlists to update when crates move or versions diverge.
@@ -38,27 +40,36 @@ def metadata() -> dict[str, Any]:
     return json.loads(output)
 
 
-# Dev-dependencies are deliberately excluded. They never reach downstream
-# consumers (`cargo publish` drops a version-less path dev-dependency entirely),
-# and crate-release.yml already ignores dev edges in both its publish ordering
-# and its strand check. Pinning a dev-dependency to a workspace version that is
-# not yet on crates.io only creates a publish-order deadlock: a crate that
-# dev-depends on a sibling bumped in the same cycle cannot package before that
+# Dev-dependencies are pinned only where the declaration already carries a
+# version of its own. A version-less path dev-dependency never reaches
+# downstream consumers (`cargo publish` drops it entirely), and crate-release.yml
+# ignores dev edges in both its publish ordering and its strand check. Adding a
+# version there would only create a publish-order deadlock: a crate that
+# dev-depends on a sibling bumped in the same cycle could not package before that
 # sibling publishes, while the sibling may in turn depend on it (host <-> llmsim).
-# Leaving such dev edges version-less keeps them stripped on publish and the
-# cycle unbroken.
-def dependency_tables(manifest: dict[str, Any]) -> Iterator[dict[str, Any]]:
-    for name in ("dependencies", "build-dependencies"):
-        table = manifest.get(name)
+# A dev-dependency that spells out a version has opted into that ordering
+# deliberately - usually because it also carries features the workspace entry
+# does not (ard dev-depends on host with `direct-egress`), so it cannot inherit
+# the pin from `[workspace.dependencies]`. Such a pin still has to track the
+# target package, or a breaking bump leaves the published crate requesting a
+# version that no longer exists. Workspace-inherited dev edges stay excluded:
+# they declare no version, so keeping them out preserves the deadlock-free
+# default.
+DEPENDENCY_KINDS = ("dependencies", "build-dependencies", "dev-dependencies")
+
+
+def dependency_tables(manifest: dict[str, Any]) -> Iterator[tuple[str, dict[str, Any]]]:
+    for kind in DEPENDENCY_KINDS:
+        table = manifest.get(kind)
         if isinstance(table, dict):
-            yield table
+            yield kind, table
     for target in manifest.get("target", {}).values():
         if not isinstance(target, dict):
             continue
-        for name in ("dependencies", "build-dependencies"):
-            table = target.get(name)
+        for kind in DEPENDENCY_KINDS:
+            table = target.get(kind)
             if isinstance(table, dict):
-                yield table
+                yield kind, table
 
 
 def target_manifest(owner: Path, dependency: dict[str, Any]) -> Path | None:
@@ -69,15 +80,44 @@ def target_manifest(owner: Path, dependency: dict[str, Any]) -> Path | None:
     return candidate if candidate.name == "Cargo.toml" else candidate / "Cargo.toml"
 
 
-def rewrite_inline_dependency(path: Path, key: str, version: str) -> bool:
+TABLE_HEADER = re.compile(r'^\[(?P<name>[^\[\]]+)\]\s*$', re.MULTILINE)
+
+
+# A manifest can declare the same package in several dependency kinds (a normal
+# dependency and a dev-dependency with extra features, say). Rewrites therefore
+# search only the tables of the kind the drift was found in - `[dependencies]`,
+# `[dev-dependencies]`, `[workspace.dependencies]`, `[target.<cfg>.dependencies]`
+# all end in the kind that owns them.
+def dependency_table_spans(text: str, kind: str) -> Iterator[tuple[int, int]]:
+    headers = list(TABLE_HEADER.finditer(text))
+    for index, header in enumerate(headers):
+        if header.group("name").strip().rsplit(".", 1)[-1] != kind:
+            continue
+        end = headers[index + 1].start() if index + 1 < len(headers) else len(text)
+        yield header.end(), end
+
+
+def rewrite_inline_dependency(path: Path, kind: str, key: str, version: str) -> bool:
     text = path.read_text()
     pattern = re.compile(
         rf'^(?P<prefix>\s*{re.escape(key)}\s*=\s*\{{)(?P<body>[^}}\n]*)(?P<suffix>\}}.*)$',
         re.MULTILINE,
     )
-    match = pattern.search(text)
-    if match is None:
-        raise ValueError(f"{path.relative_to(REPO)}: cannot rewrite non-inline dependency {key}")
+    matches = []
+    for start, end in dependency_table_spans(text, kind):
+        found = pattern.search(text[start:end])
+        if found is not None:
+            matches.append((start, found))
+    if not matches:
+        raise ValueError(
+            f"{path.relative_to(REPO)}: cannot rewrite non-inline {kind} entry {key}"
+        )
+    if len(matches) > 1:
+        raise ValueError(
+            f"{path.relative_to(REPO)}: {key} is declared in several {kind} tables; "
+            "pin it by hand"
+        )
+    offset, match = matches[0]
     body = match.group("body")
     if re.search(r'\bversion\s*=\s*"[^"]+"', body):
         new_body = re.sub(
@@ -88,7 +128,9 @@ def rewrite_inline_dependency(path: Path, key: str, version: str) -> bool:
         )
     else:
         new_body = f' version = "{version}", {body.lstrip()}'
-    new_text = text[: match.start("body")] + new_body + text[match.end("body") :]
+    body_start = offset + match.start("body")
+    body_end = offset + match.end("body")
+    new_text = text[:body_start] + new_body + text[body_end:]
     if new_text == text:
         return False
     path.write_text(new_text)
@@ -114,7 +156,7 @@ def main() -> int:
     root = load(root_path)
     workspace_dependencies = root["workspace"].get("dependencies", {})
     failures: list[str] = []
-    rewrites: dict[tuple[Path, str], str] = {}
+    rewrites: dict[tuple[Path, str, str], str] = {}
 
     for manifest_path, package in sorted(published.items(), key=lambda item: item[1]["name"]):
         manifest = load(manifest_path)
@@ -123,15 +165,21 @@ def main() -> int:
                 f"{manifest_path.relative_to(REPO)}: published package must declare an explicit version"
             )
 
-        for table in dependency_tables(manifest):
+        for kind, table in dependency_tables(manifest):
             for key, declaration in table.items():
                 if not isinstance(declaration, dict):
                     continue
+                # Only a dev-dependency that declares its own version is in
+                # scope; workspace-inherited dev edges declare none and stay out.
+                if kind == "dev-dependencies" and "version" not in declaration:
+                    continue
                 resolved = declaration
                 declaration_path = manifest_path
+                declaration_kind = kind
                 if declaration.get("workspace") is True:
                     resolved = workspace_dependencies.get(key, {})
                     declaration_path = root_path
+                    declaration_kind = "dependencies"
                 if not isinstance(resolved, dict):
                     continue
                 dependency_manifest = target_manifest(declaration_path, resolved)
@@ -141,10 +189,11 @@ def main() -> int:
                 actual = resolved.get("version")
                 if actual != expected:
                     failures.append(
-                        f"{declaration_path.relative_to(REPO)}: {key} pins {actual!r}; "
+                        f"{declaration_path.relative_to(REPO)} [{declaration_kind}]: "
+                        f"{key} pins {actual!r}; "
                         f"{published[dependency_manifest]['name']} is {expected}"
                     )
-                    rewrites[(declaration_path, key)] = expected
+                    rewrites[(declaration_path, declaration_kind, key)] = expected
 
     if check_only:
         if failures:
@@ -156,9 +205,9 @@ def main() -> int:
         return 0
 
     changed = 0
-    for (path, key), version in sorted(rewrites.items(), key=lambda item: (str(item[0][0]), item[0][1])):
+    for (path, kind, key), version in sorted(rewrites.items(), key=lambda item: tuple(map(str, item[0]))):
         try:
-            changed += rewrite_inline_dependency(path, key, version)
+            changed += rewrite_inline_dependency(path, kind, key, version)
         except ValueError as error:
             print(error, file=sys.stderr)
             return 1

--- a/scripts/test-publish-crates-order.sh
+++ b/scripts/test-publish-crates-order.sh
@@ -10,10 +10,12 @@ cd "$PROJECT_ROOT"
 python3 scripts/sync-publish-pin-versions.py --check
 
 python3 - <<'PY'
+import importlib.util
 import json
 import pathlib
 import subprocess
 import sys
+import tempfile
 import tomllib
 
 repo = pathlib.Path.cwd()
@@ -46,6 +48,72 @@ for package in published:
     require(
         isinstance(manifest.get("package", {}).get("version"), str),
         f"{manifest_path.relative_to(repo)}: published package must own an explicit version",
+    )
+
+# Pin-sync unit coverage. The ard -> host dev pin drifted through a release
+# because the sync script skipped dev edges wholesale, so dev-dependencies are
+# now discovered too, and a rewrite has to stay inside the table its drift came
+# from. The whole-workspace `--check` above covers the real edge; these cases pin
+# the discovery and rewrite behaviour behind it.
+spec = importlib.util.spec_from_file_location(
+    "sync_publish_pin_versions", repo / "scripts/sync-publish-pin-versions.py"
+)
+sync = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sync)
+
+manifest = tomllib.loads("""
+[dependencies]
+everruns-core = { path = "../core", version = "1.0.0" }
+
+[dev-dependencies]
+everruns-host = { version = "0.20.0", path = "../host", features = ["direct-egress"] }
+everruns-llmsim = { path = "../drivers/llmsim" }
+
+[target."cfg(unix)".dev-dependencies]
+everruns-sim = { path = "../sim", version = "0.1.0" }
+""")
+kinds = {
+    key: kind
+    for kind, table in sync.dependency_tables(manifest)
+    for key in table
+}
+require(
+    kinds
+    == {
+        "everruns-core": "dependencies",
+        "everruns-host": "dev-dependencies",
+        "everruns-llmsim": "dev-dependencies",
+        "everruns-sim": "dev-dependencies",
+    },
+    f"dependency_tables must report every dependency kind, got {kinds}",
+)
+
+with tempfile.TemporaryDirectory() as directory:
+    fixture = pathlib.Path(directory) / "Cargo.toml"
+    fixture.write_text(
+        '[dependencies]\n'
+        'everruns-host = { path = "../host" }\n'
+        '\n'
+        '[dev-dependencies]\n'
+        'everruns-host = { version = "0.20.0", path = "../host", features = ["direct-egress"] }\n'
+    )
+    require(
+        sync.rewrite_inline_dependency(fixture, "dev-dependencies", "everruns-host", "0.21.0"),
+        "rewriting a drifted dev-dependency pin must report a change",
+    )
+    rewritten = fixture.read_text()
+    require(
+        'everruns-host = { version = "0.21.0", path = "../host", features = ["direct-egress"] }'
+        in rewritten,
+        f"dev-dependency rewrite must keep features and update only the version, got:\n{rewritten}",
+    )
+    require(
+        'everruns-host = { path = "../host" }' in rewritten,
+        "a rewrite scoped to [dev-dependencies] must not touch the [dependencies] entry",
+    )
+    require(
+        not sync.rewrite_inline_dependency(fixture, "dev-dependencies", "everruns-host", "0.21.0"),
+        "rewriting an already-current pin must report no change",
     )
 
 legacy_macros = repo / "crates/everruns-macros"


### PR DESCRIPTION
## What changed

`scripts/sync-publish-pin-versions.py` now keeps dev-dependency pins in sync — but only the ones that declare a version of their own. Version-less and workspace-inherited dev edges are still ignored, so `cargo publish` keeps stripping them and the publish order still cannot deadlock (host ↔ llmsim).

Rewrites are now scoped to the dependency table the drift came from. A package can legitimately appear both as a normal dependency and as a dev-dependency with extra features; the previous whole-file search would have rewritten whichever line came first. Two entries of the same kind in one manifest now raise an explicit error instead of a silent guess.

Drift reports name the table: `crates/ard/Cargo.toml [dev-dependencies]: everruns-host pins '0.20.0'; everruns-host is 0.21.0`.

## Why

`crates/ard/Cargo.toml` dev-depends on `everruns-host` with `features = ["direct-egress"]`, which the `[workspace.dependencies]` entry does not carry — so it cannot inherit the pin and spells out its own version. The sync script skipped every dev edge, so that pin sat at `0.20.0` while host moved on, and v0.26.0 (host `0.20.6` → `0.21.0`) had to be corrected by hand. Left alone, a published `everruns-ard` would eventually request a `^0.20` host that no longer satisfies the workspace.

## Before / After

Induced the exact drift the release hit (ard's dev pin set back to `0.20.0`, host at `0.21.0`).

Before — `main`'s script sees nothing and fixes nothing:

```
$ python3 scripts/sync-publish-pin-versions.py --check
independent crate versions and pins verified for 41 package(s)
$ echo $?
0
$ python3 scripts/sync-publish-pin-versions.py --write
updated 0 internal dependency pin(s)
independent crate versions and pins verified for 41 package(s)
$ grep everruns-host crates/ard/Cargo.toml
everruns-host = { version = "0.20.0", path = "../host", features = ["direct-egress"] }
```

After:

```
$ python3 scripts/sync-publish-pin-versions.py --check
independent crate version validation failed:
  crates/ard/Cargo.toml [dev-dependencies]: everruns-host pins '0.20.0'; everruns-host is 0.21.0
$ echo $?
1
$ python3 scripts/sync-publish-pin-versions.py --write
updated 1 internal dependency pin(s)
independent crate versions and pins verified for 41 package(s)
```

The rewritten line is byte-identical to the hand fix — features and ordering preserved:

```toml
everruns-host = { version = "0.21.0", path = "../host", features = ["direct-egress"] }
```

With the tree as it stands (pins already correct), `--check` is green and `--write` is a no-op, so no manifest changes ship in this PR.

## Risk

- Low
- The script rewrites `Cargo.toml` files, and this widens what it may touch. Contained by three things: only dev declarations that already carry a `version` key are in scope, rewrites are confined to tables of the matching kind, and an ambiguous match aborts with a message instead of editing. `--write` still re-runs `--check` and propagates its exit code.
- Worst realistic failure is a release-prep run reporting drift that a human then inspects — `--check` runs in CI (`ci.yml`) and in `publish-crates.yml` before publishing, so a bad rewrite cannot reach crates.io unnoticed.

## Security

- Threat categories reviewed: TM-CI (release and publish tooling). Supply-chain angle considered explicitly, since this script decides the version requirements published crates carry.
- Findings and resolutions: none. The script takes no network input, no secrets, and no user-supplied arguments beyond `--check`/`--write`; every value it writes is derived from `cargo metadata` over repo-local manifests. The change widens the set of manifest lines it may rewrite, which is the one new risk — addressed by the section scoping and the fail-loud ambiguity path described under Risk. Keeping a published dev pin truthful is a small supply-chain improvement: it removes the case where `everruns-ard` on crates.io requires a host version the workspace no longer produces. No `THREAT[...]` markers exist in `scripts/`, and no new threat surface warrants a `knowledge/security/threat-model.md` entry.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---

Validation: `just pre-push` green (22/22), `bash scripts/test-publish-crates-order.sh` green, `python3 scripts/check_okf.py` green. The new unit cases fail against the pre-change script, so they are real guards. Smoke test is the Before/After above — this is release tooling with no runtime surface, so the product stack was not started.

https://claude.ai/code/session_01DGiZtLMsQ933NeQMJH1Cgo