### PR TITLE
feat(slack): generate event_subscriptions in the app manifest

### DIFF
--- a/apps/ui/src/__tests__/slack-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/slack-setup-guidance.test.tsx
@@ -22,16 +22,46 @@ describe("SlackSetupGuidance", () => {
   it("keeps the setup checklist visible after publish", () => {
     render(<SlackSetupGuidance {...baseProps} isPublished={true} />);
 
-    expect(screen.getByText("3. Publish the app")).toBeInTheDocument();
-    expect(screen.getByText("4. Configure Event Subscriptions")).toBeInTheDocument();
-    expect(screen.getByText(baseProps.webhookUrl)).toBeInTheDocument();
-    expect(screen.getByText("5. Invite the bot and test")).toBeInTheDocument();
+    expect(screen.getByText("1. Publish the app")).toBeInTheDocument();
+    expect(screen.getByText("2. Create a Slack App")).toBeInTheDocument();
+    expect(screen.getByText("3. Copy credentials back")).toBeInTheDocument();
+    expect(screen.getByText("4. Invite the bot and test")).toBeInTheDocument();
   });
 
-  it("shows create and configure actions before Slack credentials exist", () => {
-    render(<SlackSetupGuidance {...baseProps} hasSlackConfig={false} />);
+  it("no longer asks the user to configure Event Subscriptions by hand", () => {
+    render(<SlackSetupGuidance {...baseProps} isPublished={true} hasSlackConfig={false} />);
+
+    expect(screen.queryByText(/Configure Event Subscriptions/)).not.toBeInTheDocument();
+    // The manifest carries the subscriptions, so the URL is shown as information
+    // rather than as something to paste into Slack.
+    expect(screen.getByText(baseProps.webhookUrl)).toBeInTheDocument();
+  });
+
+  it("publishes before offering the manifest, and says why", () => {
+    render(<SlackSetupGuidance {...baseProps} isPublished={false} hasSlackConfig={false} />);
+
+    expect(screen.queryByRole("button", { name: "Create Slack App" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Available once the app is published/)).toBeInTheDocument();
+  });
+
+  it("shows create and configure actions once published", () => {
+    render(<SlackSetupGuidance {...baseProps} isPublished={true} hasSlackConfig={false} />);
 
     expect(screen.getByRole("button", { name: "Create Slack App" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Configure" })).toBeInTheDocument();
+  });
+
+  it("keeps the manual Request URL path for localhost, which Slack cannot reach", () => {
+    render(
+      <SlackSetupGuidance
+        {...baseProps}
+        isPublished={true}
+        hasSlackConfig={false}
+        isLocalhost={true}
+      />,
+    );
+
+    expect(screen.getByText(/ngrok http/)).toBeInTheDocument();
+    expect(screen.getByText(baseProps.webhookPath)).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/components/apps/slack-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/slack-setup-guidance.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 // Keep the Slack checklist in one component so publish-state guidance is testable.
+//
+// Publish comes first (EVE-970). Slack verifies `request_url` at the moment the
+// manifest is saved, and the generated manifest now carries `event_subscriptions`,
+// so the webhook has to be answering before the Slack app is created from it.
+// That ordering is what removes the old hand-editing step.
 
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -58,6 +63,21 @@ function StepIcon({ done }: { done: boolean }) {
   );
 }
 
+function CopyableValue({ value }: { value: string }) {
+  return (
+    <div className="flex items-center gap-2 bg-muted p-2">
+      <code className="text-xs flex-1 truncate">{value}</code>
+      <button
+        className="shrink-0 hover:text-foreground text-muted-foreground"
+        onClick={() => navigator.clipboard.writeText(value)}
+        aria-label="Copy"
+      >
+        <Copy className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}
+
 function SetupSteps({
   hasSlackConfig,
   isPublished,
@@ -70,15 +90,7 @@ function SetupSteps({
   creatingSlackApp,
   onConfigure,
 }: SlackSetupGuidanceProps) {
-  const currentStep = !hasSlackConfig
-    ? 1
-    : !isPublished
-      ? 3
-      : !webhookVerified
-        ? 4
-        : !firstMessageReceived
-          ? 5
-          : 5;
+  const currentStep = !isPublished ? 1 : !hasSlackConfig ? 2 : !firstMessageReceived ? 4 : 4;
 
   return (
     <div className="space-y-4">
@@ -89,25 +101,18 @@ function SetupSteps({
       )}
 
       <div className="flex gap-3">
-        <StepIcon done={hasSlackConfig} />
+        <StepIcon done={isPublished} />
         <div className="flex-1 space-y-1">
           <p
-            className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
+            className={`text-sm font-medium ${isPublished ? "text-muted-foreground line-through" : ""}`}
           >
-            1. Create a Slack App
+            1. Publish the app
           </p>
           {currentStep === 1 && (
-            <div className="space-y-2">
-              <p className="text-xs text-muted-foreground">
-                Opens Slack with a pre-filled manifest (bot scopes and settings are already
-                configured). Review and click <strong>Create</strong>, then install to your
-                workspace.
-              </p>
-              <Button size="sm" onClick={onCreateSlackApp} disabled={creatingSlackApp}>
-                <ExternalLink className="w-3 h-3 mr-1" />
-                {creatingSlackApp ? "Opening..." : "Create Slack App"}
-              </Button>
-            </div>
+            <p className="text-xs text-muted-foreground">
+              Click the <strong>Publish</strong> button above to activate the webhook endpoint.
+              Slack checks this URL the moment you create the app, so it has to be live first.
+            </p>
           )}
         </div>
       </div>
@@ -118,9 +123,68 @@ function SetupSteps({
           <p
             className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
           >
-            2. Copy credentials back
+            2. Create a Slack App
           </p>
           {currentStep === 1 && (
+            <p className="text-xs text-muted-foreground">
+              Available once the app is published — the manifest points Slack at this app&apos;s
+              webhook, and Slack rejects a URL that does not answer yet.
+            </p>
+          )}
+          {currentStep === 2 && (
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground">
+                Opens Slack with a pre-filled manifest. Bot scopes <em>and</em> event subscriptions
+                are already set, so there is nothing to configure by hand. Review and click{" "}
+                <strong>Create</strong>, then install to your workspace.
+              </p>
+              {isLocalhost ? (
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    Slack can&apos;t reach localhost, so the manifest&apos;s Request URL will not
+                    verify. Run{" "}
+                    <code>
+                      ngrok http{" "}
+                      {typeof window !== "undefined" ? window.location.port || "9300" : "9300"}
+                    </code>{" "}
+                    and replace the Request URL under <strong>Event Subscriptions</strong> with your
+                    ngrok URL plus this path:
+                  </p>
+                  <CopyableValue value={webhookPath} />
+                </>
+              ) : (
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    The manifest subscribes to <code>app_mention</code>,{" "}
+                    <code>message.channels</code>, <code>message.groups</code>,{" "}
+                    <code>message.im</code> and <code>message.mpim</code> at this Request URL:
+                  </p>
+                  <CopyableValue value={webhookUrl} />
+                </>
+              )}
+              <Button size="sm" onClick={onCreateSlackApp} disabled={creatingSlackApp}>
+                <ExternalLink className="w-3 h-3 mr-1" />
+                {creatingSlackApp ? "Opening..." : "Create Slack App"}
+              </Button>
+            </div>
+          )}
+          {hasSlackConfig && !webhookVerified && (
+            <p className="text-xs text-muted-foreground">
+              Waiting for Slack&apos;s first call to the Request URL.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <StepIcon done={hasSlackConfig} />
+        <div className="flex-1 space-y-1">
+          <p
+            className={`text-sm font-medium ${hasSlackConfig ? "text-muted-foreground line-through" : ""}`}
+          >
+            3. Copy credentials back
+          </p>
+          {currentStep === 2 && (
             <div className="space-y-2">
               <p className="text-xs text-muted-foreground">
                 After creating the Slack app, copy two values back here:
@@ -145,88 +209,12 @@ function SetupSteps({
       </div>
 
       <div className="flex gap-3">
-        <StepIcon done={isPublished} />
-        <div className="flex-1 space-y-1">
-          <p
-            className={`text-sm font-medium ${isPublished ? "text-muted-foreground line-through" : ""}`}
-          >
-            3. Publish the app
-          </p>
-          {currentStep === 3 && (
-            <p className="text-xs text-muted-foreground">
-              Click the <strong>Publish</strong> button above to activate the webhook endpoint.
-            </p>
-          )}
-        </div>
-      </div>
-
-      <div className="flex gap-3">
-        <StepIcon done={webhookVerified} />
-        <div className="flex-1 space-y-1">
-          <p
-            className={`text-sm font-medium ${webhookVerified ? "text-muted-foreground line-through" : ""}`}
-          >
-            4. Configure Event Subscriptions
-          </p>
-          {currentStep === 4 ? (
-            <div className="space-y-2">
-              {isLocalhost ? (
-                <>
-                  <p className="text-xs text-muted-foreground">
-                    Slack can&apos;t reach localhost. Run{" "}
-                    <code>
-                      ngrok http{" "}
-                      {typeof window !== "undefined" ? window.location.port || "9300" : "9300"}
-                    </code>{" "}
-                    then use the ngrok URL with this path as your Request URL:
-                  </p>
-                  <div className="flex items-center gap-2 bg-muted p-2">
-                    <code className="text-xs flex-1 truncate">{webhookPath}</code>
-                    <button
-                      className="shrink-0 hover:text-foreground text-muted-foreground"
-                      onClick={() => navigator.clipboard.writeText(webhookPath)}
-                    >
-                      <Copy className="w-3 h-3" />
-                    </button>
-                  </div>
-                </>
-              ) : (
-                <>
-                  <p className="text-xs text-muted-foreground">
-                    In your Slack app settings, go to <strong>Event Subscriptions</strong>, enable
-                    events, and paste this Request URL:
-                  </p>
-                  <div className="flex items-center gap-2 bg-muted p-2">
-                    <code className="text-xs flex-1 truncate">{webhookUrl}</code>
-                    <button
-                      className="shrink-0 hover:text-foreground text-muted-foreground"
-                      onClick={() => navigator.clipboard.writeText(webhookUrl)}
-                    >
-                      <Copy className="w-3 h-3" />
-                    </button>
-                  </div>
-                </>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Then subscribe to bot events: <code>message.channels</code>,{" "}
-                <code>message.groups</code>, <code>message.im</code>, <code>app_mention</code>
-              </p>
-            </div>
-          ) : (
-            <p className="text-xs text-muted-foreground">
-              Add the webhook URL to your Slack app&apos;s Event Subscriptions.
-            </p>
-          )}
-        </div>
-      </div>
-
-      <div className="flex gap-3">
         <StepIcon done={firstMessageReceived} />
         <div className="flex-1 space-y-1">
           <p
             className={`text-sm font-medium ${firstMessageReceived ? "text-muted-foreground line-through" : ""}`}
           >
-            5. Invite the bot and test
+            4. Invite the bot and test
           </p>
           <p className="text-xs text-muted-foreground">
             In Slack, use <code>/invite @botname</code> in a channel, then send a message.

--- a/crates/server/specs/slack-integration.md
+++ b/crates/server/specs/slack-integration.md
@@ -10,9 +10,12 @@ Slack is the reference implementation for the [messaging integrations](../../../
 
 ```
 Per-app manifest (recommended):
+  Publish the App        -->  webhook endpoint goes live (required first)
+                              |
   UI "Create Slack App"  -->  GET /v1/apps/{app_id}/slack/manifest  (returns YAML + create URL)
                               |
   Opens Slack "Create from manifest" with pre-filled scopes + bot user
+  + event_subscriptions (Slack verifies request_url on save)
                               |
   User copies signing_secret + bot_token back to Everruns
 
@@ -33,7 +36,7 @@ The events endpoint verifies HMAC-SHA256 signing secret, finds/creates session b
 ## Design Decisions
 
 - **One Slack App per Everruns App**: Each app has its own identity (name, avatar, scopes). This is unlike GitHub (global app) because Slack bots are user-facing with distinct identities per use case.
-- **Per-app manifest generation**: The manifest endpoint generates a YAML with correct scopes and bot user. `event_subscriptions` is omitted (requires live webhook URL, must be configured after publishing).
+- **Per-app manifest generation**: The manifest endpoint generates a YAML with correct scopes, bot user, and `event_subscriptions`. The webhook URL is fully determined by the app's public ID before the Slack app exists, so it can be declared up front; the real constraint is ordering, since Slack verifies `request_url` when the manifest is saved. That is why the endpoint serves published apps only — publish, then create the Slack app. (An earlier revision of this spec claimed `event_subscriptions` "requires a live webhook URL, must be configured after publishing" and therefore omitted it. The live-URL part is right, the conclusion was not: the fix is ordering, not manual setup.)
 - **App-scoped endpoint**: Slack is bound to an App, so the webhook is `POST /v1/apps/{app_id}/slack/events`. The App defines the harness, optional agent, signing secret, and session strategy.
 - **Unauthenticated**: Webhook and manifest requests come from Slack or the browser. Security is via Slack signing secret verification (HMAC-SHA256), not API key auth.
 - **Unscoped app lookup**: `get_app_by_public_id_unscoped()` looks up apps across all orgs since webhooks have no auth context.
@@ -86,9 +89,9 @@ Apps page at `/apps` with:
 - List of apps with status badges
 - Create page at `/apps/new` with name, harness, and optional agent/channel selection
 - Detail page at `/apps/{id}` with:
-  - "Create Slack App" button (opens Slack with pre-filled manifest)
+  - "Create Slack App" button (opens Slack with pre-filled manifest), offered only once published
   - Manual configuration fields (signing secret, bot token)
-  - Webhook URL display for Event Subscriptions
+  - Webhook URL display, informational — the manifest already declares it
 - Publish/Unpublish actions
 - Delete confirmation
 

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -211,6 +211,9 @@ pub struct SlackState {
     user_name_cache: SlackUserCache,
     /// Event-driven Slack delivery dispatcher (None in DEV_MODE without PostgreSQL).
     pub delivery_dispatcher: Option<Arc<SlackDeliveryDispatcher>>,
+    /// Backend origin including the API prefix (e.g. `https://app.example.com/api`).
+    /// The generated manifest needs it to name this server's own webhook URL.
+    pub api_base_url: String,
 }
 
 impl SlackState {
@@ -221,6 +224,7 @@ impl SlackState {
         delivery_dispatcher: Option<Arc<SlackDeliveryDispatcher>>,
         notifications_enabled: bool,
         event_delivery: crate::event_delivery::EventDelivery,
+        api_base_url: String,
     ) -> Self {
         Self {
             session_service: Arc::new(SessionService::new(db.clone())),
@@ -235,6 +239,7 @@ impl SlackState {
             db,
             user_name_cache: new_slack_user_cache(),
             delivery_dispatcher,
+            api_base_url,
         }
     }
 }
@@ -1575,9 +1580,12 @@ struct ManifestResponse {
 /// GET /v1/apps/{app_id}/slack/manifest — Generate a Slack App manifest.
 ///
 /// Returns a pre-filled YAML manifest and a URL that opens Slack's "Create app
-/// from manifest" flow. The manifest includes the correct webhook URL and bot
-/// scopes but omits `event_subscriptions` (requires a live URL, so must be
-/// configured manually after the app is created and published).
+/// from manifest" flow. The manifest carries bot scopes *and*
+/// `event_subscriptions`, so no hand-editing is needed after creation.
+///
+/// Slack verifies `request_url` when the manifest is saved, which is why this
+/// endpoint serves only published apps: the webhook has to be answering before
+/// the Slack app is created from the manifest.
 async fn handle_slack_manifest(
     State(state): State<SlackState>,
     Path(app_id): Path<String>,
@@ -1603,7 +1611,13 @@ async fn handle_slack_manifest(
 
     let display_name = truncate_display_name(&app.name);
 
-    let manifest_yaml = build_manifest_yaml(&app.name, &display_name, app.description.as_deref());
+    let request_url = slack_webhook_url(&state.api_base_url, &app.public_id.to_string());
+    let manifest_yaml = build_manifest_yaml(
+        &app.name,
+        &display_name,
+        app.description.as_deref(),
+        &request_url,
+    );
 
     // URL-encode the manifest for the Slack "create from manifest" URL
     let encoded = urlencoding_encode(&manifest_yaml);
@@ -1618,7 +1632,19 @@ async fn handle_slack_manifest(
     }))
 }
 
-/// Build the YAML manifest for a Slack app (no event_subscriptions — requires live URL).
+/// This server's Slack webhook endpoint for one app.
+///
+/// Fully determined by the app's public ID before the Slack app exists, which is
+/// what makes `event_subscriptions` generatable at all.
+fn slack_webhook_url(api_base_url: &str, app_public_id: &str) -> String {
+    format!(
+        "{}/v1/apps/{}/slack/events",
+        api_base_url.trim_end_matches('/'),
+        app_public_id
+    )
+}
+
+/// Build the YAML manifest for a Slack app.
 ///
 /// Slack requires `long_description` to be 174–4000 chars. We build it from the
 /// app's description (if any) plus a standard suffix, padding if needed.
@@ -1626,11 +1652,13 @@ fn build_manifest_yaml(
     app_name: &str,
     display_name: &str,
     app_description: Option<&str>,
+    request_url: &str,
 ) -> String {
     let name = yaml_escape(app_name);
     let display_name = yaml_escape(display_name);
     let long_desc = build_long_description(app_name, app_description);
     let long_desc = yaml_escape(&long_desc);
+    let request_url = yaml_escape(request_url);
     format!(
         "display_information:\n\
          \x20 name: \"{name}\"\n\
@@ -1653,6 +1681,14 @@ fn build_manifest_yaml(
          \x20     - users:read\n\
          \x20     - files:read\n\
          settings:\n\
+         \x20 event_subscriptions:\n\
+         \x20   request_url: \"{request_url}\"\n\
+         \x20   bot_events:\n\
+         \x20     - app_mention\n\
+         \x20     - message.channels\n\
+         \x20     - message.groups\n\
+         \x20     - message.im\n\
+         \x20     - message.mpim\n\
          \x20 org_deploy_enabled: false\n\
          \x20 socket_mode_enabled: false\n\
          \x20 token_rotation_enabled: false\n",
@@ -2558,9 +2594,95 @@ mod tests {
         assert!(truncated.is_char_boundary(truncated.len()));
     }
 
+    const TEST_REQUEST_URL: &str = "https://example.com/api/v1/apps/app_test123/slack/events";
+
+    #[test]
+    fn test_manifest_yaml_contains_event_subscriptions() {
+        let yaml = build_manifest_yaml("My Bot", "My Bot", None, TEST_REQUEST_URL);
+
+        assert!(
+            yaml.contains(&format!("    request_url: \"{TEST_REQUEST_URL}\"")),
+            "manifest must name this server's webhook:\n{yaml}"
+        );
+        for event in [
+            "      - app_mention",
+            "      - message.channels",
+            "      - message.groups",
+            "      - message.im",
+            "      - message.mpim",
+        ] {
+            assert!(
+                yaml.contains(event),
+                "manifest must subscribe {event}:\n{yaml}"
+            );
+        }
+        // event_subscriptions has to sit under `settings`, not at the root, or
+        // Slack rejects the manifest.
+        let settings = yaml.find("settings:").expect("settings section");
+        let subs = yaml
+            .find("  event_subscriptions:")
+            .expect("event_subscriptions section");
+        assert!(
+            subs > settings,
+            "event_subscriptions must nest under settings"
+        );
+    }
+
+    #[test]
+    fn test_manifest_yaml_parses_as_yaml_with_expected_shape() {
+        let yaml = build_manifest_yaml("My Bot", "My Bot", None, TEST_REQUEST_URL);
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&yaml).expect("manifest is valid YAML");
+
+        let subs = &parsed["settings"]["event_subscriptions"];
+        assert_eq!(subs["request_url"].as_str(), Some(TEST_REQUEST_URL));
+        let events: Vec<&str> = subs["bot_events"]
+            .as_sequence()
+            .expect("bot_events sequence")
+            .iter()
+            .map(|v| v.as_str().expect("event is a string"))
+            .collect();
+        assert_eq!(
+            events,
+            vec![
+                "app_mention",
+                "message.channels",
+                "message.groups",
+                "message.im",
+                "message.mpim"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_manifest_yaml_escapes_request_url() {
+        // The URL is server-configured, but a quote in it must not break out of
+        // the YAML string and corrupt the rest of the manifest.
+        let yaml = build_manifest_yaml("My Bot", "My Bot", None, r#"https://x/"evil"#);
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&yaml).expect("manifest is valid YAML");
+        assert_eq!(
+            parsed["settings"]["event_subscriptions"]["request_url"].as_str(),
+            Some(r#"https://x/"evil"#)
+        );
+    }
+
+    #[test]
+    fn test_slack_webhook_url_shape() {
+        assert_eq!(
+            slack_webhook_url("https://example.com/api", "app_abc"),
+            "https://example.com/api/v1/apps/app_abc/slack/events"
+        );
+        // A configured base with a trailing slash must not double up.
+        assert_eq!(
+            slack_webhook_url("https://example.com/api/", "app_abc"),
+            "https://example.com/api/v1/apps/app_abc/slack/events"
+        );
+    }
+
     #[test]
     fn test_manifest_yaml_contains_description_and_long_description() {
-        let yaml = build_manifest_yaml("My Bot", "My Bot", None);
+        let yaml = build_manifest_yaml("My Bot", "My Bot", None, TEST_REQUEST_URL);
         assert!(yaml.contains(r#"description: "My Bot (Powered by Everruns)""#));
         assert!(yaml.contains("AI agent powered by Everruns"));
         assert!(yaml.contains("https://everruns.com"));
@@ -2568,7 +2690,12 @@ mod tests {
 
     #[test]
     fn test_manifest_yaml_with_app_description() {
-        let yaml = build_manifest_yaml("My Bot", "My Bot", Some("A helpful assistant"));
+        let yaml = build_manifest_yaml(
+            "My Bot",
+            "My Bot",
+            Some("A helpful assistant"),
+            TEST_REQUEST_URL,
+        );
         assert!(yaml.contains("A helpful assistant"));
         assert!(yaml.contains("AI agent powered by Everruns"));
     }
@@ -2578,7 +2705,7 @@ mod tests {
         // Slack description limit is 140 chars. Worst case: 35-char app name
         // (Slack's name limit) + " (Powered by Everruns)" = 57 chars.
         let long_name = "a".repeat(35);
-        let yaml = build_manifest_yaml(&long_name, &long_name, None);
+        let yaml = build_manifest_yaml(&long_name, &long_name, None, TEST_REQUEST_URL);
         // Extract the description value
         let desc_prefix = "description: \"";
         let desc_start = yaml.find(desc_prefix).unwrap() + desc_prefix.len();
@@ -2594,7 +2721,7 @@ mod tests {
 
     #[test]
     fn test_manifest_yaml_escapes_special_chars_in_name() {
-        let yaml = build_manifest_yaml(r#"Bot "Special""#, "Bot Special", None);
+        let yaml = build_manifest_yaml(r#"Bot "Special""#, "Bot Special", None, TEST_REQUEST_URL);
         assert!(yaml.contains(r#"name: "Bot \"Special\"""#));
         assert!(yaml.contains(r#"description: "Bot \"Special\" (Powered by Everruns)""#));
     }
@@ -3123,6 +3250,7 @@ mod tests {
             None,
             false,
             crate::event_delivery::EventDelivery::in_memory(),
+            "https://example.com/api".to_string(),
         );
         let session_id = setup_test_session(&state.db).await;
 
@@ -3162,7 +3290,12 @@ mod tests {
     #[test]
     fn test_manifest_includes_history_scopes_for_thread_context() {
         // conversations.replies requires channels:history / groups:history / im:history / mpim:history
-        let yaml = build_manifest_yaml("Bot", "Bot", None);
+        let yaml = build_manifest_yaml(
+            "Bot",
+            "Bot",
+            None,
+            "https://example.com/api/v1/apps/app_x/slack/events",
+        );
         assert!(
             yaml.contains("channels:history"),
             "Manifest must include channels:history for conversations.replies"

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1256,6 +1256,7 @@ impl ServerAppBuilder {
             slack_dispatcher.clone(),
             notifications_enabled,
             event_delivery.clone(),
+            auth_config.base_url.clone(),
         );
         let webhook_rate_limiter = match valkey_for_channel_rate_limits.clone() {
             Some(client) => {

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -568,6 +568,7 @@ impl TestServer {
             None, // No delivery dispatcher in tests
             feature_flags.notifications,
             event_delivery.clone(),
+            "https://example.com/api".to_string(),
         );
         let app_webhooks_state = api::app_webhooks::AppWebhookState::new(
             db.clone(),

--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -25,30 +25,35 @@ Everruns generates a pre-filled Slack App manifest for each app, making setup fa
 2. Enter a name, select a Harness and Agent
 3. Click **Create App**: you'll be redirected to the detail page
 
-### 2. Create the Slack App
+### 2. Publish the App
+
+Click **Publish** on the App detail page. This activates the webhook endpoint.
+
+Publishing comes before creating the Slack app because the generated manifest now declares the
+Request URL, and Slack verifies that URL at the moment the manifest is saved. An unpublished app
+returns 404 from the manifest endpoint for the same reason.
+
+### 3. Create the Slack App
 
 1. On the App detail page, click **Create Slack App**
-2. This opens Slack's "Create app from manifest" page with pre-filled scopes and bot settings
+2. This opens Slack's "Create app from manifest" page with pre-filled scopes, bot settings, **and
+   event subscriptions**
 3. Review the manifest and click **Create**
 4. Install the app to your workspace when prompted
 
-### 3. Copy Credentials Back
+The manifest subscribes the bot to `app_mention`, `message.channels`, `message.groups`,
+`message.im` and `message.mpim` at your app's Request URL, so there is nothing to configure by hand.
+
+> **Local development:** Slack cannot reach `localhost`, so the generated Request URL will not
+> verify. Run `ngrok http 9300` and replace the Request URL under **Event Subscriptions** with your
+> ngrok URL plus the same `/v1/apps/{app_id}/slack/events` path.
+
+### 4. Copy Credentials Back
 
 1. In your new Slack app, go to **Basic Information** and copy the **Signing Secret**
 2. Go to **OAuth & Permissions** and copy the **Bot User OAuth Token** (`xoxb-...`)
 3. Back in Everruns, click **Configure** on the Slack Integration card
 4. Paste both values and click **Save**
-
-### 4. Configure Event Subscriptions
-
-1. **Publish** the app in Everruns first (so the webhook URL is live)
-2. Copy the **Request URL** shown on the app detail page
-3. In your Slack app settings, go to **Event Subscriptions** → Enable Events
-4. Paste the Request URL, Slack will verify it automatically
-5. Subscribe to bot events: `message.channels`, `message.groups`, `message.im`, `message.mpim`, `app_mention`
-6. Click **Save Changes**
-
-> **Note:** Event subscriptions require a live webhook URL, so the Everruns app must be published before configuring this step.
 
 ### 5. Start Using
 


### PR DESCRIPTION
## What changed

The generated Slack App manifest now declares `settings.event_subscriptions` — the app's own Request URL plus its bot events — so creating a Slack app from it needs no hand-editing.

A fresh setup drops from five steps to four, and loses the fiddly one:

**Before:** create app → Create Slack App → paste 2 credentials → publish → *open Event Subscriptions, paste the Request URL, re-subscribe to five bot events by hand* → invite

**After:** create app → **publish** → Create Slack App → install → paste 2 credentials → invite

Fixes [EVE-970](https://linear.app/everruns/issue/EVE-970/generate-the-slack-manifest-with-event-subscriptions-and-publish).

## Why

`build_manifest_yaml` omitted `event_subscriptions`, justified in the spec as "requires live webhook URL, must be configured after publishing".

That reason is half right. `settings.event_subscriptions.request_url` and `bot_events` are ordinary manifest fields, and the webhook URL is fully determined by the app's public ID *before* the Slack app exists — so it can be declared up front. The real constraint is ordering: Slack verifies `request_url` at the moment the manifest is saved, so the Everruns app has to be published and answering first. The manifest endpoint already served published apps only, so nothing new had to be gated — that ordering just becomes what the UI and docs teach.

## Before / After

`build_manifest_yaml` output, same inputs. **Before**, `settings` was three flags:

```yaml
settings:
  org_deploy_enabled: false
  socket_mode_enabled: false
  token_rotation_enabled: false
```

**After:**

```yaml
settings:
  event_subscriptions:
    request_url: "https://app.everruns.com/api/v1/apps/app_01k2c3/slack/events"
    bot_events:
      - app_mention
      - message.channels
      - message.groups
      - message.im
      - message.mpim
  org_deploy_enabled: false
  socket_mode_enabled: false
  token_rotation_enabled: false
```

Evidence:

- 4 new server tests, including one that parses the manifest with `serde_yaml` and asserts the real shape (`settings.event_subscriptions.bot_events`) rather than substring-matching — a manifest that is merely *textually* right but nests wrongly is rejected by Slack, and a substring test would not catch it.
- `cargo test -p everruns-server --lib` — 2306 passed, 0 failed.
- `cargo test -p everruns-server --test slack_integration_test` — 18 passed, 0 failed, including the 3 live-Slack tests, against local Postgres 16 with all 132 migrations applied.
- `apps/ui`: full `jest` run — 1484 passed / 189 suites; `format:check` clean; `lint` clean for the touched file (repo-wide warnings are pre-existing and untouched).
- `just pre-push` — 22/22 green.

## Risk

- Low / Medium
- The manifest is consumed by Slack, so a malformed `settings` block breaks app creation outright. That is the reason for the YAML-parsing test rather than string assertions.
- Anyone who set an app up the old way is unaffected: this only changes what a *newly generated* manifest contains. Existing Slack apps keep whatever subscriptions they have.
- `SlackState::new` gained an `api_base_url` argument; call sites are `app_builder.rs` and two test harnesses.
- If `AUTH_BASE_URL`/`BASE_URL` is misconfigured, the manifest now bakes that wrong URL in rather than the user pasting a correct one by hand. The UI still displays the Request URL so a wrong value is visible before the app is created.

## Security

- Threat categories reviewed: TM-SLACK, TM-API, TM-AUTHZ, TM-TENANT, TM-WEB.
- Findings and resolutions:
  - **Manifest injection** — `request_url` now flows into a hand-built YAML string. It is server configuration (`AuthConfig::base_url`) plus the app's own public ID, neither user-controlled, but it is escaped through the existing `yaml_escape` anyway and pinned by `test_manifest_yaml_escapes_request_url`, which round-trips a quote-bearing URL through a real YAML parser. Without escaping, a quote would silently corrupt the rest of the manifest.
  - **Endpoint exposure** — unchanged. `handle_slack_manifest` is unauthenticated by design and already refuses anything that is not a published app with an enabled Slack channel; this PR adds no caller and relaxes no check. The endpoint discloses only the app's name, description and its own webhook URL, as before.
  - **Credential exposure** — none. The manifest never contained and still never contains the signing secret or bot token; those stay a manual copy-back step.
  - **No new endpoint, SQL, authz path, or frontend input.** The UI change is static copy plus a clipboard write of a server-provided string.
  - No `THREAT[...]` marker changed meaning; no threat-model update warranted.

## Follow-ups

- **`message.mpim` is included, where the issue named only four events.** The `mpim:history` scope was already in the manifest and `docs/integrations/slack.md` already told users to subscribe to `message.mpim`, so emitting only four would have regressed group DMs for anyone who followed the documented setup. The issue's "four" matched the old UI text, which was itself inconsistent with the docs; all three now agree.
- **Socket Mode for local development is deliberately not flipped here.** The issue raised it as an open question. It changes how events are transported rather than how the manifest is generated, needs its own testing against a real workspace, and would widen this PR well past its point. The ngrok path stays documented in both the UI and the docs. Worth its own issue if local setup friction is the priority.
- **`SlackSetupGuidance` and `getSlackManifest` are currently not mounted by any page** — they are covered by tests but orphaned, apparently left behind by an earlier refactor of the app detail page. This PR updates them as the issue asked, so they are correct when rewired, but no user-visible UI changes until something renders them. Flagging it rather than quietly reattaching them, which would be a separate product decision.
- OAuth install (still two hand-copied credentials) and the agent-surface toggle stay out of scope, tracked separately.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — 55 checks green, Cloudflare docs preview deployed successfully
- [x] All review comments addressed (code change or written reasoning) — no review comments were posted

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5pjWvFrbEzs4cbKBkSM2D)_


---
_Generated by [Claude Code](https://claude.ai/code)_