### PR TITLE
fix(mcp): scope server name uniqueness to the org and to live rows

### DIFF
--- a/crates/server/migrations/132_mcp_server_name_scope.sql
+++ b/crates/server/migrations/132_mcp_server_name_scope.sql
@@ -1,0 +1,23 @@
+-- EVE-964: scope MCP server name uniqueness to the organization and to live rows.
+--
+-- 001_base_schema.sql created `idx_mcp_servers_name` as a UNIQUE index on
+-- `name` alone. That was wrong twice over:
+--
+--   1. Not org-scoped. One organization creating a server called `github`
+--      stopped every other organization from ever using that name, and the
+--      resulting conflict disclosed that some other tenant held it.
+--   2. Counted dead rows. `delete_mcp_server` archives rather than removes
+--      (`status = 'archived'`), so a deleted server held its name forever.
+--
+-- `active` and `disabled` are the live states: a disabled server is
+-- configuration a user can re-enable, so reusing its name would create an
+-- ambiguous pair. `archived` and `deleted` release the name.
+--
+-- Any duplicate rows that the old global index made impossible cannot exist, so
+-- this needs no data cleanup — the new index is strictly more permissive.
+
+DROP INDEX IF EXISTS idx_mcp_servers_name;
+
+CREATE UNIQUE INDEX idx_mcp_servers_org_name_live
+    ON mcp_servers (org_id, name)
+    WHERE status IN ('active', 'disabled');

--- a/crates/server/src/storage/memory/mcp_servers.rs
+++ b/crates/server/src/storage/memory/mcp_servers.rs
@@ -10,6 +10,13 @@ use anyhow::anyhow;
 use everruns_provider::typed_id::McpServerId;
 use uuid::Uuid;
 
+/// Statuses that hold a name. Mirrors the partial unique index in
+/// `132_mcp_server_name_scope.sql`: archived and deleted servers release their
+/// name, a disabled one keeps it because it can be re-enabled (EVE-964).
+fn holds_name(status: &str) -> bool {
+    matches!(status, "active" | "disabled")
+}
+
 impl InMemoryDatabase {
     // ============================================
     // MCP Servers
@@ -20,12 +27,12 @@ impl InMemoryDatabase {
         org_id: i64,
         input: CreateMcpServerRow,
     ) -> Result<McpServerRow> {
-        // Check for duplicate name within org
+        // Check for duplicate name within org, among rows that still hold one.
         if self
             .mcp_servers
             .read()
             .values()
-            .any(|s| s.name == input.name && s.org_id == org_id)
+            .any(|s| s.name == input.name && s.org_id == org_id && holds_name(&s.status))
         {
             return Err(anyhow!(
                 "MCP server with name '{}' already exists",
@@ -165,7 +172,9 @@ impl InMemoryDatabase {
             .mcp_servers
             .read()
             .values()
-            .find(|s| s.name == name && s.org_id == org_id)
+            // Live rows only, matching the Postgres backend: an archived row
+            // no longer owns the name and must not shadow the live server.
+            .find(|s| s.name == name && s.org_id == org_id && holds_name(&s.status))
             .cloned())
     }
 

--- a/crates/server/src/storage/repositories/mcp_servers.rs
+++ b/crates/server/src/storage/repositories/mcp_servers.rs
@@ -156,7 +156,10 @@ impl Database {
             r#"
             SELECT id, org_id, name, description, url, transport_type, status, api_key_encrypted, api_key_set, headers, settings, cached_tools, tools_cached_at, created_at, updated_at, archived_at, deleted_at
             FROM mcp_servers
-            WHERE org_id = $1 AND name = $2
+            -- Live rows only. Archived and deleted rows release their name
+            -- (EVE-964), so a name can now match a dead row and a live one;
+            -- callers asking "which server is called X" mean the live one.
+            WHERE org_id = $1 AND name = $2 AND status IN ('active', 'disabled')
             "#,
         )
         .bind(org_id)

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -27,8 +27,8 @@ use everruns_server::storage::{
     CreateProviderRow, CreateSessionFileRow, CreateSessionRow, CreateSessionScheduleRow,
     CreateUserConnectionRow, CreateUserRow, Database, SessionListFilters, StorageBackend,
     UpdateAgent, UpdateAgentHealthCheckRunRow, UpdateDeclarativeCapability, UpdateEvalRow,
-    UpdateModel, UpdateOrganization, UpdateOrganizationSettings, UpdateProvider, UpdateSession,
-    UpdateSessionFile, UpdateSessionScheduleRow,
+    UpdateMcpServer, UpdateModel, UpdateOrganization, UpdateOrganizationSettings, UpdateProvider,
+    UpdateSession, UpdateSessionFile, UpdateSessionScheduleRow,
 };
 use test_harness::get_database_url;
 
@@ -2305,6 +2305,168 @@ async fn test_mcp_server_crud() {
         .await
         .expect("Failed to delete MCP server");
     assert!(deleted);
+}
+
+/// EVE-964: deleting an MCP server must release its name.
+///
+/// `delete_mcp_server` archives the row rather than removing it, and the
+/// uniqueness index counted archived rows — so a name was taken forever after
+/// one delete. Visible to real users of archived servers, not only to a test
+/// suite run twice against one database.
+#[tokio::test]
+async fn test_mcp_server_name_is_released_after_delete() {
+    let backend = create_test_backend().await;
+    let name = format!("Recycled MCP Server {}", Uuid::now_v7());
+
+    let first = backend
+        .create_mcp_server(
+            TEST_ORG_ID,
+            CreateMcpServerRow {
+                name: name.clone(),
+                description: None,
+                url: "http://localhost:3000".to_string(),
+                transport_type: "http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: None,
+            },
+        )
+        .await
+        .expect("Failed to create MCP server");
+
+    assert!(
+        backend
+            .delete_mcp_server(TEST_ORG_ID, first.id.uuid())
+            .await
+            .expect("delete should not error"),
+        "delete should report a row changed"
+    );
+
+    // The name is free again: creating it a second time must succeed.
+    let second = backend
+        .create_mcp_server(
+            TEST_ORG_ID,
+            CreateMcpServerRow {
+                name: name.clone(),
+                description: None,
+                url: "http://localhost:3000".to_string(),
+                transport_type: "http".to_string(),
+                api_key_encrypted: None,
+                headers: None,
+                settings: None,
+            },
+        )
+        .await
+        .expect("an archived server must not hold its name");
+
+    assert_ne!(second.id, first.id);
+    assert_eq!(second.name, name);
+
+    // Lookup resolves to the live row, not the archived one.
+    let by_name = backend
+        .get_mcp_server_by_name(TEST_ORG_ID, &name)
+        .await
+        .expect("lookup failed")
+        .expect("live server should be found");
+    assert_eq!(
+        by_name.id, second.id,
+        "by-name lookup must resolve the live server, not the archived row"
+    );
+}
+
+/// EVE-964: the uniqueness index was global rather than per-organization, so
+/// one org creating a server named `github` stopped every other org from ever
+/// using that name — and the resulting 409 disclosed that some other tenant
+/// held it.
+#[tokio::test]
+async fn test_mcp_server_names_are_scoped_per_org() {
+    let backend = create_test_backend().await;
+    let name = format!("Shared MCP Name {}", Uuid::now_v7());
+
+    let row = |name: String| CreateMcpServerRow {
+        name,
+        description: None,
+        url: "http://localhost:3000".to_string(),
+        transport_type: "http".to_string(),
+        api_key_encrypted: None,
+        headers: None,
+        settings: None,
+    };
+
+    let first = backend
+        .create_mcp_server(TEST_ORG_ID, row(name.clone()))
+        .await
+        .expect("Failed to create MCP server for the first org");
+
+    let other_org = TEST_ORG_ID + 1;
+    let second = backend
+        .create_mcp_server(other_org, row(name.clone()))
+        .await
+        .expect("a second org must be able to use the same server name");
+
+    assert_ne!(second.id, first.id);
+
+    // Each org sees only its own.
+    assert_eq!(
+        backend
+            .get_mcp_server_by_name(TEST_ORG_ID, &name)
+            .await
+            .expect("lookup failed")
+            .expect("first org's server should be found")
+            .id,
+        first.id
+    );
+    assert_eq!(
+        backend
+            .get_mcp_server_by_name(other_org, &name)
+            .await
+            .expect("lookup failed")
+            .expect("second org's server should be found")
+            .id,
+        second.id
+    );
+}
+
+/// The name stays reserved while the server is merely disabled: a disabled
+/// server is live configuration a user can re-enable, so reusing its name
+/// would create an ambiguous pair.
+#[tokio::test]
+async fn test_mcp_server_name_stays_taken_while_disabled() {
+    let backend = create_test_backend().await;
+    let name = format!("Disabled MCP Server {}", Uuid::now_v7());
+
+    let row = |name: String| CreateMcpServerRow {
+        name,
+        description: None,
+        url: "http://localhost:3000".to_string(),
+        transport_type: "http".to_string(),
+        api_key_encrypted: None,
+        headers: None,
+        settings: None,
+    };
+
+    let first = backend
+        .create_mcp_server(TEST_ORG_ID, row(name.clone()))
+        .await
+        .expect("Failed to create MCP server");
+
+    backend
+        .update_mcp_server(
+            TEST_ORG_ID,
+            first.id.uuid(),
+            UpdateMcpServer {
+                status: Some("disabled".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Failed to disable MCP server");
+
+    let conflict = backend.create_mcp_server(TEST_ORG_ID, row(name)).await;
+    assert!(
+        conflict.is_err(),
+        "a disabled server must keep its name reserved"
+    );
 }
 
 // ============================================

--- a/knowledge/integrations/mcp-servers.md
+++ b/knowledge/integrations/mcp-servers.md
@@ -26,7 +26,7 @@ See `crates/core/src/mcp_server.rs` for the full `McpServer` struct definition.
 
 | Field | Max Size | Notes |
 |-------|----------|-------|
-| `name` | 255 chars | Must be unique, non-empty, snake_case recommended |
+| `name` | 255 chars | Must be unique per organization among live (`active`/`disabled`) servers, non-empty, snake_case recommended |
 | `description` | 10 KB | Optional description |
 | `url` | 2 KB | Valid HTTP/HTTPS URL |
 | `headers` | 100 entries | Maximum header entries |
@@ -354,7 +354,7 @@ Delete an MCP server.
 
 1. **API Key Encryption**: API keys are encrypted at rest using envelope encryption (see `knowledge/security/encryption.md`)
 2. **API Key Not Exposed**: The `api_key_encrypted` field is never returned in API responses
-3. **Unique Names**: Server names must be unique to prevent configuration conflicts
+3. **Unique Names**: Server names must be unique within an organization to prevent configuration conflicts. Uniqueness is scoped to live servers: archiving or deleting a server releases its name, while a disabled one keeps it because it can be re-enabled (EVE-964).
 4. **SSRF Protection**: MCP server URLs are validated on create/update (static check) and re-validated with DNS resolution before each tool call and `tools/list` fetch (`validate_url_dns_pinned`). Private IPs, loopback, link-local, and cloud metadata endpoints are blocked; the DNS-pinned check also prevents DNS-rebinding attacks by verifying every resolved IP on each outbound request (TM-TOOL-018).
 
 ## MCP as Virtual Capabilities


### PR DESCRIPTION
## What changed

MCP server name uniqueness is now scoped to the organization and to live servers.

`001_base_schema.sql` created `idx_mcp_servers_name` as a UNIQUE index on `name` alone. Migration `132` replaces it with a partial index on `(org_id, name) WHERE status IN ('active', 'disabled')`.

Fixes [EVE-964](https://linear.app/everruns/issue/EVE-964/test-mcp-server-crud-cannot-run-twice-against-one-database-deleted-mcp).

## Why

Reproducing the reported symptom turned up **two** defects in that one index, and the second is the more serious of the pair.

**1. A deleted server held its name forever (the reported bug).** `delete_mcp_server` archives rather than removes the row, and the index counted archived and deleted rows. So `test_mcp_server_crud` cannot run twice against one database — the second run fails with a 409.

**2. The index was not org-scoped at all.** One organization creating a server named `github` stopped *every other organization* from ever using that name, and the resulting 409 disclosed that some other tenant held it. This is a multi-tenancy defect that the reported symptom happened to expose.

Nothing above the database depended on the global behaviour: `get_mcp_server_by_name` already took an `org_id`, and the in-memory backend already scoped its duplicate check by org. The Postgres index was the sole cause of both.

While reproducing, I also checked the claim in the issue that the test's teardown was at fault. It is not: the teardown correctly archives (`DELETE /v1/mcp-servers/{id}`) and then destroys (`POST /v1/mcp-servers/{id}/delete`). The rows end at `status = 'deleted'` and the old index counted them — exactly the issue's own diagnosis.

## Before / After

Both defects reproduce as failing tests against `main` and pass after the migration. The third test is a control: it asserts behaviour that must *not* change, and passes throughout.

Against `main`:

```
test_mcp_server_name_is_released_after_delete ... FAILED
test_mcp_server_names_are_scoped_per_org ....... FAILED
test_mcp_server_name_stays_taken_while_disabled  ok
```

After the migration:

```
test_mcp_server_name_is_released_after_delete ... ok
test_mcp_server_names_are_scoped_per_org ....... ok
test_mcp_server_name_stays_taken_while_disabled  ok
```

Other evidence:

- `cargo test -p everruns-server --test repository_integration_test -- --test-threads=1` — **44 passed, 0 failed** against local Postgres 16 with all 132 migrations.
- `cargo test -p everruns-server --lib` — **2355 passed, 0 failed**.
- `just pre-push` — **22/22 green**, including migration ordering (001..132) and migration immutability.

## Risk

- Low
- **The new index is strictly more permissive than the old one.** Every row pair the new index rejects, the old one also rejected. So rows that would now conflict cannot already exist, and the migration needs no data cleanup or backfill — it cannot fail on existing data.
- **`get_mcp_server_by_name` is narrowed to live rows in both backends.** This is required, not incidental: a name can now belong to one live row and any number of dead ones, so an unfiltered lookup could return an archived row and shadow the live server. Pinned by an assertion in the delete/recreate test.
- **The in-memory backend's create check is narrowed the same way**, so the two backends agree on when a name is free. It was already org-scoped, so only the status filter changed.
- **`disabled` deliberately still holds its name.** A disabled server is configuration a user can re-enable; letting a new server take the name would create an ambiguous pair on re-enable. This is the one behaviour a reader might expect to change and does not, so it has its own test.

## Security

- Threat categories reviewed: TM-TENANT, TM-API, TM-AUTHZ.
- Findings and resolutions:
  - **Cross-tenant information disclosure (fixed).** This is the security-relevant half of the change. Under the global index, creating an MCP server named `github` in org A caused a 409 in org B — a probe that let any tenant enumerate whether another tenant held a given server name, and denied them the name outright. Scoping the index to `org_id` closes both the disclosure and the denial. No new threat-model entry is warranted because this restores the tenant isolation TM-TENANT already asserts, rather than describing a new surface.
  - **No authz path changed.** Every caller already passed an `org_id`; the index was simply stricter than the code around it. This PR does not widen what any principal can read or write — an org still sees only its own servers, and `test_mcp_server_org_isolation_postgres` (pre-existing) still passes.
  - **No name-collision hazard introduced.** MCP tool-name sanitization operates within a single org's server set, which remains unique.
  - **No new endpoint, SQL injection surface, or credential handling.** One index definition and two `WHERE` clauses.

## Follow-ups

No follow-ups.

The issue offered two options and asked which to take rather than defaulting. This takes **option 1**, the product-side fix, for the reason the issue itself gives: a disabled or deleted server holding a name forever is surprising for real users, not only for a test suite run twice. Option 2 (unique per-run names in the test) would have hidden the tenancy defect entirely.

## Checklist

- [x] Tests added or updated — 3 new, two of which fail against `main` and one control that must not change
- [x] Backward compatibility considered — new index strictly more permissive; no data migration needed
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning) — none posted yet

---
_Generated by [Claude Code](https://claude.ai/code/session_01LA1ctJW2EBf4BTGSvHHRyz)_