### PR TITLE
fix(slack): honour Slack's Retry-After on a rate limit

### DIFF
--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -713,21 +713,102 @@ impl Default for SlackDeliveryAdapter {
     }
 }
 
-/// Slack API errors that retrying cannot fix.
+/// Slack API error codes that retrying cannot fix.
 ///
-/// The single source of truth for transient-vs-permanent (EVE-972). Both the
-/// retry loop and `ChannelDeliveryResult` mapping read it, so a send can no
-/// longer be abandoned as unretryable while being reported as transient.
-fn slack_error_is_permanent(error: &str) -> bool {
-    const PERMANENT: &[&str] = &[
-        "channel_not_found",
-        "not_authed",
-        "invalid_auth",
-        "token_revoked",
-        "account_inactive",
-        "no_text",
-    ];
-    PERMANENT.iter().any(|e| error.contains(e))
+/// The single source of truth for transient-vs-permanent (EVE-972), matched as
+/// exact codes rather than substrings of a formatted message (EVE-968).
+const PERMANENT_SLACK_ERRORS: &[&str] = &[
+    "channel_not_found",
+    "not_authed",
+    "invalid_auth",
+    "token_revoked",
+    "account_inactive",
+    "no_text",
+];
+
+/// Ceiling on an honoured `Retry-After`.
+///
+/// Slack's advice is normally seconds, but a delivery task must not be pinned by
+/// a pathological value. Worst case is `max_attempts` waits at this cap.
+const MAX_RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// A failed Slack API call, typed so the retry loop can act on the reason.
+///
+/// Before EVE-968 every failure was flattened into a string and re-examined by
+/// substring match, which threw away the one thing a 429 actually tells us:
+/// how long to wait.
+#[derive(Debug)]
+pub(crate) enum SlackApiError {
+    /// Slack asked us to slow down, and said for how long when it could.
+    RateLimited {
+        retry_after: Option<std::time::Duration>,
+    },
+    /// Retrying cannot help: bad token, missing channel, empty message.
+    Permanent(String),
+    /// Network trouble, a 5xx, or an error code we do not recognise.
+    Transient(String),
+}
+
+impl SlackApiError {
+    /// Classify a Slack `error` code from an `ok: false` body.
+    fn from_code(code: &str, retry_after: Option<std::time::Duration>) -> Self {
+        if code == "ratelimited" {
+            return Self::RateLimited { retry_after };
+        }
+        let message = format!("Slack API error: {code}");
+        if PERMANENT_SLACK_ERRORS.contains(&code) {
+            Self::Permanent(message)
+        } else {
+            Self::Transient(message)
+        }
+    }
+
+    /// Whether retrying this failure is pointless.
+    fn is_permanent(&self) -> bool {
+        matches!(self, Self::Permanent(_))
+    }
+}
+
+impl std::fmt::Display for SlackApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RateLimited {
+                retry_after: Some(d),
+            } => {
+                write!(f, "Slack API rate limited (retry after {}s)", d.as_secs())
+            }
+            Self::RateLimited { retry_after: None } => write!(f, "Slack API rate limited"),
+            Self::Permanent(message) | Self::Transient(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for SlackApiError {}
+
+/// How long to wait before the next attempt.
+///
+/// Slack's own advice beats our guess. Retrying a 429 on a 1s backoff burns the
+/// remaining attempts before the rate-limit window has even opened, which is how
+/// a burst drops replies that would otherwise have gone through (EVE-968).
+fn retry_wait(error: &SlackApiError, backoff: std::time::Duration) -> std::time::Duration {
+    match error {
+        SlackApiError::RateLimited {
+            retry_after: Some(advice),
+        } => (*advice).min(MAX_RETRY_AFTER),
+        _ => backoff,
+    }
+}
+
+/// Slack sends `Retry-After` in whole seconds.
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<std::time::Duration> {
+    headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .map(std::time::Duration::from_secs)
 }
 
 #[async_trait]
@@ -784,12 +865,10 @@ impl ChannelDeliveryAdapter for SlackDeliveryAdapter {
 }
 
 /// Map a Slack transport failure onto a `ChannelDeliveryResult`.
-fn classify_slack_failure(error: anyhow::Error) -> ChannelDeliveryResult {
-    let err = error.to_string();
-    if slack_error_is_permanent(&err) {
-        ChannelDeliveryResult::PermanentError(err)
-    } else {
-        ChannelDeliveryResult::TransientError(err)
+fn classify_slack_failure(error: SlackApiError) -> ChannelDeliveryResult {
+    match error {
+        SlackApiError::Permanent(message) => ChannelDeliveryResult::PermanentError(message),
+        other => ChannelDeliveryResult::TransientError(other.to_string()),
     }
 }
 
@@ -861,33 +940,29 @@ async fn post_to_slack_with_retry_base(
     channel: &str,
     thread_ts: &str,
     text: &str,
-) -> anyhow::Result<()> {
+) -> Result<(), SlackApiError> {
     let max_attempts = 3;
-    let mut delay = std::time::Duration::from_secs(1);
+    let mut backoff = std::time::Duration::from_secs(1);
 
     for attempt in 1..=max_attempts {
         match post_to_slack_base(base_url, bot_token, channel, thread_ts, text).await {
             Ok(()) => return Ok(()),
             Err(e) => {
-                let error_str = e.to_string();
-
-                // Non-retryable Slack API errors
-                if slack_error_is_permanent(&error_str) {
+                if e.is_permanent() || attempt == max_attempts {
                     return Err(e);
                 }
 
-                if attempt == max_attempts {
-                    return Err(e);
-                }
+                let wait = retry_wait(&e, backoff);
 
                 warn!(
                     attempt,
                     max_attempts,
+                    wait_secs = wait.as_secs(),
                     error = %e,
                     "Slack post failed, retrying"
                 );
-                tokio::time::sleep(delay).await;
-                delay *= 2;
+                tokio::time::sleep(wait).await;
+                backoff *= 2;
             }
         }
     }
@@ -904,7 +979,8 @@ pub(crate) async fn post_to_slack(
     thread_ts: &str,
     text: &str,
 ) -> anyhow::Result<()> {
-    post_to_slack_base(SLACK_API_BASE, bot_token, channel, thread_ts, text).await
+    post_to_slack_base(SLACK_API_BASE, bot_token, channel, thread_ts, text).await?;
+    Ok(())
 }
 
 /// Post a message to Slack using the Bot API (with configurable base URL for testing).
@@ -914,7 +990,7 @@ pub(crate) async fn post_to_slack_base(
     channel: &str,
     thread_ts: &str,
     text: &str,
-) -> anyhow::Result<()> {
+) -> Result<(), SlackApiError> {
     let client = reqwest::Client::new();
 
     let mut payload = serde_json::json!({
@@ -932,10 +1008,18 @@ pub(crate) async fn post_to_slack_base(
         .header("Content-Type", "application/json")
         .json(&payload)
         .send()
-        .await?;
+        .await
+        .map_err(|e| SlackApiError::Transient(e.to_string()))?;
 
     let status = response.status();
-    let body: serde_json::Value = response.json().await?;
+    // Read the header before the body is consumed: a 429 carries its advice here,
+    // not in the JSON.
+    let retry_after = parse_retry_after(response.headers());
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| SlackApiError::Transient(e.to_string()))?;
 
     if !body.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
         let error = body
@@ -943,18 +1027,25 @@ pub(crate) async fn post_to_slack_base(
             .and_then(|e| e.as_str())
             .unwrap_or("unknown");
 
-        // Rate limited — treat as retryable
-        if error == "ratelimited" {
-            return Err(anyhow::anyhow!("Slack API rate limited"));
-        }
+        let failure = SlackApiError::from_code(error, retry_after);
 
-        error!(
-            channel = channel,
-            error = error,
-            status = %status,
-            "Failed to post message to Slack"
-        );
-        return Err(anyhow::anyhow!("Slack API error: {}", error));
+        // A rate limit is routine backpressure, not a fault to shout about.
+        if matches!(failure, SlackApiError::RateLimited { .. }) {
+            debug!(
+                channel = channel,
+                retry_after_secs = ?retry_after.map(|d| d.as_secs()),
+                status = %status,
+                "Slack rate limited the post"
+            );
+        } else {
+            error!(
+                channel = channel,
+                error = error,
+                status = %status,
+                "Failed to post message to Slack"
+            );
+        }
+        return Err(failure);
     }
 
     info!(channel = channel, "Posted response to Slack");
@@ -1964,10 +2055,170 @@ mod tests {
                 "account_inactive",
                 "no_text",
             ] {
-                assert!(slack_error_is_permanent(error), "{error} must be permanent");
+                assert!(
+                    SlackApiError::from_code(error, None).is_permanent(),
+                    "{error} must be permanent"
+                );
             }
-            assert!(!slack_error_is_permanent("ratelimited"));
-            assert!(!slack_error_is_permanent("internal_error"));
+            assert!(!SlackApiError::from_code("internal_error", None).is_permanent());
+
+            // A rate limit is its own variant, never permanent.
+            assert!(matches!(
+                SlackApiError::from_code("ratelimited", None),
+                SlackApiError::RateLimited { .. }
+            ));
+        }
+    }
+
+    /// EVE-968: a 429 carries Slack's own advice on how long to wait. Ignoring it
+    /// is how a burst drops replies that would otherwise have gone through.
+    mod rate_limit_tests {
+        use super::*;
+        use std::time::Duration;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        /// Post once against a mock returning `response`, and hand back the error.
+        async fn post_against(response: ResponseTemplate) -> SlackApiError {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/chat.postMessage"))
+                .respond_with(response)
+                .mount(&mock_server)
+                .await;
+
+            post_to_slack_base(&mock_server.uri(), "xoxb-test-token", "C123", "", "hi")
+                .await
+                .expect_err("rate limited")
+        }
+
+        fn rate_limited_body() -> serde_json::Value {
+            serde_json::json!({ "ok": false, "error": "ratelimited" })
+        }
+
+        #[tokio::test]
+        async fn retry_after_header_is_propagated() {
+            let error = post_against(
+                ResponseTemplate::new(429)
+                    .insert_header("Retry-After", "30")
+                    .set_body_json(rate_limited_body()),
+            )
+            .await;
+
+            assert!(
+                matches!(
+                    error,
+                    SlackApiError::RateLimited {
+                        retry_after: Some(d)
+                    } if d == Duration::from_secs(30)
+                ),
+                "expected 30s of advice, got {error:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn rate_limit_without_header_is_still_rate_limited() {
+            let error =
+                post_against(ResponseTemplate::new(200).set_body_json(rate_limited_body())).await;
+
+            assert!(
+                matches!(error, SlackApiError::RateLimited { retry_after: None }),
+                "expected a rate limit with no advice, got {error:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn unparseable_retry_after_falls_back_to_no_advice() {
+            // Slack documents whole seconds; an HTTP-date or junk value must not
+            // panic or be mistaken for a duration.
+            let error = post_against(
+                ResponseTemplate::new(429)
+                    .insert_header("Retry-After", "Wed, 21 Oct 2026 07:28:00 GMT")
+                    .set_body_json(rate_limited_body()),
+            )
+            .await;
+
+            assert!(
+                matches!(error, SlackApiError::RateLimited { retry_after: None }),
+                "expected no usable advice, got {error:?}"
+            );
+        }
+
+        /// End to end through the retry loop, on virtual time: the first attempt
+        /// is rate limited with 30s of advice, the second succeeds, and the loop
+        /// must have waited the 30s rather than its 1s backoff.
+        #[tokio::test(start_paused = true)]
+        async fn retry_loop_waits_the_advised_window() {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/chat.postMessage"))
+                .respond_with(
+                    ResponseTemplate::new(429)
+                        .insert_header("Retry-After", "30")
+                        .set_body_json(rate_limited_body()),
+                )
+                .up_to_n_times(1)
+                .mount(&mock_server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/chat.postMessage"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({ "ok": true, "ts": "1.2" })),
+                )
+                .mount(&mock_server)
+                .await;
+
+            let started = tokio::time::Instant::now();
+            let result =
+                post_to_slack_with_retry_base(&mock_server.uri(), "xoxb-t", "C123", "", "hi").await;
+            let waited = started.elapsed();
+
+            assert!(result.is_ok(), "second attempt should succeed: {result:?}");
+            assert!(
+                waited >= Duration::from_secs(30),
+                "loop waited {waited:?}, expected the advised 30s"
+            );
+        }
+
+        #[test]
+        fn advice_wins_over_backoff() {
+            let one_second = Duration::from_secs(1);
+            assert_eq!(
+                retry_wait(
+                    &SlackApiError::RateLimited {
+                        retry_after: Some(Duration::from_secs(30))
+                    },
+                    one_second
+                ),
+                Duration::from_secs(30),
+                "a 429 saying 30s must not be retried after 1s"
+            );
+        }
+
+        #[test]
+        fn backoff_applies_without_advice() {
+            let backoff = Duration::from_secs(4);
+            for error in [
+                SlackApiError::RateLimited { retry_after: None },
+                SlackApiError::Transient("boom".to_string()),
+            ] {
+                assert_eq!(retry_wait(&error, backoff), backoff, "{error:?}");
+            }
+        }
+
+        #[test]
+        fn pathological_advice_is_capped() {
+            assert_eq!(
+                retry_wait(
+                    &SlackApiError::RateLimited {
+                        retry_after: Some(Duration::from_secs(86_400))
+                    },
+                    Duration::from_secs(1)
+                ),
+                MAX_RETRY_AFTER,
+                "a delivery task must not be pinned for a day"
+            );
         }
     }
 


### PR DESCRIPTION
## What changed

A rate-limited Slack post now waits as long as Slack asked, instead of retrying on a fixed 1s / 2s / 4s backoff. Failures are carried as a typed `SlackApiError` rather than a formatted string the caller re-parses.

Fixes [EVE-968](https://linear.app/everruns/issue/EVE-968/slack-rate-limit-retry-ignores-the-retry-after-header).

## Why

Slack answers a 429 with a `Retry-After` header saying exactly how long to wait, and we threw it away: `post_to_slack_base` flattened every failure into a string, so the header never left the transport.

The consequence is not just inefficiency. A rate limit advising **30s** burned all three attempts inside the first 7 seconds and then failed the delivery — the retries all landed before the window had opened. Under a burst (several agents replying in one workspace) that drops replies that did not need to be dropped.

Typing the error is what makes the header reachable at all. It also retires the substring matching the adapter work introduced: Slack error codes are exact values, so `err.contains("channel_not_found")` was always the wrong test — `channel_not_found_somewhere` would have matched, and a code embedded in an unrelated message would have been misclassified.

## Before / After

Transport behaviour on `429` + `Retry-After: 30`, first attempt rate limited and second attempt fine:

| | Before | After |
|---|---|---|
| Header | discarded | parsed into `RateLimited { retry_after: 30s }` |
| Wait before attempt 2 | 1s | 30s |
| Outcome | 3 attempts inside 7s, delivery **failed** | second attempt succeeds |

`retry_loop_waits_the_advised_window` drives the real retry loop against a `wiremock` Slack that rate-limits once and then succeeds, on tokio virtual time, and asserts the loop waited the advised 30s. It runs in 0.05s rather than actually sleeping.

Reproduction check: reverting just the wait decision (ignore advice, always back off) fails exactly the three tests that assert advice is honoured — including the end-to-end one — while the four covering header parsing and fallbacks still pass. So the tests bite on the bug, not on their own scaffolding.

Evidence:

- 7 new tests: header present, header absent, unparseable header, advice-beats-backoff, backoff-without-advice, cap, and the end-to-end loop.
- `cargo test -p everruns-server --lib` — 2326 passed, 0 failed.
- `cargo test -p everruns-server --test slack_integration_test` — 19 passed, incl. 3 live-Slack tests, against local Postgres 16.
- `just pre-push` 22/22 green; `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Risk

- Low
- Retry count, exponential fallback, and the permanent-vs-transient split are all unchanged; only the wait *duration* on an advised rate limit differs.
- A delivery can now occupy its task longer than before — worst case 3 waits at the 60s cap instead of 1s/2s/4s. That is deliberate: the dispatcher has no deadline (by design, since EVE-966), and the alternative is the dropped reply this PR exists to prevent. The cap is what stops a pathological `Retry-After` from pinning a task indefinitely.
- `Retry-After` is also valid as an HTTP-date; Slack documents whole seconds, so a date parses as "no advice" and falls back to backoff rather than panicking. Pinned by `unparseable_retry_after_falls_back_to_no_advice`.
- `post_to_slack_base` and `post_to_slack_with_retry_base` changed return type; `post_to_slack` keeps its `anyhow::Result` signature so callers outside this module are untouched.

## Security

- Threat categories reviewed: TM-SLACK, TM-DOS, TM-API, TM-LLM (data exposure).
- Findings and resolutions:
  - **Attacker-influenced sleep (TM-DOS)** — the one new external input is a header value that decides how long a task sleeps. Anyone able to set it already controls the Slack endpoint we post to, but it is bounded anyway: parsed as `u64` seconds (no overflow, no negatives, junk rejected) and clamped to `MAX_RETRY_AFTER` (60s). Worst case is bounded by attempts × cap.
  - **Error-detail exposure** — `SlackApiError` carries the same Slack error codes the previous strings did and still reaches only server-side logs. The EVE-966 rule that user-facing notices carry no internal detail is untouched.
  - **Classification is stricter, not looser** — exact code equality replaces substring matching, so a permanent error cannot be spoofed into looking transient (or vice versa) by an error string that merely contains a known code.
  - **Log hygiene** — a rate limit now logs at `debug` rather than `error`, since routine backpressure is not a fault. No token or message content is logged.
  - No new endpoint, SQL, authz path, or network destination.

## Follow-ups

No follow-ups. The typed error the issue suggested as an optional cleanup is included, since the header is unreachable without it.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR — 49 checks green
- [x] All review comments addressed (code change or written reasoning) — no review comments were posted

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5pjWvFrbEzs4cbKBkSM2D)_


---
_Generated by [Claude Code](https://claude.ai/code)_